### PR TITLE
fix(api-parity): 43 of the 48 "missing" C symbols are ones we export

### DIFF
--- a/docs/reference/api-parity-ledger/lifecycle.json
+++ b/docs/reference/api-parity-ledger/lifecycle.json
@@ -554,5 +554,13 @@
   "c:lifecycle_callback_t": {
     "verdict": "extension",
     "why": "`uint8_t (*nros_lifecycle_callback_t)(void *context)` -- the named typedef for a lifecycle transition callback, added by issue 0792. rclc has no counterpart because it spells its callback inline as `int (*)(void)` at each of its four `rclc_lifecycle_register_on_*` declarations and never names the type. We name it for two reasons: it is the shape ALL TWELVE of our entry points share (the six standalone and the six executor-scoped), and naming it is what makes it expressible in C at all -- the unnamed cross-crate `Option<LifecycleCallbackFnCtx>` it replaced reached the header as an opaque struct passed by value. Same convention as `nros_timer_callback_t` and `nros_guard_condition_callback_t`. The `void *context` parameter itself is the `callback-bound-at-creation` divergence recorded on `c:lifecycle_register_on_configure`."
+  },
+  "cpp:LifecycleTransition": {
+    "verdict": "extension",
+    "why": "An ENUM naming the lifecycle transition ids, which the C ABI carries as a `uint8_t` across `nros_executor_lifecycle_change_state`. rclcpp models a transition as a `Transition` OBJECT (constructed, carrying label and id) — a different shape, and its absence here is recorded separately as `cpp:Transition` (gap). This is not that object under another name: it is the id vocabulary an embedded caller passes by value, with no allocation and no lifetime."
+  },
+  "cpp:shutdown_transition_for": {
+    "verdict": "extension",
+    "why": "Maps a lifecycle state onto the shutdown transition legal FROM that state. rclcpp has no such helper: its `LifecycleNode::shutdown()` resolves the same thing inside the state machine, which is reachable because the node owns it. Ours is a free function because the state machine lives behind the C ABI and a caller holding only the current state cannot ask it."
   }
 }

--- a/docs/reference/api-parity-ledger/node.json
+++ b/docs/reference/api-parity-ledger/node.json
@@ -531,5 +531,9 @@
     "disposition": "absent",
     "verdict": "declined",
     "why": "phase-417 stage 0 — visible only because `rclcpp_compat.hpp` is now a translation unit (issue 1020). The shim ships this TYPE as a name, so its members stop inheriting \"we do not have this type\" and become their own claim. Not a new gap: a gap INSIDE a type we ship is a different statement from one about a type we do not. These specific ones are REFUSED LOUDLY (RFC-0089 W3.f): each stored its argument in a private field that nothing read and returned `*this`, so the idiomatic chained call compiled and configured nothing. They are `= delete` overloads now, sharing one diagnostic -- a refusal is per-CONCEPT, not per-symbol."
+  },
+  "c:node_init": {
+    "verdict": "rename",
+    "why": "Same capability, our name. `rcl_node_init` takes an options struct built by `rcl_node_get_default_options()` — both of which we DO export (they correlate `same`); what we do not have is the plain `init` that consumes them. Ours is `nros_node_init_ex` — not the `_with_options` / `_with_qos` pair the four entity rows name, which is its own small inconsistency — plus the adopted `rclc_node_init_default`. There is no platform reason for the suffix: `nros_node_init_ex` takes `nros_node_options_t*` exactly as `rcl_node_init` takes `rcl_node_options_t*`, so the shape is the same and only the name differs. Ours is the name that should change. The other half of this statement is `c:node_init_ex`, the ours-only row for the same function."
   }
 }

--- a/docs/reference/api-parity-ledger/other.json
+++ b/docs/reference/api-parity-ledger/other.json
@@ -1392,5 +1392,9 @@
   "rust:timestamp_available": {
     "verdict": "extension",
     "why": "phase-417 W4.d — asks whether the platform clock is available, so a caller can tell \"this record has no timestamp\" from \"this record happened at time zero\". ROS 2 has no counterpart because rcutils always has a clock; on a target built without `nros-log/platform-clock` ours does not, and the honest answer is a query rather than a zero that reads as a time. It is also what makes the C throttle's failure mode legible: with no clock a window admits every record, and `nros_log_timestamp_available()` is how a caller finds out before trusting a rate."
+  },
+  "rust:throttle_decide": {
+    "verdict": "extension",
+    "why": "The shared predicate behind `nros_warn_throttle` / `nros_trace_throttle` and their `_at` variants (already ledgered): given the last-emit instant and a period, should this record be emitted. Exposed rather than kept private because the macros are `no_std` and expand in the CALLER's crate, so the decision has to be a callable item there. rclrs throttles inside its logging macros and exposes no predicate."
   }
 }

--- a/docs/reference/api-parity-ledger/pubsub.json
+++ b/docs/reference/api-parity-ledger/pubsub.json
@@ -1741,5 +1741,13 @@
   "c:executor_add_subscription_raw": {
     "verdict": "divergence",
     "why": "phase-417 stage 6 — the callback moved OFF `*_init` and onto registration, so `rclc_{subscription,service}_init_default` now matches rclc's four-argument shape and the callback arrives here, exactly as rclc supplies it at `rclc_executor_add_subscription`.\n\nIt keeps the `nros_` prefix DELIBERATELY, and that is the whole content of this row. rclc's same-named calls deliver a DESERIALISED message into caller-owned storage; these deliver CDR BYTES. Taking rclc's spelling for a byte-oriented entry point would be a name whose contract differs -- the `PollingSubscription::take()` failure, which had rclcpp's name, rclcpp's signature and the opposite contract, and cost a spinning loop with no compile error.\n\nThe faithful rclc-shaped entry point exists beside it and DOES take the name: `nros_executor_add_subscription_typed` (W5.a), reached per-message as `<Msg>_executor_add_subscription(exec, sub, &msg, cb, ctx, invocation)` -- rclc's six arguments in rclc's order. So the two shapes are distinguished by NAME rather than by a reader noticing which one deserialises, which is what RFC-0089 asks for."
+  },
+  "c:publisher_init": {
+    "verdict": "rename",
+    "why": "Same capability, our name. `rcl_publisher_init` takes an options struct built by `rcl_publisher_get_default_options()` — both of which we DO export (they correlate `same`); what we do not have is the plain `init` that consumes them. Ours is `nros_publisher_init_with_options`, plus `_with_qos` and the adopted `rclc_publisher_init_default`. There is no platform reason for the suffix: the options are not more mandatory here than upstream, the struct is the same shape, and spelling it out costs the drop-in claim for nothing. Ours is the name that should change."
+  },
+  "c:subscription_init": {
+    "verdict": "rename",
+    "why": "Same capability, our name. `rcl_subscription_init` takes an options struct built by `rcl_subscription_get_default_options()` — both of which we DO export (they correlate `same`); what we do not have is the plain `init` that consumes them. Ours is `nros_subscription_init_with_options`, plus `_with_qos` and the adopted `rclc_subscription_init_default`. There is no platform reason for the suffix: the options are not more mandatory here than upstream, the struct is the same shape, and spelling it out costs the drop-in claim for nothing. Ours is the name that should change."
   }
 }

--- a/docs/reference/api-parity-ledger/service.json
+++ b/docs/reference/api-parity-ledger/service.json
@@ -1226,5 +1226,13 @@
   "c:executor_add_service_raw": {
     "verdict": "divergence",
     "why": "phase-417 stage 6 — the callback moved OFF `*_init` and onto registration, so `rclc_{subscription,service}_init_default` now matches rclc's four-argument shape and the callback arrives here, exactly as rclc supplies it at `rclc_executor_add_subscription`.\n\nIt keeps the `nros_` prefix DELIBERATELY, and that is the whole content of this row. rclc's same-named calls deliver a DESERIALISED message into caller-owned storage; these deliver CDR BYTES. Taking rclc's spelling for a byte-oriented entry point would be a name whose contract differs -- the `PollingSubscription::take()` failure, which had rclcpp's name, rclcpp's signature and the opposite contract, and cost a spinning loop with no compile error.\n\nThe faithful rclc-shaped entry point exists beside it and DOES take the name: `nros_executor_add_subscription_typed` (W5.a), reached per-message as `<Msg>_executor_add_subscription(exec, sub, &msg, cb, ctx, invocation)` -- rclc's six arguments in rclc's order. So the two shapes are distinguished by NAME rather than by a reader noticing which one deserialises, which is what RFC-0089 asks for."
+  },
+  "c:client_init": {
+    "verdict": "rename",
+    "why": "Same capability, our name. `rcl_client_init` takes an options struct built by `rcl_client_get_default_options()` — both of which we DO export (they correlate `same`); what we do not have is the plain `init` that consumes them. Ours is `nros_client_init_with_options`, plus `_with_qos` and the adopted `rclc_client_init_default`. There is no platform reason for the suffix: the options are not more mandatory here than upstream, the struct is the same shape, and spelling it out costs the drop-in claim for nothing. Ours is the name that should change."
+  },
+  "c:service_init": {
+    "verdict": "rename",
+    "why": "Same capability, our name. `rcl_service_init` takes an options struct built by `rcl_service_get_default_options()` — both of which we DO export (they correlate `same`); what we do not have is the plain `init` that consumes them. Ours is `nros_service_init_with_options`, plus `_with_qos` and the adopted `rclc_service_init_default`. There is no platform reason for the suffix: the options are not more mandatory here than upstream, the struct is the same shape, and spelling it out costs the drop-in claim for nothing. Ours is the name that should change."
   }
 }

--- a/scripts/api-parity.py
+++ b/scripts/api-parity.py
@@ -324,13 +324,30 @@ def ours_cpp(tmpdir):
 
 
 def ours_c(tmpdir):
+    # `rcl_` / `rclc_` are OURS here, and leaving them out made the report lie.
+    #
+    # phase-417 stage 6 step A ("the ROS 2 spellings are ours") adopted the
+    # upstream names directly for the surface where our contract matches:
+    # `nros/nros_generated.h` declares 39 `rcl_*` and 8 `rclc_*` entry points
+    # as NROS_PUBLIC. Harvesting only `nros_` made every one of them invisible
+    # on OUR side, so the correlator put them in `theirs-only` — 43 of the 48
+    # unledgered C rows were symbols we ship, under the very name the ledger
+    # would have recorded us as lacking.
+    #
+    # That is the expensive direction of wrong: a ledger row is AUTHORED and
+    # nobody re-derives it, so writing "gap: rcl has it, we do not" for a
+    # function we export would have been permanent, and every later reader
+    # would have believed it.
+    #
+    # This preprocesses OUR header, so a `rcl_*` name found here is ours by
+    # construction — upstream's headers are never on this include path.
     return extract_cxx.extract(
         '#include "nros/nros.h"\n',
         "c",
         extract_cxx.nros_c_include_args(),
         {""},
         tmpdir,
-        prefixes={"nros_", "NROS_"},
+        prefixes={"nros_", "NROS_", "rcl_", "rclc_"},
     )
 
 

--- a/scripts/api_parity/correlate.py
+++ b/scripts/api_parity/correlate.py
@@ -90,8 +90,25 @@ TYPE_SYNONYMS = {
 
 # Longest first: `rclc_` must be stripped before `rcl_`, or every rclc symbol
 # normalises to a stray leading `c_`.
+# The vendor prefixes stripped to get a language-neutral key, per side.
+#
+# OURS carries `rcl_` / `rclc_` as well as `nros_`, and that is not a typo:
+# phase-417 stage 6 step A ("the ROS 2 spellings are ours") adopted the
+# upstream names directly wherever our contract matches, so
+# `nros/nros_generated.h` declares 39 `rcl_*` and 8 `rclc_*` entry points as
+# NROS_PUBLIC. Stripping only `nros_` here left ours keyed as
+# `rcl_client_is_valid` while theirs keyed as `client_is_valid`, so 43 symbols
+# WE SHIP were reported `theirs-only` — the report said the API lacked
+# functions it exports.
+#
+# Both halves of that had to move together: the extractor's `prefixes` filter
+# (api-parity.py `ours_c`) decides what is HARVESTED, this decides what it is
+# KEYED as. Fixing either alone leaves the same 43 rows.
 LIB_PREFIXES = {
-    "c": (("nros_", "NROS_"), ("rclc_", "RCLC_", "rcl_", "RCL_")),
+    "c": (
+        ("nros_", "NROS_", "rclc_", "RCLC_", "rcl_", "RCL_"),
+        ("rclc_", "RCLC_", "rcl_", "RCL_"),
+    ),
 }
 
 


### PR DESCRIPTION
`check-api-parity` was red with 51 unledgered rows, which withdrew `test-unit` and `test-lane-contracts` from `just ci gate` — the lane stops at the first failure, so nothing below it had run for a while.

**The obvious reading was "classify 51 rows". That would have been wrong, and permanently.** A ledger row is AUTHORED and nobody re-derives it, so writing *"gap: rcl has it, we do not"* for a function we ship would have been believed by every later reader. I had 22 such rows drafted — `declined` for the options getters, `gap` for the `is_valid` and `fini` families — before noticing this in our own generated header:

```c
NROS_PUBLIC bool rcl_clock_time_started(const struct nros_clock_t *);
```

## The actual defect

phase-417 stage 6 step A ("the ROS 2 spellings are ours") adopted the upstream names directly wherever our contract matches: `nros/nros_generated.h` declares **39 `rcl_*` and 8 `rclc_*` entry points as `NROS_PUBLIC`**. The tool could not see any of them, in **two independent places** — and fixing either alone changes nothing:

- `ours_c()` harvested with `prefixes={"nros_", "NROS_"}`, so they were never collected;
- `correlate.LIB_PREFIXES["c"]` stripped only `nros_`/`NROS_` on our side, so anything collected keyed as `rcl_client_is_valid` while upstream keyed as `client_is_valid`.

Both now carry `rcl_`/`rclc_` on our side too. This preprocesses *our own* header, so a `rcl_*` name found there is ours by construction — upstream's headers are never on that include path.

| | before | after |
|---|---|---|
| `same` | 39 | **101** |
| `theirs-only` | 416 | 354 |
| unledgered | 48 | **5** |

Sixty-two symbols move from "we lack this" to "we have this", which is what was true all along.

## The 8 rows that are real

- **5 × `rename`** — `c:{client,service,publisher,subscription,node}_init`. We export both `rcl_*_get_default_options` and the options struct (they correlate `same` now); what is missing is the plain `init` that consumes them. Ours is `nros_*_init_with_options`, and for node `nros_node_init_ex`, which takes `nros_node_options_t*` exactly as `rcl_node_init` takes `rcl_node_options_t*`. Same shape, different name, no platform reason — so `rename` per the schema, and they join the campaign's work list rather than being excused. The node row cites its ours-only half, `c:node_init_ex`.
- **3 × `extension`** — `cpp:LifecycleTransition` (an id enum; rclcpp's `Transition` *object* is separately ledgered as a gap, so this is not that under another name), `cpp:shutdown_transition_for` (rclcpp resolves it inside a state machine a C-ABI caller cannot reach), `rust:throttle_decide` (the throttle macros are `no_std` and expand in the caller's crate, so the predicate has to be a callable item there).

The ledger edits are inserted textually rather than re-serialised: the shards preserve insertion order, not a sort, so a `json.dump` round-trip rewrote 5,800 lines for 8 rows. The diff is **+32 lines, nothing else touched**.

## Verified

`just check api-parity` green; `--self-test` 0 failures; `just check fast` 258/258; and **`just ci gate` passes all six steps** — `test-unit` and `test-lane-contracts` run again.

## Worth knowing

`api-parity` is not on the fast line, so nothing on the push path or the required PR context runs it. It appears only at `just ci gate`, which is why a report that had been wrong about 43 symbols went unnoticed — the same shape as the `check-build` problem CLAUDE.md already records. Not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)