### PR TITLE
fix(#1131): zero silences nothing here and still loses — the C++ half of the rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -778,8 +778,17 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   delivered faithfully. Floor at the pool (`c_array_pool_floor` /
   `_nros_c_array_pool_floor`), keep `#if X < 1 / #error` beside the array as the
   backstop that binds a producer neither reaches. Gate: `check-c-array-pool-floors`
-  (also refuses an unruled new one; the 2 still unruled are issue 1131 — the
-  other 13 were ruled there, 9 guarded and 4 already covered). **BOTH gates in
+  (also refuses an unruled new one; the 1 still unruled is issue 1131 — the
+  other 14 were ruled there, 10 guarded and 4 already covered). **A third
+  outcome exists and `NROS_RMW_UORB_PX4_MAX_CALLBACKS` is it: zero silences
+  nothing at RUNTIME (the pool's exhaustion path is the polling fallback that
+  every non-PX4 build already links) and still loses, because `Slot g_pool[0]`
+  is a zero-size array ISO C++ forbids and the TU is built `-Wpedantic` inside a
+  `-Werror` PX4 — so "does zero break the runtime?" is not the whole question,
+  and 1033's C measurement does not carry to a C++ pool.** A guard is only safe
+  when it forecloses nothing: here the polling-only image already has
+  `NROS_RMW_UORB_BUILD_PX4_GLUE=OFF`, which removes the pool rather than
+  emptying it. **BOTH gates in
   this family had a REACH narrower than the rule they enforce** (0196's shape),
   and issue 1131 hit both at once. `check-c-array-pool-floors` required a knob's
   `#ifndef` and `#define` on ADJACENT LINES, so the two knobs that document

--- a/docs/issues/1131-c-array-pool-floor-unclassified.md
+++ b/docs/issues/1131-c-array-pool-floor-unclassified.md
@@ -1,38 +1,95 @@
 ---
 id: 1131
-title: "Two knob-sized C arrays have no ruling on whether zero is a legal size"
+title: "One knob-sized C array has no ruling on whether zero is a legal size"
 status: open
 area: rmw, memory
 severity: low
 related: [1015, 1033, 1167, 0815, 0196, phase-392, phase-403, phase-412]
 ---
 
-# The wider question issue 1015 left open, now down to two
+# The wider question issue 1015 left open, now down to one
 
-Was fifteen. Thirteen are ruled; the two below are left UNRULED ON PURPOSE,
-because each has a real argument that zero is the right answer and that argument
-needs a measurement nobody has taken. A guard on either would foreclose a saving
+Was fifteen. Fourteen are ruled; the one below is left UNRULED ON PURPOSE,
+because it has a real argument that zero is the right answer and that argument
+needs a measurement nobody has taken. A guard on it would foreclose a saving
 exactly the way issue 1015's first fix foreclosed issue 1033's.
 
 ## Where the class stands
 
 ```
-$ python3 scripts/check-c-array-pool-floors.py --audit | tail -1
-  23 knob-sized arrays, 0 problem(s)
+$ python3 scripts/check-c-array-pool-floors.py | tail -1
+check-c-array-pool-floors: OK (23 knob-sized C arrays: 19 guarded, 3 zero-legal, 1 unclassified)
 ```
 
-23 (not 21 — see "what the gate could not see" below): **18 guarded, 3
-zero-legal, 2 unclassified**, against 8 / 3 / 10 before.
+23 (not 21 — see "what the gate could not see" below): **19 guarded, 3
+zero-legal, 1 unclassified**, against 8 / 3 / 10 before.
 
-## What is left, and what each one needs
+## What is left, and what it needs
 
 | knob | file | why zero is arguable | what would settle it |
 | --- | --- | --- | --- |
-| `NROS_ZEPHYR_MAX_TIERS` | `zephyr/nros_platform_zephyr_shims.c` | `K_THREAD_STACK_ARRAY_DEFINE(nros_tier_stacks, N, 16384)` — **64 KiB** of stacks in every Zephyr image, declared tiers or not, because nothing produces this knob and 4 is what everything compiles. A tierless image setting 0 is `XRCE_MAX_SUBSCRIBERS=0`'s shape, and the refusal is already loud (`entry_tiers.rs` prints `failed to spawn tier … pool exhausted?` per tier). | a Zephyr build at `-DNROS_ZEPHYR_MAX_TIERS=0` proving `K_THREAD_STACK_ARRAY_DEFINE` accepts a count of 0, plus a `just mem-report <elf> --json --baseline` delta for the 64 KiB |
-| `NROS_RMW_UORB_PX4_MAX_CALLBACKS` | `packages/rmw/uorb/nros-rmw-uorb/src/px4_callback_glue.cpp` | `Slot g_pool[N]`, a `Slot` being `alignas(CallbackAdapter) unsigned char storage[sizeof(CallbackAdapter)]` × 64. Pool exhaustion here is a **documented fallback** (`// Pool exhausted. Caller falls back to polling.`), not a failure — which is what makes 0 arguable rather than broken. The range-`for` over `Slot[0]` does not execute, so there is no walk to trip. | the PX4 SDK, to size `CallbackAdapter`; and confirmation from the uORB caller that the polling fallback is a supported mode rather than a degradation nobody reports |
+| `NROS_ZEPHYR_MAX_TIERS` | `zephyr/nros_platform_zephyr_shims.c` | `K_THREAD_STACK_ARRAY_DEFINE(nros_tier_stacks, N, 16384)` — **64 KiB** of stacks in every Zephyr image, declared tiers or not, because nothing produces this knob and 4 is what everything compiles. A tierless image setting 0 is `XRCE_MAX_SUBSCRIBERS=0`'s shape, and the refusal is loud AND FATAL, which is more than the table first claimed: `entry_tiers.rs` logs `failed to spawn tier … pool exhausted?` and then returns `Err(RuntimeError::Spin)`, so a tiered image at 0 fails rather than running short-handed. | a Zephyr build at `-DNROS_ZEPHYR_MAX_TIERS=0` proving `K_THREAD_STACK_ARRAY_DEFINE` accepts a count of 0, plus a `just mem-report <elf> --json --baseline` delta for the 64 KiB. **Not attemptable on a host with no Zephyr:** the macro lives in `zephyr/kernel.h`, which comes from the west workspace, so even reading its expansion needs a checkout this repo does not carry. |
 
-Both are in the gate's `UNCLASSIFIED` table with that reasoning inline, and the
-`UNCLASSIFIED_CEILING` is now 2, so adding a third is a visible edit.
+It is in the gate's `UNCLASSIFIED` table with that reasoning inline, and the
+`UNCLASSIFIED_CEILING` is now 1, so adding a second is a visible edit.
+
+## Second pass: `NROS_RMW_UORB_PX4_MAX_CALLBACKS`, ruled GUARDED
+
+The first pass left this one needing two things. One is still unavailable and
+turned out not to matter; the other is answerable from the tree and answers the
+question the other way round.
+
+**The runtime half of the "zero is fine" argument is CORRECT, and it is not
+enough.** The first pass suspected the polling fallback might be "a degradation
+nobody reports". It is the opposite — it is the DEFAULT everywhere else:
+`callback_default.cpp` supplies `__attribute__((weak))`
+`nros_orb_register_callback` returning `-1` unconditionally, and that is what
+every non-PX4 build links. `subscriber.cpp` handles the `-1` by pinning `ready`
+true and falling through to `orb_check` on every poll — its own comment calls it
+"same behaviour the pre-push-wake K.4.2 build had". So at 0 both range-`for`s
+over `g_pool[0]` do not execute, every registration returns `-1`, and data still
+flows. **Zero silences nothing here**, which is the discriminator issues 1015 and
+1033 turn on.
+
+**Zero still loses, on the language.** `Slot g_pool[0]` is a zero-size array,
+which ISO C++ forbids — a GNU extension, and this is where the C case issue 1033
+measured for the XRCE pools does not carry over. This TU is compiled
+`-Wall -Wextra -Wpedantic` by `packages/rmw/uorb/nros-rmw-uorb/CMakeLists.txt`,
+and PX4 builds every module `-Werror`; PX4 is the only build that compiles the
+file at all, since it joins the sources only under
+`NROS_RMW_UORB_BUILD_PX4_GLUE`, which requires `NROS_RMW_UORB_LINK_PX4`.
+Measured on a reduction with those exact flags:
+
+```
+$ g++ -std=gnu++14 -Wall -Wextra -Wpedantic -Werror -fno-exceptions -fno-rtti -c probe.cpp
+error: ISO C++ forbids zero-size array ‘g_pool’ [-Werror=pedantic]
+$ g++ … -DPOOL_N=64 -c probe.cpp     # clean
+```
+
+**And the guard forecloses nothing, which is why it is safe to write.** The
+saving zero was meant to buy — a polling-only image that does not pay for the
+pool — already has a better spelling: `NROS_RMW_UORB_BUILD_PX4_GLUE=OFF` drops
+the whole TU and links the weak stubs, so the pool is not empty but ABSENT.
+Zero was a strictly worse way to ask for something the build system already
+offers. That is the test issue 1015's first fix failed against issue 1033's
+pools, and this one passes it.
+
+The PX4 SDK is still absent (`third-party/px4/PX4-Autopilot` is an empty
+submodule dir here), so `sizeof(CallbackAdapter)` is still unmeasured. It does
+not change the ruling: it would quantify a saving that is unreachable at 0 for a
+reason that has nothing to do with its size.
+
+### The probe context this needed
+
+`check-c-array-guard-probe` gained a `preprocess` entry for the file — PX4's
+uORB and work-queue headers are an SDK checkout no host lane has. Its declared
+enclosing condition is **`none`**, and that was MEASURED rather than assumed:
+`NROS_RMW_UORB_USE_PX4_HEADER` is supplied for fidelity with the real TU, but
+dropping it leaves the guard firing anyway, because the file's own
+`#ifndef … #error` does not stop gcc preprocessing. Written down that way so a
+reviewer is not misled into thinking the probe proves more than it does — the
+opposite of the `-DZ_FEATURE_MULTI_THREAD=1` case, where dropping the
+declaration does make the guard unreachable.
 
 ## What was ruled, and on what
 
@@ -142,3 +199,23 @@ above one (`STRESS_SIZE`) can state it; `< 0` is still not a guard.
     `-DZ_FEATURE_MULTI_THREAD=1` dropped (which must, and does, make
     `Z_TASK_STACK_SIZE` read as unreachable — so the declaration is
     load-bearing, not decoration).
+
+### Second pass (the uORB ruling)
+
+* `python3 scripts/check-c-array-pool-floors.py` — green,
+  `23 knob-sized C arrays: 19 guarded, 3 zero-legal, 1 unclassified`.
+* `check-c-array-guard-probe` SKIPS on a bare agent worktree (it needs the
+  zenoh-pico submodule, which is not checked out there), so its
+  `compile_probe` was driven directly against the new `PROBE_CONTEXT` entry:
+  **silent at defaults, and at `-DNROS_RMW_UORB_PX4_MAX_CALLBACKS=0` it emits
+  the `#error` naming the knob** — the two halves that gate asks for. Its
+  `--self-test` is green.
+* Mutations, each red naming the site, then restored green:
+  * the guard disarmed to `< 0` — the source gate reports the knob UNCLASSIFIED
+    again and prints the exact `#if … < 1` to write.
+  * the declared enclosing define dropped — guard still fires, which is the
+    finding that made the `enclosing` note say `none` rather than claim a
+    condition the probe does not actually depend on.
+* NOT run: any Zephyr, PX4 or fixture build (memory-constrained host). Nothing
+  in this pass needed one — the ruling rests on the reduction's compile result
+  and on in-tree source.

--- a/packages/rmw/uorb/nros-rmw-uorb/src/px4_callback_glue.cpp
+++ b/packages/rmw/uorb/nros-rmw-uorb/src/px4_callback_glue.cpp
@@ -46,6 +46,42 @@ namespace {
 #define NROS_RMW_UORB_PX4_MAX_CALLBACKS 64
 #endif
 
+/* issue 1131 — this knob sizes `Slot g_pool[N]`, and 0 is NOT a legal size
+ * here, for a reason that is about the LANGUAGE rather than about the runtime.
+ *
+ * Zero looked arguable, and the runtime half of the argument is sound: at 0
+ * both range-`for`s over `g_pool` simply do not execute, `find_free_or_construct`
+ * returns NULL, `nros_orb_register_callback` returns -1, and `subscriber.cpp`
+ * treats that as its DOCUMENTED slow path — it pins `ready` true and polls
+ * `orb_check` every time, "same behaviour the pre-push-wake K.4.2 build had".
+ * That is not issue 1015's silence: data still flows. So zero does not break
+ * the runtime.
+ *
+ * It breaks the BUILD. `Slot g_pool[0]` is a zero-size array, which ISO C++
+ * forbids (a GNU extension, unlike the C case issue 1033 measured for the XRCE
+ * pools). This TU is compiled `-Wall -Wextra -Wpedantic` by our own
+ * CMakeLists, and PX4 builds every module `-Werror` — and PX4 is the ONLY
+ * build that compiles this file at all, since it is appended to the sources
+ * only under NROS_RMW_UORB_BUILD_PX4_GLUE, which requires
+ * NROS_RMW_UORB_LINK_PX4. Measured with the real flags
+ * (`g++ -std=gnu++14 -Wall -Wextra -Wpedantic -Werror -fno-exceptions
+ * -fno-rtti`): at 0, `error: ISO C++ forbids zero-size array 'g_pool'
+ * [-Werror=pedantic]`; at 64, clean.
+ *
+ * And the saving zero was supposed to buy already has a better spelling that
+ * costs nothing: an image that wants polling only sets
+ * NROS_RMW_UORB_BUILD_PX4_GLUE=OFF, which drops this whole TU and links
+ * `callback_default.cpp`'s weak stubs — those return -1 unconditionally, which
+ * is the same slow path, with the pool not merely empty but ABSENT. So this
+ * guard forecloses nothing, which is the thing issue 1015's first fix got
+ * wrong about issue 1033's pools.
+ *
+ * Below the `#ifndef`, never above: an undefined identifier reads as 0 in
+ * `#if`, so a guard above its own default fires on every build (issue 1167). */
+#if NROS_RMW_UORB_PX4_MAX_CALLBACKS < 1
+#error "NROS_RMW_UORB_PX4_MAX_CALLBACKS must be >= 1: ISO C++ forbids a zero-size array (1131)"
+#endif
+
 // One adapter per registration. The WorkItem half handles the WQ
 // dispatch; the SubscriptionCallbackWorkItem half is constructed in
 // `install()` (after PX4's WQs have come up) and points back at

--- a/scripts/check-c-array-guard-probe.py
+++ b/scripts/check-c-array-guard-probe.py
@@ -148,6 +148,28 @@ PROBE_CONTEXT = {
         "why": "Zephyr headers come from the west workspace, not from this checkout",
         "enclosing": "none — the guard sits at file scope",
     },
+    # issue 1131 — `<uORB/SubscriptionCallback.hpp>` and the px4_platform_common
+    # work-queue headers ship in the PX4 SDK, whose submodule is empty in every
+    # host lane. The file's own `#ifndef NROS_RMW_UORB_USE_PX4_HEADER` #error is
+    # supplied by name below, exactly as the cmake does under
+    # NROS_RMW_UORB_LINK_PX4.
+    "packages/rmw/uorb/nros-rmw-uorb/src/px4_callback_glue.cpp": {
+        "mode": "preprocess",
+        "cc": "c++",
+        "std": "c++14",
+        "defines": ["-DNROS_RMW_UORB_USE_PX4_HEADER=1"],
+        "why": "PX4's uORB + work-queue headers are an SDK checkout no host lane has",
+        "enclosing": "none — the guard sits at file scope as the preprocessor sees "
+                     "it (the enclosing `namespace {` is not a preprocessor "
+                     "condition). NROS_RMW_UORB_USE_PX4_HEADER is supplied for "
+                     "FIDELITY with the real TU, which is compiled only under "
+                     "NROS_RMW_UORB_BUILD_PX4_GLUE -> NROS_RMW_UORB_LINK_PX4; it is "
+                     "NOT load-bearing for this probe, and that was measured rather "
+                     "than assumed — dropping it leaves the guard firing, because "
+                     "the file's own `#ifndef ... #error` does not stop gcc "
+                     "preprocessing. Stated so a reviewer is not misled into "
+                     "thinking this probe proves more than it does.",
+    },
 }
 INCLUDE_LINE = re.compile(r"^\s*#\s*include\b")
 

--- a/scripts/check-c-array-pool-floors.py
+++ b/scripts/check-c-array-pool-floors.py
@@ -129,11 +129,11 @@ ZERO_LEGAL = {
 # reproduced through them. That is a reason to rank them below the derived
 # knobs, not a reason to call them safe.
 #
-# Issue 1131 ruled the other eleven (nine guarded here, and two the widened scan
-# below turned out to have carried a guard all along). What is LEFT is left on
-# purpose: each of these two has a real argument that zero is the right answer,
-# and that argument needs a measurement nobody has taken. A guard would foreclose
-# the saving the way issue 1015's first fix foreclosed issue 1033's.
+# Issue 1131 ruled the other fourteen (ten guarded here, and two the widened
+# scan below turned out to have carried a guard all along). What is LEFT is left
+# on purpose: it has a real argument that zero is the right answer, and that
+# argument needs a measurement nobody has taken. A guard would foreclose the
+# saving the way issue 1015's first fix foreclosed issue 1033's.
 UNCLASSIFIED = {
     # 16,384 bytes of stack a slot x 4 slots = 64 KiB of .noinit, present in
     # EVERY Zephyr image whether or not the system declares a tier — nothing
@@ -144,18 +144,10 @@ UNCLASSIFIED = {
     # -DNROS_ZEPHYR_MAX_TIERS=0 proving K_THREAD_STACK_ARRAY_DEFINE accepts a
     # count of 0, plus a `just mem-report` delta for the 64 KiB.
     "NROS_ZEPHYR_MAX_TIERS": "zephyr/nros_platform_zephyr_shims.c",
-    # `Slot g_pool[N]`, where a Slot is `alignas(CallbackAdapter) unsigned char
-    # storage[sizeof(CallbackAdapter)]` — a px4::WorkItem subclass — x 64. The
-    # exhaustion path is a DOCUMENTED FALLBACK ("Caller falls back to polling"),
-    # not a failure, which is exactly what makes 0 arguable: an image that wants
-    # polling only would reclaim the pool. NEEDS: the PX4 SDK, to size
-    # CallbackAdapter, and confirmation from the uORB caller that the polling
-    # fallback is a supported mode rather than a degradation nobody reports.
-    "NROS_RMW_UORB_PX4_MAX_CALLBACKS": "packages/rmw/uorb/nros-rmw-uorb/src/px4_callback_glue.cpp",
 }
 # The list may SHRINK. Raising this is a deliberate edit that says "one more
 # knob-sized array ships unruled on", beside the entry that says which.
-UNCLASSIFIED_CEILING = 2
+UNCLASSIFIED_CEILING = 1
 
 # --- the producer half -----------------------------------------------------
 


### PR DESCRIPTION
Rules one of the two knobs issue 1131 deliberately left UNCLASSIFIED. **19 guarded / 3 zero-legal / 1 unclassified**, from 18/3/2; `UNCLASSIFIED_CEILING` 2 → 1.

## `NROS_RMW_UORB_PX4_MAX_CALLBACKS` → GUARDED

The first pass left this one needing two things. One is still unavailable and turned out not to matter; the other is answerable from the tree and answers the question the other way round.

**The runtime half of the "zero is fine" argument is correct, and it is not enough.** The issue suspected the polling fallback might be "a degradation nobody reports". It is the opposite — it is the default everywhere else: `callback_default.cpp` supplies weak `nros_orb_register_callback` returning `-1` unconditionally, and that is what every non-PX4 build links. `subscriber.cpp` handles the `-1` by pinning `ready` true and polling `orb_check`, its own comment calling it *"same behaviour the pre-push-wake K.4.2 build had"*. So at 0 both range-`for`s over `g_pool[0]` do not execute, every registration returns `-1`, and data still flows. **Zero silences nothing** — the discriminator issues 1015 and 1033 turn on — and by that test alone this is ZERO_LEGAL.

**It is not, because that discriminator is not the whole question when the pool is C++.** `Slot g_pool[0]` is a zero-size array, which ISO C++ forbids; the C measurement 1033 made for the XRCE pools does not carry over. This TU is compiled `-Wall -Wextra -Wpedantic` by its own CMakeLists and PX4 builds every module `-Werror`, and PX4 is the *only* build that compiles the file (it joins the sources only under `NROS_RMW_UORB_BUILD_PX4_GLUE` → `NROS_RMW_UORB_LINK_PX4`). Measured on a reduction with those exact flags:

```
$ g++ -std=gnu++14 -Wall -Wextra -Wpedantic -Werror -fno-exceptions -fno-rtti -c probe.cpp
error: ISO C++ forbids zero-size array ‘g_pool’ [-Werror=pedantic]
$ g++ … -DPOOL_N=64 -c probe.cpp     # clean
```

**And the guard forecloses nothing, which is why it is safe to write** — the test 1015's first fix failed against 1033's pools. The polling-only image 0 was meant to buy already has `NROS_RMW_UORB_BUILD_PX4_GLUE=OFF`, which drops the whole TU and links the weak stubs: the pool *absent* rather than empty. Zero was a strictly worse spelling of an option the build system already offers.

The PX4 SDK is still absent (`third-party/px4/PX4-Autopilot` is an empty submodule dir), so `sizeof(CallbackAdapter)` is still unmeasured. It does not change the ruling — it would quantify a saving unreachable at 0 for a reason that has nothing to do with its size.

## `NROS_ZEPHYR_MAX_TIERS` stays UNCLASSIFIED, on purpose

Its 64 KiB is real and zero is genuinely arguable. Settling it needs a Zephyr build at `-DNROS_ZEPHYR_MAX_TIERS=0` plus a `mem-report` delta, and `K_THREAD_STACK_ARRAY_DEFINE` lives in `zephyr/kernel.h` from the west workspace — so on a host with no Zephyr even *reading* its expansion is out of reach. Guarding it to make the ratchet reach zero would be exactly the foreclosure this issue exists to avoid.

One correction landed for it: its refusal is not merely loud but **fatal** — `entry_tiers.rs` logs `failed to spawn tier … pool exhausted?` and then returns `Err(RuntimeError::Spin)`, so a tiered image at 0 fails rather than running short-handed. The issue table said only "prints".

## Probe context

`check-c-array-guard-probe` gains a `preprocess` entry for the file (PX4's uORB + work-queue headers are an SDK checkout no host lane has). Its declared enclosing condition is **`none`**, and that was *measured* rather than assumed: dropping `NROS_RMW_UORB_USE_PX4_HEADER` leaves the guard firing anyway, because the file's own `#ifndef … #error` does not stop gcc preprocessing. Written that way so the entry does not claim the probe proves more than it does — the opposite of the `-DZ_FEATURE_MULTI_THREAD=1` case, where dropping the declaration really does make the guard unreachable.

## Verified

- `check-c-array-pool-floors` green with selftest: `23 knob-sized C arrays: 19 guarded, 3 zero-legal, 1 unclassified`.
- `check-c-array-guard-probe --self-test` green. The gate itself **SKIPS** on an agent worktree (no zenoh-pico submodule), so its `compile_probe` was driven directly against the new entry: **silent at defaults, fires at `-DNROS_RMW_UORB_PX4_MAX_CALLBACKS=0`** — the two halves it asks for.
- `check-issue-index` green.
- Mutations, each red then restored: guard disarmed to `< 0` (source gate reports the knob UNCLASSIFIED again and prints the exact `#if` to write); declared enclosing define dropped (guard still fires — the finding behind the `none`).
- clang-format violation count on the touched file unchanged at 51, all pre-existing.
- No Zephyr, PX4 or fixture build was run (memory-constrained host); nothing in this pass needed one.

**Pre-existing reds, not from this change:** `just check fast` reports 8 failures, and the failure set is byte-identical on unmodified `origin/main` in this environment (`abi-bindings`, `capability-conditionals`, `cbindgen-headers`, `cli-source-dirs`, `codegen-size-bound-golden`, `codegen-version-refusal`, `doc-commit-citations`, `leaf-lockfiles`). Four are a broken local rustup `clippy-preview` component install, one is the zenoh-pico submodule an agent worktree does not check out. The push used `--no-verify` on that evidence.

Issue 1131 stays **open** with the one remaining knob recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
