### PR TITLE
fix(#430 W3): the reserved-parameter hook ran before the store's verdict

### DIFF
--- a/docs/issues/1203-parameter-builder-bypasses-reserved-parameter-hook.md
+++ b/docs/issues/1203-parameter-builder-bypasses-reserved-parameter-hook.md
@@ -1,0 +1,55 @@
+---
+id: 1203
+title: "`Executor::parameter`'s `ParameterBuilder` declares straight into the
+  store, so `use_sim_time` named through it attaches no clock source"
+status: open
+type: bug
+area: core
+severity: low
+related: [1202, phase-425, phase-430]
+found: 2026-09-07
+---
+
+## What
+
+`Executor::parameter::<T>(name)` (`packages/core/nros-node/src/executor/spin.rs`)
+hands out a `nros_params::ParameterBuilder` holding `&mut p.server`. Its
+terminal verbs (`.mandatory()`, `.optional()`, `.read_only()`) declare THROUGH
+that borrow, so the executor never observes the write.
+
+`use_sim_time` is a reserved parameter: the executor, not the app, acts on it
+(`note_reserved_parameter` → `refresh_use_sim_time_from_store` →
+`reconcile_ros_time_source`). Both `declare_parameter` paths call the hook —
+issue 1202 fixed their ordering and added the missing one — but the builder
+reaches neither, so:
+
+```rust
+executor.parameter::<bool>("use_sim_time")?.default(true).mandatory()?;
+```
+
+stores `use_sim_time = true`, lists it over `ros2 param list`, and attaches no
+`/clock` subscription. The parameter reads as on and does nothing, which is the
+same "sim time on, no clock source" state 1202 described, arrived at by a
+different door.
+
+## Why it was not fixed with 1202
+
+The builder holds an exclusive borrow of the server for its whole lifetime, so
+there is no point at which the executor can be told what it declared. Closing
+this needs one of:
+
+* the builder's terminal verbs returning through the executor rather than the
+  server (a signature change on a public API), or
+* the reconcile reading the store when it has no recorded opinion — cheap only
+  once phase-430 W2 declares `use_sim_time = false` on every node, after which
+  `sim_time_stated` is always true and the read is not a per-spin scan for
+  images that never mention the parameter.
+
+W2 is the natural home. Until then, declare `use_sim_time` through
+`Executor::declare_parameter` / `declare_parameter_with_descriptor`, both of
+which carry the hook.
+
+## Reproduction
+
+None in-tree: nothing in the repo declares `use_sim_time` through the builder.
+The gap is reachable by any consumer that uses the rclrs-shaped verb.

--- a/docs/issues/archived/1202-reserved-parameter-hook-precedes-store-verdict.md
+++ b/docs/issues/archived/1202-reserved-parameter-hook-precedes-store-verdict.md
@@ -1,0 +1,90 @@
+---
+id: 1202
+title: "`note_reserved_parameter` ran before the parameter store's verdict, so a
+  REFUSED `use_sim_time` re-declaration detached the `/clock` source while the
+  store kept the old value"
+status: resolved
+type: bug
+area: core
+severity: medium
+related: [1203, phase-425, phase-430]
+found: 2026-09-07
+---
+
+## What
+
+`Executor::declare_parameter` (`packages/core/nros-node/src/executor/spin.rs`)
+called `note_reserved_parameter(name, &value)` **before** `params.server.declare(
+name, value)` and **unconditionally** — the hook recorded the caller's PROPOSED
+value, then the store decided separately whether to take it.
+
+`ParameterServer::declare` refuses a name it already holds (it returns `false`
+and changes nothing; a set goes through `apply`/`set`, not through a second
+declaration). So on a node that had declared `use_sim_time = true`:
+
+```rust
+executor.declare_parameter("use_sim_time", ParameterValue::Bool(true));   // accepted
+executor.declare_parameter("use_sim_time", ParameterValue::Bool(false));  // REFUSED
+```
+
+the second call returned `false`, left the store reading `use_sim_time = true`,
+and still set `sim_time_requested = false`. The next `reconcile_ros_time_source`
+then called `time_source::set_active(false)`, so `/clock` samples stopped being
+installed.
+
+The result is a state the parameter cannot name: **sim time recorded as ON, no
+clock source armed**, and nothing to reconcile it back — the reconcile believes
+the switch, and the switch believes a write that never happened. A subsequent
+`ros2 param get <node> use_sim_time` answers `true` while every ROS-time timer
+runs on system time.
+
+Found by the phase-430 survey (finding E) while making
+`just check node-std-tests` compile on `phase-428-w10-qos-ssot`; PR #629 pinned
+the behaviour in `use_sim_time_attaches_and_detaches_the_clock_source` with a
+comment naming this item rather than fixing it there.
+
+## The sibling, same class
+
+`Executor::declare_parameter_with_descriptor` carried **no reserved hook at
+all**. `declare_parameter_with_descriptor("use_sim_time", Bool(true), desc)`
+stored the parameter and attached nothing, so the same declaration meant two
+different things depending on whether the app passed a descriptor. Found by
+sweeping the seam, not by a report.
+
+## Scope
+
+`use_sim_time` is the tree's ONLY reserved parameter —
+`nros_node::time_source::USE_SIM_TIME_PARAM` is the only such constant, and
+`grep -rn 'note_reserved\|RESERVED_PARAM\|use_sim_time' packages/core/nros-node/src
+packages/core/nros-params/src` finds no sibling name. (ROS 2's other
+statically-typed names — `start_type_description_service`, `qos_overrides.*` —
+have no nano-ros implementation to switch.)
+
+## Fix (phase-430 W3)
+
+* The hook runs **after** the store answers and **only on acceptance**, in both
+  declare paths.
+* It takes only the NAME and reads the value back out of the store, through
+  `refresh_use_sim_time_from_store` — the same read the runtime
+  `ros2 param set` path uses. The switch therefore follows what the store
+  HOLDS, never what a caller proposed, and the declare path and the wire path
+  cannot disagree about the value.
+* `refresh_use_sim_time_from_store` becomes `pub(crate)` so both callers, and a
+  test that changes the store directly, share one read instead of a second
+  spelling.
+
+Tests (`packages/core/nros-node/src/executor/tests.rs`):
+
+* `use_sim_time_follows_the_store_verdict_not_the_caller` — accepted `true`
+  attaches; a REFUSED re-declaration leaves both the stored value AND the source
+  alone; an accepted `false` through the store detaches; an accepted `true`
+  re-arms. Both halves are asserted, because the defect was the two halves
+  disagreeing: checking only one reads as correct on the broken code.
+* `use_sim_time_declared_with_a_descriptor_attaches_the_clock_source` — the
+  sibling path.
+* `use_sim_time_attaches_and_detaches_the_clock_source` now turns the switch off
+  through the store rather than through a refused re-declaration.
+
+## Not fixed here
+
+The `ParameterBuilder` path bypasses the executor entirely — issue 1203.

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -7935,40 +7935,59 @@ impl<'s> Executor<'s> {
     /// Declare a parameter with a value. Returns `true` if successful.
     pub fn declare_parameter(&mut self, name: &str, value: nros_params::ParameterValue) -> bool {
         self.ensure_parameter_store();
+        let accepted = match &mut self.params {
+            Some(params) => params.server.declare(name, value),
+            None => false,
+        };
         // phase-425 W3b — `use_sim_time` is RESERVED, exactly as in ROS 2: its
         // value is not a value the app reads, it is the switch that attaches the
         // time source. This is the one seam every language funnels through
         // (`nros::main!`'s launch bakes via `apply_param_services`, nros-c's
         // `nros_parameter_declare_*`, nros-cpp's `params_shim`), so hooking it
         // here covers all of them instead of once per entry path.
-        self.note_reserved_parameter(name, &value);
-        if let Some(params) = &mut self.params {
-            params.server.declare(name, value)
-        } else {
-            false
+        //
+        // phase-430 W3 / issue 1202 — the hook runs AFTER the store's verdict
+        // and only on acceptance. It used to run first and unconditionally, so
+        // a re-declaration the store REFUSES (the name is already there) still
+        // flipped the switch: the store kept `use_sim_time = true` while the
+        // `/clock` source detached, leaving an executor with sim time recorded
+        // as on and no source attached, which is neither of the two states the
+        // parameter can name.
+        if accepted {
+            self.note_reserved_parameter(name);
         }
+        accepted
     }
 
     /// phase-425 W3b — record a reserved parameter's effect. Today that is
-    /// `use_sim_time` and nothing else.
+    /// `use_sim_time` and nothing else: it is the tree's only reserved name,
+    /// and [`time_source::USE_SIM_TIME_PARAM`](crate::time_source::USE_SIM_TIME_PARAM)
+    /// is the only such constant.
+    ///
+    /// Called only after the store ACCEPTED a declaration, and it reads the
+    /// value back OUT of the store instead of taking the caller's: what the
+    /// switch must follow is what the store holds, and the two are the same
+    /// thing only while every write succeeds (issue 1202). The read is
+    /// [`refresh_use_sim_time_from_store`](Self::refresh_use_sim_time_from_store),
+    /// the same one the runtime `ros2 param set` path uses, so the declare path
+    /// and the wire path cannot disagree about the value.
     ///
     /// A non-bool `use_sim_time` is IGNORED rather than rejected: parameter
     /// declaration has no channel to report a complaint on (it returns "did the
     /// store take it"), and refusing the declaration outright would fail a node
     /// for a parameter ROS 2 lets it declare. The time source simply does not
     /// attach, which is the same outcome as `false`.
-    #[cfg_attr(
-        not(all(feature = "sim-time", any(has_rmw, test))),
-        allow(unused_variables)
-    )]
-    fn note_reserved_parameter(&mut self, name: &str, value: &nros_params::ParameterValue) {
+    ///
+    /// Not covered: [`Executor::parameter`](Self::parameter)'s
+    /// [`ParameterBuilder`](nros_params::ParameterBuilder) borrows the server
+    /// and declares through it, so the executor never sees the write and
+    /// `use_sim_time` named that way attaches nothing — issue 1203.
+    fn note_reserved_parameter(&mut self, name: &str) {
         #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
-        if name == crate::time_source::USE_SIM_TIME_PARAM
-            && let nros_params::ParameterValue::Bool(enable) = value
-        {
-            self.sim_time_requested = *enable;
-            self.sim_time_stated = true;
+        if name == crate::time_source::USE_SIM_TIME_PARAM {
+            self.refresh_use_sim_time_from_store();
         }
+        let _ = name;
     }
 
     /// phase-425 W3b — a parameter service handled `n` requests this spin.
@@ -7997,13 +8016,21 @@ impl<'s> Executor<'s> {
         descriptor: nros_params::ParameterDescriptor,
     ) -> bool {
         self.ensure_parameter_store();
-        if let Some(params) = &mut self.params {
-            params
+        let accepted = match &mut self.params {
+            Some(params) => params
                 .server
-                .declare_with_descriptor(name, value, Some(descriptor))
-        } else {
-            false
+                .declare_with_descriptor(name, value, Some(descriptor)),
+            None => false,
+        };
+        // phase-430 W3 / issue 1202 — the sibling declare path, which had NO
+        // reserved hook at all: `declare_parameter_with_descriptor` stored
+        // `use_sim_time` and attached nothing, so the same declaration meant
+        // two different things depending on whether the app passed a
+        // descriptor. Same seam, same verdict ordering, one shared hook.
+        if accepted {
+            self.note_reserved_parameter(name);
         }
+        accepted
     }
 
     /// Get a parameter value by name.
@@ -9237,10 +9264,17 @@ impl<'s> Executor<'s> {
     ///
     /// Called after a parameter service actually handled something, which is
     /// what makes a runtime `ros2 param set <node> use_sim_time true` work
-    /// without a per-spin scan of the store. The declaration path does not need
-    /// it — `declare_parameter` records the value directly.
+    /// without a per-spin scan of the store.
+    ///
+    /// phase-430 W3 / issue 1202 — the declaration path calls it too, through
+    /// `note_reserved_parameter`, once the store has accepted the write. It
+    /// used to record the value directly from the caller's argument, which is
+    /// the same thing only while the store never refuses. One read for both
+    /// paths; a second spelling is the drift this function exists to prevent.
+    /// `pub(crate)` for the same reason: a test that changes the store directly
+    /// needs the entry point a parameter service uses, not a copy of it.
     #[cfg(all(feature = "sim-time", feature = "param-services", any(has_rmw, test)))]
-    fn refresh_use_sim_time_from_store(&mut self) {
+    pub(crate) fn refresh_use_sim_time_from_store(&mut self) {
         if let Some(params) = self.params.as_ref()
             && let Some(enable) = params
                 .server

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -421,11 +421,18 @@ fn the_default_subscription_buffer_is_derived_from_the_type() {
 #[test]
 fn naming_a_receive_buffer_opts_out_of_the_derivation() {
     const N: usize = 4096;
-    assert!(
-        N > crate::config::DEFAULT_RX_BUF_SIZE,
-        "the fixture is only meaningful while N is off the default, or an \
-         opt-out that silently fell back would still pass"
-    );
+    // A `const` block: both sides are constants, so this is a compile-time
+    // claim about the fixture, not a run-time check. Written as a plain
+    // `assert!` it is `clippy::assertions_on_constants`, which `-D warnings`
+    // takes red under `cargo clippy -p nros-node --all-targets` — a lane no
+    // merge-gating job runs, which is why it sat here.
+    const {
+        assert!(
+            N > crate::config::DEFAULT_RX_BUF_SIZE,
+            "the fixture is only meaningful while N is off the default, or an \
+             opt-out that silently fell back would still pass"
+        )
+    };
 
     let mut executor: Executor = executor_with_clock(MockSession::new());
     let nid = executor.node_builder("explicit_sizing").build().unwrap();
@@ -2115,7 +2122,20 @@ fn use_sim_time_attaches_and_detaches_the_clock_source() {
 
     // Turning it off stops SAMPLES. The subscription stays — the executor has
     // no entity removal — so the gate is what must change.
-    executor.declare_parameter("use_sim_time", nros_params::ParameterValue::Bool(false));
+    //
+    // phase-430 W3 / issue 1202 — through the STORE, which is the only way it
+    // can happen: a second `declare_parameter` is a refusal (the name is
+    // already there), and the switch no longer follows a refused write. This is
+    // the `ros2 param set <node> use_sim_time false` path, verdict first.
+    assert!(
+        executor
+            .params_mut()
+            .expect("the declaration above created the store")
+            .apply("use_sim_time", nros_params::ParameterValue::Bool(false))
+            .is_success(),
+        "an existing bool parameter set to a bool is an ordinary accepted set"
+    );
+    executor.refresh_use_sim_time_from_store();
     let _ = executor.spin_once(core::time::Duration::from_millis(0));
     assert!(
         !crate::time_source::is_active(),
@@ -2124,6 +2144,134 @@ fn use_sim_time_attaches_and_detaches_the_clock_source() {
 
     // The global and the override are put back by `SimTimeGuard`'s drop, which
     // restores what it observed instead of asserting a default.
+}
+
+/// phase-430 W3 / issue 1202 — the reserved-parameter switch follows the
+/// STORE'S VERDICT, not the caller's proposal.
+///
+/// `note_reserved_parameter` used to run unconditionally, ahead of
+/// `params.server.declare(...)`. A re-declaration is a REFUSAL — the name is
+/// already there — so `declare_parameter("use_sim_time", false)` on a node that
+/// had declared it `true` returned `false`, changed nothing in the store, and
+/// still detached the `/clock` source. That left the executor in a state the
+/// parameter cannot name: sim time recorded as ON, no source installed, and
+/// nothing to reconcile it back, because the reconcile believes the switch.
+///
+/// The negative control for the fix is the middle block: on the pre-fix code it
+/// reports `is_active() == false` while the store still reads `Some(true)`.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn use_sim_time_follows_the_store_verdict_not_the_caller() {
+    let _sim_time = SimTimeGuard::acquire();
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+    drop(executor.create_node("verdict_node").expect("create node"));
+
+    // Accepted `true` attaches.
+    assert!(
+        executor.declare_parameter("use_sim_time", nros_params::ParameterValue::Bool(true)),
+        "the first declaration of a name is an acceptance"
+    );
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        executor.ros_time_source_installed(),
+        "accepted true must attach"
+    );
+    assert!(
+        crate::time_source::is_active(),
+        "attached and not armed drops every sample"
+    );
+
+    // A REFUSED re-declaration must change neither half. Both are asserted,
+    // because the defect was precisely the two halves disagreeing: checking
+    // only the store, or only the source, reads as correct on the broken code.
+    assert!(
+        !executor.declare_parameter("use_sim_time", nros_params::ParameterValue::Bool(false)),
+        "a second declaration of a declared name is a refusal, not a set"
+    );
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert_eq!(
+        executor.params().and_then(|p| p.get_bool("use_sim_time")),
+        Some(true),
+        "a refused declaration must leave the stored value alone"
+    );
+    assert!(
+        crate::time_source::is_active(),
+        "the refused declaration detached the source anyway: the store keeps \
+         `true` while /clock samples stop being installed, which is an executor \
+         with sim time on and no clock source (issue 1202)"
+    );
+    assert!(
+        executor.ros_time_source_installed(),
+        "the subscription must survive a refused write"
+    );
+
+    // An ACCEPTED false — the wire-facing set, which is how a running node is
+    // told — detaches.
+    assert!(
+        executor
+            .params_mut()
+            .expect("store")
+            .apply("use_sim_time", nros_params::ParameterValue::Bool(false))
+            .is_success()
+    );
+    executor.refresh_use_sim_time_from_store();
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        !crate::time_source::is_active(),
+        "an accepted false must stop samples being installed"
+    );
+
+    // And back on: the switch is a switch, not a one-way latch.
+    assert!(
+        executor
+            .params_mut()
+            .expect("store")
+            .apply("use_sim_time", nros_params::ParameterValue::Bool(true))
+            .is_success()
+    );
+    executor.refresh_use_sim_time_from_store();
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        crate::time_source::is_active(),
+        "an accepted true must re-arm the source that is still installed"
+    );
+}
+
+/// phase-430 W3 / issue 1202 — the sibling declare path carries the same hook.
+///
+/// `declare_parameter_with_descriptor` had none at all, so the same reserved
+/// name meant two different things depending on whether the app passed a
+/// descriptor: `use_sim_time = true` with one stored a parameter and attached
+/// nothing. Same class as the ordering above, found by sweeping the seam rather
+/// than the reported site.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn use_sim_time_declared_with_a_descriptor_attaches_the_clock_source() {
+    let _sim_time = SimTimeGuard::acquire();
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+    drop(
+        executor
+            .create_node("descriptor_node")
+            .expect("create node"),
+    );
+
+    let descriptor =
+        nros_params::ParameterDescriptor::new("use_sim_time", nros_params::ParameterType::Bool)
+            .expect("descriptor")
+            .with_description("use simulated time");
+    assert!(executor.declare_parameter_with_descriptor(
+        "use_sim_time",
+        nros_params::ParameterValue::Bool(true),
+        descriptor,
+    ));
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        executor.ros_time_source_installed(),
+        "a descriptor is metadata; it cannot change what the reserved name means"
+    );
+    assert!(crate::time_source::is_active());
 }
 
 /// phase-425 W3b — a non-bool `use_sim_time` attaches nothing.


### PR DESCRIPTION
**phase-430 W3 only.** The phase doc is not on `main` — it rides on PR #629
(`phase-428-w10-qos-ssot`), whose survey recorded this as finding E. This PR
does not touch it.

## The defect

`Executor::declare_parameter` called `note_reserved_parameter` **first** and
**unconditionally**, off the value the CALLER proposed, and only then asked the
store to take it. `ParameterServer::declare` refuses a name it already holds, so

```rust
executor.declare_parameter("use_sim_time", Bool(true));   // accepted
executor.declare_parameter("use_sim_time", Bool(false));  // REFUSED -> false
```

returned `false`, changed nothing in the store, and still set
`sim_time_requested = false`. The next `reconcile_ros_time_source` called
`time_source::set_active(false)`, so `/clock` samples stopped being installed.

The result is a state the parameter cannot name: **sim time recorded as ON, no
clock source armed**, with nothing to reconcile it back — the reconcile believes
the switch, and the switch believes a write that never happened. A later
`ros2 param get <node> use_sim_time` answers `true` while every ROS-time timer
runs on system time.

## The fix

* The hook runs **after** the store answers and **only on acceptance**.
* It takes only the NAME and reads the value back **out of the store**, through
  `refresh_use_sim_time_from_store` — the same read the runtime `ros2 param set`
  path uses. The switch follows what the store HOLDS, never what a caller
  proposed, and the declare path and the wire path cannot disagree about the
  value. That function becomes `pub(crate)` so both callers share one read
  instead of growing a second spelling.

## The class, swept

```
grep -rn 'note_reserved\|RESERVED_PARAM\|use_sim_time' \
    packages/core/nros-node/src packages/core/nros-params/src
```

`use_sim_time` is the tree's **only** reserved parameter
(`time_source::USE_SIM_TIME_PARAM` is the only such constant; ROS 2's other
statically-typed names have no nano-ros implementation to switch). But the seam
has three write paths and only one was hooked:

| path | before | now |
| --- | --- | --- |
| `declare_parameter` | hook first, unconditional | hook after, on acceptance |
| `declare_parameter_with_descriptor` | **no hook at all** — stored the parameter and attached nothing | same hook, same ordering |
| `Executor::parameter` → `ParameterBuilder` | bypasses the executor entirely | unchanged — **issue 1203** |

The builder holds `&mut server` for its whole lifetime, so there is no point at
which the executor can be told what it declared; closing it needs either a
public signature change or phase-430 W2's "declare `use_sim_time = false` on
every node", after which the reconcile can read the store without a per-spin
scan. Filed rather than half-fixed.

## Tests

`use_sim_time_follows_the_store_verdict_not_the_caller` asserts **both** halves
at every step — the stored value and the clock source — because the defect was
precisely those two disagreeing, and a test checking only one reads as correct
on the broken code. Accepted `true` attaches; a refused re-declaration changes
neither; an accepted `false` through the store detaches; an accepted `true`
re-arms.

`use_sim_time_declared_with_a_descriptor_attaches_the_clock_source` covers the
sibling path.

`use_sim_time_attaches_and_detaches_the_clock_source` no longer turns the switch
off through a refused re-declaration — PR #629 left a comment there pinning this
bug — and goes through the store instead, which is how a running node is
actually told.

### Negative control

On a temporary revert of the production half (WIP commit, not `git stash`), with
the new tests unchanged:

```
test executor::tests::use_sim_time_declared_with_a_descriptor_attaches_the_clock_source ... FAILED
test executor::tests::use_sim_time_follows_the_store_verdict_not_the_caller ... FAILED

---- use_sim_time_follows_the_store_verdict_not_the_caller ----
panicked at packages/core/nros-node/src/executor/tests.rs:2198:5:
the refused declaration detached the source anyway: the store keeps `true`
while /clock samples stop being installed, which is an executor with sim time
on and no clock source (issue 1202)

---- use_sim_time_declared_with_a_descriptor_attaches_the_clock_source ----
panicked at packages/core/nros-node/src/executor/tests.rs:2270:5:
a descriptor is metadata; it cannot change what the reserved name means

test result: FAILED. 2 passed; 2 failed
```

## Drive-by

In a file this change already touches: the `N > DEFAULT_RX_BUF_SIZE` claim in
`naming_a_receive_buffer_opts_out_of_the_derivation` is a compile-time claim
about the fixture, so it becomes a `const` block. As a plain `assert!` it is
`clippy::assertions_on_constants`, which took the clippy invocation below red —
a lane no merge-gating job runs, which is why it sat there.

## Ran

| command | result |
| --- | --- |
| `cargo test -p nros-node --lib --features std,sim-time,param-services` | **373 passed**, 0 failed, 2 ignored |
| `cargo clippy -p nros-node --all-targets --features std,sim-time,param-services -- -D warnings` | clean |
| `just check fast` | 263 of 265; two reds, neither reading a file in this diff — this worktree's uninitialised `zenoh-pico` submodule (`capability-conditionals`), and `doc-commit-citations`, whose three phase-428 baseline entries resolve here because the local object store carries PR #629's branch (the baseline itself says to drop them when #629 lands) |

Tier: `just ci gate`-shaped (compile + unit, no fixtures), narrowed to the crate
this touches. No fixture, SDK, QEMU or cross toolchain involved.

## Issues

* `docs/issues/archived/1202-…` — the ordering defect, filed `status: resolved`
  because this PR closes it.
* `docs/issues/1203-…` — the `ParameterBuilder` bypass, open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
