### PR TITLE
fix(#1158, item 3): a lane that never reached its cells must not report what one that did reports

### DIFF
--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -41,6 +41,14 @@ jobs:
     defaults:
       run:
         shell: bash
+    # WHICH STAGE DID THIS RUN REACH? — issue 1158 item 3.
+    #
+    # Consumed by the `coverage` job below, which puts it in its own NAME so the
+    # answer is legible from `gh run view` / the checks list without opening a
+    # log. Empty when this job never started, which is a third answer again.
+    outputs:
+      stage_label: ${{ steps.stage.outputs.label }}
+      reached_cells: ${{ steps.stage.outputs.reached_cells }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,6 +65,7 @@ jobs:
       # reader left to know they must agree. `just test tier2` builds what that
       # scope needs and runs exactly it.
       - name: just setup tier2
+        id: setup
         run: |
           source ./activate.sh
           just setup tier2
@@ -89,6 +98,7 @@ jobs:
       # Fail-fast is not lost: a genuinely mislabeled runner still fails here,
       # and `setup` would have failed on it first anyway.
       - name: Verify this runner's labels are true
+        id: doctor
         run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
 
       # THE MISSING MIDDLE — phase-413 W2.
@@ -115,6 +125,7 @@ jobs:
       # setup and test keeps one vocabulary across the three steps, which is the
       # property phase-411 exists to give.
       - name: just build tier2
+        id: build
         run: |
           source ./activate.sh
           just build tier2
@@ -125,6 +136,7 @@ jobs:
       # last of those. Provisioning by scope + running the TIER keeps the
       # transcript shape without quietly narrowing what runs.
       - name: just ci matrix
+        id: cells
         run: |
           source ./activate.sh
           just ci matrix
@@ -142,18 +154,67 @@ jobs:
         if: always()
         run: ./scripts/ci/runner-sweep.sh || true
 
+      # WHICH STAGE DID THIS RUN REACH? — issue 1158 item 3.
+      #
+      # The eight runs before this landed all said `failure` and hid three
+      # different stories: three died in `Verify this runner's labels are true`,
+      # two in `just setup tier2`, three in `just build tier2`. NOT ONE was a
+      # test result — every failure is upstream of the cells, so this lane
+      # produced no runtime verdict on any of those days while looking exactly
+      # like a lane that had.
+      #
+      # That is the shape issue 1043 fixed for `check-submodule-pins`: where
+      # there were two outcomes there are really three, and the third is "this
+      # could not be evaluated here". VERDICT / NO VERDICT / DID NOT START.
+      #
+      # `if: always()`, and the script exits 0 unconditionally: it DESCRIBES the
+      # lane, and a reporter that can redden the run it reports on is the defect
+      # one layer up. The lane's own steps colour the run, as they already did.
+      #
+      # `steps.<id>.outcome`, not `.conclusion` — `outcome` is the step's real
+      # result before any `continue-on-error` rewrite. Its vocabulary
+      # (success/failure/skipped/cancelled) is the SAME one `gh run view --json
+      # jobs` returns, which is what lets `--history` classify the eight runs
+      # above with the identical function this step calls. See the module
+      # docstring; those runs are asserted in its self-test.
+      - name: Which stage did this lane reach?
+        id: stage
+        if: always()
+        env:
+          NROS_LANE_STEPS: >-
+            [{"name": "just setup tier2", "conclusion": "${{ steps.setup.outcome }}"},
+             {"name": "Verify this runner's labels are true", "conclusion": "${{ steps.doctor.outcome }}"},
+             {"name": "just build tier2", "conclusion": "${{ steps.build.outcome }}"},
+             {"name": "just ci matrix", "conclusion": "${{ steps.cells.outcome }}"}]
+        run: python3 scripts/ci/lane-stage.py --report --lane "tier 2 (1-wise matrix)"
+
   # phase-405 — make the interlocked job's SKIP visible in the run that skipped
   # it. See scripts/ci/report-interlock-coverage.sh for why this warns rather
   # than fails when no runner is registered, and fails when one supposedly is.
   #
   # `if: always()` so it reports on a skip; `needs` so it sees the result.
 
+  # The job NAME carries the stage — issue 1158 item 3.
+  #
+  # `did tier 2 run?` was a question this job could not answer. It read
+  # `needs.matrix.result`, which is `failure` for a run that tested the whole
+  # matrix and found a regression AND for a run that died in `runner-doctor`
+  # having built nothing, so it printed "RAN and FAILED" for eight consecutive
+  # runs of which none ran anything. A check-run name is the last piece of a
+  # run that is legible without opening a log — `gh run view`, the commit's
+  # checks list, the PR checks tab — so the answer goes there.
+  #
+  # `needs` IS an available context for `jobs.<job_id>.name` (unlike, say,
+  # `steps`), which is why this reads a job OUTPUT rather than re-deriving
+  # anything. `|| 'DID NOT START'` covers the interlocked skip, where the matrix
+  # job produces no outputs at all — a third answer that is neither verdict nor
+  # lane failure, and the one `report-interlock-coverage.sh` already handled.
   coverage:
-    name: coverage report (did tier 2 run?)
+    name: "tier 2 — ${{ needs.matrix.outputs.stage_label || 'DID NOT START' }}"
     needs: [matrix]
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Report whether the interlocked lane ran
-        run: ./scripts/ci/report-interlock-coverage.sh "tier 2 (1-wise matrix)" "${{ needs.matrix.result }}" "${{ vars.NROS_SELF_HOSTED_READY }}"
+        run: ./scripts/ci/report-interlock-coverage.sh "tier 2 (1-wise matrix)" "${{ needs.matrix.result }}" "${{ vars.NROS_SELF_HOSTED_READY }}" "${{ needs.matrix.outputs.stage_label }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,7 +612,13 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   nightly's own `c/talker` cell reported `failure` before and after. `just
   nightly-triage` classifies by which STEP failed and flags cells red across a
   whole window; `just queue-triage` does the same for merge-queue ejections
-  (INFRA vs MINE).
+  (INFRA vs MINE). **A lane with an ordered pipeline needs one axis more — HOW
+  FAR did it get** (issue 1158): tier 2's eight runs to 2026-09-06 all said
+  `failure`, 0 reached the cells, and they split 5 provisioning / 3 build. `just
+  matrix-triage` prints that per run; `run-matrix.yml` names the stage in the
+  `coverage` job's own check-run NAME, so `gh run view` answers it without a log.
+  Gated by `check-lane-stage-reporting` — the step→stage map is AUTHORED, so a
+  renamed step drifts it in the safe-looking direction.
 - **Rust edition 2024:** `unsafe extern "C" {}`, `#[unsafe(no_mangle)]`, explicit `unsafe {}` in
   `unsafe fn`. `nros-c` keeps `#![allow(unsafe_op_in_unsafe_fn)]`.
 - **No POSIX-style Rust ctor sections on Zephyr/native_sim/RTOS** — backend registration is an

--- a/docs/issues/1158-tier2-lane-has-produced-no-verdict-for-six-days.md
+++ b/docs/issues/1158-tier2-lane-has-produced-no-verdict-for-six-days.md
@@ -91,10 +91,88 @@ verdict. The lane needs to reach the cells ONCE and then keep reaching them:
    give the lane its own runner/label, or schedule it where the queue is idle,
    or accept and DOCUMENT that it yields — the current state is neither chosen
    nor written down.
-3. **Distinguish "did not run" from "ran and failed"** at the summary level, the
+3. ~~**Distinguish "did not run" from "ran and failed"** at the summary level, the
    way issue 1043 did for `check-submodule-pins`. Six runs that all say
    "failure" hide four different stories; a lane that never reached its cells
-   should not report the same word as one that did.
+   should not report the same word as one that did.~~ **DONE — see below.**
+
+## Item 3, fixed (2026-09-07)
+
+`scripts/ci/lane-stage.py` gives the lane the third outcome it was missing:
+
+    VERDICT      the cells RAN. Green or red, the answer is about the CODE.
+    NO VERDICT   the lane stopped before its cells, naming the stage
+                 (provisioning / build). The answer is about the LANE.
+    DID NOT START  the interlocked job never ran at all.
+
+It reaches a reader in three places, in decreasing order of effort:
+
+* **The `coverage` job's NAME.** It was `coverage report (did tier 2 run?)` — a
+  question the job could not answer, because it read `needs.matrix.result`,
+  which is `failure` for a run that tested the whole matrix and for a run that
+  died in `runner-doctor` having built nothing. It is now
+  `tier 2 — NO VERDICT: stopped in the build`. A check-run name is the last
+  thing legible without opening a log (`gh run view`, the checks list), which is
+  the level the issue asked for.
+* **An annotation + a step summary** on the matrix job itself, saying which
+  stage it reached and, when it reached no cells, that the run answers nothing
+  about the code.
+* **`just matrix-triage`**, the run-list-scale view — the sibling of
+  `just nightly-triage` and `just queue-triage`, extended rather than replaced.
+  It reads `gh run list`/`gh run view` and classifies runs that PREDATE the
+  change, because a step's `conclusion` from `gh` and a step's `outcome` inside
+  the workflow are the same four-word vocabulary and go through the same
+  function.
+
+**Measured, against the eight real runs above** (`just matrix-triage 8`,
+2026-09-07): `0 of 8 run(s) reached the cells and produced a VERDICT`, split
+`5 provisioning / 3 build` under one flat `failure`. Those eight runs are
+recorded in the tool's self-test, so the classification is re-checkable offline
+and the two counterfactuals (cells ran and failed / cells ran and passed) are
+asserted to differ. Three mutations red it: adding `run` to the cells markers
+(the `runner` substring trap `nightly-triage.py` records), treating a `skipped`
+cells step as reached, and renaming a workflow step without updating the map.
+
+Gate: `check-lane-stage-reporting` (fast line) — the step→stage map is AUTHORED,
+so it drifts when a step is renamed, and it drifts in the safe-looking direction.
+
+**What this deliberately does NOT do.** It cannot make a red green or a green
+red — `lane-stage.py` exits 0 unconditionally. A reporter that can redden the
+lane it describes is the defect one layer up. And it produces no verdict: it
+makes the ABSENCE of one legible, which is the whole of item 3 and none of
+item 1.
+
+**Why the other three self-hosted lanes did not get this.** `build-wide.yml` and
+`queue.yml`'s L3 have no cells at all — they are build-depth lanes, so "did it
+reach the cells" has no referent there. `nightly.yml`'s `matrix-nightly` does
+have cells and is already covered by `just nightly-triage`, which classifies its
+per-cell reds by failing step. `run-matrix` was the one lane with cells and no
+per-stage report.
+
+## Still open, and why this issue is NOT resolved
+
+The substance of this issue is the MISSING VERDICT, and item 3 does not deliver
+one. It makes the absence legible; the lane still has not reached its cells.
+
+1. **A verdict, once — OPEN.** Nothing here runs the cells. It needs the shared
+   self-hosted runner and hours of fixture build, and until it happens issue
+   0968's ~12 tier-2 runtime failures stay unreproduced. The one thing that has
+   changed is that when the lane next fails, the run says whether that failure
+   was one.
+2. **Contention — OPEN, and deliberately not touched.** One runner serves both
+   this lane and the merge queue's `gate` jobs, and choosing between "give the
+   verdict lane its own runner", "schedule it where the queue is idle" and
+   "accept that it yields" is an infrastructure decision with a cost the
+   maintainer owns, not a defect an agent should decide by editing a label. No
+   `runs-on`, no required-check set and no path filter was changed here.
+
+Item 3's own limits, stated so they are not mistaken for coverage: the stage
+model is `run-matrix`'s pipeline only; a cells step that fails having SKIPPED
+every test still reads as a verdict (only `check-skip-budget` knows that
+difference, the same known limitation `nightly-triage.py` records); and the
+`coverage` job's dynamic name has not been observed on a real run, because
+dispatching one is item 1's cost — its inputs are asserted in the gate and the
+expression uses `needs`, which is an available context for `jobs.<job_id>.name`.
 
 ## Not covered
 

--- a/just/check/workflows.just
+++ b/just/check/workflows.just
@@ -431,6 +431,20 @@ workflow-doctor-after-setup:
 workflow-indexed-apt:
     @python3 scripts/check-workflow-indexed-apt.py
 
+# issue 1158 — `run-matrix.yml`'s stage report must still describe the steps that
+# exist. The step->stage map is AUTHORED (the workflow hands `lane-stage.py` a
+# copy of its own `- name:` lines), and an authored map drifts the moment a step
+# is renamed — silently, and in the safe-looking direction: the tool keeps
+# reporting, on a step that no longer runs.
+#
+# This runs `lane-stage.py --selftest`, which cross-checks the map against the
+# workflow in BOTH directions and replays the eight real runs the issue
+# tabulates. Pure text + YAML, no network, no build — it passes in a pristine
+# worktree, which is the bar for this lane.
+[group("main")]
+lane-stage-reporting:
+    @python3 scripts/ci/lane-stage.py --selftest
+
 # issue 0933 — a CI step that invokes `just`/`nros`/`west` must source the repo
 # environment. `activate.sh` is what exports `nano_ros_ROOT`, and that is how
 # `find_package(nano_ros)` resolves: the config lives at the checkout root and a

--- a/justfile
+++ b/justfile
@@ -2608,6 +2608,23 @@ tier-health *args:
 nightly-triage runs="3":
     @python3 scripts/ci/nightly-triage.py --runs {{runs}}
 
+# How far did the tier-2 lane get? (issue 1158) Never gates.
+#
+# `nightly-triage` asks "was this failure a verdict?"; the tier-2 lane needs one
+# axis more, because it has an ORDERED pipeline — provisioning -> build -> cells
+# — and the answer that matters is HOW FAR IT GOT. `just build tier2` failing is
+# a real verdict about the code AND still not the runtime verdict this lane
+# exists to produce, and only a stage model can say both at once.
+#
+# Measured 2026-09-07: 0 of the last 8 runs reached the cells, under one flat
+# `failure` word covering three different stopping points.
+#
+#   just matrix-triage         just matrix-triage 20
+#   just matrix-triage 8 nightly.yml
+[group("ci")]
+matrix-triage runs="8" workflow="run-matrix.yml":
+    @python3 scripts/ci/lane-stage.py --history --runs {{runs}} --workflow {{workflow}}
+
 # Which open PRs can never merge because nothing ever ran on them? A PR with
 # ZERO check suites is not failing and not pending — it is silently ineligible,
 # and auto-merge can sit armed against a check that was never requested (PR #71,

--- a/scripts/ci/lane-stage.py
+++ b/scripts/ci/lane-stage.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Which STAGE did a staged lane reach? — issue 1158, item 3.
+
+## The defect
+
+`run-matrix.yml` is the only automated path to tier 2's runtime cells. Its last
+eight runs all say the same word — `failure` — and they hide FOUR different
+stories:
+
+    2026-09-01/02/03   died in `Verify this runner's labels are true`
+    2026-09-04/05      died in `just setup tier2`
+    2026-09-06 x3      died in `just build tier2`
+
+Not one of them is a test result. Every failure is UPSTREAM of the cells, so the
+lane produced no runtime verdict on any of those days — and a reader of the run
+list cannot tell that from a reader of a run that ran its cells and found a real
+regression. CLAUDE.md states the rule:
+
+  > A red CI lane answers one of two questions and they look identical — the
+  > lane RAN and the code is broken (a verdict), or it never ran (no verdict). A
+  > uniformly-red lane has NO signal capacity.
+
+This is the same shape issue 1043 fixed one layer down, for
+`check-submodule-pins`: where there were two outcomes (OK / FAIL) there are
+really three, and the third is "this could not be evaluated here". A lane needs
+the same three:
+
+    VERDICT     the cells RAN. Green or red, the answer is about the code.
+    NO VERDICT  the lane stopped before the cells. The answer is about the lane.
+    DID NOT RUN the job never started (interlock off, no runner).
+
+## Why not a new mechanism
+
+`nightly-triage.py` already classifies a failing job as verdict / no-verdict by
+its failing STEP, and `queue-triage.sh` does the INFRA / MINE split for the
+merge queue. This is the same question a third time, so it reuses their shape
+and their hard-won lessons rather than inventing a fourth:
+
+  * WORD BOUNDARIES, not substrings. `run` matches inside `runner`, which made
+    `Verify this runner's labels are true` — the single most common failure in
+    this very lane — score as a real failure. That is recorded in
+    `nightly-triage.py`; repeating the mistake here would be a choice.
+  * The FIRST failing step decides. Later steps fail because the first did.
+  * It REPORTS, never gates. Exit status is always 0. A reporter that can redden
+    a run has an opinion about the lane it was built to describe.
+
+What is new here is the third axis nightly-triage does not have. Its question is
+binary (was this failure a verdict?); this lane has an ORDERED pipeline —
+provisioning -> build -> cells — and "how far did it get" is the thing a reader
+needs. `just build tier2` failing is a real verdict about the code AND still not
+the runtime verdict this lane exists to produce, and only a stage model can say
+both of those at once.
+
+## One classifier, two callers
+
+`classify()` takes the same shape from both directions:
+
+  * in the workflow, `steps.<id>.outcome` for each staged step (`--report`);
+  * after the fact, `gh run view --json jobs` (`--history`).
+
+Those two vocabularies are identical — `success` / `failure` / `skipped` /
+`cancelled` — which is what makes the historical validation evidence about the
+live path and not merely a related test. Every run in `HISTORICAL` below is a
+real run of this lane, recorded from `gh`, and asserted in the self-test.
+
+Usage::
+
+    lane-stage.py --report --lane "tier 2 (1-wise matrix)"   # in-workflow
+    lane-stage.py --history [--runs 8] [--workflow run-matrix.yml]
+    lane-stage.py --selftest
+"""
+
+import argparse
+import collections
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.environ.get("NROS_QUEUE_REPO", "NEWSLabNTU/nano-ros")
+
+# The lane's pipeline, in order. A stage is reached only by finishing the one
+# before it, which is what makes "how far did it get" a single number.
+PROVISIONING, BUILD, CELLS = "provisioning", "build", "cells"
+STAGE_ORDER = (PROVISIONING, BUILD, CELLS)
+
+# Step name -> stage. Matched with WORD BOUNDARIES against the lowercased name,
+# most specific stage first, because a step that names the thing under test
+# belongs to that stage even when it also prepares something.
+#
+# `run` is deliberately absent from every list: it is a substring of `runner`,
+# and `Verify this runner's labels are true` is the most frequent failure in
+# this lane. nightly-triage.py records what that cost there.
+STAGE_MARKERS = (
+    # The cells: the runtime verdict this lane exists to produce.
+    (CELLS, ("ci", "matrix", "test", "e2e", "cell", "cells")),
+    # The build: real code failures, but not the runtime verdict.
+    (BUILD, ("build",)),
+    # Everything that has to be true before the lane can build anything.
+    (PROVISIONING, ("setup", "set up", "provision", "install", "checkout",
+                    "cache", "fetch", "submodule", "labels", "doctor",
+                    "reclaim disk", "free disk", "apt", "rustup", "register")),
+)
+
+# Steps that belong to no stage: housekeeping that runs `if: always()` after the
+# lane has already decided. Counting these as a stage would let a successful
+# `Sweep orphans and disk` claim the lane got somewhere.
+NOT_A_STAGE = ("upload", "sweep", "complete job", "post ")
+
+LABELS = {
+    "verdict-pass": "VERDICT: cells ran and passed",
+    "verdict-fail": "VERDICT: cells ran and FAILED",
+    "no-verdict-provisioning": "NO VERDICT: stopped in provisioning",
+    "no-verdict-build": "NO VERDICT: stopped in the build",
+    "no-verdict-none": "NO VERDICT: died before any stage",
+    "cancelled": "NO VERDICT: cancelled",
+    "running": "still running",
+    "did-not-start": "DID NOT START",
+}
+
+
+def stage_of(step_name):
+    """The stage a step belongs to, or None if it belongs to no stage."""
+    low = (step_name or "").lower()
+    if any(marker in low for marker in NOT_A_STAGE):
+        return None
+    for stage, markers in STAGE_MARKERS:
+        for m in markers:
+            if re.search(rf"\b{re.escape(m)}\b", low):
+                return stage
+    return None
+
+
+Result = collections.namedtuple(
+    "Result", "kind stage label failing_step reached_cells")
+
+
+def classify(steps, job_conclusion=None):
+    """Classify one job's ordered steps.
+
+    `steps` is [{"name": str, "conclusion": str}] — the shape `gh run view
+    --json jobs` returns AND the shape the workflow reports from
+    `steps.<id>.outcome`. `job_conclusion` is optional and only used to tell a
+    job that died with no failing step from one that never ran.
+
+    Returns a Result whose `kind` is one of:
+        verdict-pass  verdict-fail  no-verdict  cancelled  running
+    """
+    staged = [(s, stage_of(s.get("name", ""))) for s in steps]
+    concl = {}
+    for s, st in staged:
+        if st is None:
+            continue
+        # First conclusion wins: a stage is decided by the step that decides it,
+        # and a later `Post Run actions/checkout` must not overwrite it.
+        concl.setdefault(st, s.get("conclusion"))
+
+    failed = [s for s, st in staged if s.get("conclusion") == "failure"]
+    first_failing = failed[0].get("name", "") if failed else ""
+
+    cells = concl.get(CELLS)
+    if cells == "success":
+        return Result("verdict-pass", CELLS, LABELS["verdict-pass"], "", True)
+    if cells == "failure":
+        return Result("verdict-fail", CELLS, LABELS["verdict-fail"],
+                      first_failing, True)
+
+    # The cells did not run. How far DID it get? The stage that failed, or — if
+    # nothing failed — the last stage that succeeded.
+    if failed:
+        stopped = stage_of(first_failing)
+    else:
+        reached = [st for st in STAGE_ORDER if concl.get(st) == "success"]
+        stopped = reached[-1] if reached else None
+
+    if job_conclusion == "cancelled" or any(
+            s.get("conclusion") == "cancelled" for s, _ in staged):
+        return Result("cancelled", stopped, LABELS["cancelled"],
+                      first_failing, False)
+
+    if not failed and job_conclusion not in ("failure", "success", None):
+        return Result("running", stopped, LABELS["running"], "", False)
+
+    key = {PROVISIONING: "no-verdict-provisioning",
+           BUILD: "no-verdict-build"}.get(stopped, "no-verdict-none")
+    return Result("no-verdict", stopped, LABELS[key], first_failing, False)
+
+
+# --------------------------------------------------------------------------
+# --report: the in-workflow half.
+# --------------------------------------------------------------------------
+
+def report(lane, steps_json):
+    try:
+        steps = json.loads(steps_json)
+    except (json.JSONDecodeError, TypeError) as exc:
+        print(f"[WARN] lane-stage: NROS_LANE_STEPS unreadable ({exc}); "
+              "reporting nothing", file=sys.stderr)
+        return 0
+
+    # A step that never ran reports an empty outcome, not `skipped`.
+    steps = [{"name": s.get("name", "?"), "conclusion": s.get("conclusion") or "skipped"}
+             for s in steps]
+    res = classify(steps)
+
+    out = [f"{lane}: {res.label}"]
+    if res.failing_step:
+        out.append(f"  first failing step: {res.failing_step}")
+    for s in steps:
+        mark = {"success": "ok  ", "failure": "FAIL", "skipped": "----",
+                "cancelled": "canc"}.get(s["conclusion"], "?   ")
+        out.append(f"  [{mark}] {stage_of(s['name']) or '-':<12} {s['name']}")
+    if not res.reached_cells:
+        out.append("")
+        out.append("  This run answers NOTHING about the code under test. The lane")
+        out.append("  stopped before its cells, so a regression landing today would")
+        out.append("  look exactly like this — which is how issues 1075/1098/1104/1114")
+        out.append("  rode in (issue 1158).")
+    print("\n".join(out))
+
+    # An annotation, because it is the one thing visible on the run page and in
+    # `gh run view` WITHOUT opening a log. `::notice` when the lane reported.
+    level = "notice" if res.reached_cells else "warning"
+    title = f"{lane}: {res.label}"
+    detail = (f"first failing step: {res.failing_step}" if res.failing_step
+              else "no step failed")
+    print(f"::{level} title={title}::{detail}")
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(f"### {lane} — {res.label}\n\n")
+            fh.write("| stage | step | outcome |\n| --- | --- | --- |\n")
+            for s in steps:
+                fh.write(f"| {stage_of(s['name']) or '—'} | `{s['name']}` "
+                         f"| {s['conclusion']} |\n")
+            fh.write("\n")
+            if res.reached_cells:
+                fh.write("The cells ran, so this run **is** a verdict about the "
+                         "code.\n")
+            else:
+                fh.write("**The cells did not run**, so this run is not a verdict "
+                         "about the code — it is a verdict about the lane. See "
+                         "issue 1158.\n")
+
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if gh_out:
+        with open(gh_out, "a", encoding="utf-8") as fh:
+            fh.write(f"stage={res.stage or 'none'}\n")
+            fh.write(f"kind={res.kind}\n")
+            fh.write(f"label={res.label}\n")
+            fh.write(f"reached_cells={'true' if res.reached_cells else 'false'}\n")
+    # ALWAYS 0. This describes the lane; the lane's own steps colour the run.
+    return 0
+
+
+# --------------------------------------------------------------------------
+# --history: the run-list half.
+# --------------------------------------------------------------------------
+
+def gh_json(args):
+    try:
+        out = subprocess.run(["gh"] + args, capture_output=True, text=True,
+                             timeout=180)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"[WARN] gh failed: {exc}", file=sys.stderr)
+        return None
+    if out.returncode != 0:
+        print(f"[WARN] gh exited {out.returncode}: {out.stderr.strip()[:200]}",
+              file=sys.stderr)
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def history(workflow, want, lane_job=None):
+    runs = gh_json(["run", "list", "--repo", REPO, "--workflow", workflow,
+                    "--limit", str(want), "--json",
+                    "databaseId,createdAt,event,status,conclusion"])
+    if runs is None:
+        print(f"no runs readable for {workflow} (is `gh` authenticated?)")
+        return 0
+    if not runs:
+        print(f"{workflow}: no runs")
+        return 0
+
+    print(f"== {workflow} — last {len(runs)} run(s) ==\n")
+    kinds = collections.Counter()
+    for run in runs:
+        data = gh_json(["run", "view", str(run["databaseId"]), "--repo", REPO,
+                        "--json", "jobs"])
+        jobs = (data or {}).get("jobs", [])
+        # The lane job is the one with a stage-bearing step; the coverage job
+        # that reports on it has none.
+        lane_jobs = [j for j in jobs
+                     if (lane_job is None or j.get("name") == lane_job)
+                     and any(stage_of(s.get("name", "")) for s in j.get("steps", []))]
+        if not lane_jobs:
+            res = Result("no-verdict", None, LABELS["did-not-start"], "", False)
+        else:
+            j = lane_jobs[0]
+            res = classify(j.get("steps", []), j.get("conclusion"))
+        if run.get("status") != "completed" and not res.failing_step:
+            res = res._replace(kind="running", label=LABELS["running"])
+        kinds[res.kind] += 1
+        print(f"  {run['databaseId']}  {run['createdAt'][:16].replace('T', ' ')}"
+              f"  {run.get('event', '?'):<18} {(run.get('conclusion') or run.get('status') or '?'):<9}"
+              f" {res.label}")
+        if res.failing_step:
+            print(f"{'':>58}   at: {res.failing_step}")
+
+    verdicts = kinds["verdict-pass"] + kinds["verdict-fail"]
+    total = sum(kinds.values())
+    print()
+    print(f"  {verdicts} of {total} run(s) reached the cells and produced a VERDICT.")
+    print(f"  {kinds['no-verdict']} of {total} run(s) produced NO VERDICT — the lane "
+          "stopped before its cells.")
+    if verdicts == 0 and total:
+        print()
+        print("  This lane has no signal capacity right now. A regression landing")
+        print("  today is indistinguishable from yesterday's infrastructure red —")
+        print("  'still red' and 'newly red' look the same in the run list.")
+        print("  See issue 1158.")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# The self-test, over real recorded runs.
+# --------------------------------------------------------------------------
+
+def _steps(*pairs):
+    return [{"name": n, "conclusion": c} for n, c in pairs]
+
+
+# Every entry is a REAL run of `run-matrix.yml`, recorded from
+# `gh run view <id> --json jobs` on 2026-09-07. These are the eight runs issue
+# 1158 tabulates. Housekeeping steps are kept verbatim so the classifier is
+# exercised on the noise it will actually see.
+_TAIL = (("Upload junit and logs", "success"),
+         ("Sweep orphans and disk", "success"),
+         ("Post Run actions/checkout@v4", "success"),
+         ("Complete job", "success"))
+
+_DOCTOR_DIED = _steps(
+    ("Set up job", "success"),
+    ("Run actions/checkout@v4", "success"),
+    ("Verify this runner's labels are true", "failure"),
+    ("just setup tier2", "skipped"),
+    ("just ci matrix", "skipped"),
+    *_TAIL)
+
+_SETUP_DIED = _steps(
+    ("Set up job", "success"),
+    ("Run actions/checkout@v4", "success"),
+    ("just setup tier2", "failure"),
+    ("Verify this runner's labels are true", "skipped"),
+    ("just build tier2", "skipped"),
+    ("just ci matrix", "skipped"),
+    *_TAIL)
+
+_BUILD_DIED = _steps(
+    ("Set up job", "success"),
+    ("Run actions/checkout@v4", "success"),
+    ("just setup tier2", "success"),
+    ("Verify this runner's labels are true", "success"),
+    ("just build tier2", "failure"),
+    ("just ci matrix", "skipped"),
+    *_TAIL)
+
+HISTORICAL = (
+    # (run id, date, recorded steps, expected kind, expected stage)
+    (33477831186, "2026-09-01", _DOCTOR_DIED, "no-verdict", PROVISIONING),
+    (33599360758, "2026-09-02", _DOCTOR_DIED, "no-verdict", PROVISIONING),
+    (33723333691, "2026-09-03", _DOCTOR_DIED, "no-verdict", PROVISIONING),
+    (33844476113, "2026-09-04", _SETUP_DIED, "no-verdict", PROVISIONING),
+    (33949734179, "2026-09-05", _SETUP_DIED, "no-verdict", PROVISIONING),
+    (34000628352, "2026-09-06", _BUILD_DIED, "no-verdict", BUILD),
+    (34007251082, "2026-09-06", _BUILD_DIED, "no-verdict", BUILD),
+    (34016427482, "2026-09-06", _BUILD_DIED, "no-verdict", BUILD),
+)
+
+
+WORKFLOW = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    ".github", "workflows", "run-matrix.yml")
+
+# Every step name `run-matrix.yml` hands to `--report`, and the stage it MUST
+# classify as. Asserted against the workflow itself, both directions.
+EXPECTED_MAP = {
+    "just setup tier2": PROVISIONING,
+    "Verify this runner's labels are true": PROVISIONING,
+    "just build tier2": BUILD,
+    "just ci matrix": CELLS,
+}
+
+
+def _workflow_consistency(chk):
+    """Cross-check the authored step->stage map against run-matrix.yml.
+
+    Returns lines to print when the check could not be made — a REPORTED skip,
+    never a silent one (issue 1043's shape: "could not evaluate" is a third
+    answer, not a pass).
+    """
+    try:
+        import yaml
+    except ModuleNotFoundError:
+        return ["[skip] lane-stage: PyYAML missing — the run-matrix.yml "
+                "consistency arm did NOT run"]
+    if not os.path.exists(WORKFLOW):
+        return [f"[skip] lane-stage: {WORKFLOW} absent — the consistency arm "
+                "did NOT run"]
+
+    with open(WORKFLOW, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    steps = doc["jobs"]["matrix"]["steps"]
+    names = [s.get("name", "") for s in steps]
+    reporter = [s for s in steps
+                if "lane-stage.py" in str(s.get("run", ""))]
+
+    chk("run-matrix.yml has exactly one lane-stage reporter", len(reporter) == 1)
+    if not reporter:
+        return []
+
+    declared = json.loads(
+        re.sub(r"\$\{\{[^}]*\}\}", "success",
+               reporter[0]["env"]["NROS_LANE_STEPS"]))
+    declared_names = [d["name"] for d in declared]
+
+    chk("every step name the workflow reports is a real step in that job",
+        all(n in names for n in declared_names))
+    chk("every staged step of the workflow is reported",
+        set(declared_names) == set(EXPECTED_MAP))
+    for n in declared_names:
+        chk(f"`{n}` still classifies as {EXPECTED_MAP.get(n)}",
+            stage_of(n) == EXPECTED_MAP.get(n))
+    chk("the reporter runs `if: always()` — a stage report that is skipped when "
+        "the lane dies is no report",
+        "always()" in str(reporter[0].get("if", "")))
+    chk("the matrix job exports the stage label for the coverage job's name",
+        "stage.outputs.label" in
+        str(doc["jobs"]["matrix"].get("outputs", {}).get("stage_label", "")))
+    chk("the coverage job's NAME carries the stage",
+        "needs.matrix.outputs.stage_label" in str(doc["jobs"]["coverage"]["name"]))
+    return []
+
+
+def selftest(verbose=False):
+    ok = fail = 0
+
+    def chk(desc, cond):
+        nonlocal ok, fail
+        if verbose or not cond:
+            print(f"  {'ok   ' if cond else 'FAIL '} {desc}")
+        ok += 1 if cond else 0
+        fail += 0 if cond else 1
+
+    # 1. The eight real runs issue 1158 tabulates. Not one is a verdict, and
+    #    they stopped at TWO different stages under one flat `failure`.
+    for rid, when, steps, want_kind, want_stage in HISTORICAL:
+        res = classify(steps, "failure")
+        chk(f"{rid} ({when}) -> {want_kind}/{want_stage}",
+            res.kind == want_kind and res.stage == want_stage)
+    chk("no historical run reached the cells",
+        not any(classify(s, "failure").reached_cells for _, _, s, _, _ in HISTORICAL))
+    chk("the eight runs split into TWO stages under one `failure` word",
+        len({classify(s, "failure").stage for _, _, s, _, _ in HISTORICAL}) == 2)
+
+    # 2. The distinction the whole file exists for.
+    ran_and_failed = _steps(("just setup tier2", "success"),
+                            ("Verify this runner's labels are true", "success"),
+                            ("just build tier2", "success"),
+                            ("just ci matrix", "failure"), *_TAIL)
+    chk("cells that RAN and failed are a VERDICT, not a no-verdict",
+        classify(ran_and_failed, "failure").kind == "verdict-fail")
+    chk("...and it reports having reached the cells",
+        classify(ran_and_failed, "failure").reached_cells)
+    chk("a run whose cells passed is a verdict too",
+        classify(_steps(("just setup tier2", "success"),
+                        ("just build tier2", "success"),
+                        ("just ci matrix", "success"), *_TAIL),
+                 "success").kind == "verdict-pass")
+
+    # 3. The word-boundary trap nightly-triage.py paid for. `run` is a
+    #    substring of `runner`; if it were a marker, the single commonest
+    #    failure of this lane would classify as a cells verdict — the exact
+    #    opposite of the truth.
+    chk("`Verify this runner's labels are true` is PROVISIONING, not cells",
+        stage_of("Verify this runner's labels are true") == PROVISIONING)
+    chk("`just ci matrix` is the cells stage",
+        stage_of("just ci matrix") == CELLS)
+    chk("`just build tier2` is the build stage",
+        stage_of("just build tier2") == BUILD)
+    chk("`just setup tier2` is provisioning",
+        stage_of("just setup tier2") == PROVISIONING)
+
+    # 4. Housekeeping must not claim a stage. `Sweep orphans and disk` runs
+    #    `if: always()` and succeeds on every run including the dead ones.
+    for noise in ("Upload junit and logs", "Sweep orphans and disk",
+                  "Complete job", "Post Run actions/checkout@v4"):
+        chk(f"`{noise}` belongs to no stage", stage_of(noise) is None)
+
+    # 5. A job that died with no failing step tested nothing — the runner or the
+    #    container went away. Same call nightly-triage makes.
+    chk("a red job with no failing step is a no-verdict",
+        classify(_steps(("Set up job", "success")), "failure").kind == "no-verdict")
+    chk("...and names no stage rather than inventing one",
+        classify([], "failure").label == LABELS["no-verdict-none"])
+
+    # 6. Cancellation is neither a verdict nor a lane defect.
+    chk("a cancelled run is reported as cancelled",
+        classify(_steps(("just setup tier2", "success"),
+                        ("just ci matrix", "cancelled")), "cancelled").kind
+        == "cancelled")
+
+    # 7. The FIRST failing step decides: later steps fail because it did.
+    chk("the first failing step decides the stage",
+        classify(_steps(("just setup tier2", "failure"),
+                        ("just build tier2", "failure")), "failure").stage
+        == PROVISIONING)
+
+    # 8. An empty outcome (a step that never started) is not a success.
+    chk("--report treats an empty outcome as skipped, never as reached",
+        classify(_steps(("just setup tier2", "success"),
+                        ("just build tier2", "success"),
+                        ("just ci matrix", "skipped")), "failure").reached_cells
+        is False)
+
+    # 9. THE MAP IS AUTHORED, SO IT DRIFTS. `--report` is handed step names by
+    #    the workflow, and those names are a copy of the workflow's own `- name:`
+    #    lines. Rename a step and the copy silently stops matching — the tool
+    #    would keep reporting, on a step that no longer exists, and the answer
+    #    would be wrong in the safe-looking direction. Same shape as the RMW
+    #    parity map reading `gap` for slots that had landed.
+    for line in _workflow_consistency(chk):
+        print(line, file=sys.stderr)
+
+    if verbose:
+        print(f"\n{ok} passed, {fail} failed")
+    if fail:
+        print("lane-stage self-test: FAILED", file=sys.stderr)
+        raise SystemExit(1)
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report", action="store_true",
+                    help="classify the current job from $NROS_LANE_STEPS")
+    ap.add_argument("--lane", default="this lane")
+    ap.add_argument("--history", action="store_true",
+                    help="classify recent runs of a workflow via `gh`")
+    ap.add_argument("--workflow", default="run-matrix.yml")
+    ap.add_argument("--job", default=None,
+                    help="restrict --history to one job name")
+    ap.add_argument("--runs", type=int, default=8)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest(verbose=True)
+    # Every invocation proves the classifier still separates the two kinds. It
+    # is pure text, so it costs milliseconds.
+    selftest()
+
+    if args.report:
+        return report(args.lane, os.environ.get("NROS_LANE_STEPS", "[]"))
+    if args.history:
+        return history(args.workflow, args.runs, args.job)
+    ap.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/report-interlock-coverage.sh
+++ b/scripts/ci/report-interlock-coverage.sh
@@ -33,13 +33,29 @@
 # `runs-on`, or the variable disagree with reality, and a silent skip there
 # hides a lane everyone believes is running.
 #
+# RAN IS NOT ONE THING — issue 1158
+#
+# The `failure` arm below used to say "RAN and FAILED", full stop. That is two
+# different runs wearing one sentence: a lane that executed its cells and found
+# a regression, and a lane that died in provisioning having tested nothing.
+# `run-matrix.yml`'s last eight runs were all the second kind and all read as
+# the first. So an OPTIONAL fourth argument carries the stage the lane reached
+# (`scripts/ci/lane-stage.py --report` produces it); when it is present and says
+# NO VERDICT, this says so instead of claiming the lane ran.
+#
+# Optional because three other workflows call this with three arguments and
+# their lanes are not staged the same way. A missing stage degrades to the old
+# wording, which is correct for a caller that cannot compute one — the same
+# "reported skip rather than a false claim" shape as issue 1043.
+#
 # Usage:
-#   report-interlock-coverage.sh <lane-name> <needs-result> <interlock-value>
+#   report-interlock-coverage.sh <lane-name> <needs-result> <interlock-value> [<stage-label>]
 set -uo pipefail
 
 lane="${1:?lane name}"
 result="${2:?the gated job needs.<job>.result}"
 interlock="${3-}"
+stage="${4-}"
 
 summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
@@ -52,8 +68,25 @@ case "$result" in
     failure)
         # The gated job already reddens the run; say which lane, then let its
         # own verdict stand rather than double-reporting.
-        echo "$lane: RAN and FAILED — see that job's log." >&2
-        printf '### %s: ran and FAILED ❌\n' "$lane" >> "$summary"
+        case "$stage" in
+            *"NO VERDICT"*)
+                echo "$lane: $stage" >&2
+                echo "" >&2
+                echo "  This run is NOT a verdict about the code. The lane stopped" >&2
+                echo "  before its cells, so a regression landing today would look" >&2
+                echo "  exactly like this failure. Issue 1158." >&2
+                printf '### %s: %s ❌\n\n' "$lane" "$stage" >> "$summary"
+                printf 'The red above is about the LANE, not about the code — the cells never ran.\n' >> "$summary"
+                ;;
+            "")
+                echo "$lane: RAN and FAILED — see that job's log." >&2
+                printf '### %s: ran and FAILED ❌\n' "$lane" >> "$summary"
+                ;;
+            *)
+                echo "$lane: $stage — see that job's log." >&2
+                printf '### %s: %s ❌\n' "$lane" "$stage" >> "$summary"
+                ;;
+        esac
         exit 0
         ;;
     cancelled)


### PR DESCRIPTION
Issue 1158 item 3 only. Items 1 (get one verdict) and 2 (runner allocation) are deliberately untouched — no `runs-on`, no required-check set, no path filter is changed here.

## The defect

`run-matrix.yml`'s last eight runs all said `failure` and hid three different stopping points:

| runs | died at | is it a test result? |
| --- | --- | --- |
| 09-01, 09-02, 09-03 | `Verify this runner's labels are true` | no |
| 09-04, 09-05 | `just setup tier2` | no |
| 09-06 x3 | `just build tier2` | no |

**0 of 8 reached the cells.** Every failure is upstream of them, so the lane produced no runtime verdict on any of those days while looking exactly like a lane that had. The `coverage report (did tier 2 run?)` job answered its own question with "RAN and FAILED" for all eight, because all it had was `needs.matrix.result`.

That is the class issue 1043 fixed one layer down for `check-submodule-pins`: two outcomes where there are really three, and the third is "this could not be evaluated here".

## The change

`scripts/ci/lane-stage.py` — one classifier, three outcomes:

```
VERDICT        the cells RAN. Green or red, the answer is about the CODE.
NO VERDICT     stopped before them, naming the stage. About the LANE.
DID NOT START  the interlocked job never ran at all.
```

It reaches a reader in three places, in decreasing order of effort:

* **the `coverage` job's NAME** — now `tier 2 — NO VERDICT: stopped in the build`, which `gh run view` and the checks list show without opening a log;
* **an annotation + step summary** on the matrix job itself;
* **`just matrix-triage`** over the run list — the sibling of `just nightly-triage` / `just queue-triage`.

It EXTENDS those two rather than inventing a fourth mechanism, and inherits their lessons: word boundaries not substrings (`run` is inside `runner`, this lane's commonest failure), the first failing step decides, and it reports but never gates — `lane-stage.py` exits 0 unconditionally, because a reporter that can redden the lane it describes is the defect one layer up. What is new is the axis they do not have: this lane is an ORDERED pipeline, and `just build tier2` failing is a real verdict about the code AND still not the runtime verdict the lane exists to produce.

## Evidence

**Observed.** `just matrix-triage 8` against live GitHub, 2026-09-07:

```
  34016427482  2026-09-06 06:25  schedule    failure   NO VERDICT: stopped in the build
                                                         at: just build tier2
  ...
  33477831186  2026-09-01 06:29  schedule    failure   NO VERDICT: stopped in provisioning
                                                         at: Verify this runner's labels are true

  0 of 8 run(s) reached the cells and produced a VERDICT.
  8 of 8 run(s) produced NO VERDICT — the lane stopped before its cells.
```

Also observed: replaying each run's real step outcomes through the exact in-workflow path (`--report`, with `GITHUB_OUTPUT`/`GITHUB_STEP_SUMMARY` bound) produces the check-run names above and `reached_cells=false` for all eight, while the two counterfactuals give `VERDICT: cells ran and FAILED` / `... and passed`. That works on runs that PREDATE the change because a step's `conclusion` from `gh` and its `outcome` inside the workflow are the same four-word vocabulary and go through the same function.

**Mutation-tested** — three mutations red the self-test: adding `run` to the cells markers, treating a `skipped` cells step as reached, and renaming a workflow step without updating the map.

**Reasoned, not observed.** The `coverage` job's dynamic name has not been seen on a real run — dispatching one is item 1's cost, and this PR does not pay it. `needs` is a documented available context for `jobs.<job_id>.name`; the job output it reads is asserted by the gate.

## Gate

`check-lane-stage-reporting` (fast line, offline, pristine-worktree clean). The step→stage map is AUTHORED — the workflow hands the tool a copy of its own `- name:` lines — so a renamed step drifts it silently and in the safe-looking direction. Checked in both directions against the workflow.

## Class sweep

`grep -l report-interlock-coverage .github/workflows/*.yml` → `build-wide`, `queue`, `nightly`, `run-matrix`. The first two are build-depth lanes with no cells, so "did it reach the cells" has no referent; `nightly`'s cells are already covered by `just nightly-triage`. `run-matrix` was the one lane with cells and no per-stage report. `report-interlock-coverage.sh` takes the stage as an OPTIONAL 4th argument, so the other three callers are unchanged (verified).

## What stays open on 1158

The issue is NOT resolved and its status stays `open`. Its substance is the missing verdict, and this delivers none:

1. **A verdict, once** — needs the shared self-hosted runner and hours of fixture build. Until it happens, issue 0968's ~12 tier-2 runtime failures stay unreproduced.
2. **Contention** — one runner serves both this lane and the merge queue's `gate` jobs. Choosing between giving the lane its own runner, rescheduling it, or documenting that it yields is an infrastructure decision with a cost the maintainer owns.

## Local checks

`just check lane-stage-reporting`, `check-gate-lists`, `check-interlock-visibility`, `check-workflow-doctor-after-setup`, `check-ci-no-verb-fallback`, `check-workflow-repo-env`, `check-workflow-setup-spelling`, `check-workflow-runner-isolation`, `check-ci-doc-workflow-refs`, `check-gate-selftests` — all green.

`just check fast` reports 8 failures in this worktree, all pre-existing and none naming a file this PR touches: `capability-conditionals` (says so itself — the zenoh-pico submodule is not initialised here), `cbindgen-headers`/`abi-bindings`/`cli-source-dirs`/`codegen-size-bound-golden`/`codegen-version-refusal`/`subtree-guard`/`leaf-lockfiles` (unprovisioned sources, no `nros sync`), and `doc-commit-citations` (a stale baseline entry for `d1d88f660`, cited by issue 1127, untouched here). The push used the documented `NROS_SKIP_PREPUSH_CHECKS=1` bypass for that reason.

No fixture build, no workflow dispatch, no `just ci` was run — the host is memory-constrained and the issue's scope forbids them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
