### PR TITLE
feat(#1197): publish the backing size for probing — and why the board still cannot use it

### DIFF
--- a/docs/issues/1197-freertos-heap-cannot-learn-the-backing-size.md
+++ b/docs/issues/1197-freertos-heap-cannot-learn-the-backing-size.md
@@ -99,6 +99,75 @@ nothing would catch until an image malloc-fails at runtime — and issue 1146
 measured exactly that failure mode, finding it reports `*** MALLOC FAILED ***`
 rather than `*** STACK OVERFLOW ***`, because heap_4 hands out the task stacks.
 
+## ATTEMPTED 2026-09-07 — the board cannot be the consumer, and here is why
+
+The mechanism was built and the arithmetic validated. The board still cannot
+use it, for a reason that is structural rather than plumbing.
+
+### What works
+
+`nros-node` can publish the number as a symbol whose STORAGE SIZE is the value
+(`__NROS_LU_SZ_executor_backing`, behind `layout-size-markers`, off by default),
+and `nros-sizes-build::extract_sizes` reads exactly that shape. Verified: the
+symbol appears in `libnros_node.rlib` for `thumbv7m-none-eabi`.
+
+The arithmetic is validated independently. Probing the fifteen per-region
+`(size, align)` pairs out of the same rlib and running
+`nros-executor-layout`'s placement over them reproduces **all four** measured
+images to the byte:
+
+| image | cbs | arena | computed | linked |
+| --- | ---: | ---: | ---: | ---: |
+| `talker` | 1 | 8,192 | 20,608 | 20,608 |
+| `service-client` | 2 | 9,216 | 21,832 | 21,832 |
+| `action-server` | 1 | 20,096 | 32,512 | 32,512 |
+| defaults | 4 | 74,240 | 87,256 | 87,256 |
+
+`alloc` is discriminating: with it off every row is 96 bytes low (8 sc x 12), so
+the flag is doing real work rather than being decorative.
+
+### Why the board still cannot consume it
+
+**1. `nros-board-freertos` is in the root workspace's `exclude`, not its
+`members`.** It is a cross-only crate and its own workspace root
+(`cargo metadata` reports `workspace_root` = the board directory, 1 member). A
+nested `cargo build -p nros-node` from its build script therefore fails with
+`cannot specify features for packages outside of workspace`. It can be forced
+with `--manifest-path <repo>/Cargo.toml`, and that does build.
+
+**2. But the answer then depends on inputs the board cannot know.** Three probe
+invocations against a leaf whose linked backing is **21,832** returned:
+
+```
+--features rmw-cffi,alloc, two env vars forwarded   ->  39,416
+--features rmw-cffi,alloc, six env vars forwarded   ->  87,256   (the defaults)
+```
+
+The number is a function of the executor env AND the feature set the LEAF
+resolved for `nros-node`. The board is not on the leaf's dependency path to
+`nros-node` — it does not depend on it at all — so it can neither be told nor
+discover either one. Guessing `rmw-cffi,alloc` is the issue-0665 hazard at full
+strength, and 0665 was 16 bytes; this is tens of kilobytes.
+
+**3. The probe cache cannot save it either.** `probe_key` hashes (target,
+features). The backing varies by env, so two leaves with identical features and
+different `NROS_EXECUTOR_MAX_CBS` collide on one cache entry.
+
+### What this rules out, and what it points at
+
+The consumer of this number **must be inside `nros-node`'s dependency graph**,
+where the features and env are the ones that will actually link. The board is
+structurally the wrong place, and no amount of wiring changes that.
+
+That points at the entry, or at a crate the leaf already pulls in through
+`nros-node`, publishing the heap requirement — rather than the board deriving
+it. Whether `configTOTAL_HEAP_SIZE` can be set from there at all is the open
+question, because it is baked into the board's C at the board's build time.
+
+Which is the argument for the measurement route this issue already recommends:
+`xPortGetMinimumEverFreeHeapSize()` answers "how much heap does this image
+need" from inside the image, where every input is the real one.
+
 ## Recommended order
 
 1. Land issue 1146 (the stack default).

--- a/packages/core/nros-node/Cargo.toml
+++ b/packages/core/nros-node/Cargo.toml
@@ -17,6 +17,15 @@ categories = ["embedded", "no-std"]
 [features]
 # phase-361 W3 / issue 0591 — EMPTY; `std` is opt-in per dep-site.
 default = []
+
+# issue 1197 — emit the executor backing's per-type (size, align) as symbols a
+# build script can read out of the rlib, the way `nros-c` recovers
+# `EXECUTOR_OPAQUE_U64S` through `nros-sizes-build`.
+#
+# OFF by default and `#[used]`, so a shipped image never carries them: these are
+# ~30 statics that exist only to be measured. The probe turns the feature on for
+# its own nested build, which is a separate compilation from the linked one.
+layout-size-markers = []
 # phase-361 W2 (final) — `portable-atomic-util` is an IMPLEMENTATION dep (the
 # no_std stand-in for `std::sync::Arc`), not the heap axis, so it rides `alloc`
 # and `std` reaches it by implying `alloc`. It is declared once, on the feature

--- a/packages/core/nros-node/src/executor/backing.rs
+++ b/packages/core/nros-node/src/executor/backing.rs
@@ -124,7 +124,7 @@ use super::storage::ExecutorSizing;
 /// judged against, and a constant that disappears with its consumer cannot be
 /// compared to anything.
 #[allow(dead_code)]
-pub(crate) const EXECUTOR_BACKING_DEFAULT_U64S: usize = ExecutorSizing::DEFAULT.u64_len();
+pub const EXECUTOR_BACKING_DEFAULT_U64S: usize = ExecutorSizing::DEFAULT.u64_len();
 
 // `EXECUTOR_BACKING`, its size const, and the optional
 // `#[unsafe(link_section = …)]` on it are emitted by `build.rs`: `link_section`

--- a/packages/core/nros-node/src/executor/storage.rs
+++ b/packages/core/nros-node/src/executor/storage.rs
@@ -285,6 +285,34 @@ pub const NATIVE_UNITS: RegionUnits = RegionUnits {
     violation: unit_of::<Violation>(),
 };
 
+/// issue 1197 — publish the backing's TOTAL size as a symbol whose storage size
+/// IS the number, so a build script can recover it from the rlib without running
+/// anything. `nros-sizes-build::extract_sizes` reads exactly this shape, the way
+/// `nros-c` recovers `EXECUTOR_OPAQUE_U64S`.
+///
+/// **The total rather than the per-region units, and that is a decision.** The
+/// units alone would be more robust — they do not vary with the executor knobs,
+/// so a probe cache keyed by (target, features) is correct for them, and the
+/// caller supplies `alloc` and the counts explicitly. But the backing is
+/// `arena + tables`, and `ARENA_SIZE` is DERIVED in this crate's build script
+/// from `MAX_CBS`, `RX_BUF_SIZE` and `ACTION_CLIENTS`. A consumer computing from
+/// units would have to re-implement that derivation — a second implementation,
+/// which is the whole thing this design refuses. So the consumer probes the one
+/// number, and keys its probe directory by the executor env, because unlike the
+/// units this DOES vary with it.
+///
+/// Behind a feature and OFF by default: it is `#[used]`, and a shipped image
+/// should not carry a static that exists only to be measured. The probe enables
+/// it for its own nested build, which is a separate compilation from the linked
+/// one.
+#[cfg(feature = "layout-size-markers")]
+#[used]
+#[unsafe(no_mangle)]
+#[doc(hidden)]
+pub static __NROS_LU_SZ_executor_backing: [u8;
+    crate::executor::backing::EXECUTOR_BACKING_DEFAULT_U64S * 8] =
+    [0u8; crate::executor::backing::EXECUTOR_BACKING_DEFAULT_U64S * 8];
+
 const fn unit_of<T>() -> RegionUnit {
     RegionUnit {
         size: size_of::<T>(),


### PR DESCRIPTION
**Stacked on #708.** The probe half, built and validated. **The heap subtraction is not here**, because attempting it found a structural reason the board cannot be its consumer.

## What lands

`nros-node` publishes the backing as a symbol whose **storage size is the value** — `__NROS_LU_SZ_executor_backing`, behind `layout-size-markers`, **off by default** because it's `#[used]` and a shipped image shouldn't carry a static that exists only to be measured. `nros-sizes-build::extract_sizes` reads exactly that shape, the way `nros-c` recovers `EXECUTOR_OPAQUE_U64S`. Verified present in `libnros_node.rlib` for `thumbv7m-none-eabi`.

The **total** rather than per-region units, and that's a decision: units would be more robust (they don't vary with the executor knobs, so a cache keyed by target+features is correct for them) — but the backing is `arena + tables`, and `ARENA_SIZE` is derived in `nros-node`'s build script from `MAX_CBS`/`RX_BUF_SIZE`/`ACTION_CLIENTS`. A consumer computing from units would re-implement that derivation, which is what this design refuses.

## The arithmetic is validated regardless

Probing the fifteen per-region `(size, align)` pairs out of the rlib and running `nros-executor-layout` over them reproduces **all four** measured images to the byte:

| image | cbs | arena | computed | linked |
| --- | ---: | ---: | ---: | ---: |
| `talker` | 1 | 8,192 | 20,608 | 20,608 |
| `service-client` | 2 | 9,216 | 21,832 | 21,832 |
| `action-server` | 1 | 20,096 | 32,512 | 32,512 |
| defaults | 4 | 74,240 | 87,256 | 87,256 |

`alloc` is discriminating — every row is 96 B low with it off (8 sc × 12). So #708's model is measured, not asserted.

## Why the heap subtraction is not here

**1. `nros-board-freertos` is in the root workspace's `exclude`, not `members`.** It's cross-only and its own workspace root — `cargo metadata` reports `workspace_root` = the board dir, 1 member. A nested `cargo build -p nros-node` from its build script fails with `cannot specify features for packages outside of workspace`. It can be forced with `--manifest-path`, and that does build.

**2. But the answer then depends on inputs the board cannot know.** Against a leaf whose linked backing is **21,832**, three probe invocations returned **39,416** and **87,256** (the defaults) as the forwarded env and features varied. The number is a function of the executor env *and* the feature set the **leaf** resolved for `nros-node` — and the board isn't on the leaf's dependency path to `nros-node`; it doesn't depend on it at all. Guessing is #0665's hazard at full strength, and 0665 was 16 bytes. This is tens of kilobytes.

**3. The probe cache can't rescue it.** `probe_key` hashes (target, features); the backing varies by env, so two leaves with identical features and different `NROS_EXECUTOR_MAX_CBS` collide on one entry.

## What this rules out

The consumer **must be inside `nros-node`'s dependency graph**, where the features and env are the ones that will actually link. The board is structurally the wrong place and no wiring changes that.

That strengthens the measurement route #1197 already recommends: `xPortGetMinimumEverFreeHeapSize()` answers *"how much heap does this image need"* from inside the image, where every input is the real one — and it absorbs #1146's 256 KiB/task stack reduction in the same number.

I'd rather ship the validated mechanism plus the reason than a subtraction I can't show is correct on a real image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5