### PR TITLE
fix(check): api-parity is a gate, so it runs on the fast line

### DIFF
--- a/.config/gate-lane-exempt.txt
+++ b/.config/gate-lane-exempt.txt
@@ -37,7 +37,6 @@
 
 _gate-list-end  # the `build-serial:` terminator, a no-op, not a gate
 action-client-arena-budget  # reads BUILT IMAGES; `build-test-fixtures` runs it (phase-413 W7, issue 1001)
-api-parity  # a REPORT, not a gate; `just ci gate` and gate.yml run it by name
 archive-lang-items  # in no lane and no caller found — issue 1071's class
 book-identifiers  # in no lane and no caller found — issue 1071's class
 build  # lane verb: fans `build-serial` out through run-gates-parallel.sh

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -19,10 +19,25 @@
 # not correspond to rclc/rclcpp/rclrs carries a written verdict. 2158 rows across
 # 17 topic shards under docs/reference/api-parity-ledger/.
 #
-# NOT buildless, which is why it is here and not on the fast lane: it re-extracts
-# OUR surface every run (clang for C/C++, nightly rustdoc for Rust) so an edit
-# that moves us away from ROS 2 fails the gate instead of aging the ledger. The
-# ROS 2 side is the recorded surface and needs no ROS install.
+# It re-extracts OUR surface every run (clang for C/C++, nightly rustdoc for
+# Rust) so an edit that moves us away from ROS 2 fails the gate instead of
+# aging the ledger. The ROS 2 side is the recorded surface and needs no ROS
+# install.
+#
+# ON THE FAST LANE since this commit, and the reason it was not is worth
+# keeping. `.config/gate-lane-exempt.txt` excused it as "a REPORT, not a gate",
+# which stopped being true: the recipe runs `--check`, which EXITS NON-ZERO on
+# an unledgered row. It is a gate, and one that only `just ci gate` ran — so a
+# report that had been wrong about 43 C symbols (issue 1188: our `rcl_*` /
+# `rclc_*` exports were invisible to the correlator, and read as gaps we did
+# not have) sat unnoticed until someone ran the full tier.
+#
+# Affordable, measured warm on this host: c 0.3 s, cpp 13.9 s, rust 11.2 s.
+# It resolves NO build artifact — the C side is `-I` over source headers, and
+# the Rust side points `CARGO_TARGET_DIR` at a fresh temp dir, so it is
+# hermetic and its cost does not depend on what the tree has already built.
+# That is what makes it lane-legal: `check-lane-contracts` bans a gate that
+# RESOLVES an artifact its lane did not produce, and this produces its own.
 #
 # A new divergence fails this with the row's key and the bucket it landed in.
 # Add a row to the matching topic shard; `--topic <name>` shows the stage.


### PR DESCRIPTION
`.config/gate-lane-exempt.txt` excused it as *"a REPORT, not a gate; `just ci gate` and gate.yml run it by name"*. **That stopped being true**: the recipe runs `--check`, which exits non-zero on an unledgered row. It is a gate — and the only lane that ran it was `just ci gate`, which nothing on the push path or the required PR context invokes.

## What that cost

The report had been **wrong about 43 C symbols**. Our `rcl_*` / `rclc_*` exports — 39 and 8 of them, declared `NROS_PUBLIC` by phase-417's "the ROS 2 spellings are ours" — were invisible to the correlator on *our* side, so every one read as a theirs-only GAP. The report claimed the API lacked functions it exports. Issue 1188 fixed the correlator; the reason nobody noticed for as long as they did is that seeing it required running the full tier by hand.

## The change

The exemption file is a ratchet that "should SHRINK", and its polarity is already inverted — a recipe is a fast-lane gate **by default**. So this is one deleted line, plus the recipe comment that contradicted it (`"NOT buildless, which is why it is here and not on the fast lane"`).

## Cost, measured warm, both runs back to back

| | |
|---|---|
| fast line without api-parity | **16.1 s** |
| fast line with it | **28.1 s** |
| api-parity itself | **28.0 s — 13.7% of the lane** |

It becomes the lane's single biggest gate, and the pre-push hook gets **~75% slower in wall-clock**, 16 s → 28 s. Stating that rather than burying it: that is the trade. 28 s before a push is still an order of magnitude under `just ci gate`'s 230 s, and the gate has to run somewhere a person sees it — today it does not. If it proves too much in practice, the fallback is the required PR context rather than the hook.

## Lane-legal, which is not automatic for a gate that compiles

It resolves **no artifact its lane did not build**. The C side is `-I` over source headers; the Rust side points `CARGO_TARGET_DIR` at a fresh temp dir, so it builds its own and its cost does not depend on what the tree has already built. `check-lane-contracts` and `check-gate-lists` both green (266 fast gates derived, 33 exempt with a reason).

## Note on the lane's current state

The run above shows `2 of 266 gate(s) FAILED` — `doc-commit-citations` and `leaf-lockfiles`. **Both are red on pristine `origin/main`** with this branch stashed; neither is touched here. api-parity itself passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)