### PR TITLE
phase-426 W5: the C parameter surface can name a node, by a new name

### DIFF
--- a/docs/reference/api-parity-ledger/param.json
+++ b/docs/reference/api-parity-ledger/param.json
@@ -62,20 +62,47 @@
     "verdict": "gap",
     "why": "the `void* context` form -- and the row that matters, because BOTH rclc forms take the on-modification callback and ours takes none. So a `ros2 param set` reaching the executor-owned store notifies nobody: the C callback that does exist, `nros_parameter_server_set_callback`, is on the legacy standalone `nros_parameter_server_t`, which is not the object the services write to. Note which of our TWO C parameter stores this is. `nros_parameter_server_t` (`nros/parameter.h`) is a standalone store over caller-supplied storage and is purely node-local -- `parameter.rs` calls it \"the legacy `nros_parameter_server_t` API\" in its own comment. The store the six `rcl_interfaces/srv/*` servers read is a DIFFERENT object, the `nros_params::ParameterServer` the executor owns, reached only through `nros_executor_*_param_*`. Nothing joins them. NOTE FOR RFC-0036: line 91 says \"No parameter callbacks; parameters are read/write only\", and that is now wrong in both directions -- C ships an accept/reject set-callback on one store, and has none on the store `ros2 param` talks to. Phase 379 W3."
   },
+  "c:executor_allow_undeclared_parameters": {
+    "verdict": "divergence",
+    "why": "the C spelling of `rust:Executor::allow_undeclared_parameters`, and it exists for the same reason the Rust one does: upstream's `allow_undeclared_parameters` is a NODE OPTION given at construction (rclcpp `NodeOptions`, rclrs `allow_undeclared`), and there is no `NodeOptions` object here to carry it -- a node is a row in the executor's fixed table, so the option is a call on the executor. The SEMANTICS are upstream's: per node, off by default (issue 1151). phase-426 W5 added it because C could not reach the policy AT ALL: `nros_executor_set_param_*` on an undeclared name was a permanent `NROS_RET_NOT_FOUND` with no opt-in, so a rule that Rust and a remote `ros2 param set` both honour was unreachable from the C API that shares the store. What a user loses: it cannot be given at node-construction time, so it must be set before `nros_executor_register_parameter_services` starts answering."
+  },
+  "c:executor_allow_undeclared_parameters_on": {
+    "verdict": "divergence",
+    "why": "the node-naming half of `c:executor_allow_undeclared_parameters`; see `c:executor_declare_param_*_on` for why the node is an argument here and a receiver upstream."
+  },
   "c:executor_declare_param_*": {
     "verdict": "divergence",
     "bucket": "ours-only",
-    "why": "the service-backed parameter API: it operates on the `nros_params::ParameterServer` the EXECUTOR owns, which is the store `nros_executor_register_parameter_services` exposes to `ros2 param`. rclc has no equivalent spelling because rclc hands the executor a caller-owned server instead (`c:executor_add_parameter_server`); with static entity storage and no allocator there is one server and the executor holds it, so the executor is the handle. Gated on the `param-services` Cargo feature, which needs `alloc`. SCALARS ONLY -- bool/integer/double/string -- where the local `c:parameter_declare_*` family covers all ten `rcl_interfaces` types, so no C caller can publish an array parameter to `ros2 param`. Phase 379 W3."
+    "why": "the service-backed parameter API: it operates on the `nros_params::ParameterServer` the EXECUTOR owns, which is the store `nros_executor_register_parameter_services` exposes to `ros2 param`. rclc has no equivalent spelling because rclc hands the executor a caller-owned server instead (`c:executor_add_parameter_server`); with static entity storage and no allocator there is one server and the executor holds it, so the executor is the handle. Gated on the `param-services` Cargo feature, which needs `alloc`. SCALARS ONLY -- bool/integer/double/string -- where the local `c:parameter_declare_*` family covers all ten `rcl_interfaces` types, so no C caller can publish an array parameter to `ros2 param`. This spelling means the executor's PRIMARY node; `c:executor_declare_param_*_on` names another. Phase 379 W3; phase-426 W1/W5."
+  },
+  "c:executor_declare_param_*_on": {
+    "verdict": "divergence",
+    "bucket": "ours-only",
+    "why": "phase-426 W5 -- the node-naming half of `c:executor_declare_param_*`, and the C mirror of `rust:Executor::declare_parameter_on`. The parameter STORE is one fixed table owned by the EXECUTOR, not a container per node: there is no allocator to make a second, so a node cannot own its own. Upstream keys parameters by making the node the RECEIVER (`rclcpp::Node::declare_parameter`, rclc's `rclc_parameter_server_t` bound to a node); ours are on the executor and the node is an ARGUMENT, because an image composes several nodes onto one executor (RFC-0047) and the shared table has to be told whose parameter it is. The `_on` suffix is the same disambiguation the entity builders already use (`node_mut(id)` / `_on(...)`, phase 104.C) and the same pair Rust ships, so C and Rust name one relationship one way. It is a NEW NAME rather than a widened signature deliberately: RFC-0089 permits a signature change only where the compiler forces the edit, and the existing spellings are not wrong -- they mean the primary node and will go on meaning it -- so re-signing them would cost every C caller an edit that buys nothing. What a user loses: a ported node writes `nros_executor_declare_param_integer_on(&exec, &node, name, value)` where rclcpp writes `node->declare_parameter(name, value)`. Takes the `nros_node_t` rather than its slot index, so a node that is uninitialised or bound to another executor is refused instead of silently meaning slot 0."
   },
   "c:executor_get_param_*": {
     "verdict": "divergence",
     "bucket": "ours-only",
     "why": "the read half; see `c:executor_declare_param_*`."
   },
+  "c:executor_get_param_*_on": {
+    "verdict": "divergence",
+    "bucket": "ours-only",
+    "why": "the read half of the per-node family; see `c:executor_declare_param_*_on`."
+  },
+  "c:executor_has_param_on": {
+    "verdict": "divergence",
+    "why": "the existence predicate of the per-node family; see `c:executor_declare_param_*_on`. Upstream's correspondent is `rclcpp::Node::has_parameter`, whose receiver IS the node. A node this executor does not own answers `false`, never the primary node's answer -- defaulting the node is how a sibling's parameter reads as this one's."
+  },
   "c:executor_set_param_*": {
     "verdict": "divergence",
     "bucket": "ours-only",
     "why": "the write half; see `c:executor_declare_param_*`."
+  },
+  "c:executor_set_param_*_on": {
+    "verdict": "divergence",
+    "bucket": "ours-only",
+    "why": "the write half of the per-node family; see `c:executor_declare_param_*_on`. Routes through `Executor::set_parameter_on`, hence `ParameterServer::apply`, so a C set gets exactly the read-only / type / range / undeclared rules a remote `ros2 param set` gets (phase-426 W2)."
   },
   "c:int64_array_t": {
     "verdict": "declined",

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -365,6 +365,57 @@ c: c-fmt
     cc -fsyntax-only \
         -Ipackages/core/nros-rmw-abi/include \
         packages/rmw/cffi/tests/c_stubs/abi_layout_check.c
+    echo "  - parameters are keyed by NODE from C (phase-426 W5)"
+    # COMPILE+LINK+RUN, and it has to be: the defect is not in the
+    # declarations. A `_on` family that resolved every node to slot 0 would
+    # compile, link, and pass `param_entry_points.c` above, while a two-node C
+    # image silently shared one parameter table -- which is what the C surface
+    # did before W5, because it had no way to name a node at all.
+    #
+    # It needs a SECOND feature shape: `C_API_SHIPPED_FEATURES` does not carry
+    # `param-services`, so the archive every step above links has none of these
+    # symbols at all.
+    #
+    # That second shape gets its OWN target dir, and the reason is the
+    # config-variant guard, not tidiness. `nros_config_generated.h` is mirrored
+    # to `$CARGO_TARGET_DIR/nros-c-generated/` as a build-script SIDE EFFECT, so
+    # it carries whichever feature shape last RAN a build script -- and cargo
+    # caches both shapes' fingerprints, so switching back to one it has already
+    # built re-runs nothing and rewrites nothing. Sharing one target dir
+    # therefore links a header sized for the shipped shape against an archive
+    # built for this one: `undefined reference to nros_config_variant_sz_<hash>`
+    # when the guard fires, and a wrong `nros_executor_t` if it ever did not.
+    # A separate dir makes header and archive one build, permanently.
+    #
+    # `CARGO_TARGET_DIR`, not `--target-dir`: the mirror resolves its root from
+    # that variable FIRST and only falls back to walking up from `OUT_DIR`, and
+    # that walk reads a directory name containing a `-` as a target TRIPLE
+    # (`nros-c-param-services` looks exactly like one). With the flag alone the
+    # header landed back in the shared `target/`, clobbering the shipped one --
+    # measured, not reasoned.
+    #
+    # No router and no network: the TU registers a STUB RMW backend, because
+    # nothing on the parameter path touches the wire. `test -f` first -- a
+    # missing TU must not read as a pass (issue 0196's class).
+    test -f packages/api/nros-c/tests/run/executor_param_node_keying.c || { \
+        echo "ERROR: executor_param_node_keying.c is MISSING -- this check passes on absence." >&2; \
+        exit 1; }
+    # profile-literal-ok: unprofiled: a plain `cargo build`, so `<dir>/debug/` IS
+    # its derived output dir, and the mirrored header beside it is from this
+    # same build.
+    param_dir="$PWD/target/nros-c-param-services"
+    CARGO_TARGET_DIR="$param_dir" cargo build -p nros-c --no-default-features \
+        --features "{{C_API_SHIPPED_FEATURES}},param-services" --quiet
+    mkdir -p tmp
+    cc -std=c11 -Wall -Wextra \
+        -I"$param_dir/nros-c-generated" \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/core/nros-rmw-abi/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-c/tests/run/executor_param_node_keying.c \
+        "$param_dir/debug/libnros_c.a" -lpthread -ldl -lm \
+        -o tmp/executor_param_node_keying
+    ./tmp/executor_param_node_keying
     echo "All C checks passed!"
 
 # issue 0379 — clippy gate for the CLI sub-workspace. No lane ran clippy on

--- a/packages/api/nros-c/include/nros/nros_generated.h
+++ b/packages/api/nros-c/include/nros/nros_generated.h
@@ -431,6 +431,24 @@ typedef enum nros_support_state_t {
 } nros_support_state_t;
 
 /**
+ * Node state
+ */
+typedef enum nros_node_state_t {
+  /**
+   * Not initialized
+   */
+  NROS_NODE_STATE_UNINITIALIZED = 0,
+  /**
+   * Initialized and ready
+   */
+  NROS_NODE_STATE_INITIALIZED = 1,
+  /**
+   * Shutdown
+   */
+  NROS_NODE_STATE_SHUTDOWN = 2,
+} nros_node_state_t;
+
+/**
  * Action client state.
  */
 typedef enum nros_action_client_state_t {
@@ -491,24 +509,6 @@ typedef enum nros_goal_status_t {
    */
   NROS_GOAL_STATUS_ABORTED = 6,
 } nros_goal_status_t;
-
-/**
- * Node state
- */
-typedef enum nros_node_state_t {
-  /**
-   * Not initialized
-   */
-  NROS_NODE_STATE_UNINITIALIZED = 0,
-  /**
-   * Initialized and ready
-   */
-  NROS_NODE_STATE_INITIALIZED = 1,
-  /**
-   * Shutdown
-   */
-  NROS_NODE_STATE_SHUTDOWN = 2,
-} nros_node_state_t;
 
 /**
  * Action server state.
@@ -1159,6 +1159,130 @@ typedef struct nros_executor_t {
 } nros_executor_t;
 
 /**
+ * Phase 211.H (issue #52) — one per-topic QoS override, the C-ABI mirror of
+ * Rust's `nros_rmw::QoSOverride`. The deploy plan lowers a
+ * `qos_overrides.<topic>.<role>.<policy>` launch param into a `&'static`
+ * array of these, which the entry installs on the node via
+ * [`nros_node_set_qos_overrides`](crate::node::nros_node_set_qos_overrides);
+ * the node folds the matching entries into each entity's QoS at
+ * `create_publisher` / `create_subscription` time (setup-time, before the
+ * backend-compat check — no silent downgrade).
+ *
+ * Plain scalar fields only (no `#[repr(C)]` enums) so the C++/cbindgen header
+ * is trivially stable and there is no short-enum ABI mirror to keep in sync.
+ */
+typedef struct nros_qos_override_t {
+  /**
+   * Resolved (remapped) topic the override targets, NUL-terminated UTF-8
+   * (e.g. `"/chatter"`). Matched exactly against the entity's topic.
+   */
+  const char *topic;
+  /**
+   * `0` = publisher, `1` = subscription. Other values never match.
+   */
+  uint8_t role;
+  /**
+   * `0` = reliability, `1` = durability, `2` = history, `3` = depth,
+   * `4` = deadline, `5` = lifespan, `6` = liveliness,
+   * `7` = liveliness_lease_duration. Append-only — these numbers are baked
+   * into shipped images; `nros_rmw::qos_override_policy` is the SSoT.
+   */
+  uint8_t policy;
+  /**
+   * Policy-specific value: reliability `0`=best_effort/`1`=reliable;
+   * durability `0`=volatile/`1`=transient_local; history
+   * `0`=keep_last/`1`=keep_all; depth = the KeepLast depth; deadline /
+   * lifespan / liveliness_lease_duration = milliseconds; liveliness =
+   * the `QoSLivelinessPolicy` discriminant
+   * (`0`=none/`1`=automatic/`2`=manual_by_topic/`3`=manual_by_node).
+   */
+  uint32_t value;
+} nros_qos_override_t;
+
+/**
+ * Node structure.
+ *
+ * Represents a ROS 2 node with a name and namespace.
+ */
+typedef struct nros_node_t {
+  /**
+   * Current state
+   */
+  enum nros_node_state_t state;
+  /**
+   * Node name storage
+   */
+  uint8_t name[NROS_MAX_NAME_LEN];
+  /**
+   * Node name length
+   */
+  size_t name_len;
+  /**
+   * Namespace storage
+   */
+  uint8_t namespace_[NROS_MAX_NAMESPACE_LEN];
+  /**
+   * Namespace length
+   */
+  size_t namespace_len;
+  /**
+   * Pointer to parent support context
+   */
+  const struct nros_support_t *support;
+  /**
+   * RMW backend name (UTF-8, NUL-terminated within `rmw_name_len`).
+   * Empty (`rmw_name_len == 0`) selects the first-registered backend.
+   */
+  uint8_t rmw_name[MAX_RMW_NAME_LEN];
+  /**
+   * Length of `rmw_name` in bytes (excluding NUL). 0 = inherit.
+   */
+  size_t rmw_name_len;
+  /**
+   * Per-Node domain ID. `NROS_DOMAIN_ID_INHERIT` (== u32::MAX) means
+   * "use the support context's domain_id".
+   */
+  uint32_t domain_id_override;
+  /**
+   * SchedContext slot to inherit on every handle created by this Node
+   * (Phase 104.C.4). 0 = inherit the executor's default Fifo context.
+   */
+  uint8_t sched_context_id;
+  /**
+   * Reserved for future use (alignment + ABI stability).
+   */
+  uint8_t _reserved[3];
+  /**
+   * Opaque NodeId slot returned by `Executor::node_builder(...).build()`
+   * when this Node is bound to an Executor. 0 = primary Node (legacy
+   * single-Node path). Internal use only — readers should treat as
+   * opaque.
+   */
+  uint8_t node_id;
+  /**
+   * Phase 156 / 104.C.8.b — executor pointer for the multi-Session
+   * dispatch path. `nros_executor_node_init` populates this when
+   * the Node is bound; per-entity `nros_*_init` paths
+   * (`rclc_publisher_init_default`, `nros_subscription_init`, etc.) branch
+   * on `node_id != 0 && !executor.is_null()` to route through
+   * `Executor::node_session_mut(NodeId)` instead of the legacy
+   * support-based dispatch. NULL = legacy single-Node path
+   * (`rclc_node_init_default` / `nros_node_init_ex`).
+   */
+  const struct nros_executor_t *executor;
+  /**
+   * Pointer to a `&'static`-lifetime array of [`nros_qos_override_t`], or
+   * null. The caller (a generated entry / a hand-written app) owns the
+   * storage for the node's lifetime.
+   */
+  const struct nros_qos_override_t *qos_overrides;
+  /**
+   * Number of entries in `qos_overrides`. 0 = none.
+   */
+  size_t qos_overrides_len;
+} nros_node_t;
+
+/**
  * Phase 115.C — C-side mirror of
  * `nros_rmw::custom_transport::NrosTransportOps`. Same `#[repr(C)]`
  * layout — single ABI, no parallel definitions.
@@ -1360,130 +1484,6 @@ typedef struct nros_action_client_t {
    */
   uint64_t _opaque[ACTION_CLIENT_OPAQUE_U64S];
 } nros_action_client_t;
-
-/**
- * Phase 211.H (issue #52) — one per-topic QoS override, the C-ABI mirror of
- * Rust's `nros_rmw::QoSOverride`. The deploy plan lowers a
- * `qos_overrides.<topic>.<role>.<policy>` launch param into a `&'static`
- * array of these, which the entry installs on the node via
- * [`nros_node_set_qos_overrides`](crate::node::nros_node_set_qos_overrides);
- * the node folds the matching entries into each entity's QoS at
- * `create_publisher` / `create_subscription` time (setup-time, before the
- * backend-compat check — no silent downgrade).
- *
- * Plain scalar fields only (no `#[repr(C)]` enums) so the C++/cbindgen header
- * is trivially stable and there is no short-enum ABI mirror to keep in sync.
- */
-typedef struct nros_qos_override_t {
-  /**
-   * Resolved (remapped) topic the override targets, NUL-terminated UTF-8
-   * (e.g. `"/chatter"`). Matched exactly against the entity's topic.
-   */
-  const char *topic;
-  /**
-   * `0` = publisher, `1` = subscription. Other values never match.
-   */
-  uint8_t role;
-  /**
-   * `0` = reliability, `1` = durability, `2` = history, `3` = depth,
-   * `4` = deadline, `5` = lifespan, `6` = liveliness,
-   * `7` = liveliness_lease_duration. Append-only — these numbers are baked
-   * into shipped images; `nros_rmw::qos_override_policy` is the SSoT.
-   */
-  uint8_t policy;
-  /**
-   * Policy-specific value: reliability `0`=best_effort/`1`=reliable;
-   * durability `0`=volatile/`1`=transient_local; history
-   * `0`=keep_last/`1`=keep_all; depth = the KeepLast depth; deadline /
-   * lifespan / liveliness_lease_duration = milliseconds; liveliness =
-   * the `QoSLivelinessPolicy` discriminant
-   * (`0`=none/`1`=automatic/`2`=manual_by_topic/`3`=manual_by_node).
-   */
-  uint32_t value;
-} nros_qos_override_t;
-
-/**
- * Node structure.
- *
- * Represents a ROS 2 node with a name and namespace.
- */
-typedef struct nros_node_t {
-  /**
-   * Current state
-   */
-  enum nros_node_state_t state;
-  /**
-   * Node name storage
-   */
-  uint8_t name[NROS_MAX_NAME_LEN];
-  /**
-   * Node name length
-   */
-  size_t name_len;
-  /**
-   * Namespace storage
-   */
-  uint8_t namespace_[NROS_MAX_NAMESPACE_LEN];
-  /**
-   * Namespace length
-   */
-  size_t namespace_len;
-  /**
-   * Pointer to parent support context
-   */
-  const struct nros_support_t *support;
-  /**
-   * RMW backend name (UTF-8, NUL-terminated within `rmw_name_len`).
-   * Empty (`rmw_name_len == 0`) selects the first-registered backend.
-   */
-  uint8_t rmw_name[MAX_RMW_NAME_LEN];
-  /**
-   * Length of `rmw_name` in bytes (excluding NUL). 0 = inherit.
-   */
-  size_t rmw_name_len;
-  /**
-   * Per-Node domain ID. `NROS_DOMAIN_ID_INHERIT` (== u32::MAX) means
-   * "use the support context's domain_id".
-   */
-  uint32_t domain_id_override;
-  /**
-   * SchedContext slot to inherit on every handle created by this Node
-   * (Phase 104.C.4). 0 = inherit the executor's default Fifo context.
-   */
-  uint8_t sched_context_id;
-  /**
-   * Reserved for future use (alignment + ABI stability).
-   */
-  uint8_t _reserved[3];
-  /**
-   * Opaque NodeId slot returned by `Executor::node_builder(...).build()`
-   * when this Node is bound to an Executor. 0 = primary Node (legacy
-   * single-Node path). Internal use only — readers should treat as
-   * opaque.
-   */
-  uint8_t node_id;
-  /**
-   * Phase 156 / 104.C.8.b — executor pointer for the multi-Session
-   * dispatch path. `nros_executor_node_init` populates this when
-   * the Node is bound; per-entity `nros_*_init` paths
-   * (`rclc_publisher_init_default`, `nros_subscription_init`, etc.) branch
-   * on `node_id != 0 && !executor.is_null()` to route through
-   * `Executor::node_session_mut(NodeId)` instead of the legacy
-   * support-based dispatch. NULL = legacy single-Node path
-   * (`rclc_node_init_default` / `nros_node_init_ex`).
-   */
-  const struct nros_executor_t *executor;
-  /**
-   * Pointer to a `&'static`-lifetime array of [`nros_qos_override_t`], or
-   * null. The caller (a generated entry / a hand-written app) owns the
-   * storage for the node's lifetime.
-   */
-  const struct nros_qos_override_t *qos_overrides;
-  /**
-   * Number of entries in `qos_overrides`. 0 = none.
-   */
-  size_t qos_overrides_len;
-} nros_node_t;
 
 /**
  * Action type information.
@@ -3452,7 +3452,7 @@ NROS_PUBLIC nros_ret_t nros_parameter_server_fini(struct nros_parameter_server_t
 NROS_PUBLIC nros_ret_t nros_executor_register_parameter_services(struct nros_executor_t *executor);
 
 /**
- * Declare a string parameter on the executor's server.
+ * Declare a string parameter on the executor's PRIMARY node.
  */
 NROS_PUBLIC
 nros_ret_t nros_executor_declare_param_string(struct nros_executor_t *executor,
@@ -3460,7 +3460,17 @@ nros_ret_t nros_executor_declare_param_string(struct nros_executor_t *executor,
                                               const char *value);
 
 /**
- * Get a string parameter from the executor's server into a fixed buffer.
+ * Declare a string parameter on `node`.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_declare_param_string_on(struct nros_executor_t *executor,
+                                                 const struct nros_node_t *node,
+                                                 const char *name,
+                                                 const char *value);
+
+/**
+ * Get a string parameter from the executor's PRIMARY node into a fixed
+ * buffer.
  */
 NROS_PUBLIC
 nros_ret_t nros_executor_get_param_string(struct nros_executor_t *executor,
@@ -3469,7 +3479,17 @@ nros_ret_t nros_executor_get_param_string(struct nros_executor_t *executor,
                                           size_t max_len);
 
 /**
- * Set a string parameter on the executor's server.
+ * Get a string parameter from `node` into a fixed buffer.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_get_param_string_on(struct nros_executor_t *executor,
+                                             const struct nros_node_t *node,
+                                             const char *name,
+                                             char *out_value,
+                                             size_t max_len);
+
+/**
+ * Set a string parameter on the executor's PRIMARY node.
  */
 NROS_PUBLIC
 nros_ret_t nros_executor_set_param_string(struct nros_executor_t *executor,
@@ -3477,9 +3497,53 @@ nros_ret_t nros_executor_set_param_string(struct nros_executor_t *executor,
                                           const char *value);
 
 /**
- * Check if a parameter exists on the executor's server.
+ * Set a string parameter on `node`.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_set_param_string_on(struct nros_executor_t *executor,
+                                             const struct nros_node_t *node,
+                                             const char *name,
+                                             const char *value);
+
+/**
+ * Check if a parameter exists on the executor's PRIMARY node.
  */
 NROS_PUBLIC bool nros_executor_has_param(struct nros_executor_t *executor, const char *name);
+
+/**
+ * Check if a parameter exists on `node`.
+ *
+ * A node this executor does not own answers `false`, never the primary
+ * node's answer: "which node" is the question, and defaulting it is how a
+ * sibling's parameter comes back as this one's.
+ */
+NROS_PUBLIC
+bool nros_executor_has_param_on(struct nros_executor_t *executor,
+                                const struct nros_node_t *node,
+                                const char *name);
+
+/**
+ * May a `set` DECLARE a name the executor's PRIMARY node never declared?
+ *
+ * Upstream's `allow_undeclared_parameters` node option (issue 1151), off
+ * by default. Without it a C image could not reach the policy at all: a
+ * `nros_executor_set_param_*` on an undeclared name was a permanent
+ * `NROS_RET_NOT_FOUND` with no opt-in, so the rule was reachable from Rust
+ * and from the wire and not from here. Set it before
+ * `nros_executor_register_parameter_services` starts answering.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_allow_undeclared_parameters(struct nros_executor_t *executor,
+                                                     bool allow);
+
+/**
+ * [`nros_executor_allow_undeclared_parameters`] for `node`. Per node, as
+ * upstream: switching it on for one node leaves its siblings refusing.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_allow_undeclared_parameters_on(struct nros_executor_t *executor,
+                                                        const struct nros_node_t *node,
+                                                        bool allow);
 
 /**
  * Monotonic nanoseconds since a platform-defined epoch (RFC-0073).

--- a/packages/api/nros-c/include/nros/parameter.h
+++ b/packages/api/nros-c/include/nros/parameter.h
@@ -379,6 +379,12 @@ NROS_PUBLIC nros_ret_t nros_parameter_server_fini(struct nros_parameter_server_t
  * =================================================================== */
 
 struct nros_executor_t;
+/* `struct nros_node_t` is NOT forward-declared here: it is fully defined in
+ * <nros/nros_generated.h>, which the <nros/types.h> include at the top of this
+ * file already brings in. A redundant forward declaration would also register
+ * as a NEW TYPE on the generated-C surface (`check-codegen-version-surface`),
+ * which would demand an NROS_CODEGEN_VERSION bump for a declaration that
+ * changes nothing. */
 
 /**
  * @brief Register the 6 ROS 2 parameter services on the executor's node.
@@ -396,26 +402,26 @@ struct nros_executor_t;
  */
 NROS_PUBLIC nros_ret_t nros_executor_register_parameter_services(struct nros_executor_t* executor);
 
-/** @brief Declare a boolean parameter on the executor's server. */
+/** @brief Declare a boolean parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_declare_param_bool(struct nros_executor_t* executor,
                                                         const char* name, bool value);
-/** @brief Declare an integer parameter on the executor's server. */
+/** @brief Declare an integer parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_declare_param_integer(struct nros_executor_t* executor,
                                                            const char* name, int64_t value);
-/** @brief Declare a double parameter on the executor's server. */
+/** @brief Declare a double parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_declare_param_double(struct nros_executor_t* executor,
                                                           const char* name, double value);
-/** @brief Declare a string parameter on the executor's server. */
+/** @brief Declare a string parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_declare_param_string(struct nros_executor_t* executor,
                                                           const char* name, const char* value);
 
-/** @brief Get a boolean parameter from the executor's server. */
+/** @brief Get a boolean parameter from the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_get_param_bool(struct nros_executor_t* executor,
                                                     const char* name, bool* out_value);
-/** @brief Get an integer parameter from the executor's server. */
+/** @brief Get an integer parameter from the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_get_param_integer(struct nros_executor_t* executor,
                                                        const char* name, int64_t* out_value);
-/** @brief Get a double parameter from the executor's server. */
+/** @brief Get a double parameter from the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_get_param_double(struct nros_executor_t* executor,
                                                       const char* name, double* out_value);
 /** @brief Get a string parameter into a caller-provided null-terminated buffer. */
@@ -423,21 +429,125 @@ NROS_PUBLIC nros_ret_t nros_executor_get_param_string(struct nros_executor_t* ex
                                                       const char* name, char* out_value,
                                                       size_t max_len);
 
-/** @brief Set a boolean parameter on the executor's server. */
+/** @brief Set a boolean parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_set_param_bool(struct nros_executor_t* executor,
                                                     const char* name, bool value);
-/** @brief Set an integer parameter on the executor's server. */
+/** @brief Set an integer parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_set_param_integer(struct nros_executor_t* executor,
                                                        const char* name, int64_t value);
-/** @brief Set a double parameter on the executor's server. */
+/** @brief Set a double parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_set_param_double(struct nros_executor_t* executor,
                                                       const char* name, double value);
-/** @brief Set a string parameter on the executor's server. */
+/** @brief Set a string parameter on the executor's PRIMARY node. */
 NROS_PUBLIC nros_ret_t nros_executor_set_param_string(struct nros_executor_t* executor,
                                                       const char* name, const char* value);
 
-/** @brief Check if a parameter exists on the executor's server. */
+/** @brief Check if a parameter exists on the executor's PRIMARY node. */
 NROS_PUBLIC bool nros_executor_has_param(struct nros_executor_t* executor, const char* name);
+
+/**
+ * @brief May a set DECLARE a name the PRIMARY node never declared?
+ *
+ * Upstream's `allow_undeclared_parameters` node option, off by default. With
+ * it off, nros_executor_set_param_*() on an undeclared name is
+ * NROS_RET_NOT_FOUND and nothing is created.
+ */
+NROS_PUBLIC nros_ret_t nros_executor_allow_undeclared_parameters(struct nros_executor_t* executor,
+                                                                 bool allow);
+
+/* -------------------------------------------------------------------
+ * Per-node spellings (phase-426 W5)
+ *
+ * The parameter store is keyed by NODE, because upstream's is: an image
+ * composes several nodes onto one executor, and `/talker`'s `rate` is not
+ * `/listener`'s. The functions above name the executor's PRIMARY node, which
+ * is what a single-node image means and what
+ * nros_executor_register_parameter_services() publishes. The `_on` spellings
+ * below name any node bound to this executor by
+ * nros_executor_node_init(); they are the C mirror of Rust's
+ * `Executor::declare_parameter_on` / `_set_parameter_on` / `_get_parameter_on`
+ * pair-per-method, and they point at the SAME table, so C and C++ cannot
+ * disagree about what a node's parameters are.
+ *
+ * `node` must be INITIALISED and bound to `executor`; anything else is
+ * NROS_RET_INVALID_ARGUMENT (false for the `has` / predicate form), never a
+ * silent fallback to the primary node.
+ *
+ * These prototypes spell both handles as TYPEDEFS (`nros_executor_t*`,
+ * `const nros_node_t*`) where the block above writes `struct nros_executor_t*`.
+ * Both types are fully defined by <nros/nros_generated.h>, which the
+ * <nros/types.h> include at the top of this file pulls in, so the two spellings
+ * are the same type. The difference is `check-codegen-version-surface`: it
+ * treats any `struct` keyword in a declaration as a TYPE DECLARATION and keys
+ * the entry on the first tracked name inside it, so `struct nros_node_t* node`
+ * in a prototype puts `nros_node_t` on the generated-C surface from this header
+ * and demands an NROS_CODEGEN_VERSION bump. Nothing generated changed -- these
+ * are new functions over an existing type, and no generated tree includes this
+ * header -- so bumping would record a move that did not happen. Do not
+ * reintroduce the `struct` keyword here for consistency with the block above.
+ * ------------------------------------------------------------------- */
+
+/** @brief Declare a boolean parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_declare_param_bool_on(nros_executor_t* executor,
+                                                           const nros_node_t* node,
+                                                           const char* name, bool value);
+/** @brief Declare an integer parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_declare_param_integer_on(nros_executor_t* executor,
+                                                              const nros_node_t* node,
+                                                              const char* name, int64_t value);
+/** @brief Declare a double parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_declare_param_double_on(nros_executor_t* executor,
+                                                             const nros_node_t* node,
+                                                             const char* name, double value);
+/** @brief Declare a string parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_declare_param_string_on(nros_executor_t* executor,
+                                                             const nros_node_t* node,
+                                                             const char* name, const char* value);
+
+/** @brief Get a boolean parameter from @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_get_param_bool_on(nros_executor_t* executor,
+                                                       const nros_node_t* node, const char* name,
+                                                       bool* out_value);
+/** @brief Get an integer parameter from @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_get_param_integer_on(nros_executor_t* executor,
+                                                          const nros_node_t* node, const char* name,
+                                                          int64_t* out_value);
+/** @brief Get a double parameter from @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_get_param_double_on(nros_executor_t* executor,
+                                                         const nros_node_t* node, const char* name,
+                                                         double* out_value);
+/** @brief Get a string parameter from @p node into a caller-provided buffer. */
+NROS_PUBLIC nros_ret_t nros_executor_get_param_string_on(nros_executor_t* executor,
+                                                         const nros_node_t* node, const char* name,
+                                                         char* out_value, size_t max_len);
+
+/** @brief Set a boolean parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_set_param_bool_on(nros_executor_t* executor,
+                                                       const nros_node_t* node, const char* name,
+                                                       bool value);
+/** @brief Set an integer parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_set_param_integer_on(nros_executor_t* executor,
+                                                          const nros_node_t* node, const char* name,
+                                                          int64_t value);
+/** @brief Set a double parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_set_param_double_on(nros_executor_t* executor,
+                                                         const nros_node_t* node, const char* name,
+                                                         double value);
+/** @brief Set a string parameter on @p node. */
+NROS_PUBLIC nros_ret_t nros_executor_set_param_string_on(nros_executor_t* executor,
+                                                         const nros_node_t* node, const char* name,
+                                                         const char* value);
+
+/** @brief Check if a parameter exists on @p node. */
+NROS_PUBLIC bool nros_executor_has_param_on(nros_executor_t* executor, const nros_node_t* node,
+                                            const char* name);
+
+/** @brief nros_executor_allow_undeclared_parameters() for @p node. Per node,
+ *         as upstream: switching it on for one node leaves its siblings
+ *         refusing. */
+NROS_PUBLIC nros_ret_t nros_executor_allow_undeclared_parameters_on(nros_executor_t* executor,
+                                                                    const nros_node_t* node,
+                                                                    bool allow);
 
 #ifdef __cplusplus
 }

--- a/packages/api/nros-c/src/parameter.rs
+++ b/packages/api/nros-c/src/parameter.rs
@@ -769,8 +769,11 @@ pub unsafe extern "C" fn nros_parameter_server_fini(
 #[cfg(all(feature = "param-services", feature = "rmw-cffi"))]
 mod service_backed {
     use super::*;
-    use crate::executor::{get_executor, nros_executor_t};
-    use nros_node::{ParameterValue, SetParameterResult};
+    use crate::{
+        executor::{CExecutor, get_executor, nros_executor_t},
+        node::{nros_node_state_t, nros_node_t},
+    };
+    use nros_node::{ParameterValue, SetParameterResult, executor::NodeId};
 
     /// Read a C string up to `max_len` bytes into a `&str` slice.
     /// Returns `None` if `name` is NULL or non-UTF-8.
@@ -805,6 +808,49 @@ mod service_backed {
         NROS_RET_OK
     }
 
+    /// phase-426 W5 — resolve the `nros_node_t` an `_on` call names into the
+    /// store's node key. ONE spelling, for all fourteen `_on` entry points.
+    ///
+    /// The store is keyed by node (W1), so a C caller has to be able to say
+    /// WHICH node — and the thing a C caller holds is the `nros_node_t` it
+    /// passed to `nros_executor_node_init`, not the `u8` slot index inside it.
+    /// Taking the node rather than the index is what makes these checks
+    /// possible at all; an index argument would make every one of them a
+    /// silent out-of-range write into a sibling node's parameters.
+    ///
+    /// Refuses, in order:
+    ///
+    /// * a NULL node — the caller means the primary node, and says so by
+    ///   calling the un-suffixed spelling;
+    /// * a node that is not INITIALISED — a zeroed `nros_node_t` reads as slot
+    ///   0, so accepting it would silently mean "the primary node";
+    /// * a node bound to a DIFFERENT executor — two executors have two stores,
+    ///   and slot 3 of one names nothing in the other. `rclc_node_init_default`
+    ///   leaves `executor` NULL and `node_id` 0 (the legacy single-node path),
+    ///   which IS the primary node and is accepted;
+    /// * a slot the executor never built. Slot 0 is always legal — an executor
+    ///   with no `nros_executor_node_init` call still HAS a primary node, and
+    ///   `Executor::nodes()` is empty until one is built, so a membership test
+    ///   alone would refuse the commonest image in the tree.
+    unsafe fn node_key(
+        exec: &CExecutor,
+        executor: *mut nros_executor_t,
+        node: *const nros_node_t,
+    ) -> Option<NodeId> {
+        let node = node.as_ref()?;
+        if node.state != nros_node_state_t::NROS_NODE_STATE_INITIALIZED {
+            return None;
+        }
+        if !node.executor.is_null() && node.executor != executor.cast_const() {
+            return None;
+        }
+        let id = NodeId::from_raw(node.node_id);
+        if node.node_id != 0 && exec.node(id).is_none() {
+            return None;
+        }
+        Some(id)
+    }
+
     /// Register the 6 ROS 2 parameter services on the executor's node.
     ///
     /// After this call, parameters declared via
@@ -824,6 +870,21 @@ mod service_backed {
         }
     }
 
+    /// phase-426 W2/W5 — the ONE translation of a write's verdict into the C
+    /// return code, for all eight setters.
+    ///
+    /// The mapping used to be written out twice (the scalar macro and
+    /// `nros_executor_set_param_string`); W5 doubles the number of setters, and
+    /// four copies of a `match` over an enum that grows is how one of them ends
+    /// up reporting an `OutOfRange` as `NROS_RET_OK`.
+    fn set_result_to_ret(result: SetParameterResult) -> nros_ret_t {
+        match result {
+            SetParameterResult::Success => NROS_RET_OK,
+            SetParameterResult::NotFound | SetParameterResult::Undeclared => NROS_RET_NOT_FOUND,
+            _ => NROS_RET_INVALID_ARGUMENT,
+        }
+    }
+
     macro_rules! impl_executor_param_scalar {
         (
             name: $name:ident,
@@ -833,7 +894,7 @@ mod service_backed {
             doc: $doc:literal
         ) => {
             paste::paste! {
-                #[doc = "Declare " $doc " parameter on the executor's server."]
+                #[doc = "Declare " $doc " parameter on the executor's PRIMARY node."]
                 #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn [<nros_executor_declare_param_ $name>](
                     executor: *mut nros_executor_t,
@@ -854,7 +915,32 @@ mod service_backed {
                     }
                 }
 
-                #[doc = "Get " $doc " parameter from the executor's server."]
+                #[doc = "Declare " $doc " parameter on `node`."]
+                #[unsafe(no_mangle)]
+                pub unsafe extern "C" fn [<nros_executor_declare_param_ $name _on>](
+                    executor: *mut nros_executor_t,
+                    node: *const nros_node_t,
+                    name: *const c_char,
+                    value: $T,
+                ) -> nros_ret_t {
+                    if executor.is_null() {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    }
+                    let Some(n) = cstr_to_str(name) else {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    };
+                    let exec = get_executor(&mut (*executor)._opaque);
+                    let Some(id) = node_key(exec, executor, node) else {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    };
+                    if exec.declare_parameter_on(id, n, $from(value)) {
+                        NROS_RET_OK
+                    } else {
+                        NROS_RET_ALREADY_EXISTS
+                    }
+                }
+
+                #[doc = "Get " $doc " parameter from the executor's PRIMARY node."]
                 #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn [<nros_executor_get_param_ $name>](
                     executor: *mut nros_executor_t,
@@ -877,7 +963,34 @@ mod service_backed {
                     }
                 }
 
-                #[doc = "Set " $doc " parameter on the executor's server."]
+                #[doc = "Get " $doc " parameter from `node`."]
+                #[unsafe(no_mangle)]
+                pub unsafe extern "C" fn [<nros_executor_get_param_ $name _on>](
+                    executor: *mut nros_executor_t,
+                    node: *const nros_node_t,
+                    name: *const c_char,
+                    out_value: *mut $T,
+                ) -> nros_ret_t {
+                    if executor.is_null() || out_value.is_null() {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    }
+                    let Some(n) = cstr_to_str(name) else {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    };
+                    let inner = get_executor(&mut (*executor)._opaque);
+                    let Some(id) = node_key(inner, executor, node) else {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    };
+                    match inner.get_parameter_on(id, n).and_then(|v| v.$as()) {
+                        Some(v) => {
+                            *out_value = v.into();
+                            NROS_RET_OK
+                        }
+                        None => NROS_RET_NOT_FOUND,
+                    }
+                }
+
+                #[doc = "Set " $doc " parameter on the executor's PRIMARY node."]
                 #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn [<nros_executor_set_param_ $name>](
                     executor: *mut nros_executor_t,
@@ -898,13 +1011,29 @@ mod service_backed {
                     // which is a SECOND answer to "may this set happen" — the
                     // duplication RFC-0019/0020 forbids, and the seam through
                     // which issue 1151's rules could be bypassed from C.
-                    match exec.set_parameter(n, $from(value)) {
-                        SetParameterResult::Success => NROS_RET_OK,
-                        SetParameterResult::NotFound | SetParameterResult::Undeclared => {
-                            NROS_RET_NOT_FOUND
-                        }
-                        _ => NROS_RET_INVALID_ARGUMENT,
+                    set_result_to_ret(exec.set_parameter(n, $from(value)))
+                }
+
+                #[doc = "Set " $doc " parameter on `node`."]
+                #[unsafe(no_mangle)]
+                pub unsafe extern "C" fn [<nros_executor_set_param_ $name _on>](
+                    executor: *mut nros_executor_t,
+                    node: *const nros_node_t,
+                    name: *const c_char,
+                    value: $T,
+                ) -> nros_ret_t {
+                    if executor.is_null() {
+                        return NROS_RET_INVALID_ARGUMENT;
                     }
+                    let Some(n) = cstr_to_str(name) else {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    };
+                    let exec = get_executor(&mut (*executor)._opaque);
+                    let Some(id) = node_key(exec, executor, node) else {
+                        return NROS_RET_INVALID_ARGUMENT;
+                    };
+                    // Same `apply` routing as the primary spelling above.
+                    set_result_to_ret(exec.set_parameter_on(id, n, $from(value)))
                 }
             }
         };
@@ -929,7 +1058,7 @@ mod service_backed {
         doc: "a double"
     );
 
-    /// Declare a string parameter on the executor's server.
+    /// Declare a string parameter on the executor's PRIMARY node.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn nros_executor_declare_param_string(
         executor: *mut nros_executor_t,
@@ -953,7 +1082,36 @@ mod service_backed {
         }
     }
 
-    /// Get a string parameter from the executor's server into a fixed buffer.
+    /// Declare a string parameter on `node`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn nros_executor_declare_param_string_on(
+        executor: *mut nros_executor_t,
+        node: *const nros_node_t,
+        name: *const c_char,
+        value: *const c_char,
+    ) -> nros_ret_t {
+        if executor.is_null() {
+            return NROS_RET_INVALID_ARGUMENT;
+        }
+        let (Some(n), Some(v)) = (cstr_to_str(name), cstr_to_str(value)) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        let Some(pv) = ParameterValue::from_string(v) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        let exec = get_executor(&mut (*executor)._opaque);
+        let Some(id) = node_key(exec, executor, node) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        if exec.declare_parameter_on(id, n, pv) {
+            NROS_RET_OK
+        } else {
+            NROS_RET_ALREADY_EXISTS
+        }
+    }
+
+    /// Get a string parameter from the executor's PRIMARY node into a fixed
+    /// buffer.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn nros_executor_get_param_string(
         executor: *mut nros_executor_t,
@@ -974,7 +1132,32 @@ mod service_backed {
         }
     }
 
-    /// Set a string parameter on the executor's server.
+    /// Get a string parameter from `node` into a fixed buffer.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn nros_executor_get_param_string_on(
+        executor: *mut nros_executor_t,
+        node: *const nros_node_t,
+        name: *const c_char,
+        out_value: *mut c_char,
+        max_len: usize,
+    ) -> nros_ret_t {
+        if executor.is_null() || out_value.is_null() || max_len == 0 {
+            return NROS_RET_INVALID_ARGUMENT;
+        }
+        let Some(n) = cstr_to_str(name) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        let inner = get_executor(&mut (*executor)._opaque);
+        let Some(id) = node_key(inner, executor, node) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        match inner.get_parameter_on(id, n).and_then(|v| v.as_string()) {
+            Some(s) => str_to_cbuf(s, out_value, max_len),
+            None => NROS_RET_NOT_FOUND,
+        }
+    }
+
+    /// Set a string parameter on the executor's PRIMARY node.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn nros_executor_set_param_string(
         executor: *mut nros_executor_t,
@@ -992,14 +1175,34 @@ mod service_backed {
         };
         let exec = get_executor(&mut (*executor)._opaque);
         // phase-426 W2 — same routing as the scalar setters above.
-        match exec.set_parameter(n, pv) {
-            SetParameterResult::Success => NROS_RET_OK,
-            SetParameterResult::NotFound | SetParameterResult::Undeclared => NROS_RET_NOT_FOUND,
-            _ => NROS_RET_INVALID_ARGUMENT,
-        }
+        set_result_to_ret(exec.set_parameter(n, pv))
     }
 
-    /// Check if a parameter exists on the executor's server.
+    /// Set a string parameter on `node`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn nros_executor_set_param_string_on(
+        executor: *mut nros_executor_t,
+        node: *const nros_node_t,
+        name: *const c_char,
+        value: *const c_char,
+    ) -> nros_ret_t {
+        if executor.is_null() {
+            return NROS_RET_INVALID_ARGUMENT;
+        }
+        let (Some(n), Some(v)) = (cstr_to_str(name), cstr_to_str(value)) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        let Some(pv) = ParameterValue::from_string(v) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        let exec = get_executor(&mut (*executor)._opaque);
+        let Some(id) = node_key(exec, executor, node) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        set_result_to_ret(exec.set_parameter_on(id, n, pv))
+    }
+
+    /// Check if a parameter exists on the executor's PRIMARY node.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn nros_executor_has_param(
         executor: *mut nros_executor_t,
@@ -1013,6 +1216,70 @@ mod service_backed {
         };
         let inner = get_executor(&mut (*executor)._opaque);
         inner.get_parameter(n).is_some()
+    }
+
+    /// Check if a parameter exists on `node`.
+    ///
+    /// A node this executor does not own answers `false`, never the primary
+    /// node's answer: "which node" is the question, and defaulting it is how a
+    /// sibling's parameter comes back as this one's.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn nros_executor_has_param_on(
+        executor: *mut nros_executor_t,
+        node: *const nros_node_t,
+        name: *const c_char,
+    ) -> bool {
+        if executor.is_null() {
+            return false;
+        }
+        let Some(n) = cstr_to_str(name) else {
+            return false;
+        };
+        let inner = get_executor(&mut (*executor)._opaque);
+        let Some(id) = node_key(inner, executor, node) else {
+            return false;
+        };
+        inner.get_parameter_on(id, n).is_some()
+    }
+
+    /// May a `set` DECLARE a name the executor's PRIMARY node never declared?
+    ///
+    /// Upstream's `allow_undeclared_parameters` node option (issue 1151), off
+    /// by default. Without it a C image could not reach the policy at all: a
+    /// `nros_executor_set_param_*` on an undeclared name was a permanent
+    /// `NROS_RET_NOT_FOUND` with no opt-in, so the rule was reachable from Rust
+    /// and from the wire and not from here. Set it before
+    /// `nros_executor_register_parameter_services` starts answering.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn nros_executor_allow_undeclared_parameters(
+        executor: *mut nros_executor_t,
+        allow: bool,
+    ) -> nros_ret_t {
+        if executor.is_null() {
+            return NROS_RET_INVALID_ARGUMENT;
+        }
+        let exec = get_executor(&mut (*executor)._opaque);
+        exec.allow_undeclared_parameters(allow);
+        NROS_RET_OK
+    }
+
+    /// [`nros_executor_allow_undeclared_parameters`] for `node`. Per node, as
+    /// upstream: switching it on for one node leaves its siblings refusing.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn nros_executor_allow_undeclared_parameters_on(
+        executor: *mut nros_executor_t,
+        node: *const nros_node_t,
+        allow: bool,
+    ) -> nros_ret_t {
+        if executor.is_null() {
+            return NROS_RET_INVALID_ARGUMENT;
+        }
+        let exec = get_executor(&mut (*executor)._opaque);
+        let Some(id) = node_key(exec, executor, node) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        exec.allow_undeclared_parameters_on(id, allow);
+        NROS_RET_OK
     }
 }
 

--- a/packages/api/nros-c/tests/run/executor_param_node_keying.c
+++ b/packages/api/nros-c/tests/run/executor_param_node_keying.c
@@ -1,0 +1,335 @@
+/* phase-426 W5 — the C parameter surface names a NODE, and the store keeps
+ * two nodes' parameters apart.
+ *
+ * The store is one fixed table owned by the executor (there is no allocator to
+ * give each node its own), keyed by node since W1. Before W5 the C surface had
+ * no way to say WHICH node: every `nros_executor_*_param_*` meant the primary
+ * one, so a two-node C image could declare `rate` exactly once and `ros2 param
+ * get /listener rate` would answer with `/talker`'s value. The `_on` spellings
+ * close that, and this is the test that would have caught it.
+ *
+ * COMPILE-AND-RUN rather than a signature probe, because the defect is not in
+ * the declarations: a `_on` family that resolved every node to slot 0 would
+ * compile, link, and pass `param_entry_points.c`, while every assertion below
+ * about a sibling's value would fail.
+ *
+ * The RMW backend here is a STUB, and deliberately: nothing on this path
+ * touches the wire. `nros_executor_init` needs a session pointer, and
+ * `nros_executor_node_init` needs an executor to build node slots in, so the
+ * seventeen slots `nros_rmw_cffi_register_named` requires are filled with
+ * refusals and only `create_session` does anything. That keeps the test a
+ * source-gate test — no router, no network, no timing — while still driving
+ * the real `Executor`, the real `nros_params::ParameterServer` and the real
+ * `apply` rules.
+ */
+
+#include <nros/nros.h>
+#include <nros/rmw_vtable.h>
+
+#include <stdio.h>
+#include <string.h>
+
+/* ---- the stub backend ------------------------------------------------- */
+
+static int g_stub_session;
+
+static rmw_ret_t stub_create_session(const char* locator, uint8_t mode, uint32_t domain_id,
+                                     const char* node_name, const rmw_session_options_t* options,
+                                     rmw_session_t* out) {
+    (void)locator;
+    (void)mode;
+    (void)domain_id;
+    (void)node_name;
+    (void)options;
+    if (out == NULL) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    /* Non-NULL is the whole contract this test needs: `nros_executor_init`
+     * refuses a NULL session pointer, and nothing below ever publishes. */
+    out->backend_data = &g_stub_session;
+    return NROS_RMW_RET_OK;
+}
+
+static rmw_ret_t stub_destroy_session(rmw_session_t* session) {
+    (void)session;
+    return NROS_RMW_RET_OK;
+}
+
+static rmw_ret_t stub_drive_io(rmw_session_t* session, int32_t timeout_ms) {
+    (void)session;
+    (void)timeout_ms;
+    return NROS_RMW_RET_OK;
+}
+
+/* Every remaining REQUIRED slot refuses. A test that reached one of these
+ * would fail with `NROS_RMW_RET_UNSUPPORTED` rather than quietly succeeding
+ * against a backend that does nothing. */
+static rmw_ret_t
+stub_create_publisher(const rmw_node_t* node, const rmw_message_type_support_t* type_support,
+                      const char* topic_name, uint32_t domain_id, const rmw_qos_profile_t* qos,
+                      const rmw_publisher_options_t* options, rmw_publisher_t* out) {
+    (void)node;
+    (void)type_support;
+    (void)topic_name;
+    (void)domain_id;
+    (void)qos;
+    (void)options;
+    (void)out;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_destroy_publisher(rmw_publisher_t* publisher) {
+    (void)publisher;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_publish(const rmw_publisher_t* publisher, rmw_byte_span_t payload) {
+    (void)publisher;
+    (void)payload;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t
+stub_create_subscription(const rmw_node_t* node, const rmw_message_type_support_t* type_support,
+                         const char* topic_name, uint32_t domain_id, const rmw_qos_profile_t* qos,
+                         const rmw_subscription_options_t* options, rmw_subscription_t* out) {
+    (void)node;
+    (void)type_support;
+    (void)topic_name;
+    (void)domain_id;
+    (void)qos;
+    (void)options;
+    (void)out;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_destroy_subscription(rmw_subscription_t* subscription) {
+    (void)subscription;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_take(const rmw_subscription_t* subscription, rmw_mut_byte_span_t* out,
+                           bool* taken) {
+    (void)subscription;
+    (void)out;
+    (void)taken;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_has_data(rmw_subscription_t* subscription, bool* out_has_data) {
+    (void)subscription;
+    (void)out_has_data;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_create_service(const rmw_node_t* node,
+                                     const rmw_service_type_support_t* type_support,
+                                     const char* service_name, uint32_t domain_id,
+                                     const rmw_qos_profile_t* qos, rmw_service_t* out) {
+    (void)node;
+    (void)type_support;
+    (void)service_name;
+    (void)domain_id;
+    (void)qos;
+    (void)out;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_destroy_service(rmw_service_t* server) {
+    (void)server;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_take_request(const rmw_service_t* server, rmw_mut_byte_span_t* request,
+                                   int64_t* seq_out, bool* taken) {
+    (void)server;
+    (void)request;
+    (void)seq_out;
+    (void)taken;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_has_request(rmw_service_t* server, bool* out_has_request) {
+    (void)server;
+    (void)out_has_request;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_send_response(const rmw_service_t* server, int64_t seq,
+                                    rmw_byte_span_t response) {
+    (void)server;
+    (void)seq;
+    (void)response;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_create_client(const rmw_node_t* node,
+                                    const rmw_service_type_support_t* type_support,
+                                    const char* service_name, uint32_t domain_id,
+                                    const rmw_qos_profile_t* qos, rmw_client_t* out) {
+    (void)node;
+    (void)type_support;
+    (void)service_name;
+    (void)domain_id;
+    (void)qos;
+    (void)out;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static rmw_ret_t stub_destroy_client(rmw_client_t* client) {
+    (void)client;
+    return NROS_RMW_RET_UNSUPPORTED;
+}
+
+static const nros_rmw_vtable_t STUB_VTABLE = {
+    .create_session = stub_create_session,
+    .destroy_session = stub_destroy_session,
+    .drive_io = stub_drive_io,
+    .create_publisher = stub_create_publisher,
+    .destroy_publisher = stub_destroy_publisher,
+    .publish = stub_publish,
+    .create_subscription = stub_create_subscription,
+    .destroy_subscription = stub_destroy_subscription,
+    .take = stub_take,
+    .has_data = stub_has_data,
+    .create_service = stub_create_service,
+    .destroy_service = stub_destroy_service,
+    .take_request = stub_take_request,
+    .has_request = stub_has_request,
+    .send_response = stub_send_response,
+    .create_client = stub_create_client,
+    .destroy_client = stub_destroy_client,
+};
+
+/* `nros_support_init_rmw` calls this before opening the session — the RTOS
+ * registration seam (phase 155.B.4). A hosted image usually gets the same
+ * effect from the backend archive's `.init_array` ctor; here the backend IS
+ * this TU, so registering explicitly is both simpler and the path an embedded
+ * image would take. */
+void nros_app_register_backends(void);
+void nros_app_register_backends(void) {
+    (void)nros_rmw_cffi_register_named("stub", &STUB_VTABLE);
+}
+
+/* ---- assertions ------------------------------------------------------- */
+
+static int g_failures;
+
+#define CHECK(cond, ...)                                                                           \
+    do {                                                                                           \
+        if (!(cond)) {                                                                             \
+            ++g_failures;                                                                          \
+            printf("FAIL %s:%d: ", __FILE__, __LINE__);                                            \
+            printf(__VA_ARGS__);                                                                   \
+            printf("\n");                                                                          \
+        }                                                                                          \
+    } while (0)
+
+int main(void) {
+    struct nros_support_t support;
+    struct nros_executor_t executor = rclc_executor_get_zero_initialized_executor();
+    struct nros_node_t talker;
+    struct nros_node_t listener;
+    struct nros_node_t stranger;
+    int64_t got = 0;
+    char text[32];
+
+    memset(&support, 0, sizeof(support));
+    memset(&talker, 0, sizeof(talker));
+    memset(&listener, 0, sizeof(listener));
+    memset(&stranger, 0, sizeof(stranger));
+
+    CHECK(nros_support_init_rmw(&support, NULL, 0, "param_node_keying", "stub") == NROS_RET_OK,
+          "support init");
+    CHECK(nros_executor_init(&executor, &support, 8) == NROS_RET_OK, "executor init");
+    CHECK(nros_executor_node_init(&executor, &talker, "talker", NULL) == NROS_RET_OK,
+          "talker node init");
+    CHECK(nros_executor_node_init(&executor, &listener, "listener", NULL) == NROS_RET_OK,
+          "listener node init");
+    CHECK(talker.node_id != listener.node_id, "two nodes landed in ONE executor slot (%u == %u)",
+          (unsigned)talker.node_id, (unsigned)listener.node_id);
+    if (g_failures != 0) {
+        printf("executor_param_node_keying: %d setup failure(s)\n", g_failures);
+        return 1;
+    }
+
+    /* THE acceptance: the same name on two nodes is two parameters. */
+    CHECK(nros_executor_declare_param_integer_on(&executor, &talker, "rate", 10) == NROS_RET_OK,
+          "declare rate on talker");
+    CHECK(nros_executor_declare_param_integer_on(&executor, &listener, "rate", 20) == NROS_RET_OK,
+          "a sibling's identical name must be a DIFFERENT parameter, not a collision");
+
+    CHECK(nros_executor_get_param_integer_on(&executor, &talker, "rate", &got) == NROS_RET_OK &&
+              got == 10,
+          "talker read back %lld, expected 10", (long long)got);
+    CHECK(nros_executor_get_param_integer_on(&executor, &listener, "rate", &got) == NROS_RET_OK &&
+              got == 20,
+          "listener read back %lld, expected 20", (long long)got);
+
+    /* A write on one node does not move its sibling's value. */
+    CHECK(nros_executor_set_param_integer_on(&executor, &talker, "rate", 11) == NROS_RET_OK,
+          "set rate on talker");
+    CHECK(nros_executor_get_param_integer_on(&executor, &listener, "rate", &got) == NROS_RET_OK &&
+              got == 20,
+          "a set on talker moved listener's value to %lld", (long long)got);
+
+    /* `has` answers per node too. */
+    CHECK(nros_executor_declare_param_string_on(&executor, &talker, "frame", "base_link") ==
+              NROS_RET_OK,
+          "declare frame on talker");
+    CHECK(nros_executor_has_param_on(&executor, &talker, "frame"), "talker should have `frame`");
+    CHECK(!nros_executor_has_param_on(&executor, &listener, "frame"),
+          "`frame` leaked from talker to listener");
+    CHECK(nros_executor_get_param_string_on(&executor, &talker, "frame", text, sizeof(text)) ==
+              NROS_RET_OK,
+          "read frame back from talker");
+    CHECK(strcmp(text, "base_link") == 0, "talker frame read back as %s", text);
+    CHECK(nros_executor_get_param_string_on(&executor, &listener, "frame", text, sizeof(text)) ==
+              NROS_RET_NOT_FOUND,
+          "listener answered for a parameter only talker declared");
+
+    /* The un-suffixed spellings mean the PRIMARY node — the first node built,
+     * which is `talker` here. That is the claim the whole "C keeps its shape"
+     * half of W5 rests on, so assert it rather than assuming it. */
+    CHECK(talker.node_id == 0, "the first node built should be the primary slot, got %u",
+          (unsigned)talker.node_id);
+    CHECK(nros_executor_get_param_integer(&executor, "rate", &got) == NROS_RET_OK && got == 11,
+          "the un-suffixed getter read %lld, expected the primary node's 11", (long long)got);
+
+    /* The `apply` rules reach the `_on` setters, per node. An undeclared name
+     * is refused (issue 1151) until THAT node opts in, and the opt-in does not
+     * reach its sibling. */
+    CHECK(nros_executor_set_param_integer_on(&executor, &talker, "fresh", 1) == NROS_RET_NOT_FOUND,
+          "an undeclared name must be refused, not created");
+    CHECK(!nros_executor_has_param_on(&executor, &talker, "fresh"),
+          "a refused set created the parameter anyway");
+    CHECK(nros_executor_allow_undeclared_parameters_on(&executor, &talker, true) == NROS_RET_OK,
+          "opt talker into undeclared sets");
+    CHECK(nros_executor_set_param_integer_on(&executor, &talker, "fresh", 1) == NROS_RET_OK,
+          "talker opted in and the set was still refused");
+    CHECK(nros_executor_set_param_integer_on(&executor, &listener, "fresh", 1) ==
+              NROS_RET_NOT_FOUND,
+          "allow_undeclared leaked from talker to listener");
+
+    /* A node this executor does not own resolves to nothing — never silently
+     * to the primary node, which is what an unchecked `uint8_t` slot argument
+     * would have given us. */
+    CHECK(nros_executor_declare_param_integer_on(&executor, &stranger, "rate", 99) ==
+              NROS_RET_INVALID_ARGUMENT,
+          "an uninitialised node was accepted (it reads as slot 0)");
+    CHECK(nros_executor_declare_param_integer_on(&executor, NULL, "rate", 99) ==
+              NROS_RET_INVALID_ARGUMENT,
+          "a NULL node was accepted");
+    CHECK(!nros_executor_has_param_on(&executor, &stranger, "rate"),
+          "an uninitialised node answered with the primary node's parameters");
+    CHECK(nros_executor_get_param_integer_on(&executor, &talker, "rate", &got) == NROS_RET_OK &&
+              got == 11,
+          "a refused declare disturbed talker's value (%lld)", (long long)got);
+
+    if (g_failures != 0) {
+        printf("executor_param_node_keying: %d failure(s)\n", g_failures);
+        return 1;
+    }
+    printf("executor_param_node_keying: two nodes, two parameter tables, one store\n");
+    return 0;
+}


### PR DESCRIPTION
phase-426 **W5 only**, on top of #719 (W1+W2). Do not merge before that one.

## What was missing

W1 keyed the parameter store by node and W2 routed the C setters through
`ParameterServer::apply`, but every C entry point still meant one node — the
primary one. A two-node C image could declare `rate` exactly once, and
`ros2 param get /listener rate` answered with `/talker`'s value.

This adds the node-naming half: fourteen `_on` spellings over the same
`nros_params::ParameterServer` the six services read, plus the
`allow_undeclared_parameters` pair that C could not reach at all.

## The naming decision, and the argument

#719's report suggested `_on` variants beside the existing symbols. Checked
against RFC-0089 rather than taken on convenience:

RFC-0089 permits a signature change **when the compiler forces the edit**, and C
would force this one — an added parameter makes every existing call "too few
arguments to function", which is an error, not the warning a *swapped* pointer
argument produces. So the rule does not forbid widening the existing symbols. It
just does not recommend it, and three things do:

1. **The existing symbols are not wrong.** Since W1 they mean the executor's
   PRIMARY node, exactly as Rust's `declare_parameter` means
   `declare_parameter_on(NodeId::PRIMARY, …)`. The licence to change a signature
   is for a signature that lies; this one does not. Widening it costs every C
   caller an edit that buys nothing and puts an explicit primary-node argument
   in the commonest call in the tree.
2. **The Rust SSoT already ships this exact pair**, method for method.
   RFC-0019/0020 makes the C API a thin wrapper over it, so mirroring the pair
   *is* the thin wrapper. rclc has no correspondent to port from — it hands the
   executor a caller-owned `rclc_parameter_server_t` — so this is clause 3
   (invent where upstream has nothing, and ledger it), and what we invent should
   look like what we already have.
3. **phase-417's reorder rule requires a rename beside a reorder** precisely
   because C diagnoses a swapped or added pointer argument as a warning. The
   `_on` suffix is that rename taken to its limit: no existing signature moves
   at all, so no translation unit anywhere can quietly start meaning something
   new.

The node is passed as `const nros_node_t*`, not as the `u8` slot index inside
it. That is what makes the checks possible — one helper, `node_key`, for all
fourteen entry points, refusing a NULL node, an uninitialised one (a zeroed
`nros_node_t` reads as slot 0, so accepting it would silently mean the primary
node), one bound to a different executor, and a slot the executor never built.
An index argument would have made each of those a silent write into a sibling's
parameters.

## Class fixes, not sites

* `nros_executor_allow_undeclared_parameters[_on]` did not exist, so
  `nros_executor_set_param_*` on an undeclared name was a permanent
  `NROS_RET_NOT_FOUND` with no opt-in — issue 1151's rule was reachable from
  Rust and from the wire and not from the API sharing the store.
* `set_result_to_ret` — the `SetParameterResult` → `nros_ret_t` mapping was
  already written twice; W5 doubles the setter count.
* `nros_parameter_*` (the caller-storage `nros_parameter_server_t`) is
  untouched. It is still a separate store; joining it to the executor's table is
  not the node-key half and is not attempted here.

## Test

`packages/api/nros-c/tests/run/executor_param_node_keying.c`, wired into
`just check c`. Compile-and-run, because a `_on` family that resolved every node
to slot 0 would compile, link and pass the existing `param_entry_points.c`
signature probe. **Verified by mutation**: forcing `node_key` to return
`NodeId::PRIMARY` turns six of its assertions red.

It registers a STUB RMW backend (seventeen required vtable slots, sixteen of
them refusals) because nothing on the parameter path touches the wire — no
router, no network, no timing, so the lane stays source-gate cheap.

Two lane details worth reviewer attention:

* the test needs `param-services`, which `C_API_SHIPPED_FEATURES` does not
  carry, so it builds a second feature shape;
* that shape gets its own `CARGO_TARGET_DIR`. `nros_config_generated.h` is
  mirrored to `$CARGO_TARGET_DIR/nros-c-generated/` as a build-script **side
  effect**, and cargo caches both shapes' fingerprints — so switching back to a
  shape it has already built re-runs no build script and rewrites no header.
  Sharing one target dir linked a shipped-shape header against a param-services
  archive: `undefined reference to nros_config_variant_sz_<hash>`. `--target-dir`
  alone was not enough either: the mirror falls back to walking up from
  `OUT_DIR` and reads a directory name containing a `-` as a target TRIPLE, so
  `nros-c-param-services` sent the header back to the shared `target/`,
  clobbering the shipped one. Both measured.

## Verification

| gate | result |
| --- | --- |
| `just check c` | pass (new step included, and idempotent on re-run) |
| `just check cbindgen-headers` | pass (3 headers match a fresh generation) |
| `just check rmw-abi-shape` | pass (0 undeclared diffs) |
| `just check api-parity` | pass — every divergence carries a ledger entry |
| `just check api-parity-ledger` | pass (0 self-test failures) |
| `just check fast` | 2 of 265 fail, **both pre-existing** and reproduced on the base with this diff stashed: `capability-conditionals` wants an uninitialised zenoh-pico submodule, `doc-commit-citations` has four stale baseline entries |
| `cargo test -p nros-c --lib` | 31 passed |
| `cargo test -p nros-node --lib --features std,param-services` | 373 passed, 2 ignored |
| clippy (`-p nros-c`, param-services shape) | clean |

Ledger: eight new `param.json` rows (the four `_on` globs, `has_param_on`, the
`allow_undeclared_parameters` pair), and the two pre-existing un-suffixed glob
rows now say which node they mean.

`NROS_CODEGEN_VERSION` is deliberately **not** bumped. The `_on` prototypes
spell their handles as typedefs where the block above writes
`struct nros_executor_t*`, because `check-codegen-version-surface` reads any
`struct` keyword in a declaration as a type DECLARATION — so
`struct nros_node_t* node` in a prototype would put `nros_node_t` on the
generated-C surface from this header and demand a version bump for new functions
over an existing type, in a header no generated tree includes. The header says
so in a comment, so nobody restores the keyword for consistency.

## What remains unproven until W4 lands

The phase's acceptance for W5 is "a mixed C/C++ workspace fixture declares from
one language and reads from the other". **That is half proven here, and the
other half is W4's, being done in parallel.** What this branch establishes is
that the C half reaches the shared table with the right node key and the right
`apply` rules — asserted end to end by the new test. That the **C++** half
reaches the SAME table is exactly what W4 makes true by deleting
`rclcpp::Node`'s inline `ParameterServer` and `ComponentNode`'s facade. Until it
lands, a parameter declared through `rclcpp::Node::declare_parameter` is still
invisible to this surface, and no cross-language fixture can show the read. No
`nros-cpp` file is touched by this PR.

Also untouched, by instruction (W3 owns them in a parallel agent):
`register_parameter_services`, `executor_sizing.rs`, `packages/api/nros/src/node.rs`.

One observation for whoever picks up the next item: `C_API_SHIPPED_FEATURES`
does not include `param-services`, so the shipped `libnros_c.a` exports none of
the `nros_executor_*_param_*` family — the header declares them unconditionally
and only a consumer that opts the feature in gets the symbols. Pre-existing, not
changed here, but it means "the C surface follows" is true of the API and not
yet of the default archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
