### PR TITLE
fix(#1202): the posix board declines a wake it cannot take

### DIFF
--- a/cmake/board/nano-ros-board-freertos-posix.cmake
+++ b/cmake/board/nano-ros-board-freertos-posix.cmake
@@ -162,6 +162,30 @@ set(NROS_PLATFORM_FREERTOS_HEAP_3 ON CACHE BOOL
 set(NROS_PLATFORM_FREERTOS_WITH_BAREMETAL_COMPAT OFF CACHE BOOL
     "freertos-posix: the host C library provides what cyclonedds_compat.c fills in" FORCE)
 
+# Issue 1202 — no wake from Cyclone's own thread on this board.
+#
+# The kernel port here runs tasks as host pthreads, and Cyclone is the HOST
+# library, so `on_data_available` arrives on a thread the port never registered.
+# Waking the executor from it enters the scheduler from a foreign thread, which
+# `vPortYield` asserts on; captured from a core of an ASI controller image:
+#
+#   #6  vPortYield ()
+#   #7  xQueueGenericSend ()
+#   #8  nros_platform_wake_signal ()
+#   #9  nros_rmw_cyclonedds::on_data_available(int, void*)
+#   #10 libddsc.so.0                        <- Cyclone's receive thread
+#
+# Deterministic to reproduce: SIGINT the running image (this port deliberately
+# leaves SIGINT unblocked in every thread, "so this can be used to break into
+# GDB"), and the abort follows.
+#
+# The RMW declines the slot instead, and the runtime falls back to the poll-only
+# path it already documents. The cost is wake LATENCY on this simulator board;
+# every other FreeRTOS board keeps the listener, because there Cyclone's threads
+# ARE the platform's threads.
+set(NROS_RMW_CYCLONEDDS_FOREIGN_WAKE OFF CACHE BOOL
+    "freertos-posix: Cyclone's receive thread is not a FreeRTOS thread (issue 1202)" FORCE)
+
 # Read by `cmake/platform/nano-ros-freertos.cmake` BEFORE it stages the Phase
 # 186 Cyclone flags. Those set `WITH_FREERTOS`/`WITH_LWIP` on ddsrt, which
 # selects a ddsrt whose sockets are lwIP's — against a build with no lwIP to

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
@@ -304,6 +304,26 @@ set_target_properties(nros_rmw_cyclonedds PROPERTIES
 # ddsc objects is fragile — see 204.14); enable with
 # `-DNROS_RMW_CYCLONEDDS_IPO=ON` where the toolchain supports it. Pair with
 # `-DCMAKE_BUILD_TYPE=MinSizeRel` (`-Os`) for the smallest wrapper.
+# Issue 1202 — decline the data-available wake slot on a platform that cannot be
+# woken from a thread it does not own.
+#
+# Cyclone calls `on_data_available` from ITS OWN receive thread. On every board
+# where Cyclone's threads are the platform's threads that is fine and it is what
+# gives the executor an asynchronous wake. On the FreeRTOS POSIX port, tasks are
+# host pthreads and Cyclone is the host library, so that thread is foreign and
+# entering the scheduler from it aborts (`vPortYield` asserts
+# `prvIsFreeRTOSThread`). The runtime already supports the alternative: a NULL
+# wake slot means poll-only, with a bounded `condvar_wait_until`.
+#
+# Default ON so every existing board keeps the wake it has; the POSIX board
+# turns it off (cmake/board/nano-ros-board-freertos-posix.cmake).
+option(NROS_RMW_CYCLONEDDS_FOREIGN_WAKE
+       "Install the Cyclone data-available listener, which wakes the executor \
+from Cyclone's own receive thread" ON)
+if(NOT NROS_RMW_CYCLONEDDS_FOREIGN_WAKE)
+    target_compile_definitions(nros_rmw_cyclonedds PRIVATE NROS_RMW_CYCLONEDDS_NO_FOREIGN_WAKE=1)
+endif()
+
 option(NROS_RMW_CYCLONEDDS_IPO "Enable IPO/LTO on the Cyclone RMW wrapper" OFF)
 if(NROS_RMW_CYCLONEDDS_IPO)
     include(CheckIPOSupported)

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/session.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/session.cpp
@@ -124,6 +124,34 @@ rmw_ret_t session_set_wake_callback(rmw_session_t* session,
     if (session == nullptr || session->backend_data == nullptr) {
         return NROS_RMW_RET_INVALID_ARGUMENT;
     }
+#ifdef NROS_RMW_CYCLONEDDS_NO_FOREIGN_WAKE
+    /* Issue 1202 — this build's platform cannot be woken from a thread it does
+     * not own, so decline the slot and let the runtime fall back to its
+     * poll-only path (`spin.rs`: "Poll-only backends (NULL `set_wake_callback`
+     * slot)"). `condvar_wait_until` is bounded, so the cost is wake LATENCY,
+     * not liveness.
+     *
+     * The FreeRTOS POSIX port runs tasks as host pthreads; Cyclone is the host
+     * library, so `on_data_available` arrives on a thread the port never
+     * registered. Captured from the core of an ASI controller image:
+     *
+     *   #5  freertos_assert_failed ()
+     *   #6  vPortYield ()
+     *   #7  xQueueGenericSend ()
+     *   #8  nros_platform_wake_signal ()
+     *   #9  nros_rmw_cyclonedds::on_data_available(int, void*)
+     *   #10 libddsc.so.0                      <- Cyclone's receive thread
+     *
+     * `vPortYield` asserts `prvIsFreeRTOSThread()`. There is no safe variant to
+     * substitute: this port's `xPortSetInterruptMask()` returns 0 and its
+     * `vPortDisableInterrupts()` no-ops for a foreign thread, so the FromISR
+     * give would drop the assert and keep the race — a quieter bug, not a
+     * fixed one. The only correct answer is not to enter the scheduler from
+     * that thread at all. */
+    (void)cb;
+    (void)ctx;
+    return NROS_RMW_RET_UNSUPPORTED;
+#else
     auto* state = as_state(session);
 
     if (cb == nullptr) {
@@ -171,6 +199,7 @@ rmw_ret_t session_set_wake_callback(rmw_session_t* session,
         }
     }
     return NROS_RMW_RET_OK;
+#endif
 }
 
 rmw_ret_t session_create(const char* /*locator*/, uint8_t /*mode*/, uint32_t domain_id,


### PR DESCRIPTION
Fixes #1202. Depends on nothing; the issue's own PR (#717) carries the writeup and its correction.

## The stack, from the core

`systemd-coredump` had kept the original abort:

```
#5  freertos_assert_failed ()
#6  vPortYield ()
#7  xQueueGenericSend ()
#8  nros_platform_wake_signal ()
#9  nros_rmw_cyclonedds::(anonymous namespace)::on_data_available(int, void*)
#10 libddsc.so.0                      <- Cyclone's receive thread
```

Cyclone calls `on_data_available` from its own receive thread. On the FreeRTOS POSIX port, tasks are host pthreads and Cyclone is the host library, so that thread is one the kernel never registered — and `vPortYield` asserts `prvIsFreeRTOSThread()`.

## Why not a cheaper fix

Swapping in the `FromISR` give looks like the obvious answer and is worse. On this port:

```c
UBaseType_t xPortSetInterruptMask( void ) { return ( UBaseType_t ) 0; }
void vPortDisableInterrupts( void ) { if( prvIsFreeRTOSThread() == pdTRUE ) { ... } }
```

so the ISR variant masks nothing for a foreign caller — it would drop the assert and keep the race. And `portYIELD_FROM_ISR` expands to `vPortYield()` here anyway, so it is not even quiet.

There is no safe primitive to substitute. The correct answer is not to enter the scheduler from that thread.

## The change

The RMW declines the wake slot when the platform cannot take a foreign wake, and the runtime uses the poll-only path it already documents (`spin.rs`: *"Poll-only backends (NULL `set_wake_callback` slot)"*). `condvar_wait_until` is bounded, so the cost is wake **latency**, not liveness.

Default ON — every existing board keeps its listener, because there Cyclone's threads *are* the platform's threads. Only `nano-ros-board-freertos-posix.cmake` turns it off, in the same place and shape as that board's existing `NROS_PLATFORM_FREERTOS_WITH_BAREMETAL_COMPAT OFF`.

## Verification

Reproduction is deterministic — `kill -INT` on the running image, since this port leaves SIGINT unblocked in every thread on purpose ("so this can be used to break into GDB while in a critical section").

| | SIGINT result |
|---|---|
| before | `rc=134`, `FreeRTOS ASSERT FAILED: port.c:389`, core dumped |
| after | no assert, no core, process still running |

`NROS_RMW_CYCLONEDDS_FOREIGN_WAKE:BOOL=OFF` confirmed in the built cache.

**Delivery still works** on the poll-only path — with a publisher on `/vehicle/status/steering_status` for 12 s, the controller logs "Waiting for steering data" once (before the publisher starts) while the three unpublished inputs keep reporting every cycle:

```
Waiting for steering data        1
Waiting for odometry data        5
Waiting for trajectory data      5
Waiting for acceleration data    5
```

That check was wrong on its first run — `ros2 topic pub` failed with `UnsupportedTypeSupport` and published nothing. The pre-fix control produced the identical output, which is what caught it; the numbers above are from the run where the publisher actually ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WynxXLGyzeL8iJQvvNcJMm
