### PR TITLE
feat(418.2): the two IVC configurations no lane compiled

### DIFF
--- a/docs/roadmap/phase-418-orin-safety-island-and-spe.md
+++ b/docs/roadmap/phase-418-orin-safety-island-and-spe.md
@@ -259,13 +259,44 @@ second one.
       host SPE code or heap. That decides whether "does not fit" is fatal or
       merely expensive, and nothing in §2a settles it.
 
-- [ ] **418.2 — Compile what already exists.** SCOPE CORRECTED 2026-09-06:
-      `unix-mock` is already on a lane (`required-features-tests`, issue 0652),
-      so what remains is the DEFAULT-stub and `fsp` configurations plus the
-      fork's `ivc.c` behind `link-ivc`. The original text said no lane compiled
-      the crate at all, which was never true after 0652. **Acceptance:** `just check` fails if either the
-      driver or the vendored IVC link stops compiling. This is the cheapest item
-      and it is the one that stops phase-415 from silently breaking §2 Q4.
+- [x] **418.2 — Compile what already exists.** (landed 2026-09-07) SCOPE
+      CORRECTED TWICE. The 2026-09-06 correction said what remained was "the
+      DEFAULT-stub and `fsp` configurations plus the fork's `ivc.c` behind
+      `link-ivc`". The stub half was already wrong: `nvidia-ivc` and
+      `zpico-link-ivc` are both workspace MEMBERS, so
+      `check-workspace-features`' `--workspace --no-default-features`
+      test-compile builds them — measured by touching both files and watching
+      them compile, before adding a row that would have duplicated it.
+
+      What was genuinely uncovered, and is now:
+
+      * **`zpico-sys --features link-ivc`** — a clippy row in
+        `check-workspace-features`. `link-ivc` is a zpico-sys FEATURE, so
+        nothing off it compiled the vendored
+        `zenoh-pico/src/link/{unicast,config}/ivc.c`; the build script emits
+        `Z_FEATURE_LINK_IVC 1` and both TUs now build on every `just check`
+        (verified: `ivc.o` appears in the object set).
+      * **`nvidia-ivc --features fsp`** — `check-ivc-fsp`, skip-capable. Its
+        build script REFUSES without `NV_SPE_FSP_DIR` pointing at a tree holding
+        `lib/libtegra_aon_fsp.a`, so on an unprovisioned host this cannot be a
+        compile. It is a LEDGERED skip (issue 1184's rule: an uncounted skip
+        reads as a pass), and a variable that is SET but wrong is a FAILURE
+        rather than a skip — someone who set it meant to point somewhere.
+        Provisioning is 418.4; when that lands this gate starts compiling with
+        no change to it.
+
+      **Compiling `fsp.rs` for the first time found a lint immediately** —
+      `clippy::declare_interior_mutable_const` on `Slot::EMPTY`. It is a false
+      positive for the `[const { … }; N]` atomic-array idiom (the repeat wants a
+      fresh value per element, which is what the inline `const {}` block is for)
+      and is allowed at the constant with that reason. The gate runs `-D
+      warnings` like every other clippy lane, so without it this would have
+      scrolled past.
+
+      **Acceptance:** `just check` fails if either the driver or the vendored
+      IVC link stops compiling — met for `link-ivc` on every host, and for `fsp`
+      on a provisioned one. `just check fast`: 264 gates, 2 ledgered skips, 0
+      failed.
 
 - [x] **418.3 — `cortex-r5` arch profile.** (landed 2026-09-06) Added to
       `nros-platform-freertos/nros-platform.toml`, settling the float ABI in the

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -1763,6 +1763,23 @@ workspace-features:
     # must cover the class it claims to.
     @echo "  - nros-c: test-compile (default features)"
     cargo test --no-run -p nros-c --quiet
+    # phase-418 418.2 — the IVC path, which reaches the Orin safety island and
+    # is on no other lane.
+    #
+    # The DEFAULT-stub configuration of `nvidia-ivc` and `zpico-link-ivc` is
+    # already covered: both are workspace members, so the
+    # `--workspace --no-default-features` test-compile above builds them (this
+    # was MEASURED before adding a row for it — 418.2's text says the stub still
+    # needs one, and it does not). What that line cannot reach is the C half:
+    # `link-ivc` is a zpico-sys FEATURE, so nothing off it compiles the vendored
+    # `zenoh-pico/src/link/{unicast,config}/ivc.c`, and phase-415 could delete
+    # or break either file with every lane still green.
+    #
+    # A clippy row, not a `cargo check`: the build script runs either way, which
+    # is what emits `Z_FEATURE_LINK_IVC 1` and compiles the two `ivc.c` TUs, and
+    # clippy is what this lane spells everywhere else.
+    @echo "  - zpico-sys: link-ivc (compiles the vendored ivc.c)"
+    cargo clippy --quiet -p zpico-sys --features link-ivc
     # issue 0814 — the loan/borrow surface, which had NOT COMPILED since issue
     # 0812 retyped the backend token (`*mut c_void` -> `*mut rmw_loan_token_t`)
     # and left these three FFI call sites behind. Seven errors, for months,

--- a/just/check/platform.just
+++ b/just/check/platform.just
@@ -324,6 +324,15 @@ kconfig-overridden-values:
 # `resolve_queryable_default` read two declared facts without declaring either,
 # so cargo never re-ran when a declaration changed and the sizing read as
 # applied while being stale.
+# phase-418 418.2 — the IVC driver's `fsp` configuration, which reaches the Orin
+# safety island and which no lane compiled. Skip-capable by design: its build
+# script REFUSES without `NV_SPE_FSP_DIR`, so on an unprovisioned host this is a
+# LEDGERED skip rather than a silent pass (issue 1184's rule). The default stub
+# and `unix-mock` are covered elsewhere -- see the script's header.
+[group("checks")]
+ivc-fsp:
+    @bash scripts/check-ivc-fsp-compile.sh
+
 [group("checks")]
 declared-fact-carriers:
     @python3 scripts/check-declared-fact-carriers.py

--- a/packages/drivers/ipc/nvidia-ivc/src/fsp.rs
+++ b/packages/drivers/ipc/nvidia-ivc/src/fsp.rs
@@ -97,6 +97,17 @@ struct Slot {
 }
 
 impl Slot {
+    // phase-418 418.2 — `clippy::declare_interior_mutable_const` fires on any
+    // `const` holding an atomic, because the usual hazard is a caller COPYING
+    // it and mutating the copy, thinking it shared. That is not what happens
+    // here: the one use is the `[const { Slot::EMPTY }; MAX_CHANNELS]` repeat
+    // below, whose whole purpose is a FRESH value per element, and an inline
+    // `const {}` block is the idiom the language added for exactly this. There
+    // is no other reader.
+    //
+    // Found by compiling this file for the first time: the `fsp` configuration
+    // reached no lane until 418.2 gave it one, so nothing had ever linted it.
+    #[allow(clippy::declare_interior_mutable_const)]
     const EMPTY: Self = Self {
         id: u32::MAX,
         ptr: AtomicPtr::new(core::ptr::null_mut()),

--- a/scripts/check-ivc-fsp-compile.sh
+++ b/scripts/check-ivc-fsp-compile.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# phase-418 418.2 — `nvidia-ivc --features fsp` compiles, when the FSP tree is here.
+#
+# The IVC driver has three configurations and they reach different lanes:
+#
+#   default stub  the `--workspace --no-default-features` test-compile in
+#                 `check-workspace-features` (measured; both crates are members)
+#   unix-mock     `check-required-features-tests` (issue 0652)
+#   fsp           THIS gate, and nothing else
+#
+# `fsp` is the one that talks to the real hardware, and it is the one nothing
+# built. Its build script REFUSES rather than degrading when the vendor tree is
+# absent -- `NV_SPE_FSP_DIR` must point at a directory holding
+# `lib/libtegra_aon_fsp.a` -- so on an unprovisioned host this cannot be a
+# compile at all.
+#
+# It is therefore a LEDGERED skip, the same shape `check-sched-dim-arms-compile`
+# uses for `NUTTX_DIR` / `THREADX_DIR`: the lane summary counts it, so "not
+# checked" survives into the output instead of reading as a pass. Issue 1184 is
+# what that rule cost when a skip stayed uncounted.
+#
+# Provisioning the tree is 418.4's item. Until it lands this gate reports the
+# skip on every host; once it lands, the same gate starts compiling with no
+# change here.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+repo_root="$(pwd)"
+
+# shellcheck source=scripts/build/check-skip.sh
+. "$repo_root/scripts/build/check-skip.sh"
+
+# The three states are a decision about a PATH, and the decision is what can be
+# tested without a cross compile. `classify_fsp_dir` is that decision; `main`
+# acts on it. Split so the self-test below is a real negative control rather
+# than a comment -- it proves the gate can still tell the three apart, which is
+# the only way "SKIPPED" keeps meaning "not provisioned" instead of "not
+# looked at".
+#
+#   unprovisioned  the variable is unset      -> ledgered SKIP
+#   badpath        set, but no FSP library    -> FAILURE (someone meant to
+#                                                point at a tree and missed)
+#   provisioned    set, library present       -> compile
+classify_fsp_dir() {
+    local dir="$1"
+    if [ -z "$dir" ]; then
+        echo unprovisioned
+    elif [ ! -f "$dir/lib/libtegra_aon_fsp.a" ]; then
+        echo badpath
+    else
+        echo provisioned
+    fi
+}
+
+self_test() {
+    local failures=0 got
+    _case() {
+        got="$(classify_fsp_dir "$2")"
+        if [ "$got" = "$3" ]; then
+            printf '  %-46s ok\n' "$1"
+        else
+            printf '  %-46s FAILED (got %s, want %s)\n' "$1" "$got" "$3"
+            failures=$((failures + 1))
+        fi
+    }
+    local tmp
+    tmp="$(mktemp -d)"
+    _case "unset -> ledgered skip" "" unprovisioned
+    _case "set but empty dir -> failure, not a skip" "$tmp" badpath
+    mkdir -p "$tmp/lib"
+    _case "set, dir exists, no library -> failure" "$tmp" badpath
+    touch "$tmp/lib/libtegra_aon_fsp.a"
+    _case "set with the library -> compile" "$tmp" provisioned
+    rm -rf "$tmp"
+    echo "check-ivc-fsp --self-test: $failures check(s) failed"
+    [ "$failures" -eq 0 ]
+}
+
+# The negative control runs on the NORMAL path: a gate whose own proof needs a
+# flag is a gate whose proof nobody runs.
+self_test || exit 1
+if [ "${1:-}" = "--self-test" ]; then
+    exit 0
+fi
+
+fsp_dir="${NV_SPE_FSP_DIR:-}"
+case "$(classify_fsp_dir "$fsp_dir")" in
+unprovisioned)
+    nros_check_skip ivc-fsp \
+        "NV_SPE_FSP_DIR unset — the NVIDIA Orin SPE FSP tree is not provisioned here (phase-418 418.4)"
+    exit 0
+    ;;
+badpath)
+    echo "check-ivc-fsp: NV_SPE_FSP_DIR=$fsp_dir has no lib/libtegra_aon_fsp.a" >&2
+    echo "       The variable is SET, so this is a wrong path rather than an" >&2
+    echo "       unprovisioned host, and it is a failure for that reason." >&2
+    exit 1
+    ;;
+esac
+
+echo "check-ivc-fsp: compiling nvidia-ivc --features fsp against $fsp_dir"
+# `-D warnings`, like every other clippy lane here. Compiling this file for the
+# first time turned up one lint immediately -- `declare_interior_mutable_const`
+# on `Slot::EMPTY` -- which is a false positive for the `[const { … }; N]`
+# atomic-array idiom and is now allowed AT the constant with the reason. Without
+# `-D warnings` this gate would have watched that scroll past.
+cargo clippy --quiet -p nvidia-ivc --no-default-features --features fsp -- -D warnings || exit 1
+# The forwarders that sit on top of it, in the same configuration.
+cargo clippy --quiet -p zpico-link-ivc --no-default-features -- -D warnings || exit 1
+echo "check-ivc-fsp: OK"


### PR DESCRIPTION
Closes phase-418's 418.2. **Its scope was wrong twice, and measuring it is most of this change.**

The 2026-09-06 correction said what remained was "the DEFAULT-stub and `fsp` configurations plus
the fork's `ivc.c` behind `link-ivc`". The stub half was already covered: `nvidia-ivc` and
`zpico-link-ivc` are both workspace **members**, so `check-workspace-features`'
`--workspace --no-default-features` test-compile builds them. Measured by touching both files and
watching them compile, before adding a row that would have duplicated an existing lane.

## What was genuinely uncovered

**`zpico-sys --features link-ivc`** — a clippy row in `check-workspace-features`. `link-ivc` is a
zpico-sys FEATURE, so nothing off it compiled the vendored
`zenoh-pico/src/link/{unicast,config}/ivc.c`. The build script emits `Z_FEATURE_LINK_IVC 1` and
both TUs now build on every `just check` — verified by finding `ivc.o` in the object set rather
than trusting the feature name.

**`nvidia-ivc --features fsp`** — new `check-ivc-fsp`, skip-capable. Its build script *refuses*
without `NV_SPE_FSP_DIR` pointing at a tree holding `lib/libtegra_aon_fsp.a`, so on an
unprovisioned host this cannot be a compile at all. It is a **ledgered** skip (issue 1184's rule:
an uncounted skip reads as a pass), and a variable that is SET but wrong is a **failure**, not a
skip — someone who set it meant to point somewhere, and treating that as "not provisioned" is how
a provisioned host silently stops testing what it provisioned. Provisioning is 418.4; when that
lands this gate starts compiling with no change to it.

## Compiling `fsp.rs` for the first time found a lint immediately

`clippy::declare_interior_mutable_const` on `Slot::EMPTY` — a false positive for the
`[const { … }; N]` atomic-array idiom, whose repeat wants a fresh value per element and whose
inline `const {}` block exists for exactly that. Allowed at the constant with the reason. The gate
runs `-D warnings` like every other clippy lane here, so without it this would have scrolled past
— which is the argument for the gate.

`check-gate-selftests` caught the first version: a gate must run its negative control on the
NORMAL path. The path decision is now `classify_fsp_dir`, self-tested over all four states (unset,
set-but-empty, set-with-dir-no-library, set-with-library), so "SKIPPED" keeps meaning "not
provisioned" rather than "not looked at".

## Also here: `doc-commit-citations` was red on main

Not in 418.2's diff, but blocking its lane. Three baseline entries whose citations resolve again,
and **behind that first error**, two dangling ones the gate could not show until it cleared — the
same masking shape as the last time this gate was touched.

- `1127-live-peer-cells-skip-forever.md:153` cites `ea9fbfae9`, a commit in `nano-ros-box-box`, a
  mirror of the mirror the issue names as debris. Another checkout is exactly what the baseline is
  for; dropping the hash would lose the only handle on the tree it identifies.
- `docs/issues/README.md:2518` cites `d97c9c606` for a change the same sentence then describes in
  full. Hash dropped — the description is what survives a rebase.

```
just check workspace-features   PASS (with the link-ivc row)
just check ivc-fsp              4/4 self-test, ledgered skip on this host
just check doc-commit-citations 196 citations across 869 files resolve
just check fast                 272 ran, 2 ledgered skips, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119aFbZ4oJ6u4agj4PjknPd