### PR TITLE
fix(check): the mirror-tree citation pair was restored by halves

### DIFF
--- a/.config/doc-commit-citations-baseline.txt
+++ b/.config/doc-commit-citations-baseline.txt
@@ -42,12 +42,6 @@ db91f2bad
 
 # ---- DEAD -------------------------------------------------------------------
 
-# `docs/issues/README.md`, the curated index. Two "Recently resolved" entries
-# name the commit that closed an issue, and those commits are gone. The issue
-# numbers beside them (#0952, #0750) are the durable identifier and are already
-# in the text, so these can be dropped rather than re-resolved.
-22e511442
-
 # `docs/roadmap/phase-359-drop-std-campaign.md`, the four-row table of std
 # symbols and the commit that removed each. The symbol names and issue numbers
 # in the same rows survive; the hashes did not.
@@ -75,5 +69,9 @@ d97c9c606
 # which is the case this file's header calls "another checkout" and the exact
 # thing it exists to hold. `e63d3e11b` shrank the ratchet past them and left
 # `main` red; a ratchet may only shrink where the citation RESOLVES, and these
-# never will.
+# never will. `9c0702322` restored the pair PARTIALLY — `ea9fbfae9` came back
+# and `d1d88f660`, the mirror's own HEAD named in the same sentence, did not,
+# so `main` stayed red for the half that was still missing. Both belong here:
+# the comment above says "those hashes", plural, and always meant both.
+d1d88f660
 ea9fbfae9


### PR DESCRIPTION
`check-doc-commit-citations` was red on `main`. **Two separate baseline faults, in opposite directions** — the ratchet caught both, because it fails on a stale entry as well as on a new dangling one.

## A stale entry

`22e511442` sat under DEAD with a comment saying its commit was gone. It is not gone: `git cat-file -t` resolves it, and it is `feat(#0750 B): key the NuttX snapshot on the CONFIG, not the arch`. A baseline line that no longer offends is debt of its own — it claims a citation cannot be checked when it can. Removed, along with its comment block, which described *two* entries where the other had already been dropped.

## A missing entry

With that gone, the gate reached the real problem: `docs/issues/1127-live-peer-cells-skip-forever.md:152` cites `d1d88f660`, which this clone does not have and never will. It is the HEAD of **another checkout** — the distrobox mirror at `/mnt/wd/data/projects/nano-ros-box`, which the issue itself records as 323 commits behind `main`.

That is exactly the FOREIGN class the file's header defines: *"the sentence is CORRECT and the commit is in another repository… rewriting the hash would replace a true sentence with a wrong one."* So this is a baseline entry, not a prose edit.

The block for it already existed and already said **"those hashes"**, plural — the mirror and its accidental `nano-ros-box-box`. But only `ea9fbfae9` was listed: `e63d3e11b` shrank the ratchet past both, and `9c0702322` restored one. `main` stayed red for the half still missing. Both are listed now, and the comment records the halving so the next person restoring this pair does not restore half of it again.

## On the other red

`leaf-lockfiles` was also failing when I last reported the pair. It is **green on current `main`** with nothing from me — it either got fixed alongside, or was stale state in my tree at the time. I re-ran it before and after this change rather than assume.

Verified: `just check fast` **276/276**, with api-parity now the slowest gate at 26.9 s — matching the 28 s measured when #721 moved it onto the lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)