### PR TITLE
fix(phase-413 W2): my stack-floor hook took SIGPIPE and killed the build it was added to

### DIFF
--- a/scripts/build/workspace-fixtures-build.sh
+++ b/scripts/build/workspace-fixtures-build.sh
@@ -462,9 +462,20 @@ build_workspace() {
             # `--board-for-row` because the row's path spells the PLATFORM and
             # the gate's path sniff looks for the BOARD; an unmapped platform
             # RAISES rather than passing, so a new one is a decision.
+            #
+            # `-print -quit`, NOT `| head -1`. Under this script's
+            # `set -euo pipefail`, a `find` that still has output to write when
+            # `head` exits takes SIGPIPE, the pipeline reports 141, and the
+            # command substitution kills the script. It survived review and a
+            # local run because this tree had exactly ONE match, so `find`
+            # finished before `head` left; CI had more, and the build died
+            # immediately after `built: … native_entry` with no message of its
+            # own — `error: recipe build-workspace-fixtures failed on line 234`
+            # and nothing else. `-quit` stops find itself at the first hit, so
+            # there is no second writer and no pipeline to fail.
             local _sf_elf
             _sf_elf="$(find "$dir/$out_root" -type f -name "$entry" \
-                -path "*/$row_profile_dir/*" 2>/dev/null | head -1)"
+                -path "*/$row_profile_dir/*" -print -quit 2>/dev/null)"
             if [ -n "$_sf_elf" ]; then
                 python3 "$NROS_REPO_ROOT/scripts/check-stack-floor.py" \
                     --board-for-row "$platform" "$_sf_elf"


### PR DESCRIPTION
**`host-tests` is red on `main`, and W2's own stack-floor hook is why.** First run to carry W2, and it died at `Build workspace fixtures`:

```
built: examples/workspaces/rust/target-fixtures/nros-relwithdebinfo/native_entry
error: recipe `build-workspace-fixtures` failed on line 234 with exit code 1
```

No message of its own, right after a successful build, because there was nothing to print — the script died on an exit status.

## Cause

```sh
_sf_elf="$(find ... | head -1)"
```

under the script's `set -euo pipefail`. When `find` still has output to write after `head -1` exits, it takes SIGPIPE, the pipeline reports **141**, and the command substitution takes the script with it. Reproduced directly:

```
$ bash -c 'set -euo pipefail; x="$(find / -maxdepth 4 -name "*.so*" | head -1)"; echo survived'
(no output)   rc=141
```

It passed local verification and review because **this tree has exactly one match** for that find, so `find` finished before `head` left. CI had more. A hazard that needs a second match to appear is invisible to the check I actually ran — I confirmed the hook returned 0 for the `linux` row, and did not look at the shape of the call.

## Fix

`-print -quit`: `find` stops at the first hit itself, so there is no second writer and no pipeline to fail. Same result, one process.

## Sweep

```
grep -rn 'find .*| *head' scripts/ just/ justfile
```

Zero other instances. The remaining `| head -1` sites are `grep`/`ls`/`sed`, which finish on their own or already carry `|| true` — `find` is the one that keeps walking a tree after its reader is gone, which is what makes this its hazard and not a general one.

`just check fast`: 276/276. But the verification that matters here is the lane, not the gate line: **`host-tests` has to get past `Build workspace fixtures`**, which no run has done since W2 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK