### PR TITLE
fix(check): the citation ratchet's stale check was branch-sensitive, and main paid for it three times

### DIFF
--- a/.config/doc-commit-citations-baseline.txt
+++ b/.config/doc-commit-citations-baseline.txt
@@ -77,3 +77,19 @@ d97c9c606
 # `main` red; a ratchet may only shrink where the citation RESOLVES, and these
 # never will.
 ea9fbfae9
+
+# ---- RE-ADDED 2026-09-08 — removed while still needed --------------------
+#
+# All three were taken out of this file by a tree in which they were NOT
+# dangling, and `main` went red. `839f69b5c` and `fe807a999` are fixed on PR
+# #629's branch (replaced with descriptions of the commits), so any checkout
+# carrying that work sees them resolve; `main` does not have it. `d1d88f660`
+# names a `ros2` distrobox tree, which no checkout of THIS repository will ever
+# resolve — the FOREIGN case above.
+#
+# The gate no longer FAILS on a seemingly-stale entry for exactly this reason;
+# it reports one. Remove these two when #629 lands:
+839f69b5c
+fe807a999
+# Keep this one permanently — foreign, like its two siblings above:
+d1d88f660

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,6 +500,56 @@ open B. It costs one queue cycle and has no failure mode. Stack only when B is
 genuinely blocked on A's code, which is rarer than it feels — `just claim` exists
 so two agents do not need the same work in flight.
 
+### What stacking costs, measured 2026-09-07
+
+Three things the choice above does not price. None of them changes the
+rejected-work argument — that is still the reason stacking exists — but an agent
+weighing "I do not want to block on A" should know what the alternative buys.
+
+**A stacked PR CANNOT arm auto-merge.** Auto-merge is a property of the BASE
+branch, not of the pull request: GitHub only enables it where the base has
+something to wait on. `main` has the ruleset and the queue; `fix/a` has neither,
+so the request is refused outright —
+
+    $ gh pr merge 704 --auto
+    --merge, --rebase, or --squash required when not running interactively
+    $ gh pr merge 704 --auto --rebase
+    GraphQL: Pull request Protected branch rules not configured for this branch
+             (enablePullRequestAutoMerge)
+
+Note the second command still exits **0** — the error is on stderr. `gh pr merge
+--auto` returning success is not evidence that anything armed; only
+`autoMergeRequest` is. Reading the exit code is how a sweep reports armed PRs
+that are not.
+
+So B needs a human at both ends: one merge into `fix/a`, then A shepherded
+through the queue. It also never enters the queue itself, so it gets none of the
+`max_entries_to_build: 5` speculative parallelism — stacking SERIALISES
+throughput, which is the opposite of the reason it usually gets reached for.
+
+**Rebasing A strands B.** The queue is not the only thing that moves `fix/a`;
+so does every rebase of A onto a newer `main`. B's base then stops being an
+ancestor and B cannot be restacked mechanically, because its copies of A's
+commits conflict with their own rebased twins. Measured on #704 after #629 was
+rebased twice: common ancestor an old `main` tip, base **110 commits** past it,
+and the restack conflicted on `bd4b087c1` — one of A's own commits. The remedy
+is to wait for A to land, retarget B to `main`, and rebase there.
+
+**The `main`-based alternative self-cleans, because the queue rebase-merges.**
+`merge_method=REBASE` replays A's commits onto `main` with new hashes and
+IDENTICAL patch content, so `git rebase` drops B's copies by patch-id with no
+intervention. Measured the same day: #699 went 22 commits to 1, #550 4 to 1,
+#626 2 to 1, every drop verified present on `main` by subject. This property is
+load-bearing on the merge method — under a squash queue the patch-ids would not
+match and every carried commit would conflict instead.
+
+When you do carry A's commits on a `main`-based branch: cherry-pick only what B
+actually needs (usually A's interface, not its whole diff), say so in the PR
+body so a reviewer does not read A's diff as B's work, and after each rebase
+CHECK THE COMMIT COUNT and confirm every dropped commit is genuinely on `main`.
+That check is what separates a legitimate patch-id skip from a silently lost
+commit, and both happened in one afternoon.
+
 ## When the merge queue rejects your pull request
 
 A merge group tests **`main` + your PR**, which is a commit that exists nowhere

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,19 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   the required set, and never path-filter a required workflow: a check that
   produces no verdict blocks forever, which deadlocked two PRs on 2026-08-28.
   Read AGENTS.md "Branch policy" — it has the flow and the break-glass.
+- **A STACKED pull request cannot arm auto-merge, and rebasing its parent strands
+  it.** Auto-merge is a property of the BASE branch: `main` has the ruleset and
+  the queue, a feature branch has neither, so GitHub refuses
+  (`Protected branch rules not configured for this branch`) — and `gh pr merge
+  --auto` still exits 0, so only `autoMergeRequest` proves anything armed. A stack
+  also never enters the queue, so it forfeits the 5-way speculative build and
+  SERIALISES what it was reached for. Prefer basing on `main` and cherry-picking
+  only what you need from the parent: the queue rebase-merges, so the carried
+  commits drop by patch-id on the next rebase with no intervention (#699 22->1,
+  #550 4->1, #626 2->1, each drop verified on main). Check the commit count after
+  every rebase — a patch-id skip and a silently lost commit look identical until
+  you do. The one thing stacking still buys is that a REJECTED parent cannot ship
+  inside the child. -> AGENTS.md "What stacking costs".
 - **Never `git add -A` / `git add .`** — stage the paths you actually changed
   (`git add <path>…`, or `git add -u <dir>` for tracked-only edits). A blanket add
   scoops up build output, leftover dirs and stray artifacts. Twice in one session it

--- a/scripts/check-doc-commit-citations.py
+++ b/scripts/check-doc-commit-citations.py
@@ -172,14 +172,29 @@ def main():
     problems = [h for h in dangling if h not in baseline]
     stale = [h for h in baseline if h not in dangling]
 
+    # A stale entry is REPORTED, not failed. It used to `return 1`, and that
+    # was wrong in a way only running it on more than one branch reveals.
+    #
+    # The baseline is keyed on a global hash, but "is this citation dangling?"
+    # is answered against the WORKING TREE. A branch that fixes a citation —
+    # PR #629 replaces two of these with descriptions of the commits — makes
+    # its baseline entries look stale, so this demanded they be deleted; on
+    # `main`, which does not have that branch, the same entries are required
+    # and their absence is a red. Both edits are locally correct and they
+    # contradict each other, so the gate drove three fix commits in one day
+    # (`055b84387`, `e63d3e11b`, `9c0702322`) and `main` was red between them.
+    #
+    # The ratchet's real protection is the other half: a NEW dangling citation
+    # fails. That is what stops the debt growing, it is branch-independent, and
+    # it is untouched. A stale entry costs a line in a file nobody reads twice
+    # — cheaper than a gate whose remedy is wrong half the time it is applied.
     if stale:
-        sys.stderr.write(
-            "check-doc-commit-citations: %d baseline entry/entries no longer "
-            "needed — the citation resolves now, or the line is gone. Remove "
-            "them:\n" % len(stale))
+        print("check-doc-commit-citations: %d baseline entry/entries may no "
+              "longer be needed (the citation resolves now, or the line is "
+              "gone). Not a failure — remove them when the branch that fixed "
+              "them has landed on `main`:" % len(stale))
         for h in sorted(stale):
-            sys.stderr.write(f"  {h}\n")
-        return 1
+            print(f"  {h}")
 
     if problems:
         sys.stderr.write(


### PR DESCRIPTION
Two changes, one cause.

## `main` is red on a gate I added, for the fourth time

`check-doc-commit-citations` fails on a baseline entry that "no longer offends". That reads like ordinary ratchet hygiene and is not: **the baseline is keyed on a global hash, while "is this citation dangling?" is answered against the working tree.**

PR #629 replaces two of these hashes with descriptions of the commits. So any checkout carrying that branch sees the entries resolve and the gate *demands* their removal — and on `main`, which lacks #629, the same entries are required and their absence is a red. Both edits are locally correct and they contradict each other.

Result: three fix commits in one day (`055b84387`, `e63d3e11b`, `9c0702322`), `main` red between them, and still red at the fourth attempt:

```
docs/roadmap/phase-428-...-sweep.md:677                `839f69b5c`
docs/roadmap/phase-428-...-sweep.md:646                `fe807a999`
docs/issues/1127-live-peer-cells-skip-forever.md:152   `d1d88f660`
```

**A gate whose remedy is wrong half the times it is applied is worse than the drift it prevents.** The stale check is now reported, not failed. The ratchet's real protection — a NEW dangling citation fails — is branch-independent and untouched.

Mutation-re-verified: injecting a dangling citation still `exit=1`; a stale entry now `exit=0` and prints one line.

The three entries go back. Two are #629's and come out when it lands; the third names a `ros2` distrobox tree and is FOREIGN, so it stays permanently.

## What it taught, written down

`AGENTS.md` already had "Stacking: when PR B builds on PR A", recommending B be based on `fix/a`. **That reason stands** — a rejected A cannot ship inside B that way. It did not price the other side, and an agent that would rather not block on A should see both. Added, all measured 2026-09-07:

- **A stacked PR cannot arm auto-merge.** Auto-merge is a property of the BASE branch; a feature branch has no ruleset to wait on. Reproduced on #704: `GraphQL: Pull request Protected branch rules not configured for this branch`. And `gh pr merge --auto` still **exits 0** when it fails — only `autoMergeRequest` proves anything armed.
- **A stack never enters the queue**, forfeiting `max_entries_to_build: 5` and serialising the throughput it was reached for.
- **Rebasing A strands B** — #704's base moved 110 commits past their common ancestor; the restack conflicted on `bd4b087c1`, one of A's own commits.
- **The `main`-based alternative self-cleans because the queue rebase-merges** — patch content survives, so carried copies drop by patch-id (#699 22→1, #550 4→1, #626 2→1, every drop verified on `main`). Load-bearing on `merge_method=REBASE`; a squash queue would conflict instead.

`CLAUDE.md` gets the one-liner and a pointer, per its own rule about not growing.

Verified: `just check doc-refs`, `doc-commit-citations`, `doc-recipe-refs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N