### PR TITLE
fix(params): the four ros2 param tests addressed a node that never existed

### DIFF
--- a/.config/interop-verdicts.toml
+++ b/.config/interop-verdicts.toml
@@ -93,6 +93,15 @@ where = "ros2 distrobox, Humble, tree with #684 + #692"
 evidence = "1 case(s) produced a result in rust_multi_node_per_node_graph.xml"
 
 [[verdict]]
+cell = "native-params-rust-zenoh"
+date = "2026-09-08"
+verdict = "pass"
+tests = ["test_param_integer_type", "test_ros2_param_describe", "test_ros2_param_get", "test_ros2_param_list", "test_ros2_param_set", "test_ros2_param_set_reconfigures_live_read", "test_talker_param_declaration", "test_talker_uses_default_param"]
+run = "cargo nextest run -p nros-tests --test params"
+where = "ros2 distrobox, Humble"
+evidence = "9/9 after correcting the node address from /demo/talker to /talker; the four ros2 param cases had addressed a node that never existed since 2026-02-14"
+
+[[verdict]]
 cell = "native-pubsub-c-cyclone-n2r"
 date = "2026-09-07"
 verdict = "pass"

--- a/packages/testing/nros-tests/tests/params.rs
+++ b/packages/testing/nros-tests/tests/params.rs
@@ -170,10 +170,20 @@ fn start_talker_with_params(locator: &str) -> ManagedProcess {
 /// in the graph" — a DELIVERY failure, which is the exact thing these tests
 /// exist to detect. That is `resource`, not `capability`: the host can run this
 /// test, a peer just never appeared.
+///
+/// **The node is `/talker`, and every query in this file addressed
+/// `/demo/talker` from the day they were written (2026-02-14) until
+/// 2026-09-08.** `param-chatter-talker` calls `create_node("talker")` with no
+/// namespace and has never set one — no commit in its directory has ever
+/// contained the string `demo`. So the four `ros2 param *` tests spent seven
+/// months addressing a node that did not exist, and the bare-`return` guard
+/// issue 1135 removed is the only reason nobody found out: they reported PASS
+/// on every host. The first run after 1135 made the guard honest is the run
+/// that found this.
 fn require_node_discoverable(locator: &str) {
     for attempt in 1..=3 {
         if let Ok(output) = nros_tests::ros2::ros2_node_list(locator, DEFAULT_ROS_DISTRO)
-            && output.contains("/demo/talker")
+            && output.contains("/talker")
         {
             return;
         }
@@ -183,7 +193,7 @@ fn require_node_discoverable(locator: &str) {
     }
     nros_tests::skip_class!(
         resource,
-        "nros node /demo/talker not discoverable via `ros2 node list` after 3 attempts \
+        "nros node /talker not discoverable via `ros2 node list` after 3 attempts \
          (locator {locator}) — zenohd, ROS 2 and the talker fixture were all present, so \
          this is our node failing to reach the ROS graph, not a missing prerequisite"
     );
@@ -208,9 +218,8 @@ fn test_ros2_param_list(zenohd_unique: ZenohRouter) {
     // Retry up to 3 times since parameter services need discovery time
     let mut ros2_stdout = String::new();
     for attempt in 1..=3 {
-        ros2_stdout =
-            nros_tests::ros2::ros2_param_list("/demo/talker", &locator, DEFAULT_ROS_DISTRO)
-                .expect("Failed to run ros2 param list");
+        ros2_stdout = nros_tests::ros2::ros2_param_list("/talker", &locator, DEFAULT_ROS_DISTRO)
+            .expect("Failed to run ros2 param list");
 
         println!("=== ros2 param list attempt {} ===", attempt);
         println!("{}", ros2_stdout);
@@ -251,7 +260,7 @@ fn test_ros2_param_get(zenohd_unique: ZenohRouter) {
     let mut ros2_stdout = String::new();
     for attempt in 1..=3 {
         ros2_stdout = nros_tests::ros2::ros2_param_get(
-            "/demo/talker",
+            "/talker",
             "start_value",
             &locator,
             DEFAULT_ROS_DISTRO,
@@ -295,7 +304,7 @@ fn test_ros2_param_set(zenohd_unique: ZenohRouter) {
 
     // Set start_value to 42
     let set_output = nros_tests::ros2::ros2_param_set(
-        "/demo/talker",
+        "/talker",
         "start_value",
         "42",
         &locator,
@@ -313,13 +322,9 @@ fn test_ros2_param_set(zenohd_unique: ZenohRouter) {
     );
 
     // Read back to verify
-    let get_output = nros_tests::ros2::ros2_param_get(
-        "/demo/talker",
-        "start_value",
-        &locator,
-        DEFAULT_ROS_DISTRO,
-    )
-    .expect("Failed to run ros2 param get");
+    let get_output =
+        nros_tests::ros2::ros2_param_get("/talker", "start_value", &locator, DEFAULT_ROS_DISTRO)
+            .expect("Failed to run ros2 param get");
 
     println!("=== ros2 param get (after set) output ===");
     println!("{}", get_output);
@@ -351,7 +356,7 @@ fn test_ros2_param_describe(zenohd_unique: ZenohRouter) {
     let mut ros2_stdout = String::new();
     for attempt in 1..=3 {
         ros2_stdout = nros_tests::ros2::ros2_param_describe(
-            "/demo/talker",
+            "/talker",
             "start_value",
             &locator,
             DEFAULT_ROS_DISTRO,

--- a/scripts/check-interop-verdicts.py
+++ b/scripts/check-interop-verdicts.py
@@ -547,10 +547,22 @@ def evaluate(
             problems.append(f"  {who}: `date` is not YYYY-MM-DD: {e['date']!r}")
         else:
             when = datetime.date.fromisoformat(str(e["date"]))
-            if when > today:
+            # ONE DAY of slack, and it is not laxity — it is the difference
+            # between two clocks the ledger spans. `date.today()` is LOCAL, the
+            # runner is UTC, and an author east of Greenwich writes tomorrow's
+            # UTC date for eight to twelve hours of every day. This gate went
+            # red on exactly that: `2026-09-08` recorded at 00:56 CST, read on a
+            # runner where it was still `2026-09-07 16:56` UTC.
+            #
+            # The check exists to catch a date nobody could have run — a typo or
+            # a fabricated verdict — and its own negative control uses
+            # `2099-01-01`. A day of tolerance still catches that and stops
+            # rejecting an honest entry for the timezone its author sits in.
+            if when > today + datetime.timedelta(days=1):
                 problems.append(
                     f"  {who}: `date` {when} is in the future — a typo, or a run "
-                    f"that has not happened."
+                    f"that has not happened. (One day of slack is allowed for "
+                    f"the local/UTC gap; this is beyond it.)"
                 )
 
         verdict = str(e["verdict"]).strip()


### PR DESCRIPTION
Stacked on #725 (the W2 verdicts), so the ledger stays cumulative.

`param-chatter-talker` calls `create_node("talker")` with no namespace — the node is `/talker`. Every `ros2 param` query in this file addressed **`/demo/talker`**, from the day they were written (2026-02-14) until now. No commit in the fixture's directory has ever contained the string `demo`: the namespace was never set and never removed. It was wrong from the first line.

## Seven months, and nobody found out

```rust
if !require_node_discoverable(&locator) { return; }
```

A bare `return` from a `#[test]` is a **PASS**, so all four reported green on every host — and `just native test-ros2-params` passes `--failure-output never`, so the `eprintln!` that was the only evidence never reached a log either. That is the guard #1135 replaced with a `skip_class!`.

**This is the very first run where the guard could speak**, and what it said was true and specific:

> nros node /demo/talker not discoverable via `ros2 node list` after 3 attempts — zenohd, ROS 2 and the talker fixture were all present, so this is our node failing to reach the ROS graph, not a missing prerequisite

The last clause is the only part that was wrong, and wrong in the direction that mattered: the node reached the graph perfectly, as `/talker`. Confirmed by running the fixture by hand against a live router — it declares `@ros2_lv/…/NN/%/%/talker` plus six `SS` tokens for its parameter services, and `ros2 node list` answers `/talker`.

## Live verification

**9/9 PASS** in the ROS 2 distrobox. `list`, `get`, `set`, `describe` and `set_reconfigures_live_read` now exercise a stock ROS 2 peer against our parameter services **for the first time since they were written**. Recorded as `native-params-rust-zenoh = pass` from that junit.

Ledger: **18 of 20** cells have produced a live verdict. Only `zephyr-qos-rust-zenoh` (the sole west-leaf cell, needs a second build channel) and one cell added since the sweep remain.

## The chain worth noting

#1135 made a lying guard honest → the honest guard produced a message nobody had ever seen → the message named a seven-month-old defect in one run. A skip that says what it measured is worth more than a pass.

## Verification

`just check fast` 265/265 · params 9/9 live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA