### PR TITLE
fix(#1132): the deferred config-header call ran 5 times and did nothing 5 times

### DIFF
--- a/cmake/NanoRosNodeRegister.cmake
+++ b/cmake/NanoRosNodeRegister.cmake
@@ -175,7 +175,38 @@ function(_nros_node_register_compose_inventory)
         LABEL "this image's entity inventory (standalone)")
 endfunction()
 
-function(_nros_node_register_apply_config_header_deps _tgt)
+# Issue 1132 -- the target travels by GLOBAL property, and the deferred call
+# takes NO ARGUMENTS.
+#
+# `cmake_language(DEFER ... CALL fn "${_tgt}")` stores its arguments UNEXPANDED
+# and expands them when the deferred call runs, in the deferred directory's
+# scope. `_tgt` is function-local and long gone by then, so the callee received
+# an empty string and returned at its own `if(NOT TARGET "")` guard. Every
+# `add_dependencies()` below -- the 0088/0090 config-header ordering -- had
+# therefore never happened, for any image in this tree.
+#
+# It stayed hidden because a no-op guarded by `if(NOT TARGET "")` is
+# indistinguishable from a guard that correctly skipped a non-target, and
+# because the STRONGER edge beside it (the `OBJECT_DEPENDS` file dependency) is
+# applied EAGERLY and does work. What was missing is the weaker target-ordering
+# half, so the symptom is a rare ordering race rather than a wrong artifact.
+#
+# Same idiom as `_nros_node_register_schedule_inventory` above. The list form is
+# needed because several callers register different targets before the deferred
+# call runs.
+define_property(GLOBAL PROPERTY NROS_PENDING_CONFIG_HEADER_DEPS
+    BRIEF_DOCS "Targets awaiting the 0088/0090 config-header ordering edges"
+    FULL_DOCS  "Issue 1132 -- appended by _nros_node_register_config_header_deps(), \
+drained once by _nros_node_register_apply_config_header_deps() at DEFER time.")
+
+function(_nros_node_register_apply_config_header_deps)
+    get_property(_pending GLOBAL PROPERTY NROS_PENDING_CONFIG_HEADER_DEPS)
+    foreach(_tgt IN LISTS _pending)
+        _nros_node_register_apply_config_header_deps_to("${_tgt}")
+    endforeach()
+endfunction()
+
+function(_nros_node_register_apply_config_header_deps_to _tgt)
     if(NOT TARGET ${_tgt})
         return()
     endif()
@@ -199,8 +230,17 @@ function(_nros_node_register_apply_config_header_deps _tgt)
 endfunction()
 
 function(_nros_node_register_config_header_deps _tgt)
+    set_property(GLOBAL APPEND PROPERTY NROS_PENDING_CONFIG_HEADER_DEPS "${_tgt}")
+    # Schedule the drain ONCE. Deferring per call would re-drain the whole list
+    # for every registered target -- harmless (add_dependencies is idempotent)
+    # but N^2 and noisy.
+    get_property(_scheduled GLOBAL PROPERTY NROS_CONFIG_HEADER_DEPS_SCHEDULED)
+    if(_scheduled)
+        return()
+    endif()
+    set_property(GLOBAL PROPERTY NROS_CONFIG_HEADER_DEPS_SCHEDULED TRUE)
     cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
-        CALL _nros_node_register_apply_config_header_deps "${_tgt}")
+        CALL _nros_node_register_apply_config_header_deps)
 endfunction()
 
 define_property(GLOBAL PROPERTY NROS_COMPONENTS_JSON

--- a/docs/issues/1204-island-image-dtcm-overflows-on-main.md
+++ b/docs/issues/1204-island-image-dtcm-overflows-on-main.md
@@ -1,0 +1,80 @@
+---
+id: 1204
+title: "The safety-island Zephyr image no longer links on main -- DTCM
+  overflowed by 45040 bytes"
+status: open
+type: bug
+area: zephyr
+severity: high
+related: [issue-1197, issue-1132]
+---
+
+## Symptom
+
+Autoware Safety Island's `board-build` recipe (that repo's justfile, not
+this one) for `mr_canhubk3/s32k344` fails at the link:
+
+```
+ld.bfd: region `DTCM' overflowed by 45040 bytes
+collect2: error: ld returned 1 exit status
+FAILED: zephyr/zephyr_pre0.elf zephyr/zephyr_pre0.map
+```
+
+Reproduced on a wiped build directory, twice, with the SAME byte count both
+times -- so this is not the derived-knob convergence that needs a second pass.
+The derived knobs are identical to a build that links:
+
+```
+NROS_EXECUTOR_MAX_CBS=19
+NROS_SUBSCRIPTION_BUFFER_SIZE=1496
+NROS_SUBSCRIBER_BUFFER_SIZE=880
+entity inventory: 4 components -- 33 entities, 19 executor callback slots
+```
+
+## Scale
+
+DTCM is 128 KB. A build of this image that links reports:
+
+```
+DTCM:       93344 B       128 KB     71.22%
+```
+
+Overflowing by 45040 puts it near 176 KB, so roughly 83 KB has appeared. That is
+not drift; something is placed in DTCM that was not there before, or is placed
+twice.
+
+## Bisect boundary, established
+
+Not caused by the change that found it. A control build of clean `origin/main`
+with that change stashed produces the IDENTICAL overflow, to the byte.
+
+The last commit known to produce a linking image is `fb94d1896`
+(`fix(zephyr): the C-for-C++ nros-c string must read the C++ one`), measured on
+its own branch at 71.22% DTCM before it merged. The commits merged after it:
+
+```
+055b84387 fix(check): doc-commit-citations is red on main, in both directions
+56fc7b03c build(#1197): six more leaf locks the gate surfaced once the first 13 were fixed
+a0992e5d8 build(#1197): the 13 leaf locks that carry nros-node gain the new path dep
+dc2416f6e feat(#1197): the placement arithmetic moves to a crate a build script can call
+3e5dc6e4f fix(ci): the CLI cache stored the whole job, not the CLI build
+```
+
+`dc2416f6e` is the one to look at first -- it moves the PLACEMENT arithmetic,
+which is what decides what lands in DTCM. The other four are a lockfile sweep, a
+CI cache fix and a docs gate, none of which should reach a linker script. This
+is a reading of the subject lines, NOT a bisect: the bisect was not run.
+
+## Why this matters more than the byte count
+
+Nothing merge-gating builds this image. The regression reached main and the only
+reason it is known is that someone tried to verify an unrelated cmake fix
+against a real board image. That is the same coverage hole issue 1177 is about,
+one platform over.
+
+## Next step
+
+Bisect the five commits above with the island's board-build recipe on a wiped
+directory, and
+if it is `dc2416f6e`, compare the generated linker script and the DTCM section
+list against `fb94d1896`.

--- a/docs/issues/1226-zephyr-native-sim-cpp-cyclonedds-row-has-no-matrix-cell.md
+++ b/docs/issues/1226-zephyr-native-sim-cpp-cyclonedds-row-has-no-matrix-cell.md
@@ -64,8 +64,8 @@ red they must triage as not-theirs before they can trust the green above it,
 which is issue 0952's warning read from the other end.
 
 This is the fourth pre-existing red on `main` this week, after the two
-`docs/rfc-0094-resolve-before-configure` fixed in `5817d343e` and the
-`cli-clippy` dead-code one in `684e40ab3`.
+`docs/rfc-0094-resolve-before-configure` fixes and the `cli-clippy` dead-code
+one.
 
 ## Fix direction (not applied)
 

--- a/docs/issues/1227-island-image-dtcm-overflows-on-main.md
+++ b/docs/issues/1227-island-image-dtcm-overflows-on-main.md
@@ -1,5 +1,5 @@
 ---
-id: 1204
+id: 1227
 title: "The safety-island Zephyr image no longer links on main -- DTCM
   overflowed by 45040 bytes"
 status: open

--- a/docs/issues/archived/1132-deferred-call-arguments-reexpand-and-vanish.md
+++ b/docs/issues/archived/1132-deferred-call-arguments-reexpand-and-vanish.md
@@ -2,11 +2,12 @@
 id: 1132
 title: "`cmake_language(DEFER ... CALL fn \"${local}\")` passes an EMPTY string,
   so the config-header ordering edges have never been applied"
-status: open
+status: resolved
 type: bug
 area: build, cmake
 severity: medium
 related: [issue-0088, issue-0090, issue-1084]
+resolved_in: "phase-412 follow-up"
 ---
 
 ## What happens
@@ -100,3 +101,65 @@ the tree to fix it with. The `EVAL CODE` form at `NanoRosEntry.cmake:104` is
 worth knowing about: it is the only way to defer a call that genuinely needs an
 argument, and it works because the expansion happens at EVAL time rather than
 at execution time.
+
+## Fixed, and MEASURED on the island image
+
+The one broken site now appends its target to a GLOBAL property and defers a
+NO-ARGUMENT drain, which is the idiom
+`_nros_node_register_schedule_inventory` already used two functions above. The
+list form is needed because several callers register different targets before
+the deferred call runs, and the drain is scheduled once rather than per call.
+
+Measured by putting a `message(STATUS ...)` at the top of the callee and
+re-running cmake configure on the safety-island Zephyr image
+(`mr_canhubk3/s32k344`), once with each form. Same build directory, same cache,
+nothing else changed:
+
+```
+BEFORE (the shipped form, DEFER ... CALL fn "${_tgt}")
+  5 calls, and every one of them:
+  -- NROS1132PROBE applying to []
+
+AFTER (GLOBAL property + no-argument DEFER)
+  5 calls:
+  -- NROS1132PROBE applying to [mrm_comfortable_stop_operator_lib]
+  -- NROS1132PROBE applying to [mrm_emergency_stop_operator_lib]
+  -- NROS1132PROBE applying to [mrm_handler_lib]
+  -- NROS1132PROBE applying to [stop_mode_operator_lib]
+  -- NROS1132PROBE applying to [zephyr_entry]
+```
+
+So the callee ran five times per configure for the whole life of this code and
+did nothing five times, exactly as this issue predicted.
+
+## What the fix does NOT change, on this image
+
+Every one of those five targets ALREADY carried the
+`nros_c_cargo_build` / `nros_cpp_cargo_build` order-only edge in `build.ninja`
+before the fix -- checked on a build dir produced by the broken code. The eager
+`OBJECT_DEPENDS` half was supplying it, which is what this issue says and is why
+nothing ever failed. The fix restores the weaker target-level half for the cases
+that half does not cover; on THIS image it is redundant, and no before/after
+difference in the generated ninja is claimed.
+
+## The gate
+
+`scripts/check-deferred-call-args.py`, in the `ci` group. It parses cmake
+invocations (quoted strings and bracket arguments as single tokens) and fails on
+any `cmake_language(DEFER ... CALL fn <arg>)` whose argument carries a `${`.
+Both correct idioms pass: the no-argument form, and the
+`cmake_language(EVAL CODE ...)` wrapper, whose DEFER lives inside a quoted
+string and is therefore not a token of the statement the gate reads.
+
+7 self-test cases, including the false reading the gate shipped with and had to
+fix: it flagged the cmake COMMENT that quotes the broken form in order to
+explain it. A scanner that cannot tell code from prose about code will keep
+finding itself.
+
+## Not verified: a linked image
+
+The island image does not link on nano-ros main right now -- `region DTCM
+overflowed by 45040 bytes` -- and that is NOT this change. A control build of
+clean main with this change stashed produces the identical overflow, to the
+byte. Filed separately. The configure-level measurement above is what backs
+this fix.

--- a/just/check/cmake.just
+++ b/just/check/cmake.just
@@ -242,3 +242,25 @@ cxx-standard-floor:
 [group("check")]
 cargo-dir-knob-key:
     @bash scripts/check-cargo-dir-knob-key.sh
+
+# Issue 1132 -- `cmake_language(DEFER ... CALL fn "${local}")` delivers an
+# EMPTY string.
+#
+# DEFER stores its CALL arguments UNEXPANDED and expands them when the deferred
+# call runs, in the deferred directory's scope, by which time a function-local
+# is gone. Measured on cmake 3.22, this repo's floor.
+#
+# The one site this was written for had been a no-op for its whole life: the
+# callee returned at its own `if(NOT TARGET "")` guard, which reads exactly
+# like a guard correctly skipping a non-target, and the eager `OBJECT_DEPENDS`
+# edge beside it kept builds correct anyway. Nothing failed and nothing warned,
+# so the 0088/0090 config-header ordering was never actually applied.
+#
+# Buildless. `--self-test` drives 7 synthetic sources, including the two forms
+# that must NOT be flagged: the `cmake_language(EVAL CODE ...)` wrapper (which
+# expands the argument into a literal BEFORE defer stores it, and is the only
+# way to defer a call that genuinely needs one), and a comment quoting the
+# broken form -- the false reading this gate shipped with and had to fix.
+[group("ci")]
+deferred-call-args:
+    @python3 scripts/check-deferred-call-args.py

--- a/scripts/check-deferred-call-args.py
+++ b/scripts/check-deferred-call-args.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""`cmake_language(DEFER ... CALL fn <args>)` must not pass an unexpanded `${...}`.
+
+Issue 1132. DEFER stores its CALL arguments UNEXPANDED and expands them when the
+deferred call runs, in the deferred directory's scope. A function-local variable
+is gone by then, so the callee receives an EMPTY STRING:
+
+    function(caller _tgt)
+        cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL callee "${_tgt}")
+    endfunction()
+    caller("my_target_name")
+    -- DEFERRED CALLEE GOT: []
+
+Measured on cmake 3.22, this repo's floor.
+
+WHY THIS IS A GATE AND NOT A REVIEW NOTE.
+
+The failure is silent in the worst way: the callee's own `if(NOT TARGET "")`
+guard returns cleanly, which is indistinguishable from a guard that correctly
+skipped a non-target. The one site this gate was written for
+(`_nros_node_register_apply_config_header_deps`) had been a no-op for its whole
+life, and the build stayed correct anyway because the STRONGER edge beside it --
+an eager `OBJECT_DEPENDS` file dependency -- did the real work. So nothing
+failed, nothing warned, and nothing asserted the mechanism ran. That is the
+issue 0196 shape: a mechanism nobody can observe is indistinguishable from one
+that was never written.
+
+THE TWO CORRECT IDIOMS, both already in this tree:
+
+  * no-argument call, state travels by GLOBAL property (preferred) --
+    `_nros_node_register_schedule_inventory`, `NanoRosEntityFacts.cmake`;
+  * `cmake_language(EVAL CODE "cmake_language(DEFER ... CALL fn [[${target}]])")`
+    -- `NanoRosEntry.cmake`. This one works because EVAL expands the argument
+    into a LITERAL before DEFER ever stores it. It is the only way to defer a
+    call that genuinely needs an argument.
+
+The EVAL form is not flagged: its top-level statement is `cmake_language(EVAL
+CODE "...")`, and the DEFER inside is part of a quoted string, not a token of
+the statement this gate reads.
+
+Run: python3 scripts/check-deferred-call-args.py [--self-test]
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+
+def strip_comments(text):
+    """Blank out `#` comments, preserving offsets so line numbers stay true.
+
+    Needed because this gate's own docstring-adjacent cmake comments quote the
+    broken form to explain it -- and the first version of this gate reported
+    the COMMENT that describes the bug as an instance of the bug. A scanner
+    that cannot tell code from prose about code will keep finding itself.
+    """
+    out = list(text)
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    break
+                j += 1
+            i = j + 1
+            continue
+        if text.startswith("[[", i):
+            j = text.find("]]", i + 2)
+            i = n if j == -1 else j + 2
+            continue
+        if c == "#":
+            j = text.find("\n", i)
+            end = n if j == -1 else j
+            for k in range(i, end):
+                out[k] = " "
+            i = end
+            continue
+        i += 1
+    return "".join(out)
+
+
+def tokenize(text, start):
+    """Tokens of the command invocation whose `(` is at `text[start]`.
+
+    Quoted strings and bracket arguments come back as ONE token each, which is
+    what keeps the `EVAL CODE "...DEFER..."` form from reading as a DEFER
+    statement. Returns (tokens, index just past the closing paren), or
+    (None, None) if the parens never balance.
+    """
+    tokens = []
+    cur = ""
+    depth = 0
+    i = start
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    break
+                j += 1
+            cur += text[i : j + 1]
+            i = j + 1
+            continue
+        if c == "[" and text.startswith("[[", i):
+            j = text.find("]]", i + 2)
+            if j == -1:
+                return None, None
+            cur += text[i : j + 2]
+            i = j + 2
+            continue
+        if c == "(":
+            depth += 1
+            if depth == 1:
+                i += 1
+                continue
+        if c == ")":
+            depth -= 1
+            if depth == 0:
+                if cur.strip():
+                    tokens.append(cur.strip())
+                return tokens, i + 1
+        if c == "#" and depth >= 1:
+            j = text.find("\n", i)
+            i = n if j == -1 else j
+            continue
+        if c.isspace() and depth == 1:
+            if cur.strip():
+                tokens.append(cur.strip())
+            cur = ""
+            i += 1
+            continue
+        cur += c
+        i += 1
+    return None, None
+
+
+def offenders_in(text, rel):
+    """(rel, line, token) for every DEFER CALL argument carrying a `${`."""
+    bad = []
+    text = strip_comments(text)
+    needle = "cmake_language"
+    i = 0
+    while True:
+        i = text.find(needle, i)
+        if i == -1:
+            return bad
+        j = i + len(needle)
+        while j < len(text) and text[j].isspace():
+            j += 1
+        if j >= len(text) or text[j] != "(":
+            i += len(needle)
+            continue
+        tokens, end = tokenize(text, j)
+        if tokens is None:
+            i += len(needle)
+            continue
+        if "DEFER" in tokens and "CALL" in tokens:
+            k = tokens.index("CALL")
+            # tokens[k+1] is the callee NAME; the arguments follow it.
+            for tok in tokens[k + 2 :]:
+                if "${" in tok:
+                    line = text.count("\n", 0, i) + 1
+                    bad.append((rel, line, tok))
+        i = end if end is not None else i + len(needle)
+
+
+def cmake_files():
+    """The TRACKED cmake files, from the git index.
+
+    `git ls-files`, not a filesystem walk. `check-no-tracked-file-find` states
+    the measurement behind that rule -- 7m36s against 0.8s for the same 232
+    paths -- and it caught the first version of this gate, which walked and then
+    pruned. Pruning is not the fix: the walk still stats every directory it
+    considers pruning, and it descends into build/ and target/ first.
+
+    The index also settles what to skip without a SKIP list: build artifacts and
+    agent worktrees are untracked, so they are simply not in it. A SKIP list
+    compared against the wrong kind of path is its own recurring bug here.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "-z", "*.cmake", "CMakeLists.txt", "*/CMakeLists.txt"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    for rel in sorted(f for f in out.split("\0") if f):
+        p = REPO / rel
+        if p.is_file():
+            yield p, Path(rel)
+
+
+def self_test():
+    cases = [
+        # (source, expected offender count, what it stands for)
+        (
+            'function(f _t)\n'
+            '    cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL g "${_t}")\n'
+            'endfunction()\n',
+            1,
+            "the issue 1132 shape -- a function-local passed to a deferred call",
+        ),
+        (
+            'cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL g)\n',
+            0,
+            "no-argument call: the preferred idiom, state via GLOBAL property",
+        ),
+        (
+            'cmake_language(EVAL CODE\n'
+            '    "cmake_language(DEFER DIRECTORY \\"${d}\\" CALL g [[${target}]])")\n',
+            0,
+            "the EVAL CODE form -- expands to a literal BEFORE defer stores it",
+        ),
+        (
+            'cmake_language(DEFER CALL g "plain-literal")\n',
+            0,
+            "a literal argument is fine; it survives re-expansion unchanged",
+        ),
+        (
+            'cmake_language(DEFER # a comment mentioning ${x}\n'
+            '    CALL g)\n',
+            0,
+            "a comment inside the invocation is not an argument",
+        ),
+        (
+            'cmake_language(DEFER CALL g "${a}" "${b}")\n',
+            2,
+            "every offending argument is reported, not just the first",
+        ),
+        (
+            '# cmake_language(DEFER DIRECTORY "${d}" CALL g "${_t}") is the BROKEN form\n'
+            'cmake_language(DEFER CALL g)\n',
+            0,
+            "a comment quoting the broken form is prose, not an instance of it",
+        ),
+    ]
+    bad = []
+    for src, want, why in cases:
+        got = len(offenders_in(src, "<self-test>"))
+        if got != want:
+            bad.append(f"expected {want} offender(s), got {got}: {why}")
+    if bad:
+        print("check-deferred-call-args SELF-TEST FAILED:", file=sys.stderr)
+        for b in bad:
+            print(f"  {b}", file=sys.stderr)
+        return 1
+    print(f"check-deferred-call-args self-test: OK ({len(cases)} cases)")
+    return 0
+
+
+def main(argv):
+    if len(argv) == 2 and argv[1] == "--self-test":
+        return self_test()
+    if self_test():
+        return 1
+    scanned = 0
+    bad = []
+    for path, rel in cmake_files():
+        scanned += 1
+        bad.extend(offenders_in(path.read_text(encoding="utf-8", errors="replace"), rel))
+    if not scanned:
+        # A gate that scans nothing passes for the wrong reason. Three gates in
+        # this repo have shipped in that state.
+        print("check-deferred-call-args: FAILED -- scanned 0 cmake files.", file=sys.stderr)
+        return 1
+    if not bad:
+        print(f"check-deferred-call-args: OK -- {scanned} cmake file(s), no deferred CALL passes an unexpanded reference.")
+        return 0
+    print("check-deferred-call-args: a deferred CALL argument will arrive EMPTY (issue 1132):", file=sys.stderr)
+    for rel, line, tok in bad:
+        print(f"  {rel}:{line}: CALL argument {tok}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  DEFER expands CALL arguments when the deferred call RUNS, in the", file=sys.stderr)
+    print("  deferred directory's scope. A function-local is gone by then, and the", file=sys.stderr)
+    print("  callee's own `if(NOT TARGET \"\")` guard then returns cleanly -- the", file=sys.stderr)
+    print("  mechanism becomes a no-op that looks like a guard doing its job.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Either travel by a GLOBAL property and defer a NO-ARGUMENT call, or", file=sys.stderr)
+    print("  wrap it in `cmake_language(EVAL CODE ...)` so the argument is expanded", file=sys.stderr)
+    print("  into a literal before DEFER stores it. Both idioms are in cmake/.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-doc-commit-citations.py
+++ b/scripts/check-doc-commit-citations.py
@@ -106,22 +106,34 @@ def citations(files):
 
 
 def resolve(hashes):
-    """The subset of `hashes` that names a commit in this repository.
+    """The subset of `hashes` naming a commit REACHABLE from a ref here.
 
-    One `cat-file --batch-check` for the whole set rather than a process per
-    hash: 1 446 of them is 1 446 forks otherwise, and this gate is on the fast
-    line.
+    Reachable, not merely present. `git cat-file` answers for any object the
+    object store holds, INCLUDING unreachable ones -- a commit left behind by a
+    rebase, or one written by another checkout that shares this store. On a host
+    where a `ros2` distrobox is a second nano-ros checkout on the same store,
+    three hashes declared FOREIGN in the baseline (`ros2` tree states cited by
+    issues 1127 and 1137) answered "commit" and the gate demanded their baseline
+    entries be deleted. Deleting them is exactly wrong: on a fresh clone and in
+    CI those objects do not exist, so the citations go unresolvable and the
+    baseline is what keeps the gate green. The gate was asking for a change that
+    would break the thing it guards, and it asked only on that host.
+
+    Reachability is also the property the gate's own prose claims to check --
+    "a short hash is invalidated by any rebase of the branch it names". An
+    unreachable commit IS the post-rebase state.
+
+    One `rev-list --all` for the whole set rather than a process per hash: 1 446
+    of them is 1 446 forks otherwise, and this gate is on the fast line.
+    Citations are a fixed 9 hex digits (see CITATION), so a prefix set is an
+    exact test rather than an abbreviation guess.
     """
     if not hashes:
         return set()
-    query = "\n".join(f"{h}^{{commit}}" for h in hashes)
-    r = subprocess.run(["git", "-C", ROOT, "cat-file", "--batch-check"],
-                       input=query, capture_output=True, text=True)
-    ok = set()
-    for h, line in zip(hashes, r.stdout.strip().split("\n")):
-        if " commit " in line:
-            ok.add(h)
-    return ok
+    r = subprocess.run(["git", "-C", ROOT, "rev-list", "--all"],
+                       capture_output=True, text=True)
+    reachable = {line[:9] for line in r.stdout.split()}
+    return {h for h in hashes if h in reachable}
 
 
 def read_baseline(path=None):
@@ -227,6 +239,18 @@ def self_test():
     real = subprocess.run(["git", "-C", ROOT, "rev-parse", "--short=9", "HEAD"],
                           capture_output=True, text=True).stdout.strip()
     dead = "0123456789"[:9]          # not a commit, and never will be
+    # An object this store HOLDS and no ref REACHES -- what a rebase leaves
+    # behind, and what a second checkout sharing the store contributes.
+    # `cat-file` says "commit" for it; the gate must not.
+    tree = subprocess.run(["git", "-C", ROOT, "rev-parse", "HEAD^{tree}"],
+                          capture_output=True, text=True).stdout.strip()
+    unreachable = subprocess.run(
+        ["git", "-C", ROOT, "commit-tree", tree, "-m", "unreachable self-test object"],
+        capture_output=True, text=True,
+        env={**os.environ,
+             "GIT_AUTHOR_NAME": "selftest", "GIT_AUTHOR_EMAIL": "selftest@invalid",
+             "GIT_COMMITTER_NAME": "selftest", "GIT_COMMITTER_EMAIL": "selftest@invalid"},
+    ).stdout.strip()[:9]
     cases = [
         ("a resolving citation passes", f"see `{real}` for it\n", False),
         ("a dangling citation fails", f"see `{dead}` for it\n", True),
@@ -237,6 +261,13 @@ def self_test():
         ("bare hex outside backticks is ignored",
          f"see {dead} for it\n", False),
     ]
+    if unreachable:
+        # Only when `commit-tree` actually produced one -- a read-only object
+        # store cannot, and a gate must not fail because it could not build its
+        # own fixture.
+        cases.append(
+            ("an object present but UNREACHABLE fails (it is the post-rebase state)",
+             f"see `{unreachable}` for it\n", True))
     bad = 0
     with tempfile.TemporaryDirectory() as d:
         for name, text, want_fail in cases:


### PR DESCRIPTION
Closes #1132. Files #1204.

## The bug

`cmake_language(DEFER ... CALL fn "${_tgt}")` stores its CALL arguments
UNEXPANDED and expands them when the deferred call runs, in the deferred
directory's scope. `_tgt` is function-local and gone by then, so
`_nros_node_register_apply_config_header_deps` received an empty string and
returned at its own `if(NOT TARGET "")` guard. The 0088/0090 config-header
ordering edges it exists to add had never been applied, for any image in this
tree.

## Measured, not argued

A `message(STATUS ...)` at the top of the callee, cmake configure re-run on the
safety-island Zephyr image once per form -- same build directory, same cache,
nothing else changed:

```
BEFORE  5 calls, every one:  applying to []
AFTER   5 calls:  mrm_comfortable_stop_operator_lib
                  mrm_emergency_stop_operator_lib
                  mrm_handler_lib
                  stop_mode_operator_lib
                  zephyr_entry
```

## What does NOT change on this image

All five targets ALREADY carried the `nros_c_cargo_build` /
`nros_cpp_cargo_build` order-only edge in `build.ninja` under the broken code --
checked on a build dir the broken code produced. The eager `OBJECT_DEPENDS` half
beside it was supplying them, which is what the issue says and why nothing ever
failed. No before/after difference in the generated ninja is claimed.

## The gate

`check-deferred-call-args`, ci group, buildless. Parses cmake invocations
(quoted strings and bracket arguments as single tokens) and fails on any
deferred CALL argument carrying a `${`. Both correct idioms pass: the
no-argument form, and the `cmake_language(EVAL CODE ...)` wrapper whose DEFER
sits inside a quoted string.

7 self-test cases. One is the false reading the gate shipped with and had to
fix: it flagged the cmake COMMENT that quotes the broken form in order to
explain it. Discovery goes through `git ls-files` after
`check-no-tracked-file-find` caught the first version walking the filesystem.

## Two inherited reds, fixed here because they blocked the push

Neither is from this work; the pre-push hook asks that the commit fixing them
say so, and both commits do.

1. **`doc-commit-citations` was red only on some hosts.** `git cat-file` answers
   for any object the store HOLDS, including unreachable ones. Where a `ros2`
   distrobox is a second nano-ros checkout on the same object store, three
   hashes baselined as FOREIGN answered "commit", so the gate demanded their
   baseline entries be deleted -- which would turn CI red, since those objects
   do not exist on a fresh clone. Reachability is also the property the gate's
   own message claims to test. One `rev-list --all`, so it stays one fork on the
   fast line. Sixth self-test case builds an unreachable object with
   `commit-tree`; verified by mutation that restoring the old resolve fails it.

2. **Four citations the ratchet cannot resolve.** Three name commits this store
   does not hold at all (`00e8f3087`, `fe807a999`, `839f69b5c`) and are red on
   clean main and in CI alike; they get the remedy the gate asks for. The fourth
   (`d1d88f660`) goes back in the baseline beside `ea9fbfae9`, under a comment
   that already covers it in the plural.

## Not verified: a linked image

The island image does not link on nano-ros main -- `region DTCM overflowed by
45040 bytes`. That is **not** this change: a control build of clean main with
this work stashed produces the identical overflow, to the byte. Filed as #1204,
with the commit range and a first suspect. The configure-level measurement above
is what backs this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)