### PR TITLE
feat(phase-412 W3): the declared QoS depth reaches the arena — 91,080 B on the island shape

### DIFF
--- a/cmake/NanoRosEntityFacts.cmake
+++ b/cmake/NanoRosEntityFacts.cmake
@@ -300,6 +300,69 @@ function(_nros_entity_budget_env _out_var)
     set(${_out_var} "${_out}" PARENT_SCOPE)
 endfunction()
 
+# _nros_qos_depth_env(<out-var>)
+#
+# phase-412 W3 / phase-403 step 2 — carry the declared QoS DEPTH to the arena.
+#
+# `nros-node/build.rs` bills every pub/sub callback slot at `PUBSUB_QOS_DEPTH`,
+# a CONSTANT 10, and says why: "Carrying the declared depths here instead is
+# phase-403 step 2's remaining wiring: `NROS_ENTITY_DECLARED_DEPTHS` and
+# `NROS_ENTITY_UNDECLARED_DEPTH_COUNT` reach cmake and stop there, so this lane
+# has nothing better to read yet." This is that wiring, on the road issue 1122
+# built.
+#
+# The over-billing is structural rather than marginal. `buffered_region` gives a
+# `depth <= 1` subscription a TripleBuffer of 3 slots and anything deeper an
+# `SpscRing` of `depth + 1`, so an image whose subscriptions all declare depth 1
+# is charged 11 slots for 3 -- on every lane, before this.
+#
+# WHAT TRAVELS IS THE MAXIMUM, not the table. The arena charges every pub/sub
+# slot the same `pubsub_entry`, so one number is what the consumer can use, and
+# the max is the only reduction that cannot under-size it. Shipping the triples
+# would hand the build script a table it has no way to attribute to slots.
+#
+# TWO GUARDS, and the second is the producer's own instruction. The status must
+# be `resolved`, and `NROS_ENTITY_UNDECLARED_DEPTH_COUNT` must be ZERO --
+# `NanoRosEntityInventory.cmake` calls it "what a consumer must refuse on",
+# because a table over the endpoints that happened to be annotated sizes an
+# image from a subset of itself. One unannotated subscription and the max is a
+# lower bound rather than a bound, which is the under-size direction.
+function(_nros_qos_depth_env _out_var)
+    set(${_out_var} "" PARENT_SCOPE)
+    if(NOT COMMAND nros_entity_inventory_knobs_file)
+        return()
+    endif()
+    nros_entity_inventory_knobs_file(_inv)
+    if(NOT EXISTS "${_inv}")
+        return()
+    endif()
+    include("${_inv}")
+    if(NOT NROS_ENTITY_DECLARED_DEPTH_STATUS STREQUAL "resolved")
+        return()
+    endif()
+    if(NOT DEFINED NROS_ENTITY_UNDECLARED_DEPTH_COUNT
+            OR NOT NROS_ENTITY_UNDECLARED_DEPTH_COUNT EQUAL 0)
+        return()
+    endif()
+    if(NOT DEFINED NROS_ENTITY_DECLARED_DEPTHS)
+        return()
+    endif()
+    # `type|topic=depth` triples. The depth is what follows the LAST `=`, so a
+    # topic containing one does not shift the field.
+    set(_max 0)
+    foreach(_triple IN LISTS NROS_ENTITY_DECLARED_DEPTHS)
+        string(REGEX MATCH "=([0-9]+)$" _m "${_triple}")
+        if(_m)
+            if(CMAKE_MATCH_1 GREATER _max)
+                set(_max "${CMAKE_MATCH_1}")
+            endif()
+        endif()
+    endforeach()
+    if(_max GREATER 0)
+        set(${_out_var} "NROS_DECLARED_MAX_QOS_DEPTH=${_max}" PARENT_SCOPE)
+    endif()
+endfunction()
+
 # nros_entity_facts_env(<target>)
 #
 # Attach this configure's accumulated entity facts to a Corrosion target's cargo
@@ -313,6 +376,11 @@ function(nros_entity_facts_env _target)
     _nros_entity_budget_env(_budget_env)
     if(_budget_env)
         list(APPEND _payload_env ${_budget_env})
+    endif()
+
+    _nros_qos_depth_env(_depth_env)
+    if(_depth_env)
+        list(APPEND _payload_env "${_depth_env}")
     endif()
 
     get_property(_seen GLOBAL PROPERTY NROS_ENTITY_FACTS_SEEN)

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -245,7 +245,47 @@ Worth the contrast, since it is the argument for having built W4 first:
 | found by | build failures, then the gate after merge | the gate, in seconds |
 | reached `main` | yes -- 8/8/8 shipped | no |
 
-## W3 — the arena, once phase-403 step 2 lands
+## W3 — the arena's DEPTH multiplier. LANDED 2026-09-08
+
+`nros-node/build.rs` billed every pub/sub callback slot at `PUBSUB_QOS_DEPTH`, a
+constant 10, and named its own blocker: "`NROS_ENTITY_DECLARED_DEPTHS` and
+`NROS_ENTITY_UNDECLARED_DEPTH_COUNT` reach cmake and stop there, so this lane
+has nothing better to read yet." They now cross, on the DECLARED road issue 1122
+built — `_nros_qos_depth_env` publishes `NROS_DECLARED_MAX_QOS_DEPTH` and
+`declared_max_qos_depth()` takes it as the default.
+
+**The MAXIMUM, not the table.** The arena charges every pub/sub slot the same
+`pubsub_entry`, so one number is what a consumer can use, and the max is the
+only reduction that cannot under-size it.
+
+**Two guards, and the second is the producer's own instruction.** Status must be
+`resolved`, and `NROS_ENTITY_UNDECLARED_DEPTH_COUNT` must be ZERO —
+`NanoRosEntityInventory.cmake` calls that "what a consumer must refuse on",
+because a table over the endpoints that happened to be annotated sizes an image
+from a subset of itself. One unannotated endpoint and the max is a lower bound
+presented as a bound.
+
+Measured on the reference island's entity shape (11 subscriptions, 4 timers, 2
+service servers), by building `nros-node` three ways:
+
+| | `PUBSUB_REGION` | `ARENA_SIZE` |
+| --- | ---: | ---: |
+| no depth declaration (the old behaviour) | 11,352 | 144,584 |
+| declared depth 1 | 3,072 | **53,504** |
+| declared depth 5 | 6,192 | 87,824 |
+
+**−91,080 B** at depth 1. The shape of it is `buffered_region`: `depth <= 1` is a
+TripleBuffer of 3 slots, anything deeper an `SpscRing` of `depth + 1`, so a
+depth-1 image was charged 11 slots for 3.
+
+Both guards are mutation-tested in `tests/cmake-entity-inventory-tests.sh`
+(seven cases, beside the writer): ignoring the undeclared count fails it, and so
+does taking the minimum instead of the maximum.
+
+What this does NOT close is the tightness question the W2 table raises — the
+model still bills the worst case per KIND, and depth is one multiplier of it.
+
+## W3 (original) — the arena, once phase-403 step 2 lands
 
 The arena is the single largest hand-set number on the island (40960 B) and the
 last big one. It is listed here rather than duplicated: **phase-403 owns steps 2

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -304,7 +304,20 @@ fn main() {
     // lane has nothing better to read yet. Budgeting the default is not a guess
     // in the meantime -- it is exactly what a subscription created with no QoS
     // argument gets, which is what "the image declared nothing" means.
-    let pubsub_region = buffered_region(PUBSUB_QOS_DEPTH, rx_recv_size);
+    // phase-412 W3 — the DECLARED depth when the image stated one for every
+    // endpoint, `PUBSUB_QOS_DEPTH` otherwise. The comment above describes the
+    // constant as what "a subscription created with no QoS argument gets",
+    // which is exactly right for an image that declared nothing and exactly
+    // wrong for one that declared depth 1 everywhere: `buffered_region` gives
+    // the latter a 3-slot TripleBuffer and the constant bills it 11 slots.
+    //
+    // cmake refuses to publish this unless every endpoint that COULD state a
+    // depth did (`NROS_ENTITY_UNDECLARED_DEPTH_COUNT == 0`), so an absent
+    // variable means "some endpoint said nothing" and the default stands. That
+    // guard belongs there rather than here: the count is a property of the
+    // declaration, and this lane cannot see it.
+    let pubsub_depth = declared_max_qos_depth().unwrap_or(PUBSUB_QOS_DEPTH);
+    let pubsub_region = buffered_region(pubsub_depth, rx_recv_size);
     let pubsub_entry = pubsub_region + PUBSUB_ENTRY_STRUCT;
 
     // phase-403 step 3 -- SUM OVER WHAT THE IMAGE DECLARES, when it declares.
@@ -460,7 +473,11 @@ fn main() {
              /// Smallest arena the derivation will produce.\n    \
              pub const FLOOR: usize = {arena_floor};\n\
          }}\n",
-        pubsub_qos_depth = PUBSUB_QOS_DEPTH,
+        // The RESOLVED depth, not the constant: this const is what
+        // `the_modelled_qos_depth_is_the_runtime_default` in `arena.rs` reads
+        // back, so emitting the constant while sizing from the declaration
+        // would make the assertion pass against a model the build did not use.
+        pubsub_qos_depth = pubsub_depth,
         pubsub_entry_struct = PUBSUB_ENTRY_STRUCT,
         action_feedback_depth = ACTION_FEEDBACK_DEPTH,
         arena_base_overhead = ARENA_BASE_OVERHEAD,
@@ -643,6 +660,22 @@ fn env_opt_usize(name: &str) -> Option<usize> {
 ///
 /// The front-end keeps winning. Migrating a knob into the ladder must not take
 /// an operator's override away, which is half of this wave's own gate.
+/// phase-412 W3 — the largest QoS depth this image DECLARES, if it declared
+/// every one.
+///
+/// `None` when cmake made no claim, which covers three different situations and
+/// deliberately does not distinguish them here: no entity inventory, a
+/// `refused` depth status, or at least one endpoint that could have stated a
+/// depth and did not. All three mean the same thing to a consumer that sizes
+/// from depth — the table describes a SUBSET of the image — and the remedy is
+/// the same, so the guard lives at the producer where the count is visible.
+fn declared_max_qos_depth() -> Option<usize> {
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_MAX_QOS_DEPTH");
+    std::env::var("NROS_DECLARED_MAX_QOS_DEPTH")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+}
+
 fn env_usize(name: &str, default: usize) -> usize {
     println!("cargo:rerun-if-env-changed={name}");
     if let Some(v) = std::env::var(name).ok().and_then(|v| v.trim().parse().ok()) {

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -164,6 +164,10 @@ KNOB_CLASS = {
     "NROS_DECLARED_SUBSCRIBER_LARGE_SIZE": ("infra", "a SIZE the resolver passes down, not a knob"),
     "NROS_DECLARED_EXECUTOR_MAX_CBS": ("infra", "a COUNT the resolver passes down, not a knob"),
     "NROS_DECLARED_EXECUTOR_ACTION_CLIENTS": ("infra", "a COUNT the resolver passes down, not a knob"),
+    # phase-412 W3 — a DEPTH the resolver passes down. Same category as the
+    # counts beside it: nobody tunes it, it is what the image DECLARED, and the
+    # arena derivation multiplies by it.
+    "NROS_DECLARED_MAX_QOS_DEPTH": ("infra", "a DEPTH the resolver passes down, not a knob"),
     "NROS_PICOLIBC_SYSROOT": ("infra", "path"),
     "NROS_RISCV64_PREFIX": ("infra", "toolchain prefix"),
     "NROS_SDK_STORE": ("infra", "path"),

--- a/tests/cmake-entity-inventory-tests.sh
+++ b/tests/cmake-entity-inventory-tests.sh
@@ -432,6 +432,75 @@ if ! nros_grep_q "NROS_DERIVED_EXECUTOR_MAX_CBS 19" "$KEEP"; then
 fi
 
 # ---------------------------------------------------------------------------
+log_header "the declared QoS DEPTH crosses the lane boundary (phase-412 W3)"
+
+# The inventory publishes the depth table and, before this, nothing read it:
+# `nros-node/build.rs` said so itself — "reach cmake and stop there, so this
+# lane has nothing better to read yet". `_nros_qos_depth_env` in
+# `cmake/NanoRosEntityFacts.cmake` is the crossing, and it is tested beside the
+# writer.
+#
+# The GUARDS are the whole safety argument and each gets a case. A table over
+# the endpoints that happened to be annotated sizes an image from a subset of
+# itself, so one unannotated endpoint must mean "no answer" — the max would
+# otherwise be a lower bound presented as a bound, which is the under-size
+# direction the arena cannot survive.
+FACTS="$PROJECT_ROOT/cmake/NanoRosEntityFacts.cmake"
+
+depth_env() {
+    # depth_env <status> <undeclared-count> <depths…>
+    local dir="$TEST_TMPDIR/depth"
+    rm -rf "$dir"; mkdir -p "$dir/nros"
+    {
+        printf 'set(NROS_ENTITY_DECLARED_DEPTH_STATUS "%s")\n' "$1"
+        [ "$2" != "-" ] && printf 'set(NROS_ENTITY_UNDECLARED_DEPTH_COUNT %s)\n' "$2"
+        shift 2
+        [ "$#" -gt 0 ] && printf 'set(NROS_ENTITY_DECLARED_DEPTHS "%s")\n' "$*"
+    } > "$dir/nros/entity_inventory.cmake"
+    cat > "$dir/run.cmake" <<EOF
+include("$MODULE")
+include("$FACTS")
+_nros_qos_depth_env(_out)
+message(STATUS "DEPTH=\${_out}")
+EOF
+    # `cmake -P` resolves CMAKE_BINARY_DIR to the CWD, and the carrier finds the
+    # fragment through `nros_entity_inventory_knobs_file()`.
+    (cd "$dir" && cmake -P run.cmake 2>&1) | sed -n 's/^-- DEPTH=//p'
+}
+
+_want() {
+    local label="$1" want="$2" got="$3"
+    if [ "$got" != "$want" ]; then
+        fail "depth: $label -- wanted '${want:-<empty>}', got '${got:-<empty>}'"
+    fi
+    check
+}
+
+_want "a fully declared table crosses as its MAXIMUM" \
+    "NROS_DECLARED_MAX_QOS_DEPTH=10" \
+    "$(depth_env resolved 0 'a|/t1=1;b|/t2=10;c|/t3=5')"
+_want "a single endpoint at depth 1 crosses as 1" \
+    "NROS_DECLARED_MAX_QOS_DEPTH=1" \
+    "$(depth_env resolved 0 'a|/t1=1')"
+# The guard the producer's own doc demands.
+_want "ONE undeclared endpoint carries nothing" \
+    "" \
+    "$(depth_env resolved 3 'a|/t1=1;b|/t2=10')"
+_want "a refused status carries nothing" \
+    "" \
+    "$(depth_env refused 0 'a|/t1=1')"
+_want "no depth table carries nothing" \
+    "" \
+    "$(depth_env resolved 0)"
+_want "a missing undeclared COUNT carries nothing" \
+    "" \
+    "$(depth_env resolved - 'a|/t1=1')"
+# A topic containing `=` must not shift the depth field.
+_want "the depth is what follows the LAST '='" \
+    "NROS_DECLARED_MAX_QOS_DEPTH=7" \
+    "$(depth_env resolved 0 'a|/odd=name=7')"
+
+# ---------------------------------------------------------------------------
 if [ "$FAILURES" -eq 0 ]; then
     log_success "cmake-entity-inventory: $CHECKS assertion(s) held"
     exit 0


### PR DESCRIPTION
`nros-node/build.rs` billed every pub/sub callback slot at `PUBSUB_QOS_DEPTH`, a constant 10, and
named its own blocker in a comment:

> Carrying the declared depths here instead is phase-403 step 2's remaining wiring:
> `NROS_ENTITY_DECLARED_DEPTHS` and `NROS_ENTITY_UNDECLARED_DEPTH_COUNT` reach cmake and stop
> there, so this lane has nothing better to read yet.

Same defect class as #1122 and #1199 — a fact CMake derives that never crosses into a build
script — and the road those built is what this uses. `_nros_qos_depth_env` publishes
`NROS_DECLARED_MAX_QOS_DEPTH`; `declared_max_qos_depth()` takes it as the **default**, so a stated
number still wins.

## Measured

Building `nros-node` three ways at the reference island's entity shape (11 subscriptions, 4
timers, 2 service servers):

| | `PUBSUB_REGION` | `ARENA_SIZE` |
| --- | ---: | ---: |
| no depth declaration (old behaviour) | 11,352 | 144,584 |
| declared depth 1 | 3,072 | **53,504** |
| declared depth 5 | 6,192 | 87,824 |

**−91,080 B** at depth 1. `buffered_region` is why: `depth <= 1` is a TripleBuffer of 3 slots,
anything deeper an `SpscRing` of `depth + 1` — so a depth-1 image was charged 11 slots for 3, on
every lane.

## The maximum, not the table

The arena charges every pub/sub slot the same `pubsub_entry`, so one number is what a consumer can
use, and the max is the only reduction that cannot under-size it. Shipping the triples would hand
the build script a table it has no way to attribute to slots.

## Two guards, and the second is the producer's own instruction

Status must be `resolved`, and `NROS_ENTITY_UNDECLARED_DEPTH_COUNT` must be **zero** —
`NanoRosEntityInventory.cmake` calls that *"what a consumer must refuse on"*, because a table over
the endpoints that happened to be annotated sizes an image from a subset of itself. One
unannotated endpoint and the max is a lower bound presented as a bound, which is the direction an
arena cannot survive: it halts during entity creation, before the first spin, so issue 0900's
advisory never prints.

## Tests

Seven cases in `tests/cmake-entity-inventory-tests.sh`, beside the writer and driven in
`cmake -P`, including a topic containing `=` (the depth is what follows the **last** one). Both
guards mutation-tested — ignoring the undeclared count fails it, and so does taking the minimum
instead of the maximum.

The emitted `PUBSUB_QOS_DEPTH` const is now the **resolved** depth rather than the literal:
`the_modelled_qos_depth_is_the_runtime_default` in `arena.rs` reads it back, and emitting the
constant while sizing from the declaration would make that assertion pass against a model the
build did not use.

```
just check fast                    275 ran, 1 ledger skip, 0 failed
just check entity-inventory-knobs  39 assertions held
just test-unit                     PASS
```

## Not closed

The tightness question the W2 table raises — the model still bills the worst case per **kind**,
and depth is one multiplier of it.

## Also here

`doc-commit-citations` was red on main and blocking the lane: `5753d8d3c` dropped the
`d97c9c606` citation and left its baseline entry standing, which the ratchet fails on.

**Rebase note:** `NROS_DECLARED_MAX_QOS_DEPTH` needs a `ROAD_UNPAIRED` entry in
`check-declared-fact-carriers` once #1199 lands — it has no cargo-leaf twin, because the sidecar
carries pool *counts* and this is a multiplier the arena applies to a count it already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119aFbZ4oJ6u4agj4PjknPd