### PR TITLE
fix(#1131): the case for zero did not survive contact with the linker

### DIFF
--- a/.config/doc-commit-citations-baseline.txt
+++ b/.config/doc-commit-citations-baseline.txt
@@ -62,11 +62,6 @@ adb4c592e
 # fixed here because this gate is a separate change and must not carry an
 # unrelated document edit.
 
-# docs/issues/README.md — an archived issue cites the commit that made a QEMU
-# failure drain the guest before killing it. Hash rebased away; the change is
-# real and the prose is the record. Dangling on main before this line.
-d97c9c606
-
 # `docs/issues/1127-live-peer-cells-skip-forever.md` — commits in ANOTHER
 # CHECKOUT. The issue is about a live-peer lane that runs inside the distrobox
 # against a mirror tree at `/mnt/wd/data/projects/nano-ros-box`, and it records

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -785,16 +785,25 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   `_nros_c_array_pool_floor`), keep `#if X < 1 / #error` beside the array as the
   backstop that binds a producer neither reaches. Gate: `check-c-array-pool-floors`
   (also refuses an unruled new one; the 1 still unruled is issue 1131 — the
-  other 14 were ruled there, 10 guarded and 4 already covered). **A third
-  outcome exists and `NROS_RMW_UORB_PX4_MAX_CALLBACKS` is it: zero silences
+  other 14 were ruled there, 10 guarded and 4 already covered). **Issue 1131
+  has since ruled the last one too, so the table is EMPTY and
+  `UNCLASSIFIED_CEILING` is 0.** The final two agree on the floor and disagree
+  entirely about WHY, which is the case for ruling each separately rather than
+  by analogy. `NROS_RMW_UORB_PX4_MAX_CALLBACKS`: zero silences
   nothing at RUNTIME (the pool's exhaustion path is the polling fallback that
   every non-PX4 build already links) and still loses, because `Slot g_pool[0]`
   is a zero-size array ISO C++ forbids and the TU is built `-Wpedantic` inside a
   `-Werror` PX4 — so "does zero break the runtime?" is not the whole question,
-  and 1033's C measurement does not carry to a C++ pool.** A guard is only safe
+  and 1033's C measurement does not carry to a C++ pool. A guard is only safe
   when it forecloses nothing: here the polling-only image already has
   `NROS_RMW_UORB_BUILD_PX4_GLUE=OFF`, which removes the pool rather than
-  emptying it. **BOTH gates in
+  emptying it. `NROS_ZEPHYR_MAX_TIERS` has NO such refusal from the language —
+  GCC's zero-length-array extension compiles
+  `K_THREAD_STACK_ARRAY_DEFINE(x, 0, N)` clean, size 0, no diagnostic — so only
+  a guard stands between a `-D` and an image whose every tier spawn fails. Its
+  case for zero was "64 KiB in EVERY Zephyr image", and `--gc-sections` had
+  already dropped it in 87 of 91 built images, the 4 carriers being exactly the
+  4 that declare tiers: zero reclaimed nothing the linker had not. **BOTH gates in
   this family had a REACH narrower than the rule they enforce** (0196's shape),
   and issue 1131 hit both at once. `check-c-array-pool-floors` required a knob's
   `#ifndef` and `#define` on ADJACENT LINES, so the two knobs that document

--- a/config/rust-targets.txt
+++ b/config/rust-targets.txt
@@ -59,6 +59,34 @@ armv7r-none-eabihf              rustup
 armv8r-none-eabihf              rustup
 riscv32imc-unknown-none-elf     rustup
 riscv64gc-unknown-none-elf      rustup
+# ARMv8-A AArch64 bare-metal — the Arm FVP BaseR AEMv8-R board
+# (`fvp-aemv8r-smp`) names it in its `nros-board.toml`, but as
+# `rust_targets = ["aarch64-unknown-none"]`, which is a FOURTH declaring form:
+# `check-rust-targets-covered` reads `[target.<triple>]` SECTIONS, not that key,
+# so the triple was declared by a board and listed nowhere while the gate
+# reported OK. The gate's reach is narrower than the rule it enforces, which is
+# issue 0196's shape inside the gate written to prevent exactly this.
+aarch64-unknown-none            rustup
+# Cortex-A / ARMv7-A bare-metal. Two ABIs, two different declaring forms, and
+# NEITHER is one the coverage gate can see:
+#
+#   armv7a-none-eabi    the single non-host target BOTH halves of
+#                       `check-repr-memory-agreement` cross-compile to, as a
+#                       CONSTANT in the gate script itself (RUST_TARGET). A
+#                       gate's own constant is a FIFTH declaring form. Until
+#                       this row existed nothing provisioned it, so that gate
+#                       reported `[SKIPPED] missing: rust-std for
+#                       armv7a-none-eabi` on every host — a check that cannot
+#                       evaluate, which reads exactly like one that found
+#                       nothing wrong.
+#   armv7a-none-eabihf  set by `scripts/zephyr/cortex-a9-rust-patch.sh`
+#                       (`set(RUST_TARGET ... PARENT_SCOPE)`) and installed
+#                       AD HOC by `just/zephyr-ci.just`. That ad-hoc install is
+#                       the installer-vs-doctor divergence this whole file
+#                       exists to end, still running for this one triple: the
+#                       CI lane had it and `just doctor` never asked for it.
+armv7a-none-eabi                rustup
+armv7a-none-eabihf              rustup
 
 # NuttX: Tier 3 custom targets, no prebuilt std. See RFC-0012 / issue 0583.
 armv7a-nuttx-eabihf             build-std

--- a/docs/issues/archived/1131-c-array-pool-floor-unclassified.md
+++ b/docs/issues/archived/1131-c-array-pool-floor-unclassified.md
@@ -1,37 +1,124 @@
 ---
 id: 1131
-title: "One knob-sized C array has no ruling on whether zero is a legal size"
-status: open
+title: "Every knob-sized C array now states whether zero is a legal size"
+status: resolved
 area: rmw, memory
 severity: low
 related: [1015, 1033, 1167, 0815, 0196, phase-392, phase-403, phase-412]
 ---
 
-# The wider question issue 1015 left open, now down to one
+# The wider question issue 1015 left open, now closed
 
-Was fifteen. Fourteen are ruled; the one below is left UNRULED ON PURPOSE,
-because it has a real argument that zero is the right answer and that argument
-needs a measurement nobody has taken. A guard on it would foreclose a saving
-exactly the way issue 1015's first fix foreclosed issue 1033's.
+Was fifteen. **All fifteen are ruled**, and the gate's `UNCLASSIFIED` table is
+empty with `UNCLASSIFIED_CEILING = 0` — so the next knob-sized array that ships
+without a ruling trips it.
+
+The last two landed on the same floor for reasons that do not transfer to each
+other, which is the argument for ruling each one rather than reasoning by
+analogy from the last: `NROS_RMW_UORB_PX4_MAX_CALLBACKS` because ISO C++ has no
+zero-size array at all, and `NROS_ZEPHYR_MAX_TIERS` because C *does* — GCC's
+zero-length-array extension takes it silently — so nothing but a guard stood
+between a `-D` and a broken image.
 
 ## Where the class stands
 
 ```
 $ python3 scripts/check-c-array-pool-floors.py | tail -1
-check-c-array-pool-floors: OK (23 knob-sized C arrays: 19 guarded, 3 zero-legal, 1 unclassified)
+check-c-array-pool-floors: OK (23 knob-sized C arrays: 20 guarded, 3 zero-legal, 0 unclassified)
 ```
 
-23 (not 21 — see "what the gate could not see" below): **19 guarded, 3
-zero-legal, 1 unclassified**, against 8 / 3 / 10 before.
+23 (not 21 — see "what the gate could not see" below): **20 guarded, 3
+zero-legal, 0 unclassified**, against 8 / 3 / 10 before.
 
-## What is left, and what it needs
+## Third pass: `NROS_ZEPHYR_MAX_TIERS`, ruled GUARDED
 
-| knob | file | why zero is arguable | what would settle it |
-| --- | --- | --- | --- |
-| `NROS_ZEPHYR_MAX_TIERS` | `zephyr/nros_platform_zephyr_shims.c` | `K_THREAD_STACK_ARRAY_DEFINE(nros_tier_stacks, N, 16384)` — **64 KiB** of stacks in every Zephyr image, declared tiers or not, because nothing produces this knob and 4 is what everything compiles. A tierless image setting 0 is `XRCE_MAX_SUBSCRIBERS=0`'s shape, and the refusal is loud AND FATAL, which is more than the table first claimed: `entry_tiers.rs` logs `failed to spawn tier … pool exhausted?` and then returns `Err(RuntimeError::Spin)`, so a tiered image at 0 fails rather than running short-handed. | a Zephyr build at `-DNROS_ZEPHYR_MAX_TIERS=0` proving `K_THREAD_STACK_ARRAY_DEFINE` accepts a count of 0, plus a `just mem-report <elf> --json --baseline` delta for the 64 KiB. **Not attemptable on a host with no Zephyr:** the macro lives in `zephyr/kernel.h`, which comes from the west workspace, so even reading its expansion needs a checkout this repo does not carry. |
+The premise this knob sat on for two passes is **false**, and measuring it was
+the whole ruling. The table above said *64 KiB of stacks in every Zephyr image,
+declared tiers or not*. It is not in every image; it is in four of them.
 
-It is in the gate's `UNCLASSIFIED` table with that reasoning inline, and the
-`UNCLASSIFIED_CEILING` is now 1, so adding a second is a visible edit.
+`nros_tier_stacks` is reachable only through `nros_zephyr_tier_task_create`. An
+image whose system declares no tier calls nothing on that path, so
+`--gc-sections` — on in every Zephyr link — drops the section. Over the **91
+built images** in this tree:
+
+| | images |
+| --- | --- |
+| carry `nros_tier_stacks` | **4** |
+| linker discarded it | **87** |
+
+and the 4 are *exactly* the four `realtime-entry` images that declare tiers.
+The correspondence is total in both directions: no image pays for a pool it
+does not use, and no tiered image is missing one.
+
+Both link flavours agree:
+
+* **mps2_an385** (`build-cortex-m-c-talker-zenoh`, tierless) — the object holds
+  `.noinit."…shims.c".1` at `0x10100` (65,792 bytes), and `zephyr_final.map`
+  lists it under *Discarded input sections* at address 0, while the 512 KiB
+  `nros_thread_stacks` is placed at `0x200769c0`. One object, one link, one
+  section kept and one dropped, on exactly the reachability distinction.
+* **native_sim** — the tiered `build-ws-c-realtime-entry-zenoh` carries
+  `nros_tier_stacks` at `0x10000`; the tierless `build-c-listener-zenoh` has no
+  such symbol.
+
+So zero reclaims nothing the linker has not already reclaimed, while in the one
+class of image that would ever set it — a tiered one — it makes
+`nros_tier_index >= NROS_ZEPHYR_MAX_TIERS` true for the *first* tier, and
+`entry_tiers.rs` returns `Err(RuntimeError::Spin)`.
+
+**The guard is load-bearing, and this is where the uORB ruling does not carry.**
+That pool is C++, where the language itself refuses `Slot g_pool[0]`. This one
+is C, and asked directly the macro takes zero **silently**:
+`K_THREAD_STACK_ARRAY_DEFINE(probe, 0, 16384)` compiles clean under the real
+`arm-zephyr-eabi` flags as a zero-length array (`B probe_stacks`, size 0, no
+diagnostic). Without a guard, `-D…MAX_TIERS=0` builds an image whose every tier
+spawn fails — issue 1015's silent-zero shape exactly.
+
+Ruled: **floor of 1**, beside the array, below its own `#ifndef` (issue 1167's
+ordering rule), matching its sibling `NROS_ZEPHYR_MAX_THREADS`. It forecloses no
+saving: the saving a tiered image can actually want is a *smaller* pool, and
+`-DNROS_ZEPHYR_MAX_TIERS=2` compiles. That is the trap issue 1015's first fix
+fell into and this one does not.
+
+### The host that "could not" run this
+
+The table above recorded *"Not attemptable on a host with no Zephyr: the macro
+lives in `zephyr/kernel.h`, which comes from the west workspace"*. That was true
+of the toolchain state, not of the host — `nros setup` provisions the west
+workspace, and this tree already carried one with 91 built images in it. The
+measurement then cost no build at all: the map files and objects were already on
+disk, and the three compile checks reused the TU's own command from
+`compile_commands.json` with `-o` redirected to scratch, so no build directory
+moved. A blocker worth re-testing before it is inherited a third time.
+
+Verified against the real toolchain:
+
+| build | result |
+| --- | --- |
+| default (4) | compiles — no regression from the guard |
+| `-DNROS_ZEPHYR_MAX_TIERS=0` | `#error "NROS_ZEPHYR_MAX_TIERS must be >= 1…"` |
+| `-DNROS_ZEPHYR_MAX_TIERS=2` | compiles — the floor forecloses no saving |
+
+Mutations, each red naming the exact site, then restored green: the guard
+deleted (`[FAIL] … sizes a fixed C array and states no floor`); the guard moved
+above its `#ifndef` (`[FAIL] … is guarded where the guard CANNOT FIRE`, and the
+probe gate red too, since it then fires at defaults).
+
+Re-runnable sweep:
+
+```
+for d in zephyr-workspace/build-*/; do
+  nm -S "$d/zephyr/zephyr.exe" 2>/dev/null | grep -c nros_tier_stacks
+done
+```
+
+### The selftest this emptied
+
+Ruling the last knob left `UNCLASSIFIED` **empty**, and the gate's own selftest
+read `next(iter(UNCLASSIFIED))` — so it raised `StopIteration` the moment the
+backlog it was protecting reached zero. The two controls now run against a
+SYNTHETIC entry: a negative control that only works while unruled debt exists
+retires itself at exactly the moment the table starts needing protection.
 
 ## Second pass: `NROS_RMW_UORB_PX4_MAX_CALLBACKS`, ruled GUARDED
 

--- a/docs/roadmap/phase-428-api-porting-principle-sweep.md
+++ b/docs/roadmap/phase-428-api-porting-principle-sweep.md
@@ -643,7 +643,7 @@ with the promotion absent — same six, and only those six. They are not in the
 > **Written independently of the section above, against the same base commit,
 > by an author who had not seen it.** Both halves found and fixed the SAME
 > `_ret_of` bug (it read `item["ret"]`; `flatten` stores return types one level
-> down under `overloads`). The section above landed first, in `fe807a999`, and
+> down under `overloads`). The section above landed first, and
 > ITS fix is the one that ships — it is the superset: it applies `canon_type`
 > inside `_ret_of` and additionally normalises `rcl_{time_point,duration}_value_t`
 > to `int64_t`, which the version here does not. What survives from this half is
@@ -674,7 +674,7 @@ not have seen.
 | `divergence` rows whose subject correlates `same:ret` | 2, both by inheritance |
 | `divergence` rows in every other bucket — NOT gated | 819 |
 
-**Re-measured after the merge** (`839f69b5c` + this half), because the other
+**Re-measured after the merge** (that earlier half + this one), because the other
 half authored 20 `divergence` rows on subjects that correlate `same` and they
 land in exactly this set — the two halves compound, they do not overlap:
 

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -1649,6 +1649,24 @@ triple = "riscv32imc-unknown-none-elf"
 [rust.target.riscv64gc]
 triple = "riscv64gc-unknown-none-elf"
 
+# ARMv8-A AArch64 bare-metal — the `fvp-aemv8r-smp` board declares it, but as
+# `rust_targets = [...]` in its `nros-board.toml`, a form the coverage gate does
+# not read; it was in NEITHER list until then.
+[rust.target.aarch64-none]
+triple = "aarch64-unknown-none"
+
+# Cortex-A / ARMv7-A bare-metal. `armv7a-none-eabi` is the target BOTH halves of
+# `check-repr-memory-agreement` cross-compile to (a constant in the gate script,
+# so nothing provisioned it and the gate reported SKIPPED on every host);
+# `armv7a-none-eabihf` is what `scripts/zephyr/cortex-a9-rust-patch.sh` sets and
+# `just/zephyr-ci.just` installed ad hoc — the installer-vs-doctor divergence
+# issue 0833 exists to end, still live for this triple.
+[rust.target.armv7a]
+triple = "armv7a-none-eabi"
+
+[rust.target.armv7a-hf]
+triple = "armv7a-none-eabihf"
+
 [rust.cargo-tool.nextest]
 crate = "cargo-nextest"
 check = { cmd = "cargo-nextest" }

--- a/packages/cli/nros-launch-resolve/Cargo.toml
+++ b/packages/cli/nros-launch-resolve/Cargo.toml
@@ -8,11 +8,27 @@
 # cannot be shadowed, and we never shadow a user's real `play_launch`.
 #
 # Its OWN workspace on purpose. It links layer 2 from the `play_launch` repo,
-# whose `ros-launch-resolve` git-deps `ros-launch-manifest` by tag (v0.1.11, in
-# the submodule's own workspace manifest); `nros-cli-core` deps the SAME rlm tag. Both resolve to one rev, but keeping
-# this crate excluded from the `packages/cli` workspace (its own lock) preserves
-# the separation the old two-copies layout needed and stays robust if the two
-# ever diverge on a pin.
+# whose `ros-launch-resolve` git-deps `ros-launch-manifest` by tag, in the
+# submodule's own manifest — and the two pins HAVE diverged, which is what this
+# separation was built for: the submodule resolves rlm at the tag its checkout
+# names, while `nros-cli-core` and the three other nano-ros crates name their
+# own. Excluding this crate from the `packages/cli` workspace gives it its own
+# lock, so each side moves on its own schedule instead of one forcing the other.
+#
+# Do not read a version out of this comment. It said `v0.1.11` while the
+# submodule was on v0.1.23 and nano-ros on v0.1.31, and asserted the two were
+# "the SAME rlm tag" long after they were not — a comment naming a pin goes
+# stale silently, because nothing compiles it. Read the pins:
+#   git grep 'ros-launch-manifest' -- '*Cargo.toml'
+#
+# rlm is OUR repo and a git-tag dep, never crates.io, so this leaf's
+# `Cargo.lock` legitimately FOLLOWS the submodule: when the submodule pin moves
+# and its rlm tag changes with it, regenerate the lock (`just lock-update "" ""
+# packages/cli/nros-launch-resolve`), re-run `just setup-launch-resolve` (issue
+# 0409) and `just check submodule-pinned-locks`. That is a lock tracking a
+# local source, not the registry drift `check-leaf-lockfiles` guards — which is
+# why that gate excludes `packages/cli/` and this one is covered by
+# `check-submodule-pinned-locks` instead.
 [package]
 name = "nros-launch-resolve"
 version = "0.5.0"

--- a/packages/testing/nros-tests/src/matrix.rs
+++ b/packages/testing/nros-tests/src/matrix.rs
@@ -790,6 +790,15 @@ pub const CELLS: &[Cell] = &[
     cell(ZephyrNativeSim, C,     Zenoh, EntryPubsub, Workspace, Runtime),
     cell(ZephyrNativeSim, Cpp,   Zenoh, EntryPubsub, Workspace, Runtime),
     cell(ZephyrNativeSim, Mixed, Zenoh, EntryPubsub, Workspace, Runtime),
+    // phase-206 W2 — the RTOS image that links Cyclone AND carries a baked
+    // bringup config (`workspace-zephyr-cpp-cyclonedds`). Its fixture row
+    // landed with commit 9ae271174 while this cell did not, so the coordinate
+    // (zephyr, cpp, cyclonedds, workspace) was a fixtures.toml orphan: built
+    // and run by the lane, modeled by nothing. `fixture_rows_all_modeled_by_matrix`
+    // is the assertion that caught it, and it is the reverse direction of the
+    // pair -- the forward one was green throughout, because a cell that does
+    // not exist cannot be missing a fixture.
+    cell(ZephyrNativeSim, Cpp,   Cyclonedds, EntryPubsub, Workspace, Runtime),
     cell(FreertosMps2, C,    Zenoh, EntryPubsub, Workspace, Runtime),
     cell(FreertosMps2, Cpp,  Zenoh, EntryPubsub, Workspace, Runtime),
     cell(FreertosMps2, Rust, Zenoh, EntryPubsub, Workspace, Runtime),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,4 +4,24 @@ components = ["rustfmt", "clippy", "rust-src", "llvm-tools"]
 # phase-418 418.3 — `armv7r-none-eabi` joins the hard-float triple already
 # here: the Orin SPE FSP is softfp (AAPCS base), so the `hf` triple is the
 # wrong ABI for that image. Neither replaces the other.
-targets = ["thumbv7em-none-eabihf", "armv7r-none-eabi", "armv7r-none-eabihf", "aarch64-unknown-none"]
+# The list is the set the GATES compile for, not a subset someone remembered.
+# It was four while `check-build` needed nine, and the gap is invisible until a
+# toolchain is reinstalled or a clone is fresh: rustup installs exactly what is
+# declared here, so the five undeclared ones survived only as residue on hosts
+# that had once added them by hand. `check-build`'s `nros-log-riscv32` then
+# fails with "can't find crate for `core`" and `repr-memory-agreement` reports
+# SKIPPED for want of `armv7a-none-eabi` — a gate that cannot evaluate, which
+# reads exactly like one that found nothing wrong.
+targets = [
+    "thumbv7em-none-eabihf",
+    "thumbv7m-none-eabi",
+    "armv7r-none-eabi",
+    "armv7r-none-eabihf",
+    "armv7a-none-eabi",
+    "armv7a-none-eabihf",
+    "aarch64-unknown-none",
+    "riscv32imc-unknown-none-elf",
+    "riscv64gc-unknown-none-elf",
+]
+# The two NuttX triples (`armv7a-nuttx-eabihf`, `riscv32imac-unknown-nuttx-elf`)
+# are custom JSON targets, not rustup ones, and are deliberately NOT listed.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,24 +4,26 @@ components = ["rustfmt", "clippy", "rust-src", "llvm-tools"]
 # phase-418 418.3 — `armv7r-none-eabi` joins the hard-float triple already
 # here: the Orin SPE FSP is softfp (AAPCS base), so the `hf` triple is the
 # wrong ABI for that image. Neither replaces the other.
-# The list is the set the GATES compile for, not a subset someone remembered.
-# It was four while `check-build` needed nine, and the gap is invisible until a
-# toolchain is reinstalled or a clone is fresh: rustup installs exactly what is
-# declared here, so the five undeclared ones survived only as residue on hosts
-# that had once added them by hand. `check-build`'s `nros-log-riscv32` then
-# fails with "can't find crate for `core`" and `repr-memory-agreement` reports
-# SKIPPED for want of `armv7a-none-eabi` — a gate that cannot evaluate, which
-# reads exactly like one that found nothing wrong.
+# MIRRORS the `rustup` rows of config/rust-targets.txt, which is the ONE list
+# (issue 0833) — do not hand-edit this against a grep of `--target`, which is
+# how it came to hold three triples the list did not and to miss one it did.
+# The `build-std` rows there (the two NuttX triples) are deliberately absent:
+# they have no prebuilt rust-std for rustup to install.
+#
+# Why duplicate the list at all: rustup reads THIS file automatically, so a
+# fresh clone gets the targets without anyone running a recipe first. That is
+# worth a mirror, and `check-rust-targets-covered` is what keeps the mirror
+# from becoming a fifth spelling — it compares this array against the `rustup`
+# rows in both directions, so neither a missing nor a stray triple can ship.
 targets = [
-    "thumbv7em-none-eabihf",
     "thumbv7m-none-eabi",
+    "thumbv7em-none-eabihf",
     "armv7r-none-eabi",
     "armv7r-none-eabihf",
-    "armv7a-none-eabi",
-    "armv7a-none-eabihf",
-    "aarch64-unknown-none",
+    "armv8r-none-eabihf",
     "riscv32imc-unknown-none-elf",
     "riscv64gc-unknown-none-elf",
+    "aarch64-unknown-none",
+    "armv7a-none-eabi",
+    "armv7a-none-eabihf",
 ]
-# The two NuttX triples (`armv7a-nuttx-eabihf`, `riscv32imac-unknown-nuttx-elf`)
-# are custom JSON targets, not rustup ones, and are deliberately NOT listed.

--- a/scripts/check-c-array-pool-floors.py
+++ b/scripts/check-c-array-pool-floors.py
@@ -129,25 +129,33 @@ ZERO_LEGAL = {
 # reproduced through them. That is a reason to rank them below the derived
 # knobs, not a reason to call them safe.
 #
-# Issue 1131 ruled the other fourteen (ten guarded here, and two the widened
-# scan below turned out to have carried a guard all along). What is LEFT is left
-# on purpose: it has a real argument that zero is the right answer, and that
-# argument needs a measurement nobody has taken. A guard would foreclose the
-# saving the way issue 1015's first fix foreclosed issue 1033's.
+# Issue 1131 ruled all fifteen, and the table below is EMPTY. It stays here
+# because emptiness is the claim: a new knob-sized array with no ruling lands
+# in it and trips `UNCLASSIFIED_CEILING`, which is now 0.
+#
+# The last two were ruled on measurements that disagree about WHY while
+# agreeing on the floor, which is the point of ruling each one separately:
+#
+#   * NROS_RMW_UORB_PX4_MAX_CALLBACKS — `Slot g_pool[N]` is C++, and ISO C++
+#     has no zero-size array at all, so 0 is not a saving that the language
+#     will express. Guarded beside the array.
+#   * NROS_ZEPHYR_MAX_TIERS — the C side has no such refusal: GCC's
+#     zero-length-array extension makes `K_THREAD_STACK_ARRAY_DEFINE(x, 0, N)`
+#     compile CLEAN (measured under the real arm-zephyr-eabi flags: `B x`,
+#     size 0, no diagnostic), so nothing but a guard stands between a `-D` and
+#     an image whose every tier spawn fails. Its case for zero rested on
+#     "64 KiB in every Zephyr image, tiers declared or not", and that premise
+#     is false: --gc-sections drops the section in any image declaring no
+#     tier. Over the 91 built images, 4 carry `nros_tier_stacks` and 87 do
+#     not, and the 4 are exactly the four realtime-entry images that declare
+#     tiers. Zero reclaims nothing the linker has not already reclaimed, while
+#     a tiered image wanting a SMALLER pool can still say 2 — the saving a
+#     floor of 1 does not foreclose.
 UNCLASSIFIED = {
-    # 16,384 bytes of stack a slot x 4 slots = 64 KiB of .noinit, present in
-    # EVERY Zephyr image whether or not the system declares a tier — nothing
-    # produces this knob, so 4 is what every image compiles. A tierless image
-    # setting 0 is the same shape as XRCE_MAX_SUBSCRIBERS=0, and the refusal is
-    # already loud (`entry_tiers.rs` prints "failed to spawn tier ... pool
-    # exhausted?" per tier). NEEDS: a Zephyr build at
-    # -DNROS_ZEPHYR_MAX_TIERS=0 proving K_THREAD_STACK_ARRAY_DEFINE accepts a
-    # count of 0, plus a `just mem-report` delta for the 64 KiB.
-    "NROS_ZEPHYR_MAX_TIERS": "zephyr/nros_platform_zephyr_shims.c",
 }
 # The list may SHRINK. Raising this is a deliberate edit that says "one more
 # knob-sized array ships unruled on", beside the entry that says which.
-UNCLASSIFIED_CEILING = 1
+UNCLASSIFIED_CEILING = 0
 
 # --- the producer half -----------------------------------------------------
 
@@ -631,15 +639,28 @@ def selftest() -> int:
     assert any(
         "ALSO carries" in p for p in check_arrays({zl: {"path": "x.h", "guarded": True}})
     )
-    uc = next(iter(UNCLASSIFIED))
-    assert any(
-        "remove it from\n    UNCLASSIFIED" in p
-        for p in check_arrays({uc: {"path": "x.c", "guarded": True}})
-    )
-    # A table entry the scan no longer finds at all.
-    stale = check_arrays({})
-    assert any(f"ZERO_LEGAL names {zl}" in p for p in stale), stale
-    assert any(f"UNCLASSIFIED names {uc}" in p for p in stale), stale
+    # These two controls are driven from a SYNTHETIC entry, not from whatever
+    # happens to be in the table. Issue 1131 ruled the last knob, so
+    # UNCLASSIFIED is now EMPTY and `next(iter(...))` raises StopIteration --
+    # a control that can only run while the backlog is non-empty is a control
+    # that retires itself at exactly the moment the table starts needing
+    # protection. The table's job from here is to stay empty; that is what
+    # UNCLASSIFIED_CEILING = 0 asserts, and these keep its machinery proven.
+    uc = "NROS_SELFTEST_SYNTHETIC_UNRULED"
+    _saved_unclassified = dict(UNCLASSIFIED)
+    UNCLASSIFIED[uc] = "x.c"
+    try:
+        assert any(
+            "remove it from\n    UNCLASSIFIED" in p
+            for p in check_arrays({uc: {"path": "x.c", "guarded": True}})
+        )
+        # A table entry the scan no longer finds at all.
+        stale = check_arrays({})
+        assert any(f"ZERO_LEGAL names {zl}" in p for p in stale), stale
+        assert any(f"UNCLASSIFIED names {uc}" in p for p in stale), stale
+    finally:
+        UNCLASSIFIED.clear()
+        UNCLASSIFIED.update(_saved_unclassified)
 
     # PRODUCERS. Green when both lanes floor all three knobs.
     assert check_producers(producer_texts()) == []

--- a/scripts/check-preconditions-provisioned.py
+++ b/scripts/check-preconditions-provisioned.py
@@ -72,6 +72,16 @@ CLASSIFICATION = {
         "unships whatever the skipped commits fixed, and setup must never "
         "silently pick a side.",
     ),
+    "the Zephyr workspace lives inside a DIFFERENT": (
+        "manual",
+        "WHERE a shared west workspace lives is a host-provisioning decision, "
+        "and the only fix is to move a directory that may hold tens of GB and "
+        "be shared by other jobs. `just setup` must never relocate one it did "
+        "not create, and it cannot know whether the second checkout around it "
+        "is someone's active tree. The probe's job is to name the cause at the "
+        "point of resolution instead of letting phase-431 W1's ownership guard "
+        "refuse 15 minutes later inside a cmake configure.",
+    ),
     "in-tree nros CLI is stale": (
         "setup",
         "`just setup-cli`, run by `_setup-common` on every setup path.",

--- a/scripts/check-rust-targets-covered.py
+++ b/scripts/check-rust-targets-covered.py
@@ -138,6 +138,66 @@ def index_triples():
     return triples
 
 
+def toolchain_file_triples():
+    """The `targets = [...]` array in rust-toolchain.toml."""
+    import re as _re
+    path = ROOT / "rust-toolchain.toml"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8")
+    m = _re.search(r"^targets\s*=\s*\[(.*?)\]", text, _re.S | _re.M)
+    if not m:
+        return set()
+    return set(_re.findall(r'"([^"]+)"', m.group(1)))
+
+
+def check_toolchain_file(known):
+    """`rustup` rows <-> rust-toolchain.toml `targets`, exactly.
+
+    A FIFTH place, and it drifted the same way the SDK index did (issue 0944).
+    rustup reads that file automatically, so it is worth keeping — but it was
+    hand-authored from a grep of `--target` rather than from this list, which
+    made it wrong in BOTH directions at once: it carried three triples no row
+    had (aarch64-unknown-none, armv7a-none-eabi, armv7a-none-eabihf) and missed
+    one that did (armv8r-none-eabihf). Same shape as the CLI source-dirs list,
+    which was blind in both directions for the same reason.
+
+    build-std rows are excluded: rustup cannot install them, and naming one here
+    makes every `rustup` invocation in the tree fail.
+    """
+    have = toolchain_file_triples()
+    if have is None:
+        return 0
+    want = {t for t, kind in known.items() if kind == "rustup"}
+    build_std = {t for t, kind in known.items() if kind == "build-std"}
+
+    absent = sorted(want - have)
+    forbidden = sorted(have & build_std)
+    stray = sorted(have - want - build_std)
+
+    if not (absent or forbidden or stray):
+        return 0
+
+    print("rust-toolchain.toml `targets` disagrees with "
+          "config/rust-targets.txt:\n", file=sys.stderr)
+    for t in absent:
+        print(f"  MISSING from rust-toolchain.toml: {t}", file=sys.stderr)
+        print("      A fresh clone or a reinstalled toolchain will not have it, "
+              "and the\n      failure arrives as `can't find crate for `core`` "
+              "in a cross build.", file=sys.stderr)
+    for t in forbidden:
+        print(f"  build-std target in rust-toolchain.toml: {t}", file=sys.stderr)
+        print("      rustup cannot install it; every rustup call in the tree "
+              "then fails.", file=sys.stderr)
+    for t in stray:
+        print(f"  in rust-toolchain.toml but in no row: {t}", file=sys.stderr)
+        print("      Add it to config/rust-targets.txt (with its declaring "
+              "site) or drop it.", file=sys.stderr)
+    print("\n  rust-toolchain.toml MIRRORS the `rustup` rows. Never hand-edit "
+          "it\n  against a grep of `--target`.", file=sys.stderr)
+    return 1
+
+
 def check_index(known):
     """`rustup` rows <-> `[rust.target.*]`, exactly. Issue 0944."""
     have = index_triples()
@@ -237,11 +297,13 @@ def main():
 
     if check_index(known) != 0:
         return 1
+    if check_toolchain_file(known) != 0:
+        return 1
 
     rustup = sum(1 for k in known.values() if k == "rustup")
     print(f"check-rust-targets-covered: OK "
           f"({len(known)} listed, {len(set(t for t, _ in declared_rows()))} declared, "
-          f"{rustup} mirrored in the SDK index)")
+          f"{rustup} mirrored in the SDK index and in rust-toolchain.toml)")
     return 0
 
 

--- a/scripts/check-tier-preconditions.sh
+++ b/scripts/check-tier-preconditions.sh
@@ -67,6 +67,17 @@ probe "cross Rust target(s) declared by this tree are not installed" \
     "just workspace rust-targets   (or: rustup target add <triple>)" \
     bash scripts/check-rust-targets-installed.sh
 
+# phase-431 W1's ownership guard, asked HERE rather than 15 minutes into a
+# fixture build. A shared west workspace nested inside a SECOND checkout is a
+# host-provisioning fact decided once, but it surfaces as an error about a
+# BINARY, deep inside a cmake configure, naming neither the workspace nor the
+# fix. That shape cost the tier-2 lane two consecutive nights (2026-09-06/-07).
+# The probe mirrors the guard's three silent cases exactly, so it can never be
+# stricter than the thing it front-runs.
+probe "the Zephyr workspace lives inside a DIFFERENT nano-ros checkout" \
+    "move it out of any checkout — see the message; do NOT reach for NROS_SKIP_STALE_CHECK=1" \
+    bash scripts/check-zephyr-workspace-checkout.sh
+
 probe "a submodule is not at the commit this superproject records" \
     "git submodule update <path>   (bypass: NROS_SKIP_SUBMODULE_DRIFT_CHECK=1)" \
     bash scripts/check-submodule-drift.sh

--- a/scripts/check-zephyr-workspace-checkout.sh
+++ b/scripts/check-zephyr-workspace-checkout.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Refuse a Zephyr workspace that lives inside a DIFFERENT nano-ros checkout.
+#
+# phase-431 W1 gave the CLI an ownership guard: if the directory `nros` is
+# operating on sits inside a nano-ros checkout, the running binary must be that
+# checkout's own `packages/cli/target/**` build. A foreign binary emits with ITS
+# OWN codegen, which can differ from this checkout's while carrying the same
+# codegen version — the version catches an incompatible emitter, not one that
+# merely moved.
+#
+# The guard is right. WHERE it fires is the problem. A shared west workspace
+# nested inside a second checkout is a property of the HOST, decided once at
+# provisioning time, but the refusal arrives ~15 minutes into a tier-2 fixture
+# build, inside a cmake configure, as an error about a binary — naming neither
+# the workspace, nor the second checkout, nor the fix. On the self-hosted runner
+# that shape cost the tier-2 lane two consecutive nights (2026-09-06, -07):
+#
+#   == zephyr == FAILED (rc=2)
+#   Error: this `nros` does not belong to the checkout it is being run against.
+#   FATAL ERROR: ... -B/mnt/<disk>/<user>/nano-ros/zephyr-workspace/...
+#
+# (the path is written generically on purpose: `<user>/nano-ros` spelled out
+# is a forbidden string here, since it reads as a GitHub org that is not ours)
+#
+# ...while the checkout under test was /home/aeon/actions-runner/_work/... .
+# Nothing in this repository selects that path (it is the runner's own
+# environment), so a reader of the tree could not discover the cause from it —
+# which is why the check belongs here, where the resolution happens.
+#
+# The three conditions below MIRROR the guard's exactly, so this can never be
+# stricter than the thing it front-runs: a workspace outside any checkout is
+# fine (the guard's own first silent case), our own checkout is fine, and a
+# checkout carrying no `packages/cli` sources is fine because nothing there
+# could have built a CLI to be foreign to. `NROS_SKIP_STALE_CHECK=1` disables
+# the guard, so it disables this too — otherwise this would fail a host that
+# has deliberately opted out.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+[ "${NROS_SKIP_STALE_CHECK:-}" = "1" ] && exit 0
+
+ws="${NROS_ZEPHYR_WORKSPACE:-}"
+if [ -z "$ws" ]; then
+    for cand in "$repo_root/zephyr-workspace" "$repo_root/../nano-ros-workspace" \
+                "$repo_root/../nano-ros-workspace-4.4"; do
+        [ -d "$cand/zephyr" ] && ws="$cand" && break
+    done
+fi
+# No workspace at all is not this check's business — the caller already warns.
+[ -n "$ws" ] && [ -d "$ws" ] || exit 0
+
+# Resolve symlinks: a `zephyr-workspace` symlinked onto a big disk reaches the
+# same second checkout as an absolute NROS_ZEPHYR_WORKSPACE, and the build tools
+# hand cmake the resolved path either way.
+ws_real="$(cd "$ws" 2>/dev/null && pwd -P)" || exit 0
+
+# The guard's marker, and its lexical walk upward.
+owner=""
+dir="$ws_real"
+while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    if [ -f "$dir/packages/core/nros-core/Cargo.toml" ]; then owner="$dir"; break; fi
+    dir="$(dirname "$dir")"
+done
+
+[ -n "$owner" ] || exit 0                            # outside any checkout — fine
+[ "$owner" != "$repo_root" ] || exit 0               # our own checkout — fine
+[ -f "$owner/packages/cli/Cargo.toml" ] || exit 0    # no CLI sources — nothing to be foreign to
+
+cat >&2 <<EOF
+The Zephyr workspace sits inside a DIFFERENT nano-ros checkout, so every
+\`nros\` invocation against it will be refused by the phase-431 W1 ownership
+guard — not here, but deep inside the fixture build.
+
+  workspace: $ws_real
+  owned by:  $owner
+  this tree: $repo_root
+
+That second checkout has \`packages/cli\`, so the guard resolves ownership to
+IT and expects $owner/packages/cli/target/**/nros — never this tree's build.
+
+Fix by moving the workspace OUT of any checkout, not by pointing it at one:
+
+  NROS_ZEPHYR_WORKSPACE=$(dirname "$owner")/zephyr-workspace
+
+A workspace outside every checkout takes the guard's own first silent case
+("the cwd is not in a checkout"), so nothing is weakened and no code changes.
+Setting NROS_SKIP_STALE_CHECK=1 also silences it, but that disables a guard
+whose whole job is to stop a foreign CLI emitting different codegen under the
+same version — a loud failure traded for a quiet wrong answer.
+EOF
+exit 1

--- a/zephyr/nros_platform_zephyr_shims.c
+++ b/zephyr/nros_platform_zephyr_shims.c
@@ -648,6 +648,32 @@ void nros_zephyr_log_2int(const char* tag, int64_t a, int64_t b) {
 #define NROS_ZEPHYR_MAX_TIERS 4
 #endif
 
+/* Floor of 1, and the reason zero is NOT the answer here is MEASURED, not
+ * assumed -- issue 1131 left this knob unruled precisely because a plausible
+ * argument said 0 (64 KiB of .noinit reclaimed by a tierless image, the shape
+ * issue 1033 ruled zero-legal for XRCE_MAX_SUBSCRIBERS). That argument rested
+ * on a premise that is false: the stacks are NOT present in every Zephyr image.
+ *
+ * `nros_tier_stacks` is the only referent of this array, and the sole path that
+ * reaches it is `nros_zephyr_tier_task_create`. In an image that declares no
+ * tier nothing calls that function, so --gc-sections (on in every Zephyr link)
+ * drops the section. Measured over the 91 built images in this tree: 4 carry
+ * `nros_tier_stacks`, 87 do not, and the 4 are EXACTLY the four realtime-entry
+ * images that declare tiers -- the correspondence is total, with no image
+ * paying for a pool it does not use. On mps2_an385 the section is listed in the
+ * map's "Discarded input sections" at 0x10100 (65,792 bytes); on native_sim the
+ * tiered image carries 0x10000 and the tierless one has no such symbol.
+ *
+ * So 0 buys nothing the linker does not already give, and in the one class of
+ * image that would define it -- a tiered one -- it makes `nros_tier_index >=
+ * NROS_ZEPHYR_MAX_TIERS` true for the FIRST tier, so every spawn fails and the
+ * system runs with no tier at all. The saving a tiered image can actually want
+ * is a SMALLER pool (2 or 3 slots, 16 KiB each), which this floor permits: it
+ * forecloses nothing, which is the trap issue 1015's first fix fell into. */
+#if NROS_ZEPHYR_MAX_TIERS < 1
+#error "NROS_ZEPHYR_MAX_TIERS must be >= 1: it sizes a C array (issue 1015)"
+#endif
+
 #ifndef NROS_ZEPHYR_TIER_STACK_SIZE
 #define NROS_ZEPHYR_TIER_STACK_SIZE 16384
 #endif


### PR DESCRIPTION
Closes the last unruled knob in issue 1131, so the gate's `UNCLASSIFIED` table
is **empty** and `UNCLASSIFIED_CEILING` drops 1 → 0.

```
check-c-array-pool-floors: OK (23 knob-sized C arrays: 20 guarded, 3 zero-legal, 0 unclassified)
check-c-array-guard-probe: OK — 20 guard(s) across 8 file(s) fire at 0 and are silent at defaults
```

Issue 1131 → `resolved`, moved to `archived/`.

## The premise was false, and that is the whole ruling

`NROS_ZEPHYR_MAX_TIERS` sat unruled on *64 KiB of tier stacks in every Zephyr
image, tiers declared or not*. It is in four of them.

`nros_tier_stacks` is reachable only through `nros_zephyr_tier_task_create`, so
an image declaring no tier gives `--gc-sections` nothing to keep. Over the **91
built images** in the tree: **4 carry it, 87 do not**, and the 4 are exactly the
four `realtime-entry` images that declare tiers — total correspondence, both
directions.

| | evidence |
| --- | --- |
| mps2_an385, tierless | `.noinit."…shims.c".1` at `0x10100` (65,792 B) listed under *Discarded input sections*, address 0 — while the 512 KiB `nros_thread_stacks` is placed at `0x200769c0`. One object, one link, one section kept and one dropped, on exactly the reachability distinction. |
| native_sim, tiered | `nros_tier_stacks` present at `0x10000` |
| native_sim, tierless | no such symbol |

So zero reclaims nothing the linker has not already reclaimed, and on a tiered
image it makes `nros_tier_index >= NROS_ZEPHYR_MAX_TIERS` true for the **first**
tier — `entry_tiers.rs` returns `Err(RuntimeError::Spin)`.

## Why this could not be ruled by analogy from the uORB knob

The commit before this one guarded `NROS_RMW_UORB_PX4_MAX_CALLBACKS` because
ISO C++ has no zero-size array. **C does.** Asked directly, the macro takes zero
*silently*: `K_THREAD_STACK_ARRAY_DEFINE(probe, 0, 16384)` compiles clean under
the real `arm-zephyr-eabi` flags — `B probe_stacks`, size 0, no diagnostic. Same
floor, and the reason does not transfer; without a guard a `-D` reaches a broken
image with nothing in the way. Issue 1015's silent-zero shape exactly.

Floor of 1, below its own `#ifndef` (issue 1167's ordering rule), matching its
sibling `NROS_ZEPHYR_MAX_THREADS`. It forecloses no saving — `-D…=2` compiles,
and a *smaller* pool is what a tiered image can actually want. That is the trap
1015's first fix fell into.

## The host that "could not" run this

The issue recorded *"not attemptable on a host with no Zephyr"*. True of the
toolchain state, not the host: `nros setup` provisions the west workspace, and
this tree already had one with 91 built images. The measurement then needed **no
build** — maps and objects were on disk, and the three compile checks reused the
TU's own command from `compile_commands.json` with `-o` redirected to scratch, so
no build directory moved.

## Two unrelated reds that stood between this and a lane verdict

- **`rust-toolchain.toml` declared 4 of the 9 rustup targets the gates compile
  for.** Invisible until a toolchain is reinstalled or a clone is fresh; the
  other five survived only as hand-added residue. `nros-log-riscv32` fails
  `can't find crate for core`, and `repr-memory-agreement` reported **SKIPPED**
  for want of `armv7a-none-eabi` — a gate that cannot evaluate reads exactly
  like one that found nothing. `check-fast` goes 264-ran-plus-1-skipped → 276
  ran with the only skip a provisioning absence that names itself.
- **`matrix::CELLS` had no cell for `(zephyr, cpp, cyclonedds, workspace)`**, so
  the fixture row from `9ae271174` was an orphan: built and run by the lane,
  modeled by nothing. Caught by `fixture_rows_all_modeled_by_matrix`. The
  forward assertion stayed green throughout — a cell that does not exist cannot
  be missing a fixture.

## The selftest this emptied

Ruling the last knob left `UNCLASSIFIED` empty, and the gate's own selftest read
`next(iter(UNCLASSIFIED))` — `StopIteration` the moment the backlog it protects
reached zero. Both controls now run against a **synthetic** entry: a negative
control that works only while unruled debt exists retires itself at exactly the
moment the table starts needing protection.

## Verification

| | |
| --- | --- |
| default (4) | compiles — no regression from the guard |
| `-DNROS_ZEPHYR_MAX_TIERS=0` | `#error "… must be >= 1: it sizes a C array (issue 1015)"` |
| `-DNROS_ZEPHYR_MAX_TIERS=2` | compiles — the floor forecloses no saving |

Mutations, each red naming the exact site, then restored green: guard deleted
(`sizes a fixed C array and states no floor`); guard moved above its `#ifndef`
(`is guarded where the guard CANNOT FIRE`, and the probe gate red too, since it
then fires at defaults).

`check-fast` 276 ran / 1 skipped; `test-unit` 1213 pass + 1 precondition skip;
`test-lane-contracts` 17/17; `declared-qos-header` 19 assertions.

Sweep, re-runnable:

```
for d in zephyr-workspace/build-*/; do
  nm -S "$d/zephyr/zephyr.exe" 2>/dev/null | grep -c nros_tier_stacks
done
```

The second commit is separate on purpose: three commit citations no clone can
resolve, which had `check-doc-commit-citations` red on main and the `pre-push`
hook blocked for everyone. The baseline file's own note says this gate "is a
separate change and must not carry an unrelated document edit"; the reverse
holds too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742