### PR TITLE
feat(phase-412 W3b): the arena's QoS depth becomes a knob, and the model splits in two

### DIFF
--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -316,7 +316,30 @@ fn main() {
     // variable means "some endpoint said nothing" and the default stands. That
     // guard belongs there rather than here: the count is a property of the
     // declaration, and this lane cannot see it.
-    let pubsub_depth = declared_max_qos_depth().unwrap_or(PUBSUB_QOS_DEPTH);
+    // phase-412 W3b — and this is the whole ladder, in one expression.
+    //
+    // `env_usize` supplies the three rungs above the builtin (an environment
+    // value, `CONFIG_NROS_PUBSUB_QOS_DEPTH` from `$DOTCONFIG`, then the
+    // board/platform descriptor); the DECLARED depth sits between those and the
+    // literal, which is where the tree's stated precedence puts a derived
+    // value: env > Kconfig/board > derived > crate default.
+    //
+    // WHY A KNOB EXISTS BESIDE THE DECLARATION. The declared depth needs a
+    // `<stem>.contract.yaml` stating `qos.depth` for EVERY endpoint — one
+    // unannotated subscription and cmake refuses, correctly, because a table
+    // over the annotated subset sizes the image from part of itself. That is a
+    // high bar for a saving worth 91,080 bytes on the island shape, and an
+    // image whose subscriptions are all KEEP_LAST(1) should not have to author
+    // a contract to say one number. This lets it say the number.
+    //
+    // The BUILTIN stays ROS 2's own default: `PUBSUB_QOS_DEPTH` is
+    // `rmw_qos_profile_default`'s KEEP_LAST(10), which is what a subscription
+    // created with no QoS argument actually gets, so an image that says nothing
+    // is still sized the way ROS would size it.
+    let pubsub_depth = env_usize(
+        "NROS_PUBSUB_QOS_DEPTH",
+        declared_max_qos_depth().unwrap_or(PUBSUB_QOS_DEPTH),
+    );
     let pubsub_region = buffered_region(pubsub_depth, rx_recv_size);
     let pubsub_entry = pubsub_region + PUBSUB_ENTRY_STRUCT;
 
@@ -452,6 +475,10 @@ fn main() {
              /// QoS history depth the pub/sub term budgets \
              (`QoSProfile::QOS_PROFILE_DEFAULT.depth`).\n    \
              pub const QOS_DEPTH: u32 = {pubsub_qos_depth};\n    \
+             /// The depth this image's arena was actually BUDGETED for — the \
+             resolved `NROS_PUBSUB_QOS_DEPTH`, which defaults to `QOS_DEPTH` \
+             when nothing states one.\n    \
+             pub const BUDGETED_QOS_DEPTH: u32 = {budgeted_qos_depth};\n    \
              /// Buffered receive region for ONE subscription at that depth.\n    \
              pub const PUBSUB_REGION: usize = {pubsub_region};\n    \
              /// Allowance for the entry STRUCT beside that region.\n    \
@@ -477,7 +504,20 @@ fn main() {
         // `the_modelled_qos_depth_is_the_runtime_default` in `arena.rs` reads
         // back, so emitting the constant while sizing from the declaration
         // would make the assertion pass against a model the build did not use.
-        pubsub_qos_depth = pubsub_depth,
+        // TWO depths, because `arena.rs` asks two different questions of them
+        // and one answer cannot serve both.
+        //
+        // `QOS_DEPTH` is the RESTATEMENT of ROS 2's default, and it exists so
+        // `the_modelled_qos_depth_is_the_runtime_default` can catch it drifting
+        // from `QoSProfile::default().depth` — a build script cannot read that
+        // const out of the crate it is building, so the number is retyped and
+        // that test is what holds the two equal. It stays the BUILTIN whatever
+        // this image budgeted, or the drift check starts asserting against a
+        // configuration instead of against ROS.
+        //
+        // `BUDGETED_QOS_DEPTH` is what the arena was actually sized for.
+        pubsub_qos_depth = PUBSUB_QOS_DEPTH,
+        budgeted_qos_depth = pubsub_depth,
         pubsub_entry_struct = PUBSUB_ENTRY_STRUCT,
         action_feedback_depth = ACTION_FEEDBACK_DEPTH,
         arena_base_overhead = ARENA_BASE_OVERHEAD,

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -789,18 +789,28 @@ mod arena_model_tests {
     /// allocator itself calls, and not through a second copy of its arithmetic.
     #[test]
     fn the_modelled_pubsub_region_covers_a_default_qos_subscription() {
+        // phase-412 W3b — against the depth this image BUDGETED, not against
+        // ROS 2's default. They are the same number until something states
+        // otherwise, and once something does, "does the model cover a DEFAULT
+        // subscription" stops being the question the image is asking: an image
+        // that budgets KEEP_LAST(1) is claiming its subscriptions are
+        // KEEP_LAST(1), and this assertion holding at depth 10 would only mean
+        // it had over-provisioned.
+        //
+        // What it still catches is the thing that matters — a budget that does
+        // not cover its own claim.
         let (slots, region) =
-            super::buffered_region_size(QoSProfile::default().depth, DEFAULT_RX_BUF_SIZE);
+            super::buffered_region_size(model::BUDGETED_QOS_DEPTH, DEFAULT_RX_BUF_SIZE);
         assert!(
             model::PUBSUB_REGION >= region,
             "the arena derivation budgets {} bytes for a subscription's \
              buffered region and the allocator claims {region} for it \
-             ({slots} slots of {DEFAULT_RX_BUF_SIZE} at the default \
+             ({slots} slots of {DEFAULT_RX_BUF_SIZE} at the budgeted \
              KEEP_LAST({}) ) — every image that derives its arena from a \
              declared subscription count is short by {} bytes per \
              subscription (issue 1190)",
             model::PUBSUB_REGION,
-            QoSProfile::default().depth,
+            model::BUDGETED_QOS_DEPTH,
             region.saturating_sub(model::PUBSUB_REGION),
         );
     }

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -89,6 +89,16 @@ KNOB_CLASS = {
         "per-session graph cache bytes; sized by the PEER graph, so it is "
         "stated rather than derived",
     ),
+    # phase-412 W3b — the arena's QoS-depth multiplier, and a SIZING knob rather
+    # than a derived one. The per-endpoint answer IS derived (from
+    # `<stem>.contract.yaml`'s `qos.depth`, when every endpoint states one) and
+    # this is the image-wide number that outranks it, which is what the ladder
+    # is for. Default 10 is ROS 2's own `rmw_qos_profile_default` KEEP_LAST(10).
+    "NROS_PUBSUB_QOS_DEPTH": (
+        "sizing",
+        "the arena's per-subscription history depth; the derived per-endpoint "
+        "form is phase-412 W3's NROS_DECLARED_MAX_QOS_DEPTH, which this outranks",
+    ),
     "ZPICO_SUBSCRIBER_BUFFER_SIZE": ("derived", "SMALL_PAYLOADS class (phase-403)"),
     "ZPICO_SUBSCRIBER_LARGE_SIZE": ("derived", "LARGE_PAYLOADS class (phase-403)"),
     "ZPICO_SUBSCRIBER_SIZE_THRESHOLD": ("derived", "SMALL_CLASS_CEILING (phase-403)"),

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1138,6 +1138,33 @@ config NROS_EXECUTOR_MAX_CBS
       native_sim listener's .bss by 219 KB (+35%) as a side effect of repairing
       the plumbing.
 
+config NROS_PUBSUB_QOS_DEPTH
+    int "QoS history depth the arena budgets per subscription"
+    default 10
+    help
+      How deep a history the executor arena reserves for each pub/sub
+      callback slot. 10 is ROS 2's own default -- `rmw_qos_profile_default`
+      is KEEP_LAST(10), which is what a subscription created with no QoS
+      argument actually gets -- so an image that says nothing here is sized
+      the way ROS would size it.
+
+      STATE 1 IF YOUR SUBSCRIPTIONS ARE KEEP_LAST(1), and the saving is large
+      rather than marginal. The buffer shape is a step function, not a slope:
+      depth 1 is a TripleBuffer of 3 slots and anything deeper is an SpscRing
+      of depth+1, so the default budgets 11 slots where 3 would do. Measured
+      on the reference island's entity shape (11 subscriptions, 4 timers, 2
+      service servers): 144,584 bytes of arena at 10, 53,504 at 1.
+
+      This is the IMAGE-WIDE number. A per-endpoint answer is derived instead
+      from `<stem>.contract.yaml`'s `qos.depth` when EVERY endpoint states one
+      (phase-412 W3); that is finer, needs no knob, and this value still wins
+      over it -- env > Kconfig/board > derived > default, the ladder every
+      derivable knob follows.
+
+      TOO SMALL IS NOT A SMALLER BUFFER. The arena is sized from this, and an
+      arena that does not fit halts during entity creation, before the first
+      spin -- so raise it, or state the depths, rather than trimming it to fit.
+
 config NROS_SUBSCRIPTION_BUFFER_SIZE
     int "Per-subscription receive buffer size in bytes (-1 = derive)"
     default -1


### PR DESCRIPTION
**Stacked on #738** (base is `work/412-depth-wiring`), because it changes the same expression.

#738 made the arena read the **declared** per-endpoint depth. That answer needs a
`<stem>.contract.yaml` stating `qos.depth` for *every* endpoint — one unannotated subscription and
cmake refuses, correctly, because a table over the annotated subset sizes the image from part of
itself. **No in-tree image has such a file**, so the 91,080 bytes #738 measured were unreachable
in practice.

`NROS_PUBSUB_QOS_DEPTH` is the image-wide number, on the ladder every derivable knob follows:
`env > Kconfig/board > declared > builtin`. An image whose subscriptions are all KEEP_LAST(1)
states one number instead of authoring a contract, and gets the same arena.

The builtin stays ROS 2's own default — `rmw_qos_profile_default`'s KEEP_LAST(10), what a
subscription created with no QoS argument actually gets — so an image that says nothing is still
sized the way ROS would size it.

## The model now emits two depths

`arena.rs` asks two different questions and #738 had them sharing one answer:

- **`QOS_DEPTH`** — the *restatement* of ROS 2's default, so
  `the_modelled_qos_depth_is_the_runtime_default` can catch it drifting from
  `QoSProfile::default().depth` (a build script can't read that const out of the crate it's
  building). It must stay the builtin whatever the image budgeted, or the drift check starts
  asserting against a configuration instead of against ROS. Mutation-verified: changing the
  restatement to 7 still fails that test.
- **`BUDGETED_QOS_DEPTH`** — what the arena was actually sized for.
  `the_modelled_pubsub_region_covers_a_default_qos_subscription` now measures against it.

That split was **found by running the tests with the knob set**: #738 emitted the resolved depth as
`QOS_DEPTH`, and both tests failed — one of them asserting that a configured image matches ROS's
default, which is not a question that image is asking. What the retargeted test still catches is
the thing that matters: a budget that does not cover its own claim.

## Measured

Reference island entity shape (11 subscriptions, 4 timers, 2 service servers):

| | `ARENA_SIZE` | `BUDGETED_QOS_DEPTH` |
| --- | ---: | ---: |
| builtin (nothing stated) | 144,584 | 10 |
| `NROS_PUBSUB_QOS_DEPTH=1` | **53,504** | 1 |
| `NROS_DECLARED_MAX_QOS_DEPTH=1` | 53,504 | 1 |
| declared 1, knob 4 | 76,472 | 4 |

The knob outranks the declaration, as the ladder requires. `QOS_DEPTH` stays 10 throughout.

Kconfig help states the trade in full, including that **too small is not a smaller buffer**: an
arena that does not fit halts during entity creation, before the first spin, so the advisory issue
0900 added never prints.

```
just check fast   275 ran, 1 ledger skip, 0 failed
just test-unit    PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119aFbZ4oJ6u4agj4PjknPd