### PR TITLE
docs(phase-438, #1223, #1187): the `#elif` arm breaks the FreeRTOS build, and the gate for it is blind

### DIFF
--- a/docs/issues/1187-freertos-embedded-cpp-freestanding-string.md
+++ b/docs/issues/1187-freertos-embedded-cpp-freestanding-string.md
@@ -94,3 +94,40 @@ is this same gate being fixed at one site at a time. One shared spelling, not a
 Acceptance is a BUILD: `bash scripts/build/fixtures-build.sh freertos cpp
 zenoh` green, with `NROS_CMAKE_EXTRA_DEFS` carrying
 `cmake/toolchain/arm-freertos-armcm3.cmake`.
+
+## Update 2026-09-08 — this is phase-438, and the measurement is in
+
+`docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md` is the class fix
+this section asks for, and the option it takes is the first one: delete the
+`#elif __has_include` arm outright, so the std surface is reachable only through
+`NROS_CPP_STD`. Measured, per-header, on this issue's own toolchain
+(`arm-none-eabi 13.2`, `-std=c++14 -ffreestanding -fno-exceptions -fno-rtti`):
+
+```
+TRACKED  : pass=26 fail=19
+STRIPPED : pass=45 fail=0
+```
+
+and on hosted `g++ 12.3` the same strip is a no-op (46 pass either way), so the
+fix is not a trade between the lanes.
+
+Two corrections to the analysis above, both measured:
+
+* **The second option — AND `__has_include` with `__STDC_HOSTED__` — does not
+  work either.** `__STDC_HOSTED__` is 0 on this lane and 1 on Zephyr's
+  `-nostdinc++` lane, where `<string>` is genuinely absent; `__has_include` is the
+  reverse. Each probe is correct on exactly one embedded lane. Only the opt-in is
+  correct on both.
+* **This issue's "with the rationale, from issue 0112" is not what 0112 says.**
+  0112 chose `NROS_CPP_STD` over `__STDC_HOSTED__`; it never chose
+  `__has_include`, which arrived later in `acf213871`. Eleven header comments
+  cite 0112 as authority for the construct. phase-438 W5 corrects them.
+
+The count here is also slightly off: **15 blocks across 11 headers**, not 19
+sites across 13. Nineteen is the `__has_include(<...>)` occurrence count and 29
+is the `#define NROS_CPP_HAS_*` line count; the block count is what W1 has to
+consolidate.
+
+Blocked on issue 1223 only in ordering: `check-cpp-freestanding-includes` cannot
+see any of these arms, so it must be taught to before they are deleted, or the
+blindness ships uncaught.

--- a/docs/issues/1223-cpp-freestanding-includes-blind-to-elif.md
+++ b/docs/issues/1223-cpp-freestanding-includes-blind-to-elif.md
@@ -1,0 +1,105 @@
+---
+id: 1223
+title: "`check-cpp-freestanding-includes` scores every `#elif` and `#else` arm as
+  guarded, so the 14 arms that actually break the FreeRTOS build are invisible
+  to the gate written to catch them"
+status: open
+type: bug
+area: [cpp, ci]
+related: [1187, 1023, 0112, 0332, 1204]
+---
+
+## Problem
+
+`check-cpp-freestanding-includes` reports
+
+```
+check-cpp-freestanding-includes: OK (64 file(s) … no ungated hosted STL includes)
+```
+
+on a tree where 19 of 45 `nros-cpp` headers fail to compile on the pinned
+embedded toolchain for exactly the reason the gate exists to prevent — a hosted
+STL header reached with `NROS_CPP_STD` undefined (issue 1187).
+
+The gate's awk tracks guard depth with three rules: push `"std"` on a
+`#if`/`#ifdef` naming `NROS_CPP_STD`, push `"other"` on any other
+`#if`/`#ifdef`/`#ifndef`, and pop on `#endif`. **`#elif` and `#else` match none
+of them.** They are ordinary text, so the frame from the opening `#if` survives
+into the alternative arm, and every include there is scored against a guard that
+is false in that arm by construction.
+
+## Reproduction
+
+Both arms below are scored `guarded=1`; only the first one is.
+
+```c++
+#if defined(NROS_CPP_STD)
+#include <string>          // guarded=1  — correct
+#elif defined(__has_include)
+#if __has_include(<vector>)
+#include <vector>          // guarded=1  — WRONG: NROS_CPP_STD is off here
+#endif
+#endif
+```
+
+`#else` is the strictly worse case, because the include there is the *fallback* —
+the code that runs precisely when `NROS_CPP_STD` is undefined:
+
+```c++
+#if defined(NROS_CPP_STD)
+#include <string>          // guarded=1  — correct
+#else
+#include <vector>          // guarded=1  — WRONG, and this arm is the common one
+#endif
+```
+
+Instrumented run of the gate's own awk over the first file:
+
+```
+1 sp=1 STDPUSH #if defined(NROS_CPP_STD)
+2 sp=1 guarded=1  #include <string>
+3 sp=1 PASSTHRU #elif defined(__has_include)     <- neither push nor pop
+4 sp=2 OTHER  #if __has_include(<vector>)
+5 sp=2 guarded=1  #include <vector>
+```
+
+## Reach
+
+Every one of the **14 two-arm `#if NROS_CPP_STD` / `#elif defined(__has_include)`
+blocks** across 11 headers (`client`, `fixed_string`, `heap_string`, `log` ×2,
+`nros`, `options` ×2, `polling_subscription`, `publisher`, `service`,
+`subscription` ×2, `timer` ×2) is invisible to this gate. `log.hpp:115`, the
+`<string>` include that is the entry point for 17 of issue 1187's 19 header
+failures, is one of them.
+
+There are also 10 `#else` lines in the same headers, each of which needs
+checking against this rule rather than against the gate's green verdict.
+
+## Why it survived
+
+Issue 1023 already found this gate's stack discipline wrong — a backend TU with
+a real `#if`/`#elif`/`#else` where a nested `#endif` popped the `NROS_CPP_STD`
+region early — and the fix was the neutral `"other"` push. That fix addressed
+the `#endif` half of the same defect and left `#elif`/`#else` unhandled, which is
+CLAUDE.md's "fix the CLASS, not the reported site" one layer down: the class is
+"a preprocessor conditional the tracker does not model", and only one of its
+three spellings got modelled.
+
+The gate then reported green over the very construct issue 1187 is about, which
+is why 1187's class landed under a green check.
+
+## Fix direction
+
+Model the alternative arms. On `#elif` and `#else`, the current frame's
+condition no longer holds, so the frame must be *replaced* rather than kept: pop
+the top and push `"other"` (an `#elif` arm is guarded by something, just not by
+what the `#if` said). An `#elif` that itself names `NROS_CPP_STD` pushes `"std"`.
+
+Acceptance is a negative control the gate does not have today: both snippets
+above must FAIL. A gate whose selftest cannot distinguish the arms is the same
+silence with extra steps — and this one currently reports OK on both.
+
+Ordering: this is a prerequisite for phase-438, whose W2 deletes the `#elif`
+arms. Fixed first, the gate turns red on the 14 arms and phase-438 W2 turns it
+green — the gate becomes the acceptance. Fixed after, the arms are gone and the
+blindness ships uncaught for whatever writes the 15th.

--- a/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
+++ b/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
@@ -1,9 +1,14 @@
 # phase-438 — the C++ std surface is an opt-in PORTING surface, not a discovered capability
 
-**Status (2026-09-08). Opened.** The C++ half of phase-359's argument. Implements
-RFC-0089's compile-or-conform rule by making the surface that rule needs an
-explicit request rather than a property of the toolchain. Re-cuts phase-427 W1,
-which currently works around this rather than fixing it.
+**Status (2026-09-08). Opened; feasibility MEASURED.** The C++ half of phase-359's
+argument. Implements RFC-0089's compile-or-conform rule by making the surface that
+rule needs an explicit request rather than a property of the toolchain. Re-cuts
+phase-427 W1, which currently works around this rather than fixing it.
+
+**It is also the class fix issue 1187 asks for**, which is the part that changes
+its priority. This was written as tidiness. The measurement says the construct it
+removes is a live breakage on the pinned embedded toolchain, and that the gate
+meant to catch that breakage structurally cannot see it (issue 1223).
 
 ## Why
 
@@ -12,8 +17,9 @@ convenience layer over the platform but a SECOND implementation of one. The C++
 side has the same shape and has never had the same campaign.
 
 The difference is that the C++ split is not even chosen. Six macros gate the
-std-flavoured API, and each is defined by this block, repeated **29 times across
-13 headers**:
+std-flavoured API, and each is defined by this block, repeated **15 times across
+11 headers** (`client`, `fixed_string`, `heap_string`, `log` ×2, `nros`, `options`
+×2, `polling_subscription`, `publisher`, `service`, `subscription` ×2, `timer` ×2):
 
 ```cpp
 #if defined(NROS_CPP_STD)
@@ -30,21 +36,79 @@ std-flavoured API, and each is defined by this block, repeated **29 times across
 `NROS_CPP_STD` is a consumer opt-in. The `#elif` arm makes the same macros
 DISCOVERED from the include path. On any hosted compiler they are on whether the
 consumer asked or not — and `rclcpp::Node` is guarded on the discovered ones
-(`nros.hpp:447`), not the requested one.
+(`nros.hpp:454`), not the requested one.
 
 **So the API shape a consumer gets is decided by what headers happen to exist.**
 A native build gets the std-flavoured node because libstdc++ is reachable, not
 because anyone wanted it.
 
-### The axis is misnamed, and the measurement says so
+### The `#elif` arm is not a benign over-broadening — it breaks the embedded build
 
-`NROS_CPP_HAS_SHARED_PTR` asks *"can this toolchain reach `<memory>`"*. The
-question the codebase actually needs answered is *"does this consumer want the
-surface that lets an upstream rclcpp file compile unmodified"*. Two different
-questions, one name — the same collapse CLAUDE.md records for
-`native`/`posix`/`linux`.
+Measured on the FreeRTOS lane's own pinned compiler
+(`~/.nros/sdk/arm-none-eabi-gcc/13.2-nros1`, `-std=c++14 -ffreestanding
+-fno-exceptions -fno-rtti`), every header compiled standalone:
 
-Measured, nothing but ported code wants the std surface:
+```
+TRACKED  (arm-none-eabi 13.2, -ffreestanding): pass=26 fail=19
+STRIPPED (the #elif arms removed)            : pass=45 fail=0
+```
+
+The 19 failures are `action_client action_server client component component_node
+fixed_string heap_string log node nros options polling_action_client
+polling_action_server polling_subscription publisher qos service subscription
+timer`, and the diagnostic is the same every time:
+
+```
+In file included from .../c++/13.2.1/string:38,
+                 from packages/api/nros-cpp/include/nros/log.hpp:115,   <-- the #elif arm
+                 from packages/api/nros-cpp/include/nros/qos.hpp:24,
+                 from packages/api/nros-cpp/include/nros/node.hpp:30,
+.../bits/requires_hosted.h:34:4: error: #error "This header is not available in freestanding mode."
+```
+
+Deleting the arm **fixes 19 headers**. On the hosted loop the same strip is a
+no-op — 46 pass before and after — so this phase's central edit is not a
+trade-off between the two lanes. It is a fix on one and neutral on the other.
+
+That is issue 1187, whose "Fix direction" asks for exactly this and asks for it
+**for the class**: "One shared spelling, not a 14th."
+
+### Neither probe is right on both embedded lanes; only the request is
+
+The reason `__has_include` cannot be repaired in place, measured directly:
+
+| | `__STDC_HOSTED__` | `__has_include(<string>)` | `#include <string>` |
+| --- | --- | --- | --- |
+| arm-none-eabi 13.2, `-ffreestanding` (FreeRTOS lane) | **0** | **TRUE** | hard `#error` |
+| Zephyr `-nostdinc++`, minimal libcpp (issue 0112's lane) | 1 | FALSE | absent |
+| hosted g++ 12.3 | 1 | TRUE | works |
+
+Each probe is right on exactly one embedded lane and wrong on the other. On the
+FreeRTOS lane `__STDC_HOSTED__` is the correct probe and `__has_include` is the
+wrong one — **the exact reverse of what eleven header comments state.** Only
+`NROS_CPP_STD` is right on both, because it is not a probe.
+
+### Those eleven comments cite issue 0112 for something 0112 did not say
+
+Eleven headers carry a comment reading, in substance, *"why the test is
+`__has_include` rather than `__STDC_HOSTED__`, issue 0112"*. Issue 0112's
+Resolution reads:
+
+> Fix (`component_node.hpp`): moved the `<string>` include into its own
+> `#ifdef NROS_CPP_STD` block, so it follows its actual consumer.
+
+0112 chose **`NROS_CPP_STD` over `__STDC_HOSTED__`** — the opt-in. It never chose
+`__has_include`. The `#elif __has_include` arm arrived later, in `acf213871`
+("feat(phase-417 stage 0+1+2b)"), and re-broadened the gate 0112 had narrowed.
+
+So this phase is not a departure from 0112. It is 0112's own fix, restored, and
+the eleven comments are wrong twice over — about what 0112 decided, and about
+which probe is correct on the lane that is actually failing. 0112's *finding*
+still holds: hostedness does not imply header availability. What changed is that
+`__has_include` stopped being a fix for it, because presence stopped implying
+usability.
+
+### The measurement: nothing but ported code wants the std surface
 
 | API form | users in the tree |
 | --- | --- |
@@ -58,62 +122,184 @@ is to prove upstream files compile), a compile test under
 `packages/api/nros-cpp/tests/compile/`, or the `diagnostic_updater` compat shim.
 **No application code uses it, on any platform.**
 
+Confirmed against the examples by rebuilding each TU's real compile line from its
+own build dir's `build.ninja` and re-running it against a stripped include tree:
+**59 TUs, 0 regressions.** Not one example names `rclcpp::Node`; the whole
+`rclcpp::` surface they touch (`shutdown`, `Result`, `Publisher`, `ok`,
+`Subscription`, `Client`, `Service`, `ClientBase`) is declared outside the guard,
+and their only library includes are `<cstdio> <cstdlib> <cstring> <cstdint>
+<cstddef> <new>`.
+
 That is the whole finding. The split is not host versus embedded. It is *ported
 rclcpp code* versus *code written for nano-ros*, and every real nano-ros
 program — native included — is on the freestanding side already.
 
 ### What it costs today
 
-* **`rclcpp::Node` does not exist on a freestanding target**, because its guard
-  is the discovered macros. That single guard is why phase-427's node merge is
-  hard: the type that is supposed to become the one node type is absent from
-  half the targets it must serve.
+* **The FreeRTOS C++ build does not compile at all** (issue 1187), and could not
+  be measured for issue 1146's app-task stack figure, so
+  `cmake/templates/freertos_app_config.c.in`'s 512 KiB serves C and C++ from one
+  number that was only ever measured on the C half.
+* **The gate that should have caught it reports green** (issue 1223).
+  `check-cpp-freestanding-includes` pushes a guard frame on `#if
+  defined(NROS_CPP_STD)` and pops only on `#endif`; `#elif` and `#else` match
+  neither rule, so the frame survives into the alternative arm and all 14 `#elif`
+  arms are scored as guarded. Issue 1023 already fixed the `#endif` half of this
+  same defect and left the other two spellings unmodelled.
+* **`rclcpp::Node` does not exist on a freestanding target.** That is why
+  phase-427's node merge is hard: the type that is supposed to become the one
+  node type is absent from half the targets it must serve. (The guard is not the
+  only obstacle — see W3.)
 * **The layout hazard has something to bite on.** Hosted-only MEMBERS
   (`owned_entities_`, the `enable_shared_from_this` base) exist because the
-  hosted API is a different shape of the same class rather than additive
-  methods over a fixed one. Issues 0135 and 0460 are this class, and px4 sets
+  hosted API is a different shape of the same class rather than additive methods
+  over a fixed one. Issues 0135 and 0460 are this class, and px4 sets
   `-DNROS_CPP_STD` on one module of a larger image deliberately, so the
   disagreement is reachable.
-* **29 hand-rolled copies of one idiom.** Not a shared helper — a repeated
-  block, which is the "second spelling rather than one helper" antipattern
-  CLAUDE.md records for the Zephyr unset-variable guard (#282 → #326).
+* **15 hand-rolled copies of one idiom.** Not a shared helper — a repeated block,
+  which is the "second spelling rather than one helper" antipattern CLAUDE.md
+  records for the Zephyr unset-variable guard (#282 → #326).
 
 ## Work items
 
-* **W1 — one detection site.** Replace the 29 blocks with a single
-  `nros/std_detect.hpp` the others include. No behaviour change; this is the
-  refactor that makes W2 a one-line edit instead of a 29-site sweep.
-  *Acceptance:* `sizeof` of every type in `check-cpp-capability-layout`'s
-  `TYPES` is unchanged, hosted and freestanding; the per-header parse loop and
-  both `-nostdinc++` lanes are unchanged; any site whose condition genuinely
-  differed from the others is recorded rather than silently normalised.
+* **W0 — teach `check-cpp-freestanding-includes` about `#elif` and `#else`
+  (issue 1223).** On either, the current frame's condition no longer holds, so
+  the frame is REPLACED rather than kept: pop and push `"other"`; an `#elif` that
+  itself names `NROS_CPP_STD` pushes `"std"`.
+  *Acceptance:* two negative controls the selftest does not have today — the
+  `#elif __has_include` block and an `#else` fallback include — must both FAIL,
+  and the gate must go RED on the 14 arms in the tracked tree. **W2 then turns it
+  green, so the gate becomes W2's acceptance.** Done in the other order, the arms
+  are gone and the blindness ships uncaught for whatever writes the 15th.
+
+* **W1 — one detection site.** Replace the 15 blocks with a single
+  `nros/std_detect.hpp` the others include. Measured feasible: **14 of the 15
+  normalise to exactly one block text**, with header name and macro name
+  consistent at all three positions in every instance.
+
+  **One block genuinely diverges and must NOT be normalised** —
+  `nros.hpp:330`, `NROS_CPP_HAS_STD_CHRONO`:
+
+  ```cpp
+  #if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<chrono>) && __has_include(<ratio>))
+  ```
+
+  Three differences, none cosmetic: no `#elif` arm at all, an `__STDC_HOSTED__`
+  conjunct, and a second probe (`<ratio>`) used as a *prerequisite* rather than a
+  proxy — `duration_cast` is defined via `std::ratio_divide`, and the safety
+  island's toolchain ships `<chrono>` with `<ratio>` absent. The 85-line comment
+  above it records three successive corrections, each measured. For this block W2
+  reduces to dropping the `||` clause.
+
+  Second thing W1 fixes, latent today: **`nros.hpp` USES `SHARED_PTR`,
+  `STD_STRING`, `STD_VECTOR` and `STD_FUNCTION` and DEFINES none of them** — it
+  depends on `publisher.hpp` / `options.hpp` / `subscription.hpp` having been
+  included first. It is the only header in that state, and a shared
+  `std_detect.hpp` removes the ordering dependency the hand-rolled copies
+  preserve.
+
+  *Acceptance:* `sizeof` of every type in `check-cpp-capability-layout`'s `TYPES`
+  is unchanged, hosted and freestanding; the per-header parse loop and both
+  `-nostdinc++` lanes are unchanged; the `STD_CHRONO` divergence is recorded in
+  the new header rather than silently normalised.
 
 * **W2 — delete the `#elif __has_include` arm.** The std surface becomes
   reachable only through `NROS_CPP_STD`. Every in-tree build path that wants it
   says so.
-  *Acceptance:* on a hosted compiler with `NROS_CPP_STD` unset, the header set
-  parses and the freestanding API is complete; the five porting templates and
-  the compat shim build with the flag set; `just check cpp` green.
 
-* **W3 — `rclcpp::Node` off the hosted-only list.** With the guard no longer
-  discovered, the class exists on every target and comes off
-  `check-cpp-capability-layout`'s `hosted_only_reason()` exemption. The gate's
-  two-way ratchet (phase-427 W0, issue 1204) fails if it is left on.
-  *Acceptance:* the freestanding arm measures `rclcpp::Node`; deleting the
-  exemption is required, not optional, and the gate says so.
+  Six places need the flag, enumerated by measurement rather than by grep:
+
+  1. `just/check/lanes.just` — the compile-test invocations for
+     `ros2_api_adoption.cpp` and `ros2_param_launch_seed.cpp`.
+  2. `scripts/build/compile-check-fixtures.sh:636` — the `cpp_compat_snippets`
+     arm (`rclcpp_node_options.cpp`, `spin_until_future_complete.cpp`), also
+     reached by `cpp_api_drift.rs`, `platform_header_compile.rs` and
+     `compile-check-signature.sh`.
+  3. **`cmake/compat/NrosRclcppCompat.cmake`** — which sets **no compile
+     definition at all** today. Every ported file reaching `<rclcpp/rclcpp.hpp>`
+     subclasses `rclcpp::Node`, so this covers five `compile_check_fixture` rows:
+     `cpp_port_minimal_publisher`, `cpp_port_rclcpp_compat_smoke`,
+     `cpp_port_topic_state_monitor`, `local_msg_pkg`, `shadowing`.
+  4. `cmake/compat/diagnostic-updater/.../diagnostic_updater.hpp` — covered by
+     (3) if the shim target carries the flag.
+  5. `scripts/check-cpp-capability-layout.sh` — **measured to fail without it**,
+     `rc=1`: *"could not measure sizeof(rclcpp::Node) in the baseline
+     configuration"*. Its `HOSTED_FLAGS=(-std=c++17)` baseline TU needs the flag.
+  6. `scripts/api-parity.py` — its `base` and `component` TUs. Note the file's
+     stated justification for passing the flag on `compat` — *"that is the
+     flavour the compat CMake path builds under"* — is **false today**, per (3);
+     W2 makes it true.
+
+  Only ONE shipping build path defines `NROS_CPP_STD` today:
+  `examples/px4/cpp/bridge/.../CMakeLists.txt:123`.
+
+  Measured regressions from the strip, hosted, before adding any flag: **6 TUs**,
+  in three groups — (A) `rclcpp::Node` and its factories vanish
+  (`ros2_api_adoption`, `ros2_api_adoption_stage2`, `ros2_one_dispatch_path`,
+  `ros2_param_launch_seed`, `spin_until_future_complete`); (B)
+  `rclcpp::NodeOptions` vanishes (`rclcpp_node_options`); (C)
+  `FixedString`↔`std::string` interop vanishes (`ros2_api_adoption:100-106`, which
+  moves with A). Every one is a *porting* TU by name and intent. A synthetic
+  `class MyNode : public rclcpp::Node` probe confirms the flag fully restores
+  today's behaviour: 3 errors stripped, 0 errors stripped + `-DNROS_CPP_STD`.
+
+  Side-finding worth its own cleanup: **`ros2_api_adoption_stage2.cpp` and
+  `ros2_one_dispatch_path.cpp` are compiled by no lane** — two of the four
+  "regressions" are in files nobody runs. Eight more compile TUs are in the same
+  state (`action_goal_uuid`, `executor_cancel`, `node_graph_forwarders`,
+  `ros2_init_argv_refusal`, and four `ros2_refuse_*_probe`). That is the
+  `check-required-features-reachable` class one directory over.
+
+  *Acceptance:* `bash scripts/build/fixtures-build.sh freertos cpp zenoh` green
+  with the arm-freertos toolchain — issue 1187's own acceptance, and a BUILD, not
+  a gate. Plus: `check-cpp-freestanding-includes` (W0-fixed) green; the per-header
+  loop on arm-none-eabi at `fail=0`; the five porting templates and the compat
+  shim build with the flag; `just check cpp` green.
+
+* **W3 — `rclcpp::Node` off the hosted-only list, and the honest reason it is
+  there.** The phase originally claimed the `nros.hpp:454` guard was all that kept
+  the class off freestanding targets. **That is wrong, and the correction is the
+  useful part.** With the guard replaced by `#if 1` and the macros off, the
+  stripped tree fails at the class head itself, `nros.hpp:546`:
+
+  ```
+  nros.hpp:546:49: error: expected template-name before '<' token
+  ```
+
+  — that is `class Node : public std::enable_shared_from_this<Node>`.
+  `rclcpp::Node` is not merely *guarded by* std, it is *spelled in* std: inside
+  the guarded block, 23 × `std::string`, 18 × `std::shared_ptr`, 9 ×
+  `std::make_shared`, 4 × `std::vector`, 4 × `std::chrono`, plus the base class.
+  Every factory returns `std::shared_ptr<...>` where the freestanding
+  `nros::Node` takes an out-ref; every name parameter is `const std::string&`
+  where `nros::Node` takes `const char*`; `Node::SharedPtr` — the alias every
+  ported file names — *is* `std::shared_ptr<Node>`; and `rclcpp::NodeOptions` is
+  a second, separate guard that a freestanding `Node` would need first.
+
+  The in-tree freestanding equivalents cover the *data* (`FixedString`,
+  `HeapString`, `Span`, `FixedSequence`) and not the *ownership shape* — there is
+  no freestanding `shared_ptr`. So W3 is scoped down to what is actually true:
+  the class comes off `hosted_only_reason()` only if W4 makes its layout
+  unconditional, and the exemption's *reason string* is corrected either way.
+  (Minor, same file: the gate prints "guarded by … at nros.hpp:447"; the `#if` is
+  at 454, and 447 is the preceding `} // namespace rclcpp`.)
+  *Acceptance:* the freestanding arm either measures `rclcpp::Node` or the
+  exemption states the ownership-shape reason rather than the guard; the two-way
+  ratchet from phase-427 W0 decides which.
 
 * **W4 — the hosted half becomes additive.** Hosted state moves behind one
   unconditional `void* hosted_`; the std-flavoured `create_*` become overloads
   rather than a second shape of the class. **This IS phase-427 W1**, and it
   belongs here because it is a consequence of W2 rather than of the node merge.
   *Acceptance:* `sizeof(rclcpp::Node)` is identical with and without
-  `NROS_CPP_STD` — measured on the freestanding arm, which is the only place
-  the macros are genuinely off.
+  `NROS_CPP_STD` — measured on the freestanding arm, which is the only place the
+  macros are genuinely off.
 
 * **W5 — say which surface a consumer is on.** The book and
-  `docs/reference/c-api-cmake.md` document `NROS_CPP_STD` as the porting
-  surface, and the CMake verb that turns it on. A consumer porting an rclcpp
-  file asks for it; a consumer writing for nano-ros never does.
+  `docs/reference/c-api-cmake.md` document `NROS_CPP_STD` as the porting surface,
+  and the CMake verb that turns it on. A consumer porting an rclcpp file asks for
+  it; a consumer writing for nano-ros never does. The eleven header comments
+  miscitng 0112 are corrected here, with the three-lane probe table as the reason.
   *Acceptance:* a reader can answer "do I need this flag" from the book without
   reading a header.
 
@@ -121,18 +307,30 @@ program — native included — is on the freestanding side already.
 
 * Deleting the std surface. It is what makes a ported file compile, which is
   RFC-0089's whole goal. This phase makes it REQUESTED, not absent.
-* `__STDC_HOSTED__`-gated sites (`result.hpp:17`, `component_node.hpp:116`, …).
-  They answer a different question — "is there a libc to print with" — and
-  issue 0112 records why `__has_include` was preferred for the C++ ones. W1
-  enumerates them; changing them is separate work.
+* Giving `rclcpp::Node` a freestanding spelling. W3 measures the distance;
+  closing it needs a freestanding ownership type, which is its own design.
+* **The other thirteen `__STDC_HOSTED__` sites** (`result.hpp:17`,
+  `result.hpp:242`, `main.hpp:45`, `main.hpp:105`, `component_node.hpp:116`,
+  `component_node.hpp:190`, `component_node.hpp:226`, `log.hpp:29`,
+  `node.hpp:16`, `node.hpp:18`, `node.hpp:1073`, `node.hpp:1209`,
+  `nros-c/check.h:36`). All thirteen guard **C-library** facilities — `printf` /
+  `fprintf`, `getenv`, `fopen` — which is a different question ("is there a libc
+  to print with"), and `__STDC_HOSTED__` is precisely what answers it. Only the
+  fourteenth, `nros.hpp:330`, mixes the two, and W1 handles that one.
 * The Rust `std` campaign, which is phase-359 and nearly done.
 
 ## Ordering
 
-Before phase-426 and phase-427. W2 changes what "delete both C++ parameter
-stores" is deleting from, and W4 is phase-427 W1 relocated. Doing it after would
-mean building the node merge on a layout whose conditionality is the thing being
-removed.
+**W0 before W2**, so the gate is the acceptance rather than a casualty.
+
+**The phase before phase-426 and phase-427.** W2 changes what "delete both C++
+parameter stores" is deleting from, and W4 is phase-427 W1 relocated. Doing it
+after would mean building the node merge on a layout whose conditionality is the
+thing being removed.
+
+Independently: **W0+W1+W2 close issue 1187**, which blocks issue 1146's C++ stack
+measurement. That is reason to land the first three items ahead of the rest
+rather than as one phase-sized change.
 
 ## Risk
 
@@ -141,3 +339,8 @@ discovered macros — they get the freestanding API where they used to get the s
 one, and the failure is a compile error naming a missing overload, which is the
 loud direction. It needs a changelog entry and a line in the book, not a
 deprecation cycle: there is no way to warn on a macro that stops being defined.
+
+The in-tree cost is bounded and enumerated (W2, six sites). The measurement that
+bounds it is a strip of the tracked headers into `tmp/`, re-running each TU's own
+recorded compile line — not a reasoning exercise, and reproducible by repeating
+it.


### PR DESCRIPTION
Stacked on #745. **Retarget to `main` once that merges.**

phase-438 was opened on a user count — 1 consumer of the hosted node against 27 of the freestanding one. The feasibility measurement inverts its priority: the construct it removes is a **live breakage** on the pinned embedded toolchain, and it is **issue 1187**, whose "Fix direction" asks for exactly this change and asks for it *for the class*.

## The measurement

Per-header, on the FreeRTOS lane's own compiler (`arm-none-eabi 13.2`, `-std=c++14 -ffreestanding -fno-exceptions -fno-rtti`):

```
TRACKED  : pass=26 fail=19
STRIPPED : pass=45 fail=0
```

Nineteen headers fixed by deleting the arm. On hosted `g++ 12.3` the same strip is a no-op (46 pass either way) — a fix on one lane, neutral on the other, not a trade.

## Why the arm cannot be repaired in place

| | `__STDC_HOSTED__` | `__has_include(<string>)` | `#include <string>` |
|---|---|---|---|
| arm-none-eabi 13.2, `-ffreestanding` | **0** | **TRUE** | hard `#error` |
| Zephyr `-nostdinc++`, minimal libcpp | 1 | FALSE | absent |
| hosted g++ 12.3 | 1 | TRUE | works |

Each probe is right on exactly one embedded lane. On the FreeRTOS lane `__STDC_HOSTED__` is correct and `__has_include` is wrong — the exact reverse of what eleven header comments state. Only `NROS_CPP_STD` is right on both, because it is not a probe.

Those eleven comments cite issue 0112 as authority for `__has_include`. **0112 did not say that.** Its Resolution chose `NROS_CPP_STD` over `__STDC_HOSTED__`; the `__has_include` arm arrived later, in `acf213871`. The phase is 0112's own fix restored.

## New issue 1223 — the gate is structurally blind to `#elif` and `#else`

`check-cpp-freestanding-includes` reports `OK` over exactly this construct. Its awk pushes a guard frame on `#if defined(NROS_CPP_STD)` and pops only on `#endif`; `#elif` and `#else` match neither rule, so the frame survives into the alternative arm and all 14 arms score as guarded. Reproduced with the gate's own awk over an 8-line synthetic. `#else` is the worse case — that arm is the one taken when `NROS_CPP_STD` is undefined.

Issue 1023 already fixed the `#endif` half of this defect and left the other two spellings unmodelled. The class is "a preprocessor conditional the tracker does not model", and one of its three spellings got modelled. This is why 1187's class landed under a green check.

It becomes **W0, ordered before W2**: fixed first, the gate goes red on the 14 arms and W2 turns it green, so the gate is W2's acceptance. Fixed after, the arms are gone and the blindness ships for whatever writes the 15th.

## Corrections to the phase

- **15 blocks across 11 headers**, not 29 sites across 13. Twenty-nine is the `#define NROS_CPP_HAS_*` *line* count.
- 14 of the 15 normalise to one block text, so `std_detect.hpp` is feasible. The 15th (`nros.hpp:330`, `STD_CHRONO`) genuinely diverges — no `#elif` arm, an `__STDC_HOSTED__` conjunct, and `<ratio>` as a *prerequisite* rather than a proxy, because the safety island ships `<chrono>` without it. Recorded, not normalised.
- `nros.hpp` **uses** four capability macros and **defines** none, depending on include order. The shared header removes that; the copies preserve it.
- **W3 was wrong.** `rclcpp::Node` is not merely *guarded by* std, it is *spelled in* std: with the guard forced open and the macros off it fails at `nros.hpp:546`, `class Node : public std::enable_shared_from_this<Node>`. Scoped down to correcting the exemption's reason string.
- W2 now enumerates the **six** places needing the flag, including `cmake/compat/NrosRclcppCompat.cmake`, which sets no compile definition at all today — so `api-parity.py`'s stated reason for passing it on `compat` is false, and W2 makes it true.
- Examples: **59 TUs, 0 regressions**, rebuilt from their own `build.ninja` compile lines. Hosted regressions are 6 TUs, every one a porting TU by name; 2 are compiled by no lane at all.
- The guard is at `nros.hpp:454`; the gate's message says 447.

## Ordering consequence

W0+W1+W2 close issue 1187, which blocks issue 1146's C++ stack measurement. That is reason to land the first three items ahead of the rest rather than as one phase-sized change.

## Tier

`just check fast` — green. Documents only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj