### PR TITLE
fix(ci): split remaining combined cache actions into restore + save

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1125,8 +1125,21 @@ jobs:
 
       # Same path + key as the `check` job's cache, or this warms nothing.
       # `check-gate-cache-keys-agree` asserts they stay identical.
-      - name: Cache CLI build (compile tier)
-        uses: actions/cache@v4
+      #
+      # RESTORE here, SAVE right after "Build nros CLI + the launch resolver"
+      # below — deliberately split. `actions/cache` saves in a POST step, at
+      # job end; by then nothing else in THIS job writes into these two
+      # `target` dirs, but a combined action still stores whatever the runner
+      # image itself leaves lying around under them plus whatever a future
+      # step here grows into. Measured on the live cache under the sibling
+      # `nros-cli-*` key in host-tests.yml: entries at 116 MB (restore/save
+      # split, bounded to the CLI build) and 8194 MB (combined action, one
+      # entry carrying a whole job's leftovers) — the repository's 10 GB
+      # Actions cache total was at 11.69 GB, so GitHub was evicting, including
+      # `gate.yml`'s own sccache entry that the required PR check reads.
+      - name: Restore CLI build cache (compile tier)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             packages/cli/target
@@ -1135,8 +1148,14 @@ jobs:
           restore-keys: |
             nros-cli-${{ runner.os }}-
 
-      - name: Cache sccache directory
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after "Build nros CLI + the launch resolver"
+      # below — same split, same reason: sccache's own dir is populated by
+      # that same step (every `cargo` call there runs through `RUSTC_WRAPPER`
+      # once "Configure sccache" exports it), and nothing after that step
+      # writes into it.
+      - name: Restore sccache directory
+        id: sccache-cache
+        uses: actions/cache/restore@v4
         with:
           path: /tmp/sccache
           key: sccache-${{ runner.os }}-check-${{ github.sha }}
@@ -1217,6 +1236,26 @@ jobs:
           # the artifact that step waits on.
           cargo test --no-run --manifest-path packages/cli/Cargo.toml
 
+      # SAVE NOW, before anything else writes into these paths (nothing after
+      # this point does). See the restore steps above for the measurement.
+      # `if: always()` is deliberately NOT set: a failed build leaves a target
+      # dir that should not become the entry every later run restores from.
+      - name: Save CLI build cache (compile tier)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            packages/cli/target
+            packages/cli/nros-launch-resolve/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
+
+      - name: Save sccache directory
+        if: steps.sccache-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/sccache
+          key: sccache-${{ runner.os }}-check-${{ github.sha }}
+
       # Say what was actually warmed. This job was green for its whole life
       # while saving nothing, because the only evidence was a `::warning::` in
       # the save step's log. A size of 0 here means the wrapper did not run and
@@ -1253,8 +1292,20 @@ jobs:
       - name: Checkout nano-ros
         uses: actions/checkout@v4
 
-      - name: Cache CLI build (Phase 218)
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after "just scaffold-journey" below —
+      # deliberately split. `actions/cache` saves in a POST step, at job end;
+      # `just scaffold-journey`'s `setup-cli` prereq is what actually populates
+      # `packages/cli/target` (via `cargo build`), and the recipe itself writes
+      # nothing else into that dir afterward. A combined action here stores
+      # whatever this job leaves behind rather than "the CLI build" alone.
+      # Measured on the live cache under the sibling `nros-cli-*` key in
+      # host-tests.yml: 116 MB (restore/save split) vs 8194 MB (combined
+      # action) — the repository's 10 GB Actions cache total was at 11.69 GB,
+      # so GitHub was evicting, including `gate.yml`'s own sccache entry that
+      # the required PR check reads.
+      - name: Restore CLI build cache (Phase 218)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/cli/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
@@ -1272,6 +1323,18 @@ jobs:
         run: |
           source ./activate.sh
           just scaffold-journey
+
+      # SAVE NOW, before anything else writes into this directory (nothing
+      # after this point does — this is the job's last step). See the restore
+      # step above for the measurement. `if: always()` is deliberately NOT
+      # set: a failed build leaves a target dir that should not become the
+      # entry every later run restores from.
+      - name: Save CLI build cache (Phase 218)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/cli/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
 
   # ----- colcon-parity (the CI image, phase-413 W3) -----
   #

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,20 @@ jobs:
       modules: ${{ steps.lane.outputs.modules }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      # RESTORE here, SAVE right after the "id: lane" build step below —
+      # deliberately split. `actions/cache` saves in a POST step, at job end;
+      # this job's only step touching these paths is the `cargo build` below,
+      # and nothing after it writes into them, so a combined action stores
+      # nothing more than the split does while risking whatever else lands
+      # under `target` in a future edit to this job. Measured on the live
+      # cache under the sibling `nros-cli-*` key in host-tests.yml: 116 MB
+      # (restore/save split) vs 8194 MB (combined action) under the SAME key —
+      # the repository's 10 GB Actions cache total was at 11.69 GB, so GitHub
+      # was evicting, including `gate.yml`'s own sccache entry that the
+      # required PR check reads.
+      - name: Restore lane-coords build cache
+        id: lane-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -119,6 +132,22 @@ jobs:
             cat lane-coords.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # SAVE NOW, before anything else writes into these paths (nothing after
+      # this point does). See the restore step above for the measurement.
+      # `if: always()` is deliberately NOT set: a failed build leaves a
+      # `target` dir that should not become the entry every later run
+      # restores from.
+      - name: Save lane-coords build cache
+        if: steps.lane-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: lane-coords-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
       - uses: actions/upload-artifact@v4
         with:
           name: tier2-nightly-lane
@@ -305,8 +334,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache CLI build (Phase 218)
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after "Build nros CLI from
+      # packages/cli/ (Phase 218)" below — deliberately split.
+      # `actions/cache` saves in a POST step, at job end; that step's
+      # composite action (`./.github/actions/setup-nros-cli`) is the SOLE
+      # populator of `packages/cli/target` in this job, and nothing after
+      # it writes into that dir. Measured on the live cache under this
+      # SAME key in host-tests.yml: 116 MB (restore/save split) vs
+      # 8194 MB (combined action) — the repository's 10 GB Actions cache
+      # total was at 11.69 GB, so GitHub was evicting, including
+      # `gate.yml`'s own sccache entry that the required PR check reads.
+      - name: Restore CLI build cache (Phase 218)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/cli/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
@@ -315,6 +355,19 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         uses: ./.github/actions/setup-nros-cli
+
+      # SAVE NOW, before anything else writes into this directory (the
+      # composite action above is the sole populator). See the restore
+      # step above for the measurement. `if: always()` is deliberately
+      # NOT set: a failed build leaves a target dir that should not
+      # become the entry every later run restores from.
+      - name: Save CLI build cache (Phase 218)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/cli/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
+
       # phase-413 W3 — provision the repo's declared `[prereq.*]` closure.
       #
       # `nros setup --system --sudo` resolves what the INDEX declares for the
@@ -675,8 +728,19 @@ jobs:
       - name: Checkout nano-ros
         uses: actions/checkout@v4
 
-      - name: Cache CLI build (Phase 218)
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after "Build nros CLI from
+      # packages/cli/ (Phase 218)" below — deliberately split.
+      # `actions/cache` saves in a POST step, at job end; that step's
+      # composite action (`./.github/actions/setup-nros-cli`) is the SOLE
+      # populator of `packages/cli/target` in this job, and nothing after
+      # it writes into that dir. Measured on the live cache under this
+      # SAME key in host-tests.yml: 116 MB (restore/save split) vs
+      # 8194 MB (combined action) — the repository's 10 GB Actions cache
+      # total was at 11.69 GB, so GitHub was evicting, including
+      # `gate.yml`'s own sccache entry that the required PR check reads.
+      - name: Restore CLI build cache (Phase 218)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/cli/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
@@ -685,6 +749,18 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         uses: ./.github/actions/setup-nros-cli
+
+      # SAVE NOW, before anything else writes into this directory (the
+      # composite action above is the sole populator). See the restore
+      # step above for the measurement. `if: always()` is deliberately
+      # NOT set: a failed build leaves a target dir that should not
+      # become the entry every later run restores from.
+      - name: Save CLI build cache (Phase 218)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/cli/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
 
       # The image registered the SDK CMake package as root; the container runs
       # with HOME=/github/home → re-register for this HOME (4.4's FindZephyr-sdk
@@ -778,8 +854,19 @@ jobs:
       - name: Checkout nano-ros
         uses: actions/checkout@v4
 
-      - name: Cache CLI build (Phase 218)
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after "Build nros CLI from
+      # packages/cli/ (Phase 218)" below — deliberately split.
+      # `actions/cache` saves in a POST step, at job end; that step's
+      # composite action (`./.github/actions/setup-nros-cli`) is the SOLE
+      # populator of `packages/cli/target` in this job, and nothing after
+      # it writes into that dir. Measured on the live cache under this
+      # SAME key in host-tests.yml: 116 MB (restore/save split) vs
+      # 8194 MB (combined action) — the repository's 10 GB Actions cache
+      # total was at 11.69 GB, so GitHub was evicting, including
+      # `gate.yml`'s own sccache entry that the required PR check reads.
+      - name: Restore CLI build cache (Phase 218)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/cli/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
@@ -788,6 +875,18 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         uses: ./.github/actions/setup-nros-cli
+
+      # SAVE NOW, before anything else writes into this directory (the
+      # composite action above is the sole populator). See the restore
+      # step above for the measurement. `if: always()` is deliberately
+      # NOT set: a failed build leaves a target dir that should not
+      # become the entry every later run restores from.
+      - name: Save CLI build cache (Phase 218)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/cli/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
 
       - name: Register the baked Zephyr SDK for this HOME
         run: /opt/zephyr-sdk/setup.sh -c
@@ -852,8 +951,19 @@ jobs:
       - name: Checkout nano-ros
         uses: actions/checkout@v4
 
-      - name: Cache CLI build (Phase 218)
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after "Build nros CLI from
+      # packages/cli/ (Phase 218)" below — deliberately split.
+      # `actions/cache` saves in a POST step, at job end; that step's
+      # composite action (`./.github/actions/setup-nros-cli`) is the SOLE
+      # populator of `packages/cli/target` in this job, and nothing after
+      # it writes into that dir. Measured on the live cache under this
+      # SAME key in host-tests.yml: 116 MB (restore/save split) vs
+      # 8194 MB (combined action) — the repository's 10 GB Actions cache
+      # total was at 11.69 GB, so GitHub was evicting, including
+      # `gate.yml`'s own sccache entry that the required PR check reads.
+      - name: Restore CLI build cache (Phase 218)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/cli/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
@@ -862,6 +972,18 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         uses: ./.github/actions/setup-nros-cli
+
+      # SAVE NOW, before anything else writes into this directory (the
+      # composite action above is the sole populator). See the restore
+      # step above for the measurement. `if: always()` is deliberately
+      # NOT set: a failed build leaves a target dir that should not
+      # become the entry every later run restores from.
+      - name: Save CLI build cache (Phase 218)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/cli/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
 
       - name: Register the baked Zephyr SDK for this HOME
         run: /opt/zephyr-sdk/setup.sh -c

--- a/scripts/check-gate-cache-keys-agree.py
+++ b/scripts/check-gate-cache-keys-agree.py
@@ -56,6 +56,40 @@ def jobs(text):
     return out
 
 
+def _path_values(blk):
+    """The `path:` value(s) of one `with:` block — a single inline value, or
+    every line of a `path: |` block scalar.
+
+    INDENTATION-SCOPED, not "any indented line": a flat `\\s{10,}` scan used to
+    sweep up `restore-keys: |` and ITS OWN block-scalar value as if they were
+    paths, because both happen to sit at the same indent as `path:` itself.
+    That was invisible as long as every restore step also carried a save step
+    with the identical `restore-keys:` tail — restore/save split (a job with a
+    restore step's `restore-keys:` but no matching save step) breaks that
+    symmetry and turns the pollution into a real false mismatch. Scoping to
+    lines STRICTLY DEEPER than `path:`'s own indent, stopping at the next line
+    that is not, is what a YAML block scalar actually means.
+    """
+    lines = blk.split("\n")
+    for i, line in enumerate(lines):
+        m = re.match(r"^(\s*)path:\s*(.*)$", line)
+        if not m:
+            continue
+        indent, val = len(m.group(1)), m.group(2).strip()
+        if val and val not in ("|", "|-", ">", ">-"):
+            return [val]
+        out = []
+        for line2 in lines[i + 1 :]:
+            if not line2.strip():
+                continue
+            indent2 = len(line2) - len(line2.lstrip(" "))
+            if indent2 <= indent:
+                break
+            out.append(line2.strip())
+        return out
+    return []
+
+
 def cache_entries(body):
     """[(path_block, key)] for every actions/cache step in a job body."""
     out = []
@@ -70,10 +104,7 @@ def cache_entries(body):
     ):
         blk = m.group(1)
         key = re.search(r"^\s*key:\s*(.+)$", blk, re.M)
-        paths = re.findall(r"^\s{10,}([^\s#][^\n]*)$", blk, re.M)
-        pth = re.search(r"^\s*path:\s*(.+)$", blk, re.M)
-        single = pth.group(1).strip() if pth and pth.group(1).strip() != "|" else None
-        norm = [single] if single else [p.strip() for p in paths if not p.strip().startswith("key:")]
+        norm = _path_values(blk)
         if key:
             out.append((tuple(sorted(p for p in norm if p)), key.group(1).strip()))
     return out
@@ -102,6 +133,41 @@ def self_test():
         cache_entries(js["b"]),
     )
     assert cache_entries(js["a"])[0][1] == "k-1"
+
+    # A restore step (with `restore-keys:`) and a save step (without) for the
+    # SAME multi-line `path: |` + `key:` must parse to the SAME entry — this
+    # is exactly the restore/save split shape, and `restore-keys:`'s own
+    # block-scalar value must never be swept in as a path.
+    t2 = (
+        "jobs:\n"
+        "  restore:\n"
+        "    steps:\n"
+        "      - uses: actions/cache/restore@v4\n"
+        "        with:\n"
+        "          path: |\n"
+        "            packages/cli/target\n"
+        "            packages/cli/nros-launch-resolve/target\n"
+        "          key: nros-cli-x\n"
+        "          restore-keys: |\n"
+        "            nros-cli-\n"
+        "  save:\n"
+        "    steps:\n"
+        "      - uses: actions/cache/save@v4\n"
+        "        with:\n"
+        "          path: |\n"
+        "            packages/cli/target\n"
+        "            packages/cli/nros-launch-resolve/target\n"
+        "          key: nros-cli-x\n"
+    )
+    js2 = jobs(t2)
+    ce_restore = cache_entries(js2["restore"])
+    ce_save = cache_entries(js2["save"])
+    assert ce_restore == ce_save, (ce_restore, ce_save)
+    assert ce_restore[0][0] == (
+        "packages/cli/nros-launch-resolve/target",
+        "packages/cli/target",
+    ), ce_restore
+
     sys.stdout.write("check-gate-cache-keys-agree self-test: OK\n")
 
 


### PR DESCRIPTION
## Defect

`actions/cache@v4` saves in a POST step, at job end. A job that also builds
fixtures, runs `just setup native`, or runs a tier writes into
`packages/cli/target` too, so a combined cache step stores not "the CLI
build" but "whatever the whole job left behind" by the time it exits.

Measured on the live cache: entries under the SAME key at **116 MB** (jobs
that already split restore/save, e.g. `host-tests.yml`) and **8194 MB**
(jobs still using the combined action). The repository's Actions cache
limit is 10 GB total and it was at 11.69 GB, so GitHub was evicting —
including `gate.yml`'s own sccache entry, which the required pull-request
check reads.

## Fix

Finishes the shape `host-tests.yml` already proved: every remaining combined
`uses: actions/cache@v4` block becomes a `restore` step (with an `id:`)
immediately followed by the step that actually populates the cached path,
then a `save` step gated on `if: steps.<id>.outputs.cache-hit != 'true'` —
deliberately with no `if: always()`, so a failed build never becomes the
entry every later run restores from.

### `gate.yml` (3 blocks converted; 2 pre-existing restore-only blocks left alone)

- `warm-cache` job, CLI + resolver build cache — save paired with **"Build
  nros CLI + the launch resolver"** (the only step writing into
  `packages/cli/target` / `packages/cli/nros-launch-resolve/target`).
- `warm-cache` job, sccache directory cache — save paired with the **same**
  step (every `cargo` call there runs through `RUSTC_WRAPPER` once
  "Configure sccache" exports it).
- `scaffold-journey` job, CLI build cache — save paired with **"just
  scaffold-journey"** (its `setup-cli` prereq is what populates
  `packages/cli/target`; nothing in the job writes there afterward).

### `nightly.yml` (5 blocks across 5 jobs)

- `lane` job, `~/.cargo/registry` + `~/.cargo/git` + `target` — save paired
  with the **`id: lane`** step's `cargo build --release -p nros-tests --bin
  lane-coords` (the job's only step touching those paths).
- `platform`, `zephyr-example-matrix`, `zephyr-dual-line-summary` and
  `zephyr-copy-out` jobs, CLI build cache — each save paired with **"Build
  nros CLI from packages/cli/ (Phase 218)"** (the
  `./.github/actions/setup-nros-cli` composite action, the sole populator of
  `packages/cli/target` in each job per its own doc comment — no other step
  in any of these jobs touches that directory).

`live-peer.yml` and `post-submit.yml` were left untouched — they mention the
cached path but carry no cache action.

## Also fixed: `scripts/check-gate-cache-keys-agree.py`

This gate (checks `gate.yml`'s warm job caches the SAME key+path as the job
it warms) went red against the `gate.yml` change above. Its path parser used
a flat `\s{10,}` regex scan that swept up a `restore-keys: |` block scalar
(and its own value line) as if it were a cached path. That bug was invisible
as long as every restore step's `restore-keys:` tail was mirrored by an
identical save step's tail — which is exactly what the combined-action shape
guaranteed, and exactly what splitting restore from save legitimately
breaks (a save step carries no `restore-keys:`).

`_path_values()` now scopes a `path: |` block scalar to lines strictly
deeper than the `path:` line's own indent, stopping at the next line that
isn't — which is what the YAML actually means — instead of grabbing
anything indented far enough regardless of which key it sits under. Added a
self-test covering the restore/save pair shape so this can't silently regress
again.

## Verify

- `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` passes
  for both `gate.yml` and `nightly.yml`.
- Re-read each edited job top-to-bottom; every save lands immediately after
  its populating step and before anything else writes that path (see the
  per-job pairing above).
- `python3 scripts/check-gate-cache-keys-agree.py --self-test` and
  `just check gate-cache-keys-agree` both pass.
- The 116 MB vs 8194 MB numbers are the MEASURED sizes already observed on
  the live cache under the same key in `host-tests.yml`'s split vs this
  repo's still-combined jobs before this PR — I cannot measure this PR's own
  effect without a CI run, so I'm not claiming a new measurement, only citing
  the existing one that motivated the fix.

## Status

Pushed and armed with `gh pr merge --auto` (merge queue owns the method — no
`--squash`/`--merge`/`--rebase` passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
