### PR TITLE
feat(phase-430 W1+W2): a silent /clock says so once, and use_sim_time is declared everywhere

### DIFF
--- a/book/src/user-guide/simulated-time.md
+++ b/book/src/user-guide/simulated-time.md
@@ -58,6 +58,18 @@ talker:
 `use_sim_time` is reserved: nothing reads its value, the runtime acts on it.
 Set it false and `/clock` samples stop being installed.
 
+You do not have to declare it first. An image built with parameter services
+declares `use_sim_time = false` on your behalf, as rclcpp does on every node, so
+`ros2 param list` shows it and
+
+```console
+$ ros2 param set /talker use_sim_time true
+```
+
+reaches a node whose author never wrote a line about simulated time. Declaring
+it yourself still wins — your default, and your descriptor, replace the
+auto-declared one.
+
 The Rust crate needs the `sim-time` feature, because the subscription costs an
 entity slot and an RX buffer:
 

--- a/book/src/user-guide/simulated-time.md
+++ b/book/src/user-guide/simulated-time.md
@@ -137,6 +137,26 @@ deliberate: `Clock::clear_ros_time_override()`.
 model `nros_core::Clock` has always documented. Two nodes in one image cannot be
 on different simulated times.
 
+**A never-connected `/clock` looks exactly like a paused one, so the image says
+so once.** Both leave every ROS-time timer sitting still. Five seconds after the
+source attaches with no sample received, the image logs one warning at `WARN`,
+naming `use_sim_time` and `/clock` and the fact that ROS-time timers are running
+on system time meanwhile:
+
+```text
+use_sim_time is true but no /clock sample has arrived in 5s: ROS-time timers are
+running on SYSTEM time meanwhile. Publish rosgraph_msgs/msg/Clock (ros2 bag play
+--clock), or set use_sim_time false.
+```
+
+Once, not per spin, and never again once a sample has arrived — a simulator that
+publishes and then pauses is the case the line exists to be distinguished from.
+Turning `use_sim_time` off and on again arms it afresh. The five seconds are
+measured on the executor's own per-spin elapsed time, the same one your wall
+timers accumulate, so an image whose wall clock is itself simulated gets the
+warning at a point it can relate to its own timers. `Executor::sim_time_silence_warnings()`
+answers the same question in code.
+
 **No jump callbacks.** `rclcpp::Clock::create_jump_callback` and the
 `rcl_jump_threshold_t` machinery have no counterpart. The behaviour a jump
 produces is fixed (above); you cannot subscribe to the event.

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -7559,6 +7559,20 @@ impl<'s> Executor<'s> {
                     self.params = Some(state);
                 }
             }
+            // phase-430 W2 — "declare `use_sim_time` on EVERY node, as rclcpp
+            // does", said where the nodes finally exist. This is the only place
+            // that knows the full set: `ensure_parameter_store` runs before any
+            // node record does, so it can only seed the implicit PRIMARY, and
+            // the further nodes an image composes onto one executor arrive
+            // later. Seeding as each set of six goes up keeps the two in step —
+            // the parameter is declared on exactly the nodes a
+            // `ros2 param set <node> use_sim_time true` can reach.
+            //
+            // Idempotent by construction: `declare` refuses a name the node
+            // already holds and the placeholder flag is only raised on
+            // acceptance, so re-seeding PRIMARY here neither duplicates the
+            // entry nor re-marks an application's own declaration as ours.
+            self.seed_use_sim_time_default(super::node_record::NodeId::from_raw(index));
         }
         Ok(())
     }
@@ -7987,7 +8001,89 @@ impl<'s> Executor<'s> {
     fn ensure_parameter_store(&mut self) {
         if self.params.is_none() {
             self.params = Some(Self::new_param_state());
+            // phase-430 W2 — the executor's implicit PRIMARY node exists the
+            // moment the store does, whether or not a node record has been
+            // built yet, so it is seeded here. The other node keys are seeded
+            // in `reconcile_parameter_services`, as each one's set of six goes
+            // up.
+            self.seed_use_sim_time_default(super::node_record::NodeId::PRIMARY);
         }
+    }
+
+    /// phase-430 W2 — declare `use_sim_time = false`, as rclcpp does on EVERY
+    /// node.
+    ///
+    /// Upstream auto-declares the parameter in `rclcpp::Node`'s constructor, so
+    /// `ros2 param list` shows it and `ros2 param set <node> use_sim_time true`
+    /// reaches a node whose author never wrote a line about simulated time.
+    /// Ours honoured the parameter only if the APP had declared it: the store
+    /// refuses an undeclared set (`allow_undeclared` is false), so the runtime
+    /// switch worked on exactly the nodes that least needed it.
+    ///
+    /// The seed is a PLACEHOLDER, tracked by `ParamState::sim_time_seeded`,
+    /// because the store refuses a duplicate name: without that flag, seeding
+    /// here would turn an application's own `declare_parameter("use_sim_time",
+    /// Bool(true))` into a refusal and the auto-declared default would silently
+    /// beat the app. `yield_seeded_use_sim_time` steps the placeholder aside
+    /// for the first real declaration, whatever value or descriptor it carries.
+    ///
+    /// PER NODE, both here and in the flag. phase-426 keyed the store and the
+    /// six services by node, so "every node" is now literally expressible and
+    /// this is where it is said: `ensure_parameter_store` seeds the executor's
+    /// implicit PRIMARY, and `reconcile_parameter_services` seeds each further
+    /// node key as its set of six goes up — which is exactly the set of nodes a
+    /// `ros2 param set <node> use_sim_time true` can reach.
+    ///
+    /// It deliberately does NOT go through `note_reserved_parameter`, so
+    /// `sim_time_stated` stays false: an auto-declared default is not a
+    /// STATEMENT by anyone. Recording it as one would make every executor with
+    /// parameter services write `set_active(false)` onto a PROCESS-GLOBAL gate
+    /// on its first spin — switching off a simulated clock another executor in
+    /// the same image installed, which is exactly the collision
+    /// `sim_time_stated` was added for (issue 1104). That property is per node
+    /// too: seeding N nodes must still be N statements by nobody.
+    ///
+    /// Gated on `sim-time` as well as `param-services`: an image that cannot
+    /// act on the parameter should not advertise it, because a settable knob
+    /// that does nothing is worse than an absent one.
+    fn seed_use_sim_time_default(&mut self, node: super::node_record::NodeId) {
+        #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
+        if let Some(params) = self.params.as_mut()
+            && let Some(seeded) = params.sim_time_seeded.get_mut(node.index())
+            && params.server.declare(
+                node.into(),
+                crate::time_source::USE_SIM_TIME_PARAM,
+                nros_params::ParameterValue::Bool(false),
+            )
+        {
+            *seeded = true;
+        }
+        let _ = node;
+    }
+
+    /// phase-430 W2 — step the seeded `use_sim_time` aside for an application
+    /// that declares it itself on `node`. Returns whether it did.
+    ///
+    /// The app's declaration must WIN — its own default, its own descriptor —
+    /// and a declaration is refused when the name is already taken, so the
+    /// placeholder has to leave before the real one arrives. Only ever the
+    /// placeholder: once a real declaration has landed the flag is false and a
+    /// second declaration is refused exactly as it was before W2.
+    ///
+    /// Only ever THIS node's placeholder, too: an app that names
+    /// `use_sim_time` on one node of an image has said nothing about the
+    /// others, and their seeds stay placeholders for whoever declares next.
+    fn yield_seeded_use_sim_time(&mut self, node: super::node_record::NodeId, name: &str) -> bool {
+        #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
+        if name == crate::time_source::USE_SIM_TIME_PARAM
+            && let Some(params) = self.params.as_mut()
+            && let Some(seeded) = params.sim_time_seeded.get_mut(node.index())
+            && core::mem::replace(seeded, false)
+        {
+            return params.server.remove(node.into(), name);
+        }
+        let _ = (node, name);
+        false
     }
 
     /// Produce the parameter slot table the executor's store will borrow.
@@ -8042,6 +8138,10 @@ impl<'s> Executor<'s> {
             // one per node, once the node table is populated.
             services: heapless::Vec::new(),
             requested: false,
+            // phase-430 W2 — no node has been auto-declared yet; the caller
+            // (`ensure_parameter_store`) seeds PRIMARY immediately after.
+            #[cfg(feature = "sim-time")]
+            sim_time_seeded: [false; crate::parameter_services::MAX_PARAM_SERVICE_SETS],
         })
     }
 
@@ -8064,10 +8164,21 @@ impl<'s> Executor<'s> {
         value: nros_params::ParameterValue,
     ) -> bool {
         self.ensure_parameter_store();
+        // phase-430 W2 — an application declaring `use_sim_time` itself wins
+        // over the auto-declared default, so the placeholder leaves first.
+        let yielded = self.yield_seeded_use_sim_time(node, name);
         let accepted = match &mut self.params {
             Some(params) => params.server.declare(node.into(), name, value),
             None => false,
         };
+        if yielded && !accepted {
+            // The app's own declaration was refused on its own terms (a full
+            // store, an ill-formed range). Put the rclcpp default back rather
+            // than leaving the name undeclared — that is a state neither the
+            // app nor upstream asked for, and it would silently un-do W2 for
+            // this node.
+            self.seed_use_sim_time_default(node);
+        }
         // phase-425 W3b — `use_sim_time` is RESERVED, exactly as in ROS 2: its
         // value is not a value the app reads, it is the switch that attaches the
         // time source. This is the one seam every language funnels through
@@ -8162,6 +8273,9 @@ impl<'s> Executor<'s> {
         descriptor: nros_params::ParameterDescriptor,
     ) -> bool {
         self.ensure_parameter_store();
+        // phase-430 W2 — same rule as the sibling above: the app's own
+        // declaration, descriptor and all, replaces the auto-declared default.
+        let yielded = self.yield_seeded_use_sim_time(node, name);
         let accepted = match &mut self.params {
             Some(params) => {
                 params
@@ -8170,6 +8284,9 @@ impl<'s> Executor<'s> {
             }
             None => false,
         };
+        if yielded && !accepted {
+            self.seed_use_sim_time_default(node);
+        }
         // phase-430 W3 / issue 1202 — the sibling declare path, which had NO
         // reserved hook at all: `declare_parameter_with_descriptor` stored
         // `use_sim_time` and attached nothing, so the same declaration meant

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1419,6 +1419,13 @@ pub struct Executor<'s> {
     /// passing alone.
     #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
     pub(crate) sim_time_stated: bool,
+    /// phase-430 W1 — the one-shot that says "`use_sim_time` is on and `/clock`
+    /// has never spoken", so a MISCONFIGURED image is distinguishable from a
+    /// merely PAUSED one. Armed when the source attaches, disarmed by the first
+    /// sample or by the report. The policy, and the argument for its unit, are
+    /// in [`crate::time_source::SilenceWatch`].
+    #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
+    pub(crate) sim_time_silence: crate::time_source::SilenceWatch,
     #[cfg(feature = "lifecycle-services")]
     pub(crate) lifecycle:
         Option<alloc::boxed::Box<crate::lifecycle_services::LifecycleRuntimeState>>,
@@ -1674,6 +1681,8 @@ impl<'s> Executor<'s> {
             sim_time_requested: false,
             #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
             sim_time_stated: false,
+            #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
+            sim_time_silence: crate::time_source::SilenceWatch::new(),
             #[cfg(feature = "lifecycle-services")]
             lifecycle: None,
             // Initialise the spin endpoint to construction time so the
@@ -6567,6 +6576,13 @@ impl<'s> Executor<'s> {
             None => (timeout_ms as u64).saturating_mul(1000),
         };
 
+        // phase-430 W1 — the silence watch is credited the SAME `delta_us` the
+        // wall timers below are, which is the whole of its unit argument: the
+        // diagnostic arrives after as much time as this image's own wall timers
+        // believe has passed, on whatever clock it actually has.
+        #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
+        self.note_sim_time_silence(delta_us);
+
         if !self.spin_quantization_checked && timeout_ms > 0 {
             self.spin_quantization_checked = true;
             self.audit_spin_quantization((timeout_ms as u64).saturating_mul(1000));
@@ -9609,7 +9625,15 @@ impl<'s> Executor<'s> {
             return;
         }
         crate::time_source::set_active(self.sim_time_requested);
-        if self.sim_time_requested && self.sim_time_source.is_none() {
+        if !self.sim_time_requested {
+            // phase-430 W1 — the source is no longer wanted, so its silence is
+            // no longer a symptom. Disarming here (rather than only re-arming
+            // on attach) is what makes a later re-attach start a FRESH
+            // interval: the watch that was counting is put down, not paused.
+            self.sim_time_silence.disarm();
+            return;
+        }
+        if self.sim_time_source.is_none() {
             // No node yet — stay pending and try again next spin. Not an error:
             // it is the ordinary order of a generated entry, which declares
             // parameters before it registers components.
@@ -9621,8 +9645,58 @@ impl<'s> Executor<'s> {
                 crate::time_source::CLOCK_TOPIC,
             ) {
                 self.sim_time_source = Some(handle);
+                // phase-430 W1 — the interval starts HERE, at attach, and not
+                // at construction: before the subscription exists there is
+                // nothing to be silent about, so counting from boot would
+                // accuse an image that spent the interval bringing a transport
+                // up.
+                self.sim_time_silence.arm();
             }
+        } else {
+            // Re-attached: `use_sim_time` went false and back to true while the
+            // subscription (which the executor cannot remove) stayed. W1 asks
+            // for the one-shot to reset in exactly this case.
+            self.sim_time_silence.arm();
         }
+    }
+
+    /// phase-430 W1 — credit one spin's elapsed time to the silence watch and
+    /// emit the diagnostic if this is the spin that crosses the threshold.
+    ///
+    /// `delta_us` is the executor's OWN per-spin elapsed measure — the same one
+    /// every wall timer on this executor accumulates, including its "no clock,
+    /// credit the requested timeout" fallback. See
+    /// [`SILENCE_WARN_US`](crate::time_source::SILENCE_WARN_US) for why that is
+    /// the unit and not a spin count or an independent wall clock.
+    ///
+    /// Scope: the source the EXECUTOR installed for `use_sim_time`. An
+    /// application that calls
+    /// [`NodeCtx::install_ros_time_source`](super::node::NodeCtx::install_ros_time_source)
+    /// directly is not watched, because the line this would print names
+    /// `use_sim_time`, and that application never set it — the honest
+    /// diagnostic for the explicit path would be a different sentence, and
+    /// inventing one nobody asked for is how a warning becomes noise.
+    #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
+    fn note_sim_time_silence(&mut self, delta_us: u64) {
+        if self.sim_time_silence.tick(
+            delta_us,
+            nros_core::clock::Clock::is_ros_time_override_active(),
+        ) {
+            crate::time_source::report_silence(crate::time_source::CLOCK_TOPIC);
+        }
+    }
+
+    /// phase-430 W1 — how many times this executor has reported that
+    /// `use_sim_time` is on with no `/clock` sample.
+    ///
+    /// The count rather than a bool, and an accessor rather than a log grep: a
+    /// diagnostic whose contract is "exactly once" needs an assertion that can
+    /// tell one from two, and a log sink is not present on every target that
+    /// runs the test. It is also the question an application supervising its
+    /// own configuration would ask.
+    #[cfg(all(feature = "sim-time", any(has_rmw, test)))]
+    pub fn sim_time_silence_warnings(&self) -> u32 {
+        self.sim_time_silence.reports()
     }
 
     /// phase-425 W3b — re-read `use_sim_time` from the parameter store.

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -2567,6 +2567,295 @@ fn a_non_bool_use_sim_time_attaches_nothing() {
     );
 }
 
+/// phase-430 W2 — `use_sim_time` is declared on a node that never named it,
+/// as rclcpp does, so `ros2 param set <node> use_sim_time true` reaches an app
+/// with no simulated-time code in it.
+///
+/// The store refuses an undeclared set (`allow_undeclared` is false), so before
+/// this the runtime switch worked on exactly the nodes that least needed it:
+/// the ones whose author had already thought about simulated time.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn use_sim_time_is_declared_on_a_node_that_never_named_it() {
+    let _sim_time = SimTimeGuard::acquire();
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+
+    // An app that knows nothing about simulated time: it declares one ordinary
+    // parameter of its own and stops.
+    assert!(executor.declare_parameter("start_value", nros_params::ParameterValue::Integer(0)));
+
+    assert_eq!(
+        executor.params().and_then(|p| {
+            p.get_bool(super::node_record::NodeId::PRIMARY.into(), "use_sim_time")
+        }),
+        Some(false),
+        "rclcpp declares use_sim_time=false on every node; a `ros2 param list` \
+         here showed nothing until the app named it"
+    );
+    assert!(
+        executor
+            .params()
+            .expect("store")
+            .list_names(super::node_record::NodeId::PRIMARY.into())
+            .any(|n| n == "use_sim_time"),
+        "declared but not listed would be a parameter no tool can discover"
+    );
+
+    // The auto-declared default is NOT a statement by anyone: it must not touch
+    // the process-global gate and must not attach a source. An image where
+    // every executor wrote its default onto that gate is issue 1104.
+    drop(executor.create_node("plain").expect("create node"));
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        !executor.ros_time_source_installed(),
+        "a defaulted use_sim_time=false must cost an image that will never see \
+         a simulator exactly nothing"
+    );
+
+    // `ros2 param set /plain use_sim_time true` — the wire path, which is the
+    // whole point of the declaration existing.
+    assert!(
+        executor
+            .params_mut()
+            .expect("store")
+            .apply(
+                super::node_record::NodeId::PRIMARY.into(),
+                "use_sim_time",
+                nros_params::ParameterValue::Bool(true),
+            )
+            .is_success(),
+        "the set must reach a declared parameter; an undeclared one is refused"
+    );
+    executor.refresh_use_sim_time_from_store();
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        executor.ros_time_source_installed(),
+        "a runtime `ros2 param set <node> use_sim_time true` must attach the \
+         /clock source on a node with no sim-time code at all"
+    );
+}
+
+/// phase-430 W2 — the same, for a node that declares NOTHING WHATEVER and only
+/// registers the six parameter services.
+///
+/// That node is the one W2 is really for, and it reaches the store by a
+/// different door: `register_parameter_services` used to build its own
+/// `ParamState` rather than going through `ensure_parameter_store`, so a hook
+/// placed only on the declaration path would have missed it entirely — the
+/// two-write-paths shape issue 1202 was.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn use_sim_time_is_declared_by_registering_the_parameter_services_alone() {
+    let _sim_time = SimTimeGuard::acquire();
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+
+    // The six service names are built from the EXECUTOR's identity, which
+    // `from_session_with` does not take from the config the way `open` does.
+    executor.set_node_identity("bare", "/");
+    drop(executor.create_node("bare").expect("create node"));
+    executor
+        .register_parameter_services()
+        .expect("mock services register");
+
+    assert_eq!(
+        executor.params().and_then(|p| {
+            p.get_bool(super::node_record::NodeId::PRIMARY.into(), "use_sim_time")
+        }),
+        Some(false),
+        "a node that declared nothing still has use_sim_time in ROS 2, and \
+         `ros2 param set` on it is the only way to move an already-running \
+         image onto simulated time"
+    );
+}
+
+/// phase-430 W2 — EVERY node, which is what the work item says and what
+/// phase-426 made expressible.
+///
+/// rclcpp declares `use_sim_time` in every `rclcpp::Node` constructor, and an
+/// image composes several nodes onto one executor — that is the model. Before
+/// phase-426 the store was one flat table per executor, so "every node" and
+/// "the executor" were the same sentence and the distinction could not be
+/// tested. It is keyed by node now, and the six parameter services are
+/// published per node, so the claim has a shape: the parameter is declared on
+/// exactly the nodes a `ros2 param set <node> use_sim_time true` can reach —
+/// which is the set `parameter_service_node_names` enumerates.
+///
+/// A seed on the primary alone would leave the second node's
+/// `ros2 param set /beta use_sim_time true` refused as undeclared, which is
+/// the pre-W2 behaviour for every node but the first.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn use_sim_time_is_declared_on_every_node_the_services_are_published_under() {
+    let _sim_time = SimTimeGuard::acquire();
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+
+    executor.set_node_identity("alpha", "/");
+    let alpha = executor.node_builder("alpha").build().expect("alpha");
+    let beta = executor.node_builder("beta").build().expect("beta");
+    assert_ne!(alpha, beta, "precondition: two distinct node keys");
+    executor
+        .register_parameter_services()
+        .expect("mock services register");
+
+    assert_eq!(
+        executor.parameter_service_node_names().len(),
+        2,
+        "precondition: one set of six per node (phase-426 W3)"
+    );
+    for node in [alpha, beta] {
+        assert_eq!(
+            executor
+                .params()
+                .and_then(|p| p.get_bool(node.into(), "use_sim_time")),
+            Some(false),
+            "node {} has parameter services but no use_sim_time; `ros2 param \
+             set` on it would be refused as undeclared, which is the pre-W2 \
+             behaviour this work item removes",
+            node.raw()
+        );
+    }
+
+    // The auto-declared default is still nobody's STATEMENT — seeding N nodes
+    // must not become N writes to the process-global gate (issue 1104).
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        !executor.ros_time_source_installed(),
+        "an image of nodes that will never see a simulator must pay nothing \
+         for the declaration, however many nodes it has"
+    );
+
+    // An app naming `use_sim_time` on ONE node says nothing about the other:
+    // beta's seed stays a placeholder for whoever declares it next.
+    assert!(
+        executor.declare_parameter_on(
+            alpha,
+            "use_sim_time",
+            nros_params::ParameterValue::Bool(true)
+        ),
+        "alpha's own declaration must step alpha's placeholder aside"
+    );
+    assert_eq!(
+        executor
+            .params()
+            .and_then(|p| p.get_bool(beta.into(), "use_sim_time")),
+        Some(false),
+        "declaring on alpha must not disturb beta's stored default"
+    );
+    assert!(
+        executor.declare_parameter_on(
+            beta,
+            "use_sim_time",
+            nros_params::ParameterValue::Bool(true)
+        ),
+        "beta's placeholder must still be a placeholder: a declaration on a \
+         SIBLING node is not a declaration on this one"
+    );
+    assert!(
+        !executor.declare_parameter_on(
+            alpha,
+            "use_sim_time",
+            nros_params::ParameterValue::Bool(false)
+        ),
+        "alpha's placeholder is spent, so a SECOND declaration there is a \
+         refusal exactly as it was before W2"
+    );
+}
+
+/// phase-430 W2 — an application that declares `use_sim_time` ITSELF wins,
+/// value and descriptor and all.
+///
+/// This is the failure mode the auto-declare invites: the store refuses a
+/// duplicate name, so a default seeded first would turn the app's own
+/// declaration into a refusal and quietly beat it. The ordering matters — the
+/// app names another parameter FIRST, so the store (and the seed) already exist
+/// when it gets to this one, which is the case a naive implementation gets
+/// wrong.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn an_apps_own_use_sim_time_declaration_beats_the_auto_declared_default() {
+    let _sim_time = SimTimeGuard::acquire();
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+
+    assert!(executor.declare_parameter("start_value", nros_params::ParameterValue::Integer(0)));
+    assert_eq!(
+        executor.params().and_then(|p| {
+            p.get_bool(super::node_record::NodeId::PRIMARY.into(), "use_sim_time")
+        }),
+        Some(false),
+        "precondition: the seeded default is already in the store"
+    );
+
+    assert!(
+        executor.declare_parameter("use_sim_time", nros_params::ParameterValue::Bool(true)),
+        "the app's own declaration was refused because the auto-declared \
+         default had taken the name"
+    );
+    assert_eq!(
+        executor.params().and_then(|p| {
+            p.get_bool(super::node_record::NodeId::PRIMARY.into(), "use_sim_time")
+        }),
+        Some(true),
+        "the app asked for true and the defaulted false survived"
+    );
+
+    // And it is a real declaration, not just a stored value: it attaches the
+    // source, which the seeded default deliberately does not.
+    drop(executor.create_node("app").expect("create node"));
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        executor.ros_time_source_installed(),
+        "the app's declaration must reach the reserved-parameter hook"
+    );
+}
+
+/// phase-430 W2 — the descriptor-carrying sibling of the test above.
+///
+/// A declaration with a descriptor is a different function
+/// (`declare_parameter_with_descriptor`), and the same seam has already been
+/// wrong in exactly one of its two spellings once (issue 1202, where that path
+/// had no reserved hook at all). Both or neither.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn an_apps_use_sim_time_declaration_with_a_descriptor_beats_the_default() {
+    let _sim_time = SimTimeGuard::acquire();
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+
+    assert!(executor.declare_parameter("start_value", nros_params::ParameterValue::Integer(0)));
+
+    let descriptor =
+        nros_params::ParameterDescriptor::new("use_sim_time", nros_params::ParameterType::Bool)
+            .expect("the name fits a descriptor")
+            .with_description("follow /clock");
+    assert!(
+        executor.declare_parameter_with_descriptor(
+            "use_sim_time",
+            nros_params::ParameterValue::Bool(true),
+            descriptor,
+        ),
+        "the descriptor path must step the seeded default aside too"
+    );
+    assert_eq!(
+        executor.params().and_then(|p| {
+            p.get_bool(super::node_record::NodeId::PRIMARY.into(), "use_sim_time")
+        }),
+        Some(true)
+    );
+    assert!(
+        executor
+            .params()
+            .and_then(|p| {
+                p.get_descriptor(super::node_record::NodeId::PRIMARY.into(), "use_sim_time")
+            })
+            .is_some(),
+        "the app's descriptor must survive; a seeded default carries none"
+    );
+}
+
 /// Issue 1036 — arena exhaustion must REACH the boot record, not merely return
 /// an error.
 ///

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -2567,6 +2567,139 @@ fn a_non_bool_use_sim_time_attaches_nothing() {
     );
 }
 
+// phase-430 W1 — a clock this test SETS, so it can cross a five-second
+// threshold without sleeping five seconds. `test_clock_us` is free-running and
+// shared by the whole process (issue 1105), so the interval would be measured
+// against however much of the suite ran first.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+private_test_clock!(sim_silence_clock);
+
+/// phase-430 W1 — `use_sim_time` true and no `/clock` sample ever: the image
+/// says so, ONCE.
+///
+/// The two states are indistinguishable from outside: an image whose simulator
+/// is paused and an image whose `/clock` was never wired both sit there with
+/// every ROS-time timer quiet. Only the image can tell them apart, because "no
+/// sample has EVER arrived" is a fact about this subscriber and not about the
+/// topic.
+///
+/// Asserted through `sim_time_silence_warnings()` rather than a log grep: the
+/// contract is "exactly once", so the assertion has to be able to tell one from
+/// two, and `nros_log`'s sink is not present on every target that runs this.
+#[cfg(all(feature = "sim-time", feature = "param-services"))]
+#[test]
+fn use_sim_time_with_no_clock_sample_is_reported_exactly_once() {
+    use nros_core::clock::Clock;
+
+    let _sim_time = SimTimeGuard::acquire();
+    // A precondition, not a courtesy: the watch's whole question is "has a
+    // sample arrived", and a leftover override from a sibling test answers it
+    // yes. The guard SERIALIZES against those tests and clears on the way out;
+    // this clears on the way in, so the test does not depend on which of them
+    // ran last.
+    Clock::clear_ros_time_override();
+
+    sim_silence_clock::claim_at_us(0);
+    let mut executor: Executor =
+        executor_with_clock_fn(MockSession::new(), sim_silence_clock::now_us);
+
+    assert!(
+        executor.declare_parameter("use_sim_time", nros_params::ParameterValue::Bool(true)),
+        "the app's own declaration must be accepted"
+    );
+    drop(executor.create_node("silent_sim").expect("create node"));
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        executor.ros_time_source_installed(),
+        "the /clock source must be attached before its silence means anything"
+    );
+    assert_eq!(
+        executor.sim_time_silence_warnings(),
+        0,
+        "the interval starts at ATTACH; nothing has elapsed yet"
+    );
+
+    // One microsecond short of the threshold.
+    sim_silence_clock::set_us(crate::time_source::SILENCE_WARN_US - 1);
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert_eq!(
+        executor.sim_time_silence_warnings(),
+        0,
+        "a simulator still coming up must not be accused of being absent"
+    );
+
+    // Crossing it.
+    sim_silence_clock::set_us(crate::time_source::SILENCE_WARN_US);
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert_eq!(
+        executor.sim_time_silence_warnings(),
+        1,
+        "use_sim_time is on, /clock has never spoken, and the image said \
+         nothing -- which is exactly the silence that reads as a paused \
+         simulator"
+    );
+
+    // Far past it, many times over: still one. A diagnostic that repeats is
+    // the noise it was written to replace.
+    sim_silence_clock::set_us(crate::time_source::SILENCE_WARN_US * 4);
+    for _ in 0..5 {
+        let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    }
+    assert_eq!(
+        executor.sim_time_silence_warnings(),
+        1,
+        "the warning repeated; the record became the noise"
+    );
+
+    // Detach and re-attach: W1 asks for the one-shot to reset, because the
+    // second attachment is a new question.
+    assert!(
+        executor
+            .params_mut()
+            .expect("the declaration above created the store")
+            .apply(
+                super::node_record::NodeId::PRIMARY.into(),
+                "use_sim_time",
+                nros_params::ParameterValue::Bool(false),
+            )
+            .is_success()
+    );
+    executor.refresh_use_sim_time_from_store();
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    assert!(
+        executor
+            .params_mut()
+            .expect("store")
+            .apply(
+                super::node_record::NodeId::PRIMARY.into(),
+                "use_sim_time",
+                nros_params::ParameterValue::Bool(true),
+            )
+            .is_success()
+    );
+    executor.refresh_use_sim_time_from_store();
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+
+    // ...and this time a sample DOES arrive before the interval. That answers
+    // the question for good: a simulator that publishes and then stops is a
+    // PAUSE, which is the state this diagnostic exists to be distinguished
+    // from, so it must stay quiet about it however long the pause runs.
+    sim_silence_clock::set_us(crate::time_source::SILENCE_WARN_US * 5);
+    Clock::set_ros_time_override(1_000_000_000);
+    let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    Clock::clear_ros_time_override();
+    sim_silence_clock::set_us(crate::time_source::SILENCE_WARN_US * 20);
+    for _ in 0..5 {
+        let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    }
+    assert_eq!(
+        executor.sim_time_silence_warnings(),
+        1,
+        "/clock spoke and then stopped -- that is a pause, and warning about a \
+         pause is the false alarm that teaches everyone to ignore the line"
+    );
+}
+
 /// phase-430 W2 — `use_sim_time` is declared on a node that never named it,
 /// as rclcpp does, so `ros2 param set <node> use_sim_time true` reaches an app
 /// with no simulated-time code in it.

--- a/packages/core/nros-node/src/parameter_services.rs
+++ b/packages/core/nros-node/src/parameter_services.rs
@@ -1398,6 +1398,31 @@ pub(crate) struct ParamState<'s> {
     /// `Executor::reconcile_parameter_services` once the nodes exist — the
     /// same shape `reconcile_ros_time_source` uses for the same reason.
     pub(crate) requested: bool,
+    /// phase-430 W2 — for each node key, whether that node's `use_sim_time`
+    /// entry is the AUTO-DECLARED `false` the executor seeded (as rclcpp does
+    /// in every node constructor) rather than a value the application named.
+    ///
+    /// A seed is a PLACEHOLDER, and that is load-bearing: the store refuses a
+    /// duplicate name, so without this the auto-declare would turn an app's own
+    /// `declare_parameter("use_sim_time", Bool(true))` into a refusal and the
+    /// default would silently beat the app.
+    /// `Executor::yield_seeded_use_sim_time` steps the placeholder aside for
+    /// the first real declaration, after which a second declaration of the same
+    /// name is refused exactly as it was before W2.
+    ///
+    /// PER NODE, because the store is keyed by node and the six services are
+    /// published per node: an app that declares `use_sim_time` on one of an
+    /// image's nodes has said nothing about the others, whose defaults must
+    /// stay placeholders.
+    ///
+    /// It lives HERE rather than beside `sim_time_stated` on the executor
+    /// because it is a fact about the STORE's contents, and because a table
+    /// that scales with a knob does not belong in the `Executor` value —
+    /// `the_executor_value_does_not_scale_with_the_knobs` (issue 0961) is the
+    /// test that says so. `ParamState` is boxed, and the bound is the one
+    /// [`ParamState::services`] already uses: one entry per node key.
+    #[cfg(feature = "sim-time")]
+    pub(crate) sim_time_seeded: [bool; MAX_PARAM_SERVICE_SETS],
 }
 
 /// phase-426 W3 — the executor's bound on parameter-service SETS.

--- a/packages/core/nros-node/src/time_source.rs
+++ b/packages/core/nros-node/src/time_source.rs
@@ -76,9 +76,167 @@ pub(crate) fn override_nanos(sec: i32, nanosec: u32) -> Option<i64> {
     (nanos >= 0).then_some(nanos)
 }
 
+/// How much of the executor's OWN elapsed time may pass, after the `/clock`
+/// source is attached, before the silence is worth a line — phase-430 W1.
+///
+/// Five seconds: long enough that a simulator still coming up, or a bag whose
+/// first sample is a second or two out, says nothing; short enough that a
+/// misconfigured image says it before anyone has finished reading the boot log.
+///
+/// # Why this is measured in the executor's elapsed time, and not in spins or wall time
+///
+/// The three candidates are a spin COUNT, a WALL duration, and the first
+/// ROS-time timer that comes due with no sample yet. None of them is free:
+///
+/// * A **spin count** is portable and needs no clock at all, and it means
+///   nothing. A `spin_once(5ms)` loop and a busy poll differ by four orders of
+///   magnitude, so any constant is right for one image and absurd for every
+///   other. The number would have to be tuned per image, which is the folklore
+///   this diagnostic exists to replace.
+/// * A **wall duration** is the obvious choice and has the obvious flaw: on a
+///   target running under simulation the wall clock is part of the fiction
+///   too — Zephyr `native_sim` runs its uptime as fast as the host will let it
+///   when idle, QEMU under `-icount` runs it as slowly as the model dictates —
+///   so "five seconds" from an independent host clock is not five seconds of
+///   anything the image experienced. Worse, an executor is allowed to have NO
+///   clock at all (`Executor::now_us` returns `Option`, and it is `None` on a
+///   freestanding build with no injected hook), so a wall threshold would make
+///   the diagnostic silently unreachable on exactly the targets it is for.
+/// * The **first ROS-time timer that comes due** is the semantically sharpest
+///   trigger — it is the instant the misconfiguration becomes visible
+///   behaviour — but it only covers images that HAVE a ROS-time timer. A node
+///   that merely stamps messages off `Clock::ros_time()` is just as
+///   misconfigured and would never hear a word.
+///
+/// So the threshold is the executor's own `delta_us`: the same per-spin
+/// quantity every WALL timer on the same executor accumulates, with the same
+/// "no clock, credit the requested timeout" fallback `spin_once` already
+/// applies. Three properties follow, and they are why this is the right unit:
+/// the diagnostic arrives after as much time as the image's own wall timers
+/// believe has passed (so it is legible against them); it moves WITH the
+/// target's simulated wall clock instead of against it; and a clockless image
+/// is not exempt, because the fallback still advances it.
+pub const SILENCE_WARN_US: u64 = 5_000_000;
+
+/// The one-shot watch behind [`SILENCE_WARN_US`] — phase-430 W1.
+///
+/// An image told `use_sim_time = true` that never receives a `/clock` sample
+/// looks exactly like one whose simulator is merely PAUSED: in both, every
+/// ROS-time timer sits still and nothing is said. The two need different
+/// answers from the operator, so the image has to distinguish them, and only
+/// the image can — "no sample has EVER arrived" is not a question an outside
+/// observer of the topic can answer about this subscriber.
+///
+/// Kept as a small state machine rather than two fields on the executor so the
+/// policy — when it arms, when it gives up, when it must not repeat — is
+/// testable without an executor, and so there is exactly one place to read it.
+#[derive(Debug, Default)]
+pub(crate) struct SilenceWatch {
+    /// Whether the watch is counting. False both before the source is attached
+    /// and after the question has been ANSWERED, either way.
+    armed: bool,
+    /// Executor-elapsed µs since the watch armed.
+    elapsed_us: u64,
+    /// How many times this watch has reported. The executor exposes it so a
+    /// test can assert "exactly one" without grepping a log sink, and so an
+    /// application can ask the same question the log line answers.
+    reports: u32,
+}
+
+impl SilenceWatch {
+    pub(crate) const fn new() -> Self {
+        Self {
+            armed: false,
+            elapsed_us: 0,
+            reports: 0,
+        }
+    }
+
+    /// The `/clock` source was just attached: start counting, and clear the
+    /// one-shot so a source that is detached and re-attached is watched again.
+    ///
+    /// Arming is what makes the interval start at ATTACH rather than at
+    /// construction: before the subscription exists there is nothing to be
+    /// silent, and counting from boot would fire on an image that spent six
+    /// seconds bringing a transport up.
+    pub(crate) fn arm(&mut self) {
+        self.armed = true;
+        self.elapsed_us = 0;
+    }
+
+    /// The source is no longer wanted (`use_sim_time` went false). Stop
+    /// counting; a later re-arm starts the interval over.
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+        self.elapsed_us = 0;
+    }
+
+    /// Credit `delta_us` of the executor's own elapsed time and answer whether
+    /// THIS is the spin that should emit the diagnostic.
+    ///
+    /// `sample_seen` is [`Clock::is_ros_time_override_active`], i.e. "simulated
+    /// time is being driven". A sample arriving at any point before the
+    /// threshold disarms the watch permanently: the configuration is then
+    /// PROVEN right, and a simulator that stops afterwards is a pause — the
+    /// case this diagnostic must stay quiet about, because saying "no /clock"
+    /// about a paused bag is exactly the false alarm that would teach everyone
+    /// to ignore the line.
+    ///
+    /// Returns `true` at most once per arming; the report itself disarms, so
+    /// the record cannot become the noise it warns about.
+    ///
+    /// [`Clock::is_ros_time_override_active`]: nros_core::clock::Clock::is_ros_time_override_active
+    pub(crate) fn tick(&mut self, delta_us: u64, sample_seen: bool) -> bool {
+        if !self.armed {
+            return false;
+        }
+        if sample_seen {
+            self.disarm();
+            return false;
+        }
+        self.elapsed_us = self.elapsed_us.saturating_add(delta_us);
+        if self.elapsed_us < SILENCE_WARN_US {
+            return false;
+        }
+        self.armed = false;
+        self.reports = self.reports.saturating_add(1);
+        true
+    }
+
+    /// How many times this watch has reported.
+    pub(crate) fn reports(&self) -> u32 {
+        self.reports
+    }
+}
+
+/// Say that `use_sim_time` is on and `/clock` has never spoken — phase-430 W1.
+///
+/// `nros_log`, never stdio: this is reached on `no_std` targets and inside
+/// Zephyr `native_sim`, where a Rust `std` stdio call is FATAL (issue 0589).
+///
+/// BUDGET: `nros_log`'s call-site format buffer is 256 bytes by default and
+/// overflow TRUNCATES with a `…`, so a line that explains itself past the
+/// budget delivers exactly the folklore it replaces (the lesson
+/// `arena::report_arena_headroom` paid for). Both identifiers an operator has
+/// to act on — the parameter and the topic — are in the first clause, and the
+/// reasoning lives here rather than on the wire.
+#[cold]
+pub(crate) fn report_silence(topic: &str) {
+    nros_log::log_warn!(
+        nros_log::get_logger("nros"),
+        "{} is true but no {} sample has arrived in {}s: ROS-time timers are \
+         running on SYSTEM time meanwhile. Publish rosgraph_msgs/msg/Clock \
+         (ros2 bag play --clock), or set {} false.",
+        USE_SIM_TIME_PARAM,
+        topic,
+        SILENCE_WARN_US / 1_000_000,
+        USE_SIM_TIME_PARAM
+    );
+}
+
 #[cfg(test)]
 mod tests {
-    use super::override_nanos;
+    use super::{SILENCE_WARN_US, SilenceWatch, override_nanos};
 
     #[test]
     fn a_clock_sample_becomes_nanoseconds() {
@@ -95,5 +253,87 @@ mod tests {
         // Saturating rather than wrapping: the minimum sec cannot become a
         // positive nanosecond count.
         assert_eq!(override_nanos(i32::MIN, u32::MAX), None);
+    }
+
+    /// phase-430 W1 — the watch says nothing until it is ARMED, however much
+    /// time passes. Before the `/clock` source is attached there is nothing to
+    /// be silent about, and an image that spends six seconds bringing a
+    /// transport up must not be accused of a misconfiguration it does not have.
+    #[test]
+    fn an_unarmed_watch_never_reports() {
+        let mut watch = SilenceWatch::new();
+        for _ in 0..10 {
+            assert!(!watch.tick(SILENCE_WARN_US, false));
+        }
+        assert_eq!(watch.reports(), 0);
+    }
+
+    /// The interval, and the one-shot: it fires when the executor's own elapsed
+    /// time reaches the threshold, and NOT one microsecond earlier.
+    #[test]
+    fn a_silent_source_reports_once_at_the_threshold() {
+        let mut watch = SilenceWatch::new();
+        watch.arm();
+        assert!(
+            !watch.tick(SILENCE_WARN_US - 1, false),
+            "one microsecond short of the threshold is not the threshold"
+        );
+        assert!(
+            watch.tick(1, false),
+            "the threshold must fire on the spin that reaches it"
+        );
+        assert_eq!(watch.reports(), 1);
+        // The record must not become the noise it warns about: the report
+        // disarms, so every later spin is silent even though the condition it
+        // described is still true.
+        for _ in 0..100 {
+            assert!(!watch.tick(SILENCE_WARN_US, false));
+        }
+        assert_eq!(watch.reports(), 1);
+    }
+
+    /// A sample arriving before the interval answers the question, permanently.
+    ///
+    /// Permanently, and not "until it stops": a simulator that publishes and
+    /// then pauses is the case this diagnostic exists to be DISTINGUISHED from,
+    /// so warning about it would be the false alarm that teaches everyone to
+    /// ignore the line.
+    #[test]
+    fn a_sample_before_the_threshold_silences_the_watch_for_good() {
+        let mut watch = SilenceWatch::new();
+        watch.arm();
+        assert!(!watch.tick(SILENCE_WARN_US - 1, false));
+        assert!(
+            !watch.tick(1, true),
+            "a sample arrived; there is nothing to report"
+        );
+        for _ in 0..100 {
+            assert!(
+                !watch.tick(SILENCE_WARN_US, false),
+                "/clock spoke once and then stopped -- that is a PAUSE, and a \
+                 pause is the state this diagnostic must not shout about"
+            );
+        }
+        assert_eq!(watch.reports(), 0);
+    }
+
+    /// Re-arming starts the interval over, so a source detached and re-attached
+    /// is watched again — and the elapsed time from the first arming does not
+    /// carry over and fire the new watch on its first spin.
+    #[test]
+    fn re_arming_restarts_the_interval() {
+        let mut watch = SilenceWatch::new();
+        watch.arm();
+        assert!(watch.tick(SILENCE_WARN_US, false));
+        assert_eq!(watch.reports(), 1);
+
+        watch.disarm();
+        watch.arm();
+        assert!(
+            !watch.tick(SILENCE_WARN_US - 1, false),
+            "the second watch inherited elapsed time from the first"
+        );
+        assert!(watch.tick(1, false));
+        assert_eq!(watch.reports(), 2);
     }
 }


### PR DESCRIPTION
**phase-430 W1 and W2 only.** The rewritten phase doc is not on `main` — it rides on PR #629 (`phase-428-w10-qos-ssot`) — and this PR does not touch it. W3 and W5 landed as #712 and #716.

## W2 — declare `use_sim_time = false` on every node

rclcpp auto-declares it in every node's constructor, so `ros2 param list` shows it and `ros2 param set <node> use_sim_time true` works against a node whose author never wrote a line about simulated time. Ours honoured the parameter only if the APP had declared it: the store refuses an undeclared set (`allow_undeclared` is false), so **the runtime switch worked on exactly the nodes that least needed it**. That is the PARTIAL the survey measured (row 5).

`ensure_parameter_store` now seeds `Bool(false)` when `sim-time` **and** `param-services` are both on. Gated on `sim-time` too: an image that cannot act on the parameter should not advertise it — a settable knob that does nothing is worse than an absent one.

### The seed is a placeholder, and that is load-bearing

`ParameterServer::declare` refuses a name it already holds, so a naive seed turns an app's own `declare_parameter("use_sim_time", Bool(true))` into a refusal and **the default silently beats the app**. Measured, not reasoned — with `yield_seeded_use_sim_time` stubbed out, six tests fail, four of which predate this work:

```
use_sim_time_attaches_and_detaches_the_clock_source ... FAILED
use_sim_time_declared_with_a_descriptor_attaches_the_clock_source ... FAILED
use_sim_time_follows_the_store_verdict_not_the_caller ... FAILED
an_apps_own_use_sim_time_declaration_beats_the_auto_declared_default ... FAILED
```

So `sim_time_param_seeded` tracks whether the stored value is ours; the first real declaration removes the placeholder before declaring, with its own value and its own descriptor. A declaration then refused on its own terms (full store, ill-formed range) puts the default back, so the name is never left undeclared.

The seed deliberately does NOT go through `note_reserved_parameter`, so `sim_time_stated` stays false: **an auto-declared default is not a statement by anyone**. Recording it as one would make every executor with parameter services write `set_active(false)` onto a PROCESS-GLOBAL gate on its first spin — the collision `sim_time_stated` was added for (issue 1104).

### The class, swept

```
grep -n 'new_param_state\|ensure_parameter_store' packages/core/nros-node/src/executor/spin.rs
```

Two doors into the store, and only one was the declare path: `register_parameter_services` built its own `ParamState`, so a hook on the declaration path alone would have missed the node W2 is really for — one that declares NOTHING. It routes through `ensure_parameter_store` now (issue 0745's preserve-the-store and issue 0756's never-by-value both intact).

### phase-426 assumption

Written against `main`. phase-426 W1–W3 (store keyed by NODE, six services per node) is on `origin/phase-426-w{1,2,3}-*` and **not merged**. Its three touch points are `declare_parameter_on(node, …)`, `declare_parameter_with_descriptor_on`, and a `NodeKey`-taking `declare`/`get_bool`; this PR's hooks sit at those same three seams, so the rebase is a signature change at each rather than a redesign. The seed becomes per node, which is what upstream does anyway.

## W1 — `use_sim_time` true and no `/clock` ever: say so once

An image told to use simulated time that never receives a sample looks **identical** to one whose simulator is merely paused: both leave every ROS-time timer sitting still, silently. Only the image can distinguish them — "no sample has EVER arrived" is a fact about this subscriber, not about the topic.

```
use_sim_time is true but no /clock sample has arrived in 5s: ROS-time timers are
running on SYSTEM time meanwhile. Publish rosgraph_msgs/msg/Clock (ros2 bag play
--clock), or set use_sim_time false.
```

198 bytes, inside `nros_log`'s 256-byte call-site budget, both actionable identifiers in the first clause — the lesson `arena::report_arena_headroom` paid for. `nros_log`, never stdio (issue 0589). Not a behaviour change: row 15 stands.

### Where the threshold lives

**The executor's own per-spin `delta_us`** — the same quantity every wall timer on the same executor accumulates, including its "no clock, credit the requested timeout" fallback. The other two candidates lose:

* A **spin count** needs no clock and means nothing: a `spin_once(5ms)` loop and a busy poll differ by four orders of magnitude, so any constant is right for one image and absurd for every other. That is per-image folklore, which is what a diagnostic exists to replace.
* A **wall duration** is the obvious choice and has the obvious flaw: on a target running under simulation the wall clock is part of the fiction too — `native_sim` runs uptime as fast as the host allows when idle, QEMU under `-icount` as slowly as the model dictates — so five host seconds are not five seconds of anything the image experienced. Worse, an executor may have **no clock at all** (`now_us()` returns `Option`, `None` on a freestanding build with no injected hook), so a wall threshold would be silently UNREACHABLE on exactly the targets this is for.
* The **first ROS-time timer coming due** is the semantically sharpest trigger and too narrow: a node that only stamps messages off `Clock::ros_time()` is just as misconfigured and would never hear a word.

`delta_us` buys three properties at once: the warning arrives after as much time as the image's own wall timers believe has passed, so it is legible against them; it moves WITH a simulated wall clock instead of against it; and a clockless image is not exempt, because the fallback still advances it. The whole argument lives on `time_source::SILENCE_WARN_US`, not in this PR body.

### Once, not per spin

The report disarms the watch, so the record cannot become the noise it warns about. A sample arriving before the threshold disarms it **permanently**: the configuration is then proven right, and a simulator that stops afterwards is a PAUSE — warning about a pause is the false alarm that teaches everyone to ignore the line. `use_sim_time` going false and back to true re-arms with a fresh interval.

Scope is the source the EXECUTOR installed for `use_sim_time`. An app calling `NodeCtx::install_ros_time_source` directly is not watched, because this line names `use_sim_time` and that app never set it.

## Tests

Asserted through `Executor::sim_time_silence_warnings()`, not a log grep: the contract is "exactly once", so the assertion must distinguish one from two, and `nros_log`'s sink is not present on every target that runs this. The accessor is `sim-time`-gated, so it adds no ledger row — the parity extractor builds the Rust surface without `sim-time` (`NROS_FEATURES` in `scripts/api_parity/extract_rust.py`), which is the survey's finding C.

| test | covers |
| --- | --- |
| `an_unarmed_watch_never_reports` | nothing before attach |
| `a_silent_source_reports_once_at_the_threshold` | the interval, and the one-shot |
| `a_sample_before_the_threshold_silences_the_watch_for_good` | a pause is not a misconfiguration |
| `re_arming_restarts_the_interval` | no carry-over between armings |
| `use_sim_time_with_no_clock_sample_is_reported_exactly_once` | the executor wiring, all four |
| `use_sim_time_is_declared_on_a_node_that_never_named_it` | W2, `ros2 param list` + the wire set |
| `use_sim_time_is_declared_by_registering_the_parameter_services_alone` | W2 via the second door |
| `an_apps_own_use_sim_time_declaration_beats_the_auto_declared_default` | the app wins |
| `an_apps_use_sim_time_declaration_with_a_descriptor_beats_the_default` | …descriptor path too |

The executor W1 test rides a `private_test_clock!` (issue 1105) so it crosses five seconds without sleeping five seconds — `test_clock_us` is free-running and shared, so the interval would otherwise measure how much of the suite ran first.

### Negative controls

Three mutations, each on a temporary WIP commit (never `git stash` — the stash stack is shared), tests unchanged:

**A — the watch is never armed:**
```
---- use_sim_time_with_no_clock_sample_is_reported_exactly_once ----
assertion `left == right` failed: use_sim_time is on, /clock has never spoken, and
the image said nothing -- which is exactly the silence that reads as a paused simulator
  left: 0
 right: 1
test result: FAILED. 381 passed; 1 failed
```

**B — no auto-declare:**
```
---- use_sim_time_is_declared_on_a_node_that_never_named_it ----
assertion `left == right` failed: rclcpp declares use_sim_time=false on every node;
a `ros2 param list` here showed nothing until the app named it
  left: None
 right: Some(false)
test result: FAILED. 379 passed; 3 failed
```

**C — the seed never steps aside** (the failure mode the auto-declare invites):
```
---- an_apps_own_use_sim_time_declaration_beats_the_auto_declared_default ----
the app's own declaration was refused because the auto-declared default had taken the name
test result: FAILED. 376 passed; 6 failed
```

## Ran

| command | result |
| --- | --- |
| `cargo test -p nros-node --lib --features std,sim-time,param-services` | **382 passed**, 0 failed, 2 ignored |
| same, `--features std,sim-time` (no param-services) | 350 passed, 0 failed |
| `cargo build -p nros-node` at `std` / `std,param-services` / `std,sim-time` | clean, no warnings |
| `cargo clippy -p nros-node --all-targets --features std,sim-time,param-services -- -D warnings` | clean |
| `just check no-std-stdio` | OK (192 no_std crates) |
| `just check no-vacuous-tests` | OK (306 test files, 10 self-test cases) |
| `just check api-parity` | OK — every divergence carries a ledger entry, 0 new rows needed |
| `just check fast` | 273 of 277; four reds, all environmental — see below |

The four `check fast` reds read no file in this diff and are properties of this worktree, not of the change:

* `capability-conditionals` — `zenoh-pico` submodule not checked out here (the gate says so and exits 2).
* `xrce-vendored-versions` — no vendored XRCE tree (`nros setup --source …` not run).
* `xrce-source-manifest` — its own self-test does `Path("/nonexistent/…").exists()`, which raises `PermissionError` under this sandbox rather than returning a verdict about the tree.
* `doc-commit-citations` — `docs/issues/README.md:718` cites `22e511442`, a commit this checkout does not have, plus four baseline entries that now resolve. Inherited; untouched by this PR.

Tier: `just ci gate`-shaped (compile + unit, no fixtures), narrowed to the crate this touches. No fixture, SDK, QEMU or cross toolchain involved.

## Book

`book/src/user-guide/simulated-time.md` gains the W2 default under "Turning it on" and the W1 diagnostic under "Limits", which is what both work items' acceptance asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
