### PR TITLE
feat(phase-439 W1, RFC-0094 D4): the resolve digest in every cargo-directory key

### DIFF
--- a/cmake/NanoRosSharedCargoDir.cmake
+++ b/cmake/NanoRosSharedCargoDir.cmake
@@ -16,6 +16,141 @@
 
 include_guard(GLOBAL)
 
+# =============================================================================
+# The KNOB half of every cargo-directory key — RFC-0094 D4, phase-439 W1.
+#
+# `nros_shared_cargo_dir()` below hashes the fields a caller hands it, and until
+# this existed the `nros-c` and NuttX callers handed it `features, rmw, board,
+# caps, profile, target` and **no knob values**. The Zephyr lane already keyed on
+# every `NROS_RESOLVED_*` (issue 0528 measured what omitting them cost there: two
+# leaves at the same (target, features) disagreeing on
+# `CONFIG_NROS_EXECUTOR_MAX_CBS` shared a probe dir, and one compiled against a
+# constant sized for the other).
+#
+# Why that gap is not a follow-up: cargo uplifts the final archive to an UNHASHED
+# name (`libnros_c.a`), so two configurations sharing a directory overwrite each
+# other's artifact and one silently links the other's numbers — issue 0616's
+# shape. RFC-0094's resolve phase makes per-image knob divergence the NORMAL case
+# rather than the exception, so landing it without this would be worse than the
+# status quo.
+#
+# ONE spelling, for the reason this file exists at all: a second per-caller list
+# is how the two would drift (issue 1025 — the fixture group key had one FORMULA
+# and two derivations of its INPUTS, and no esp32 flash image could be packed).
+#
+# TWO ROADS, because the tree has two knob-delivery mechanisms and they do not
+# overlap in time:
+#
+#  1. the RESOLVER registry — `NROS_RESOLVED_KNOBS` + `NROS_RESOLVED_<name>`,
+#     filled by `nros_resolve_knobs()`. Zephyr today; every lane once RFC-0094's
+#     stage 3.5 writes `resolved.toml` and this function reads it.
+#  2. the ENVIRONMENT — the road that reaches a build script on EVERY lane and
+#     is the one knob value knowable this early on a lane with no resolver.
+#     It is not a guess: `_nros_resolve_knob()`'s rung 1 is `$ENV{<name>}`, and
+#     `examples/fixtures.toml` states knobs exactly this way
+#     (`env = { ZPICO_MAX_QUERYABLES = "2" }`).
+#
+# Road 1 wins per name. On Zephyr an env-stated knob has ALREADY been registered
+# by rung 1 of `_nros_resolve_knob()`, so road 2 contributes nothing and the key
+# text is what that lane produced before this existed. (Road 2 can still add a
+# name on Zephyr in one case: an env-stated knob whose `_nros_resolve_knob()`
+# call the configure never reached — a backend-specific knob on the other
+# backend, say. That is a knob the reading build script WOULD see, so separating
+# on it is the answer, not a regression.) On a lane with no knob stated at all
+# BOTH roads are empty, the field list is empty, and the key text is unchanged:
+# a warm cargo directory is not invalidated for nothing. Measured — the `nros-c`
+# lane's real configure resolves to the same `d20f4167871d` before and after
+# this change when no knob is stated, and to a different directory when one is.
+# =============================================================================
+
+# The knob NAME inventory, harvested from its ONE authored site.
+#
+# `_nros_resolve_knob(<NAME> ...)` / `_nros_resolve_derivable_knob(<NAME> ...)`
+# in `zephyr/cmake/nros_cargo_build.cmake` is where this tree writes down which
+# environment variables are knobs. `check-kconfig-knob-forwarding` already
+# treats that set as authoritative — it holds every name there to a Rust build
+# script that reads it — so those build scripts run on every lane and an
+# env-stated value of any of these names changes compiled output on any lane.
+#
+# READ rather than copied. A cmake-side list of the same 43 names would be a
+# second spelling of an authored set, which is the drift this repo keeps paying
+# for; nano-ros is consumed only as a source distribution (`add_subdirectory`),
+# so the file is always present and its absence is a real breakage rather than a
+# reason to degrade.
+set(_NROS_KNOB_INVENTORY_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/../zephyr/cmake/nros_cargo_build.cmake"
+    CACHE INTERNAL "phase-439 W1 — the authored knob-name inventory")
+
+function(_nros_knob_inventory out_var)
+    if(DEFINED NROS_KNOB_INVENTORY_CACHED)
+        set(${out_var} "${NROS_KNOB_INVENTORY_CACHED}" PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT EXISTS "${_NROS_KNOB_INVENTORY_FILE}")
+        message(FATAL_ERROR
+            "nano-ros: the knob inventory is missing — "
+            "${_NROS_KNOB_INVENTORY_FILE} does not exist. Every shared cargo "
+            "directory keys on the knob values (RFC-0094 D4), and an EMPTY "
+            "inventory would key on none of them silently, which is the "
+            "collision this exists to prevent. Do not degrade past this.")
+    endif()
+    file(STRINGS "${_NROS_KNOB_INVENTORY_FILE}" _lines
+        REGEX "_nros_resolve(_derivable)?_knob\\([A-Z0-9_]+")
+    set(_names "")
+    foreach(_line IN LISTS _lines)
+        string(REGEX MATCHALL "_nros_resolve(_derivable)?_knob\\([A-Z0-9_]+"
+            _hits "${_line}")
+        foreach(_hit IN LISTS _hits)
+            string(REGEX REPLACE "^_nros_resolve(_derivable)?_knob\\(" "" _n "${_hit}")
+            list(APPEND _names "${_n}")
+        endforeach()
+    endforeach()
+    list(REMOVE_DUPLICATES _names)
+    list(SORT _names)
+    if(NOT _names)
+        message(FATAL_ERROR
+            "nano-ros: the knob inventory at ${_NROS_KNOB_INVENTORY_FILE} "
+            "yielded NO names. Either the resolver's call spelling changed or "
+            "the file did; an empty inventory silently keys every shared cargo "
+            "directory on zero knobs (RFC-0094 D4). Fix the harvest, do not "
+            "let it pass empty.")
+    endif()
+    set(NROS_KNOB_INVENTORY_CACHED "${_names}" CACHE INTERNAL
+        "phase-439 W1 — knob names harvested from the resolver's own call sites")
+    set(${out_var} "${_names}" PARENT_SCOPE)
+endfunction()
+
+# nros_knob_key_fields(<out_var>)
+#
+# The knob fields for a cargo-directory KEY, as `<NAME>=<value>` elements ready
+# to append to `nros_shared_cargo_dir(... KEY ...)`. Empty when this configure
+# has resolved and states no knob — which is the whole reason an existing image
+# whose knobs did not move keeps the directory it already has.
+function(nros_knob_key_fields out_var)
+    set(_fields "")
+    set(_seen "")
+    # Road 1 — the resolver registry, in registry order, so a lane that already
+    # keyed on it produces the same text it always did.
+    foreach(_k IN LISTS NROS_RESOLVED_KNOBS)
+        if(NOT "${_k}" IN_LIST _seen)
+            list(APPEND _seen "${_k}")
+            list(APPEND _fields "${_k}=${NROS_RESOLVED_${_k}}")
+        endif()
+    endforeach()
+    # Road 2 — the environment, for the names the resolver did not answer for.
+    _nros_knob_inventory(_names)
+    foreach(_k IN LISTS _names)
+        if("${_k}" IN_LIST _seen)
+            continue()
+        endif()
+        if(DEFINED ENV{${_k}} AND NOT "$ENV{${_k}}" STREQUAL "")
+            list(APPEND _seen "${_k}")
+            list(APPEND _fields "${_k}=$ENV{${_k}}")
+        endif()
+    endforeach()
+    set(${out_var} "${_fields}" PARENT_SCOPE)
+endfunction()
+
 # nros_shared_cargo_dir(<out_var> KEY <field>...)
 #
 # Issue 0805 — resolve `NROS_SHARED_CARGO_ROOT` + a KEY to a concrete shared

--- a/docs/roadmap/phase-439-resolve-before-configure.md
+++ b/docs/roadmap/phase-439-resolve-before-configure.md
@@ -2,12 +2,15 @@
 
 **Status (2026-09-08). Opened from RFC-0094. W0 and W1 are the routing diff and
 the digest key — both are PRECONDITIONS and neither changes behaviour. W2–W4 are
-the three landings. W0 has LANDED and corrected three of the RFC's numbers; W4
-has LANDED; W1–W3 are not started.**
+the three landings. **W0, W1 and W4 have LANDED; W2 and W3 are not started.**
+
+W0 corrected three of RFC-0094's own numbers — the count of `package.xml`, the
+size of the declare-but-no-file class, and how many of the 21 side-changers are
+already handled by another mechanism.
 
 W4 landed out of the stated order because it depends on none of the others: it
 is the RMW axis alone (descriptors, the cmake seam, the link strategies), while
-W0/W1's preconditions are about routing and cargo-directory keys.
+W0's and W1's preconditions are about routing and cargo-directory keys.
 
 Implements [RFC-0094](../design/0094-resolve-before-configure.md). Read its
 "Design" section first; this doc carries work items and acceptance only.
@@ -116,6 +119,41 @@ every `NROS_RESOLVED_*`; the `nros-c` and NuttX lanes do not.
 **Acceptance:** two images differing ONLY in a derived knob resolve to different
 cargo directories. Mutation-tested — revert the key change and the collision
 reappears, demonstrated rather than argued.
+
+**LANDED 2026-09-08.** The knob half has ONE spelling, `nros_knob_key_fields()`
+in `cmake/NanoRosSharedCargoDir.cmake`, and all three callers append it. It
+reads TWO roads: the resolver registry (`NROS_RESOLVED_KNOBS`, Zephyr today and
+every lane once W2 writes `resolved.toml`) and, for the names the resolver did
+not answer for, the ENVIRONMENT — which is how `examples/fixtures.toml` states a
+knob and the only knob road knowable at key time on a lane with no resolver. The
+knob NAME inventory is READ from its one authored site rather than copied: the
+43 `_nros_resolve_knob(<NAME> …)` call sites `check-kconfig-knob-forwarding`
+already treats as authoritative.
+
+Measured, on the real `nros-c` call site (two root configures, `posix`/`zenoh`,
+differing only in `ZPICO_MAX_QUERYABLES`):
+
+| | no knob stated | `ZPICO_MAX_QUERYABLES=2` |
+| --- | --- | --- |
+| with W1 | `…/d20f4167871d` | `…/ba45165655e7` |
+| key change reverted | `…/d20f4167871d` | `…/d20f4167871d` — COLLIDES |
+| restored | `…/d20f4167871d` | `…/ba45165655e7` |
+
+The left column is identical in all three rows, which is the other half of the
+acceptance: an image whose knobs did not move keeps the directory it already
+has, so no warm cargo directory in the tree is invalidated.
+
+The bash-owned fixture group key (`nros_fixture_group_slug`) needed no change —
+its signature is already (platform, cargo args, **sorted env**), measured:
+`qemu-esp32-baremetal` vs `qemu-esp32-baremetal-4118800323` at
+`ZPICO_MAX_QUERYABLES=2` and `-4054584529` at 4. Every other cargo target dir in
+the tree is per-build-dir (`${CMAKE_BINARY_DIR}/nros-rust`, `nros-rust-ws-<n>`,
+`<ffi-crate>/target`), serves one configuration, and has no key to carry.
+
+Gate: `check-cargo-dir-knob-key`, which drives the production cmake through
+`cmake -P` rather than re-deriving the key, and whose NEGATIVE CONTROL runs on
+the normal path — with the knob fields removed the two images must COLLIDE, so a
+green verdict is a demonstration rather than an assertion.
 
 ## W2 — Stage 3.5, the resolve phase
 

--- a/just/check/cmake.just
+++ b/just/check/cmake.just
@@ -223,3 +223,22 @@ workspace-fmt:
 [group("check")]
 cxx-standard-floor:
     @python3 scripts/check-cxx-standard-floor.py
+
+# RFC-0094 D4 / phase-439 W1 — two images differing ONLY in a derived knob must
+# not share a cargo directory.
+#
+# `nros_shared_cargo_dir()` hashes the fields its caller supplies, and cargo
+# uplifts the archive to an UNHASHED `libnros_c.a`, so two configurations that
+# hash the same overwrite each other's artifact and one links the other's
+# numbers (issue 0616's shape). The `nros-c` and NuttX keys carried no knob
+# values at all until W1; the Zephyr key already did, because issue 0528
+# measured what omitting them cost there.
+#
+# The gate DRIVES the production cmake (`cmake -P` on the shared module) rather
+# than re-deriving the key, and its negative control runs on the normal path:
+# with the knob fields taken back out — the pre-W1 shape, i.e. what reverting
+# the change produces — the two images must COLLIDE. A green here is therefore
+# a demonstration, not an assertion.
+[group("check")]
+cargo-dir-knob-key:
+    @bash scripts/check-cargo-dir-knob-key.sh

--- a/packages/api/nros-c/CMakeLists.txt
+++ b/packages/api/nros-c/CMakeLists.txt
@@ -128,18 +128,27 @@ nros_resolve_cargo_profile()
 #
 # Sorted, because a key must not depend on the order the features happened to be
 # appended in.
+#
+# phase-439 W1 (RFC-0094 D4) — plus the KNOB values, which this key carried none
+# of. The fields above are the inputs `nros_feature_set()` is a function of, and
+# a pool size is not one of them: two images at the same features/rmw/board/caps
+# differing only in `ZPICO_MAX_QUERYABLES` hashed IDENTICALLY and the second took
+# the first's uplifted `libnros_c.a`. `nros_knob_key_fields()` is the ONE
+# spelling of "what is the knob half" — never a list here.
 if(COMMAND nros_share_corrosion_cargo_dir)
     string(REPLACE ";" "," _caps_flat "${_caps}")
     set(_features_key ${_features})
     list(SORT _features_key)
     string(REPLACE ";" "," _features_flat "${_features_key}")
+    nros_knob_key_fields(_knob_fields)
     nros_share_corrosion_cargo_dir(KEY
         "features=${_features_flat}"
         "rmw=${NANO_ROS_RMW}"
         "board=${NANO_ROS_BOARD}"
         "caps=${_caps_flat}"
         "profile=${NROS_CARGO_PROFILE}"
-        "target=${Rust_CARGO_TARGET}")
+        "target=${Rust_CARGO_TARGET}"
+        ${_knob_fields})
 endif()
 
 corrosion_import_crate(

--- a/packages/api/nros-c/cmake/nros-nuttx.cmake
+++ b/packages/api/nros-c/cmake/nros-nuttx.cmake
@@ -303,14 +303,23 @@ function(nros_nuttx_build_example)
     # rv-virt — so a dir shared across arches would serve build-script output
     # compiled against the other arch's headers. Triple + profile + FFI crate
     # keeps them apart (the two arches also use different FFI crates).
+    #
+    # phase-439 W1 (RFC-0094 D4) — and the KNOB values. This lane's cargo command
+    # is hand-rolled and carries no knob env of its own, so every knob it
+    # compiles against arrives through the INHERITED process environment (the
+    # shape `examples/fixtures.toml` rows state: `env = { ZPICO_MAX_QUERYABLES =
+    # "2" }`). Two leaves at the same triple/profile/ffi differing only there
+    # hashed identically, which is issue 0616's shape one lane over.
     set(_shared_cargo_dir "")
     if(COMMAND nros_shared_cargo_dir)
+        nros_knob_key_fields(_nnbe_knob_fields)
         nros_shared_cargo_dir(_shared_cargo_dir KEY
             "triple=${_NNBE_TARGET_TRIPLE}"
             "profile=${_NROS_NUTTX_PROFILE}"
             "ffi=${_NNBE_FFI_CRATE_DIR}"
             "nuttx=${NUTTX_DIR}"
-            "defconfig=${NROS_NUTTX_DEFCONFIG}")
+            "defconfig=${NROS_NUTTX_DEFCONFIG}"
+            ${_nnbe_knob_fields})
     endif()
     if(_shared_cargo_dir)
         set(_cargo_target_dir "${_shared_cargo_dir}")

--- a/scripts/check-cargo-dir-knob-key.sh
+++ b/scripts/check-cargo-dir-knob-key.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Two images differing ONLY in a derived knob must not share a cargo directory —
+# RFC-0094 D4 / phase-439 W1, acceptance A4.
+#
+# # The failure this prevents
+#
+# `nros_shared_cargo_dir()` hashes the fields its caller hands it, and cargo
+# uplifts the final archive to an UNHASHED name (`libnros_c.a`). So two
+# configurations that hash the same overwrite each other's artifact and one
+# silently links the other's numbers — issue 0616's shape, diagnosed a long way
+# from its cause. Until phase-439 the `nros-c` and NuttX keys carried
+# `features, rmw, board, caps, profile, target` and **no knob values**, while a
+# pool size is exactly what changes the compiled archive: issue 0528 measured
+# the same omission on the Zephyr lane, where two leaves disagreeing on
+# `CONFIG_NROS_EXECUTOR_MAX_CBS` shared a probe dir and one compiled against a
+# constant sized for the other.
+#
+# RFC-0094's resolve phase makes per-image knob divergence the NORMAL case, so
+# this is a precondition for it rather than a follow-up.
+#
+# # Why it drives cmake instead of reading it
+#
+# The probe (`scripts/lib/shared-cargo-key-probe.cmake`) calls the PRODUCTION
+# `nros_knob_key_fields()` and the PRODUCTION normalise-and-hash. A gate that
+# re-derived the key in bash would pass against its own copy of the rule, which
+# is the defect and not the test.
+#
+# # What it asserts
+#
+#   1. no knob stated       -> the key text is byte-identical to the pre-439
+#                              base key, so no warm cargo directory in the tree
+#                              is invalidated for nothing
+#   2. a knob stated        -> a DIFFERENT directory from (1)
+#   3. the same knob twice  -> the SAME directory (a key is a function of the
+#                              configuration, not of when it was computed)
+#   4. a different VALUE    -> a different directory (presence is not enough)
+#   5. a knob from another
+#      family (executor)    -> also separates
+#   6. NEGATIVE CONTROL     -> with the knob fields removed from the key, (2)
+#                              COLLIDES with (1). This is the mutation the
+#                              acceptance asks for, run on the normal path: if
+#                              it ever stops colliding, this gate is measuring
+#                              something other than the knob half and its green
+#                              means nothing.
+#   7. the inventory is the AUTHORED one -- names harvested from the resolver's
+#      own `_nros_resolve_knob()` call sites, not a second list in cmake.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# issue 0726 — a `grep -q` conditional cannot tell a tool ERROR from a NON-MATCH,
+# and the two branch the same way while meaning opposite things. `nros_grep_q`
+# exits 2 on a failure to run rather than reporting a finding.
+# shellcheck source=scripts/lib/grep-q.sh
+source scripts/lib/grep-q.sh
+
+PROBE="scripts/lib/shared-cargo-key-probe.cmake"
+[ -f "$PROBE" ] || { echo "[FAIL] missing $PROBE" >&2; exit 1; }
+
+command -v cmake >/dev/null 2>&1 || {
+    echo "[FAIL] cmake not on PATH — this gate computes the key with the" >&2
+    echo "       production cmake code and cannot answer without it." >&2
+    exit 1
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+
+# probe <mode> <field> [ENV=VAL ...]
+# Echoes the DIR= or KEY= line's value for one probe run.
+probe() {
+    local mode="$1" field="$2"
+    shift 2
+    local out
+    if ! out="$(env "$@" cmake -DNROS_PROBE_ROOT="$TMP/store" \
+        -DNROS_PROBE_MODE="$mode" -P "$PROBE" 2>&1)"; then
+        echo "[FAIL] probe ($mode, $*) did not run:" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    fi
+    local line
+    line="$(printf '%s\n' "$out" | sed -n "s/^${field}=//p")"
+    if [ -z "$line" ]; then
+        echo "[FAIL] probe ($mode, $*) printed no ${field}= line:" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    fi
+    printf '%s' "$line"
+}
+
+expect_ne() {
+    local what="$1" a="$2" b="$3"
+    if [ "$a" = "$b" ]; then
+        echo "[FAIL] $what — both resolved to $a" >&2
+        fail=1
+    fi
+}
+
+expect_eq() {
+    local what="$1" a="$2" b="$3"
+    if [ "$a" != "$b" ]; then
+        echo "[FAIL] $what" >&2
+        echo "         first:  $a" >&2
+        echo "         second: $b" >&2
+        fail=1
+    fi
+}
+
+# The negative control, run unconditionally on the normal path: with the knob
+# fields taken back out of the key — the pre-phase-439 shape, which is what
+# reverting the change produces — the two images of assertion 2 must COLLIDE.
+#
+# A gate whose discriminator is broken (a probe that never ran, an env that
+# never reached cmake, a mode flag that stopped being read) would report every
+# comparison as "different" and look green. This is the control that refuses
+# that: it demands the probe DEMONSTRATE the collision it exists to prevent.
+self_test() {
+    local base collide
+    base="$(probe base-only DIR)"
+    collide="$(probe base-only DIR ZPICO_MAX_QUERYABLES=2)"
+    if [ "$base" != "$collide" ]; then
+        echo "[FAIL] negative control: with the knob fields removed from the" >&2
+        echo "       key, two images differing in ZPICO_MAX_QUERYABLES were" >&2
+        echo "       expected to COLLIDE and did not. Something other than the" >&2
+        echo "       knob half is moving this hash, so a green verdict from the" >&2
+        echo "       assertions below would not be about phase-439 W1." >&2
+        echo "         no knob: $base" >&2
+        echo "         knob=2:  $collide" >&2
+        return 1
+    fi
+    return 0
+}
+
+self_test || fail=1
+
+base_key="$(probe base-only KEY)"
+plain_key="$(probe with-knobs KEY)"
+expect_eq "an image stating no knob must keep the key it already had (a warm cargo directory is not invalidated for nothing)" \
+    "$base_key" "$plain_key"
+
+plain="$(probe with-knobs DIR)"
+knob2="$(probe with-knobs DIR ZPICO_MAX_QUERYABLES=2)"
+expect_ne "two images differing ONLY in ZPICO_MAX_QUERYABLES share a cargo directory (RFC-0094 D4)" \
+    "$plain" "$knob2"
+
+knob2_again="$(probe with-knobs DIR ZPICO_MAX_QUERYABLES=2)"
+expect_eq "the same configuration computed twice must give the same directory" \
+    "$knob2" "$knob2_again"
+
+knob4="$(probe with-knobs DIR ZPICO_MAX_QUERYABLES=4)"
+expect_ne "two images differing only in the VALUE of ZPICO_MAX_QUERYABLES share a cargo directory" \
+    "$knob2" "$knob4"
+
+cbs="$(probe with-knobs DIR NROS_EXECUTOR_MAX_CBS=8)"
+expect_ne "two images differing only in NROS_EXECUTOR_MAX_CBS share a cargo directory" \
+    "$plain" "$cbs"
+
+# The inventory is READ from the resolver's own call sites, so a knob that gains
+# a `_nros_resolve_knob()` line joins the key with no second edit. Spot-check
+# both families rather than the whole list: the point is that the harvest works,
+# not to restate 43 names here.
+inventory="$(env cmake -DNROS_PROBE_MODE=inventory -P "$PROBE" 2>&1 | sed -n 's/^KNOB=//p')"
+for want in ZPICO_MAX_QUERYABLES NROS_EXECUTOR_MAX_CBS NROS_XRCE_MAX_SUBSCRIBERS; do
+    nros_grep_q -x "$want" <<<"$inventory" && continue
+    echo "[FAIL] $want is not in the harvested knob inventory — the key" >&2
+    echo "       cannot separate two images that differ only in it." >&2
+    fail=1
+done
+
+if [ "$fail" != 0 ]; then
+    echo "" >&2
+    echo "  Every cargo-directory key carries the resolve digest (RFC-0094 D4)." >&2
+    echo "  The knob half has ONE spelling — nros_knob_key_fields() in" >&2
+    echo "  cmake/NanoRosSharedCargoDir.cmake — and every caller of" >&2
+    echo "  nros_shared_cargo_dir() / nros_share_corrosion_cargo_dir() appends" >&2
+    echo "  it. Do not write a per-caller knob list (issue 1025)." >&2
+    exit 1
+fi
+
+# Counted in the shell rather than with `grep -c`: same 0/1/>=2 conflation, and
+# a tool failure there would print a plausible number rather than a missing one.
+read -r -a _knob_names <<<"$(printf '%s' "$inventory" | tr '\n' ' ')"
+echo "cargo-dir-knob-key OK — ${#_knob_names[@]} knob(s) in the key, negative control collided as required."

--- a/scripts/lib/shared-cargo-key-probe.cmake
+++ b/scripts/lib/shared-cargo-key-probe.cmake
@@ -1,0 +1,58 @@
+# The shared-cargo-directory key, computed by the PRODUCTION code — phase-439 W1.
+#
+# `check-cargo-dir-knob-key.sh` drives this in cmake SCRIPT mode (`cmake -P`) so
+# the thing under test is `cmake/NanoRosSharedCargoDir.cmake` itself: the same
+# `nros_knob_key_fields()` the `nros-c`, NuttX and Zephyr lanes call, and the
+# same normalise-and-hash. A probe that re-derived the key would pass against
+# its own copy of the rule, which is the defect and not the test.
+#
+#   -DNROS_PROBE_ROOT=<dir>     where the keyed directories are created
+#   -DNROS_PROBE_MODE=with-knobs   the key as it is built today
+#                     base-only    the key WITHOUT the knob fields — the
+#                                  pre-phase-439 shape, kept as the gate's
+#                                  negative control (revert the change and the
+#                                  collision must reappear)
+#                     inventory    print the harvested knob NAMES and stop
+#
+# Prints `DIR=` and `KEY=` on stdout, one per line.
+
+cmake_minimum_required(VERSION 3.20)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosSharedCargoDir.cmake")
+
+if(NOT DEFINED NROS_PROBE_MODE)
+    set(NROS_PROBE_MODE "with-knobs")
+endif()
+
+if(NROS_PROBE_MODE STREQUAL "inventory")
+    _nros_knob_inventory(_names)
+    foreach(_n IN LISTS _names)
+        message("KNOB=${_n}")
+    endforeach()
+    return()
+endif()
+
+if(NOT NROS_PROBE_ROOT)
+    message(FATAL_ERROR "shared-cargo-key-probe: -DNROS_PROBE_ROOT is required")
+endif()
+set(NROS_SHARED_CARGO_ROOT "${NROS_PROBE_ROOT}")
+
+# A fixed stand-in for the six fields the `nros-c` lane already keyed on. Their
+# VALUES are irrelevant to what this probe measures — every run holds them
+# constant, so the only thing that can move the hash is the knob half.
+set(_key
+    "features=alloc,platform-posix,rmw-cffi"
+    "rmw=zenoh"
+    "board=host"
+    "caps="
+    "profile=release"
+    "target=x86_64-unknown-linux-gnu")
+
+if(NOT NROS_PROBE_MODE STREQUAL "base-only")
+    nros_knob_key_fields(_knob_fields)
+    list(APPEND _key ${_knob_fields})
+endif()
+
+nros_shared_cargo_dir(_dir KEY ${_key})
+message("DIR=${_dir}")
+message("KEY=${_dir_KEY_TEXT}")

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -978,9 +978,13 @@ function(_nros_root_cargo_dir out_var features)
         endif()
         set(_key "triple=${NROS_RUST_TARGET}" "profile=${NROS_CARGO_PROFILE}"
                  "features=${features}")
-        foreach(_knob IN LISTS NROS_RESOLVED_KNOBS)
-            list(APPEND _key "${_knob}=${NROS_RESOLVED_${_knob}}")
-        endforeach()
+        # phase-439 W1 — the knob loop that stood here moved into
+        # `nros_knob_key_fields()` so the `nros-c` and NuttX lanes get the SAME
+        # rule rather than a second copy of it (RFC-0094 D4). Road 1 of that
+        # function is this registry, in this order, so the text it returns here
+        # is what the loop produced and no Zephyr image changes directory.
+        nros_knob_key_fields(_knob_fields)
+        list(APPEND _key ${_knob_fields})
         nros_shared_cargo_dir(_dir KEY ${_key})
     endif()
     if(NOT _dir)


### PR DESCRIPTION
Implements **phase-439 W1 / RFC-0094 D4** — the resolve digest in every cargo-directory key.

**Stacked on #747** (base is `docs/rfc-0094-resolve-before-configure`, per AGENTS.md "Stacking"), because it inherits that branch's two fixes for the reds on `main` and because it edits the phase doc #747 introduces. When #747 lands, GitHub retargets this to `main`.

## Why this is a precondition, not a follow-up

`nros_shared_cargo_dir()` hashes the fields its caller supplies, and cargo uplifts the final archive to an **unhashed** name (`libnros_c.a`). Two configurations that hash the same overwrite each other's artifact and one silently links the other's numbers — issue 0616's shape. The `nros-c` and NuttX keys carried `features, rmw, board, caps, profile, target` and **no knob values**; the Zephyr key already carried every `NROS_RESOLVED_*`, because issue 0528 measured the same omission there.

RFC-0094's resolve phase (W2) makes per-image knob divergence the normal case, so D1 without D4 is worse than the status quo.

## What changed

One spelling, `nros_knob_key_fields()` in `cmake/NanoRosSharedCargoDir.cmake`, appended by all three callers — never a per-caller list (issue 1025's lesson one seam over). It reads two roads:

1. the **resolver registry** (`NROS_RESOLVED_KNOBS` + `NROS_RESOLVED_<name>`) — Zephyr today, every lane once W2 writes `resolved.toml`. Same names, same order, so the Zephyr loop it replaces produces identical text.
2. the **environment**, for names road 1 did not answer for. Not a guess: `_nros_resolve_knob()`'s rung 1 is `$ENV{<name>}`, and `examples/fixtures.toml` states knobs exactly that way (`env = { ZPICO_MAX_QUERYABLES = "2" }`). It is the only knob road knowable at key time on a lane with no resolver.

The knob **name** inventory is READ from its one authored site rather than copied — the 43 `_nros_resolve_knob(<NAME> …)` call sites `check-kconfig-knob-forwarding` already treats as authoritative. An empty harvest is FATAL, not a degrade: a silently empty inventory keys every directory on zero knobs, which is the collision.

## Acceptance — measured, on the real `nros-c` call site

Two root configures (`posix`/`zenoh`, `-DNROS_SHARED_CARGO_ROOT=…`) differing only in `ZPICO_MAX_QUERYABLES`:

| | no knob stated | `ZPICO_MAX_QUERYABLES=2` |
| --- | --- | --- |
| with this change | `…/d20f4167871d` | `…/ba45165655e7` |
| key change reverted | `…/d20f4167871d` | `…/d20f4167871d` — **collides** |
| restored | `…/d20f4167871d` | `…/ba45165655e7` |

The left column is identical in all three rows — an image whose knobs did not move keeps the directory it already has, so no warm cargo directory in the tree is invalidated for nothing.

## Producers surveyed, not assumed

* three cmake callers, all changed — `packages/api/nros-c/CMakeLists.txt`, `packages/api/nros-c/cmake/nros-nuttx.cmake`, `zephyr/cmake/nros_cargo_build.cmake`;
* the bash fixture group key needed no change, and that was **measured** rather than read: `nros_fixture_group_slug` is already a function of sorted env — `qemu-esp32-baremetal` vs `qemu-esp32-baremetal-4118800323` at `ZPICO_MAX_QUERYABLES=2` and `-4054584529` at 4, stable across repeats;
* every other cargo target dir in the tree is per-build-dir (`${CMAKE_BINARY_DIR}/nros-rust`, `nros-rust-ws-<name>`, `<ffi-crate>/target`, `${CMAKE_CURRENT_BINARY_DIR}/cargo-target`), serves one configuration, and has no key to carry.

## Gate

`check-cargo-dir-knob-key` drives the **production** cmake through `cmake -P` rather than re-deriving the key, and its negative control runs on the **normal path**: with the knob fields taken back out — the pre-W1 shape, i.e. what reverting produces — the two images must collide. A gate whose discriminator broke would report every comparison as "different" and look green; this refuses that.

## Tier run

`just ci gate` (`check::cli-fresh` + `check::fast` (266 gates) + `check::build` + `test-unit`), on a worktree provisioned for it (zenoh-pico, mbedtls, micro-xrce-dds-client, micro-cdr, cyclonedds, play_launch; `just setup-cli`; `just setup-launch-resolve`) and with `NROS_BUILD_ROOT` pointed at the worktree's own `build/`, because `nros_build_root` resolves to the *main* checkout from a linked worktree and the shared `uorb-check` cmake cache then names the wrong source dir.

Green except one failure, **pre-existing on `main` and measured as such**: `check cli-clippy` fails `-D dead-code` on `nros-cli-core/src/codegen/entry/render.rs:132` `template_keys`, introduced by `dab953ec0` (phase-432 W3), and it reproduces identically with this branch's changes stashed. It lives only in `check::build`, which no merge-gating event runs, which is how it survives. `just test-unit` is green on its own (1213 passed, 1 `[SKIPPED]` precondition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5
