### PR TITLE
feat(phase-439 W4): cmake ASKS the descriptors instead of being generated at, and `uorb` becomes selectable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,22 @@ project(NanoRos VERSION 0.1.0 LANGUAGES C CXX)
 option(NANO_ROS_BUILD_CODEGEN "Build the nros-codegen tool" ON)
 # phase-347 W3 — the FOURTH closed list of backends, and the one that had rotted
 # furthest: it offered `dds`, retired in Phase 169, and omitted `uorb`, which the
-# tree ships. Both the default and the cmake-gui choices now come from the
-# descriptors (`packages/rmw/*/*/nros-rmw.toml`) via `NROS_RMW_KNOWN`.
+# tree ships. Both the default and the cmake-gui choices come from the
+# descriptors (`nros-rmw.toml`) rather than from a list kept here.
+#
+# phase-439 W4 — and they come from the provider SCAN now, not from a generated
+# `NROS_RMW_KNOWN` literal that was written into `NanoRosRmwDispatch.cmake` when
+# the `nros` binary was compiled. That literal could only ever name backends in
+# THIS checkout; the scan reaches the user's workspace too (RFC-0094 D5).
+# `SOFT` because these two lines are cosmetic — the help string and the
+# cmake-gui drop-down — and a configure that cannot list the choices is still a
+# configure. Selecting one is not cosmetic, and `nros_rmw_dispatch` below has no
+# such arm.
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/NanoRosRmwDispatch.cmake")
+nros_rmw_known(_nros_rmw_choices SOFT)
 set(NANO_ROS_RMW "zenoh" CACHE STRING
-    "RMW backend — one of: ${NROS_RMW_KNOWN}")
-set_property(CACHE NANO_ROS_RMW PROPERTY STRINGS ${NROS_RMW_KNOWN})
+    "RMW backend — one of: ${_nros_rmw_choices}")
+set_property(CACHE NANO_ROS_RMW PROPERTY STRINGS ${_nros_rmw_choices})
 set(NANO_ROS_PLATFORM "posix" CACHE STRING
     "Target platform (canonical: posix/freertos/nuttx/threadx; legacy: freertos_armcm3, nuttx_armv7a, threadx_linux, threadx_riscv64)")
 set_property(CACHE NANO_ROS_PLATFORM PROPERTY STRINGS
@@ -259,146 +269,175 @@ if(NOT TARGET NanoRos)
 endif()
 
 # ---------------------------------------------------------------------------
-# Phase 137.3 — RMW dispatch (inline form). Each branch pulls in the
-# corresponding staticlib (or notes a gap) and links the RMW target into
-# `NanoRos::NanoRos`. We keep the dispatch inline for Phase 137; per-RMW
-# `cmake/rmw/nano-ros-rmw-<rmw>.cmake` modules land in Phase 138 once
-# the per-platform layout (138 / 139) is in place.
+# RMW link dispatch — phase-439 W4 (RFC-0094 D5).
+#
+# WHAT THIS REPLACES
+#
+# An `if/elseif/else` chain over backend NAMES, closing on
+#
+#     else()
+#         message(FATAL_ERROR "Unknown NANO_ROS_RMW: '${NANO_ROS_RMW}' "
+#             "(expected: zenoh, xrce, or cyclonedds)")
+#
+# — the SECOND closed list of backends in the tree and the one that decides
+# (issue 1215). Its contradiction sat 370 lines up in this same file: `:29`
+# advertises `${NROS_RMW_KNOWN}` in the cmake-gui drop-down, which has named
+# `uorb` since phase-347 W3, and this arm hard-failed on it. So `uorb` — an
+# in-tree, zero-Rust C++ backend that announces itself, ships a descriptor and
+# builds standalone in `just check rmw-uorb` — was advertised and unselectable,
+# and the `NROS_RMW_CMAKE_TARGET` guard in `nros-cpp/CMakeLists.txt` written to
+# link it had never once fired, because no arm ever created the target.
+#
+# WHAT DECIDES NOW
+#
+# The backend's own `[rmw.link]` declaration, read through `nros_rmw_dispatch`.
+# The three arms were never three backends — they were three LINK STRATEGIES,
+# and a backend knows which one it wants:
+#
+#   umbrella  the backend is a Rust rlib BUNDLED into `libnros_c.a` /
+#             `libnros_cpp.a` and anchored there. Nothing separate reaches the
+#             link line, so there is nothing to do here. (zenoh, xrce)
+#   cmake     the backend is a CMake project. add_subdirectory its declared
+#             dir and whole-archive its declared target into both umbrellas.
+#             (cyclonedds, uorb, and any provider a user ships)
+#
+# Adding a backend is a `package.xml` announcement plus an `nros-rmw.toml`. It
+# is NOT an edit here, which is RFC-0094's acceptance A2 and RFC-0071 D5's
+# original one: "a fifth backend added out-of-tree with zero core edits."
 # ---------------------------------------------------------------------------
-if(NANO_ROS_RMW STREQUAL "zenoh" OR NANO_ROS_RMW STREQUAL "xrce")
-    # Phase 241.D3-rev — the zenoh / xrce Rust backend is now BUNDLED into the
-    # umbrella staticlib (`libnros_c.a` / `libnros_cpp.a`, built with the
-    # `cffi-zenoh-cffi` / `cffi-xrce-c` feature in their CMakeLists) and force-linked
-    # + auto-registered by the umbrella's `rmw_backend` `.init_array` ctor. The
-    # standalone `nros-rmw-{zenoh,xrce}-cffi-staticlib` archives + the `-u` register
-    # forcing are retired — there is no separate backend archive to link.
-elseif(NANO_ROS_RMW STREQUAL "cyclonedds")
-    # Phase 144.fix — Cyclone DDS is a standalone C++ CMake project
-    # (NOT a Rust crate via corrosion). It builds a libnros_rmw_cyclonedds.a
-    # that registers the C++ vtable via nros_rmw_cffi_register at .init_array
-    # time. add_subdirectory invokes the project's own CMakeLists.txt.
-    #
-    # Phase 186 — the backend's nros_provide_cyclonedds() resolves Cyclone:
-    # a prebuilt install on CMAKE_PREFIX_PATH wins; otherwise it self-provisions
-    # from CYCLONEDDS_SOURCE_DIR. As the project root we own third-party/, so
-    # default that to the pinned submodule — a bare cmake build then needs no
-    # `just cyclonedds` pre-step. A user overrides with -DCMAKE_PREFIX_PATH
-    # (their install) or -DCYCLONEDDS_SOURCE_DIR (their checkout).
-    if(NOT DEFINED CYCLONEDDS_SOURCE_DIR
-       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third-party/dds/cyclonedds/CMakeLists.txt")
-        set(CYCLONEDDS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third-party/dds/cyclonedds"
-            CACHE PATH "CycloneDDS source tree for self-provisioning (Phase 186)")
+nros_rmw_dispatch("${NANO_ROS_RMW}")
+
+# ---------------------------------------------------------------------------
+# _nros_link_cmake_rmw(<target>) — wire a CMake-provided backend into <target>.
+#
+# ONE implementation for the two consumers. This block used to exist twice,
+# ~45 lines apart, differing only in the target name — and its own comments
+# said so ("Issue 0837 — same flag, same missing edge; see the C umbrella
+# above. One property, both consumers."). A second spelling of a link rule is
+# how issue 0837 came to be a separate issue from 0475 in the first place.
+#
+# WHOLE-ARCHIVE, and why it is not `target_link_libraries`. The backend's
+# registration object is referenced by nothing — it self-registers from a
+# constructor — so a plain archive link drops it and the image boots with no
+# backend and no diagnostic. And `target_link_libraries` with the archive
+# BESIDE the flag is worse than useless: it reorders ld's single pass and
+# breaks the whole-archive group outright (`undefined reference to ddsrt_*`,
+# issue 0475). The archives ride ONE flag string; the rebuild edges come from
+# `NANO_ROS_LINK_DEPEND_FILES` and `NanoRosLink.cmake`'s `LINK_DEPENDS`, which
+# is the file edge a raw `-Wl,` flag cannot carry.
+#
+# `NROS_RMW_COMPANION_LIBRARIES` is what a backend APPENDS to that flag —
+# cyclonedds names its `libddsc` there. Generic on purpose: the root has no
+# business knowing that one backend has a companion library, and issue 0837
+# was exactly the cost of a second archive in a flag with no channel to declare
+# it through.
+# ---------------------------------------------------------------------------
+function(_nros_link_cmake_rmw _target)
+    if(NOT TARGET ${_target})
+        return()
     endif()
-    add_subdirectory(packages/rmw/cyclonedds/nros-rmw-cyclonedds)
-    if(TARGET nros_rmw_cyclonedds)
-        # The Linux/BSD link path below whole-archives the backend via a raw
-        # linker flag so the registration object cannot be dropped. Raw
-        # `$<TARGET_FILE:...>` link flags do not add a build-order edge for
-        # consumers of this INTERFACE library, so keep the dependency explicit.
-        add_dependencies(NanoRos nros_rmw_cyclonedds)
-        if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES "BSD"
-           OR CMAKE_SYSTEM_NAME STREQUAL "Generic")
-            # RFC-0042 D3 — `--allow-multiple-definition` dropped (cffi single-def
-            # via the provider). Whole-archive kept: Cyclone is C/C++ (libddsc + the
-            # C++ wrapper), so it carries no Rust core/std COMDAT closure to collide
-            # — the `-u` swap the Rust-staticlib backends need does not apply here.
-            if(NROS_RMW_CYCLONEDDS_DDSC_LIBRARY)
-                target_link_libraries(NanoRos INTERFACE
-                    "-Wl,--whole-archive,$<TARGET_FILE:nros_rmw_cyclonedds>,${NROS_RMW_CYCLONEDDS_DDSC_LIBRARY},--no-whole-archive")
-                # Issue 0837 — every FILE named inside that flag needs a rebuild
-                # edge, not just the backend archive.
-                #
-                # Issue 0475 gave `nros_rmw_cyclonedds` one (in
-                # `nano_ros_link_rmw`). `libddsc.a` rides the SAME flag string
-                # and never got one, so a cyclonedds submodule bump rebuilt
-                # `libddsc.a` and left every executable linking the old one:
-                # measured `lib/libddsc.a` at 18:06 against `c_talker` at 15:45,
-                # with `cmake --build` exiting 0 having done nothing. Fixing the
-                # reported site instead of the class is what left it.
-                #
-                # Recorded as a LIST on `NanoRos` so the link seam consumes
-                # whatever the flag names: a third archive added to either flag
-                # is covered by existing, rather than needing a third
-                # `LINK_DEPENDS` line somewhere else.
-                set_property(TARGET NanoRos APPEND PROPERTY
-                    NANO_ROS_LINK_DEPEND_FILES "${NROS_RMW_CYCLONEDDS_DDSC_LIBRARY}")
-                # phase-368 W4 — the flag above names the SDK's libddsc.so by
-                # ABSOLUTE PATH, but ld records only its SONAME (libddsc.so.0),
-                # so without an RPATH the runtime loader searches the default
-                # paths and finds nothing on a ROS-less host. It worked on dev
-                # machines by ACCIDENT: a sourced ROS env put ROS's own libddsc
-                # on LD_LIBRARY_PATH — a different build of the library than
-                # the one linked. The clean-container probe caught it as
-                # "error while loading shared libraries: libddsc.so.0" on the
-                # first scaffolded cyclone workspace run. Stamp the linked
-                # library's own directory as RPATH on every consumer.
-                get_filename_component(_nros_ddsc_dir
-                    "${NROS_RMW_CYCLONEDDS_DDSC_LIBRARY}" DIRECTORY)
-                target_link_options(NanoRos INTERFACE
-                    "-Wl,-rpath,${_nros_ddsc_dir}")
-            else()
-                target_link_libraries(NanoRos INTERFACE
-                    "-Wl,--whole-archive,$<TARGET_FILE:nros_rmw_cyclonedds>,--no-whole-archive")
+    # Raw `$<TARGET_FILE:...>` link flags carry no build-ORDER edge for
+    # consumers of an INTERFACE library, so keep the dependency explicit.
+    add_dependencies(${_target} ${NROS_RMW_CMAKE_TARGET})
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES "BSD"
+       OR CMAKE_SYSTEM_NAME STREQUAL "Generic")
+        set(_flag "-Wl,--whole-archive,$<TARGET_FILE:${NROS_RMW_CMAKE_TARGET}>")
+        foreach(_companion IN LISTS NROS_RMW_COMPANION_LIBRARIES)
+            string(APPEND _flag ",${_companion}")
+            # Issue 0837 — every FILE named inside that flag needs a rebuild
+            # edge, not just the backend archive. `libddsc.a` rode the same
+            # string with no edge, so a cyclonedds submodule bump rebuilt it and
+            # relinked nothing: `lib/libddsc.a` at 18:06 against `c_talker` at
+            # 15:45, with `cmake --build` exiting 0 having done nothing.
+            # Recorded as a LIST on `NanoRos` so the link seam consumes whatever
+            # the flag names — a third archive is covered by existing.
+            set_property(TARGET NanoRos APPEND PROPERTY
+                NANO_ROS_LINK_DEPEND_FILES "${_companion}")
+            # phase-368 W4 — a companion named by ABSOLUTE PATH still records
+            # only its SONAME in the link, so without an RPATH the runtime
+            # loader searches the default paths and finds nothing on a host that
+            # has no ROS. It worked on dev machines by ACCIDENT: a sourced ROS
+            # env put ROS's own libddsc on LD_LIBRARY_PATH — a DIFFERENT build
+            # of the library than the one linked. Stamp the linked library's own
+            # directory on every consumer.
+            get_filename_component(_companion_dir "${_companion}" DIRECTORY)
+            if(_companion_dir)
+                target_link_options(${_target} INTERFACE
+                    "-Wl,-rpath,${_companion_dir}")
             endif()
-        else()
-            target_link_libraries(NanoRos INTERFACE nros_rmw_cyclonedds)
+        endforeach()
+        string(APPEND _flag ",--no-whole-archive")
+        target_link_libraries(${_target} INTERFACE "${_flag}")
+    else()
+        target_link_libraries(${_target} INTERFACE ${NROS_RMW_CMAKE_TARGET})
+    endif()
+
+    # A C++ backend in a C binary: the C driver does not pull in the C++
+    # runtime, so `operator new`/`delete`/`std::nothrow` go unresolved.
+    # Propagate through the INTERFACE; harmless for C++ apps. WHICH backends
+    # need it is DECLARED (`[rmw.link] needs_cxx_linker`), not a name test.
+    # issue 0835 — the property, not the label: see
+    # `nros_platform_hosted_cxx_runtime` for why this used to read
+    # `NANO_ROS_PLATFORM STREQUAL "threadx"` and why that was load-bearing on
+    # six example leaves misreporting their platform.
+    if(NROS_RMW_NEEDS_CXX_LINKER)
+        nros_platform_hosted_cxx_runtime(_hosted_cxx "${NANO_ROS_PLATFORM}")
+        if(_hosted_cxx)
+            target_link_libraries(${_target} INTERFACE stdc++)
         endif()
-        # Cyclone DDS's RMW wrapper is C++ (operator new/delete,
-        # std::nothrow). A C application linking `NanoRos::NanoRos`
-        # drives the link with the C compiler, which does NOT pull in
-        # the C++ runtime — so C examples (e.g. examples/native/c/
-        # cyclonedds/) fail with undefined `operator new`/`delete` /
-        # `std::nothrow`. Propagate the C++ stdlib through the INTERFACE
-        # so any C consumer resolves them. Harmless for C++ apps (the
-        # C++ driver already links it).
-        # issue 0835 — the property, not the label. See
-        # `nros_platform_hosted_cxx_runtime` for why this used to read
-        # `NANO_ROS_PLATFORM STREQUAL "threadx"` and why that spelling was
-        # load-bearing on six example leaves misreporting their platform.
-        nros_platform_hosted_cxx_runtime(_nros_hosted_cxx "${NANO_ROS_PLATFORM}")
-        if(_nros_hosted_cxx)
-            target_link_libraries(NanoRos INTERFACE stdc++)
-        endif()
-        # Phase 241.D3-rev — the C++ umbrella (NanoRosCpp = nros-cpp-headers) no longer
-        # links NanoRos (the C umbrella), so it must pull the Cyclone C++ backend lib +
-        # libddsc itself. Cyclone is C/C++ (no Rust std closure), so whole-archive is
-        # safe here. libstdc++ is wired for ALL languages incl. C (per design: Cyclone
-        # needs the C++ runtime even in a C binary).
-        if(TARGET nros-cpp-headers)
-            add_dependencies(nros-cpp-headers nros_rmw_cyclonedds)
-            if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES "BSD"
-               OR CMAKE_SYSTEM_NAME STREQUAL "Generic")
-                if(NROS_RMW_CYCLONEDDS_DDSC_LIBRARY)
-                    target_link_libraries(nros-cpp-headers INTERFACE
-                        "-Wl,--whole-archive,$<TARGET_FILE:nros_rmw_cyclonedds>,${NROS_RMW_CYCLONEDDS_DDSC_LIBRARY},--no-whole-archive")
-                    # Issue 0837 — same flag, same missing edge; see the C
-                    # umbrella above. One property, both consumers.
-                    set_property(TARGET NanoRos APPEND PROPERTY
-                        NANO_ROS_LINK_DEPEND_FILES "${NROS_RMW_CYCLONEDDS_DDSC_LIBRARY}")
-                    # Same RPATH stamp as the C umbrella above (one defect,
-                    # two consumers) — see the comment there.
-                    get_filename_component(_nros_ddsc_dir
-                        "${NROS_RMW_CYCLONEDDS_DDSC_LIBRARY}" DIRECTORY)
-                    target_link_options(nros-cpp-headers INTERFACE
-                        "-Wl,-rpath,${_nros_ddsc_dir}")
-                else()
-                    target_link_libraries(nros-cpp-headers INTERFACE
-                        "-Wl,--whole-archive,$<TARGET_FILE:nros_rmw_cyclonedds>,--no-whole-archive")
-                endif()
-            else()
-                target_link_libraries(nros-cpp-headers INTERFACE nros_rmw_cyclonedds)
-            endif()
-            # issue 0835 — same property, same helper; one defect, two consumers.
-            nros_platform_hosted_cxx_runtime(_nros_hosted_cxx "${NANO_ROS_PLATFORM}")
-            if(_nros_hosted_cxx)
-                target_link_libraries(nros-cpp-headers INTERFACE stdc++)
-            endif()
-        endif()
+    endif()
+endfunction()
+
+if(NROS_RMW_LINK_STRATEGY STREQUAL "umbrella")
+    # Phase 241.D3-rev — the backend is BUNDLED into the umbrella staticlib
+    # (`libnros_c.a` / `libnros_cpp.a`, built with the cffi feature the
+    # descriptor names) and force-linked + auto-registered from there. The
+    # standalone `nros-rmw-{zenoh,xrce}-cffi-staticlib` archives and the `-u`
+    # register forcing are retired — there is no separate backend archive to
+    # link, which is what `[rmw.link] rlib_dep` says.
+elseif(NROS_RMW_LINK_STRATEGY STREQUAL "cmake")
+    # A backend that needs something resolved BEFORE its own configure ships a
+    # fragment beside its descriptor. The root includes it blind: what a
+    # backend needs provisioned is the backend's business, and the alternative
+    # is the `if(NANO_ROS_RMW STREQUAL "cyclonedds")` pre-step this wave
+    # deleted. cyclonedds uses it to default `CYCLONEDDS_SOURCE_DIR` to the
+    # pinned submodule so a bare cmake build needs no `just cyclonedds`.
+    if(EXISTS "${NROS_RMW_CMAKE_DIR}/nros-rmw-provision.cmake")
+        include("${NROS_RMW_CMAKE_DIR}/nros-rmw-provision.cmake")
+    endif()
+    if(NOT NROS_RMW_CMAKE_TARGET)
+        message(FATAL_ERROR
+            "nano-ros: rmw '${NROS_RMW_NAME}' declares the `cmake` link "
+            "strategy but names no target. Add "
+            "`[rmw.provides.cmake] target = \"<cmake target>\"` to "
+            "${NROS_RMW_PACKAGE_DIR}/nros-rmw.toml.")
+    endif()
+    # A binary directory named after the backend, not after its source path:
+    # an out-of-tree provider is outside `CMAKE_SOURCE_DIR`, and
+    # `add_subdirectory()` REQUIRES an explicit binary dir for one.
+    add_subdirectory("${NROS_RMW_CMAKE_DIR}"
+        "${CMAKE_BINARY_DIR}/nros-rmw-${NROS_RMW_NAME}")
+    if(TARGET ${NROS_RMW_CMAKE_TARGET})
+        _nros_link_cmake_rmw(NanoRos)
+        # Phase 241.D3-rev — the C++ umbrella no longer links the C one, so it
+        # must pull the backend itself. One defect, two consumers, one helper.
+        _nros_link_cmake_rmw(nros-cpp-headers)
+    else()
+        message(FATAL_ERROR
+            "nano-ros: rmw '${NROS_RMW_NAME}' declares cmake target "
+            "'${NROS_RMW_CMAKE_TARGET}', which its own CMakeLists.txt "
+            "(${NROS_RMW_CMAKE_DIR}) did not create. The descriptor and the "
+            "project disagree; nothing downstream can link this backend.")
     endif()
 else()
+    # Not a closed list of NAMES — a closed list of STRATEGIES, which is a
+    # property of this file (it implements them) rather than of the tree.
     message(FATAL_ERROR
-        "Unknown NANO_ROS_RMW: '${NANO_ROS_RMW}' "
-        "(expected: zenoh, xrce, or cyclonedds)")
+        "nano-ros: rmw '${NROS_RMW_NAME}' declares link strategy "
+        "'${NROS_RMW_LINK_STRATEGY}', which this build does not implement "
+        "(known: umbrella, cmake). See `[rmw.link] strategy` in "
+        "${NROS_RMW_PACKAGE_DIR}/nros-rmw.toml.")
 endif()
 
 # ---------------------------------------------------------------------------

--- a/cmake/NanoRosFeatureSet.cmake
+++ b/cmake/NanoRosFeatureSet.cmake
@@ -119,38 +119,51 @@ function(nros_feature_set out_var)
     # `nros_rmw_dispatch` accepted only the first three and FATAL_ERROR'd on
     # uorb: two lists disagreeing about the same tree. Both now read
     # `NROS_RMW_KNOWN`, which is derived from `packages/rmw/*/*/nros-rmw.toml`.
-    nros_rmw_is_known("${_FS_RMW}" _fs_rmw_known)
-    if(NOT _fs_rmw_known AND NOT _FS_RMW STREQUAL "none")
-        message(FATAL_ERROR
-            "nros_feature_set: unknown RMW '${_FS_RMW}' "
-            "(provided by a descriptor: ${NROS_RMW_KNOWN}; or 'none')")
-    endif()
-    # The two crates spell the same selection differently — nros-cpp has
-    # `rmw-{zenoh,xrce}-cffi`, nros-c has `cffi-zenoh-cffi` / `cffi-xrce-c`.
-    # That is a real vocabulary difference, not an alias, so CRATE selects the
-    # spelling rather than the caller post-processing the list. (Renaming the
-    # features to match would be a nicer end state, but it is a separate change
-    # with its own blast radius.)
-    if(_FS_CRATE STREQUAL "c")
-        if(_FS_RMW STREQUAL "zenoh")
-            list(APPEND _feats cffi-zenoh-cffi)
-        elseif(_FS_RMW STREQUAL "xrce")
-            list(APPEND _feats cffi-xrce-c)
-        else()
-            list(APPEND _feats rmw-cffi)
-        endif()
-    elseif(_FS_CRATE STREQUAL "cpp")
-        if(_FS_RMW STREQUAL "zenoh")
-            list(APPEND _feats rmw-zenoh-cffi)
-        elseif(_FS_RMW STREQUAL "xrce")
-            list(APPEND _feats rmw-xrce-cffi)
-        else()
-            list(APPEND _feats rmw-cffi)
-        endif()
-    else()
+    if(NOT _FS_CRATE STREQUAL "c" AND NOT _FS_CRATE STREQUAL "cpp")
         message(FATAL_ERROR
             "nros_feature_set: CRATE must be 'c' or 'cpp' (got '${_FS_CRATE}') — "
             "the two crates spell the rmw feature differently.")
+    endif()
+    # `none` is not a backend and has no descriptor; it is the absence of one.
+    if(_FS_RMW STREQUAL "none" OR _FS_RMW STREQUAL "")
+        list(APPEND _feats rmw-cffi)
+    else()
+        nros_rmw_is_known("${_FS_RMW}" _fs_rmw_known)
+        if(NOT _fs_rmw_known)
+            nros_rmw_known(_fs_known_names)
+            message(FATAL_ERROR
+                "nros_feature_set: unknown RMW '${_FS_RMW}' "
+                "(announced by a provider: ${_fs_known_names}; or 'none')")
+        endif()
+        nros_rmw_dispatch("${_FS_RMW}")
+        # phase-439 W4 — the two crates spell the same selection differently
+        # (nros-cpp has `rmw-zenoh-cffi`, nros-c has `cffi-zenoh-cffi` and, for
+        # xrce, `cffi-xrce-c`), and that is a real vocabulary difference rather
+        # than an alias. It used to be an `if(_FS_RMW STREQUAL "zenoh")` chain
+        # here — the closed list issue 1219 counted as one of five, and the one
+        # that would silently hand a fifth backend the wrong feature. The
+        # spellings are DECLARED now: `[rmw.link] c_cffi_feature` (authored,
+        # because `cffi-xrce-c` follows no convention) and the derived
+        # `<cargo_feature>-cffi` for nros-cpp.
+        #
+        # An EMPTY feature is the correct answer, not a missing one: a backend
+        # that is not a Rust rlib (cyclonedds, uorb) is bundled into neither
+        # umbrella, so both fall back to the RMW-agnostic `rmw-cffi` — which is
+        # exactly what the old `else()` arm did for them.
+        if(_FS_CRATE STREQUAL "c")
+            set(_fs_rmw_feature "${NROS_RMW_C_CFFI_FEATURE}")
+        else()
+            set(_fs_rmw_feature "${NROS_RMW_UMBRELLA_CFFI_FEATURE}")
+        endif()
+        # `rlib_dep` is what says "this backend is bundled into the umbrella".
+        # Without it the cffi feature names a feature the umbrella crate does
+        # not have, and cargo fails on an unknown feature rather than falling
+        # back — so the DECLARATION gates the use of the name.
+        if(NROS_RMW_RLIB_DEP AND _fs_rmw_feature)
+            list(APPEND _feats "${_fs_rmw_feature}")
+        else()
+            list(APPEND _feats rmw-cffi)
+        endif()
     endif()
 
     # ---- platform ----------------------------------------------------------
@@ -235,13 +248,27 @@ function(nros_feature_set out_var)
         elseif(_cap STREQUAL "lifecycle")
             list(APPEND _feats lifecycle-services)
         elseif(_cap STREQUAL "safety")
-            # zenoh-only: the CRC path lives in that backend.
-            if(_FS_RMW STREQUAL "zenoh")
+            # phase-439 W4 — DECLARED, not named. This read
+            # `if(_FS_RMW STREQUAL "zenoh")` and warned "only the zenoh RMW
+            # carries the CRC path", while `nros-cpp/CMakeLists.txt` had already
+            # moved to `"safety" IN_LIST NROS_RMW_CAPABILITIES` (phase-347 W4).
+            # Two sites, one rule, one of them fixed: a third-party backend
+            # declaring `safety = "<its feature>"` was honoured on one path and
+            # refused with a WRONG explanation on the other — issue 1219's
+            # 0196-shaped half.
+            #
+            # `safety-e2e` stays spelled here because it is the UMBRELLA's
+            # feature (nros-c / nros-cpp), which forwards to whatever the
+            # backend calls its own implementation — the right-hand side of
+            # `[rmw.capabilities]`, which core never learns. What moved is the
+            # CONDITION: which backends offer the capability.
+            if("safety" IN_LIST NROS_RMW_CAPABILITIES)
                 list(APPEND _feats safety-e2e)
             else()
                 message(WARNING
-                    "nros_feature_set: capability 'safety' ignored — only the zenoh "
-                    "RMW carries the CRC path (got RMW=${_FS_RMW}).")
+                    "nros_feature_set: capability 'safety' ignored — RMW "
+                    "'${_FS_RMW}' does not declare it in its nros-rmw.toml "
+                    "[rmw.capabilities].")
             endif()
         else()
             message(FATAL_ERROR

--- a/cmake/NanoRosGenerateInterfaces.cmake
+++ b/cmake/NanoRosGenerateInterfaces.cmake
@@ -68,6 +68,11 @@ include("${CMAKE_CURRENT_LIST_DIR}/NanoRosBoardFacts.cmake")
 # `nros_read_package_xml_body()` — regex reads of a package.xml must not see
 # commented-out elements (phase-348 W1).
 include("${CMAKE_CURRENT_LIST_DIR}/NanoRosPackageXml.cmake")
+# phase-439 W4 — this file CALLS `nros_rmw_dispatch()` (the per-message codegen
+# hook) and never included the module that defines it, relying entirely on a
+# transitive include from whoever pulled it in. `include_guard(GLOBAL)` makes
+# this free where that already happened, and correct where it did not.
+include("${CMAKE_CURRENT_LIST_DIR}/NanoRosRmwDispatch.cmake")
 
 # =========================================================================
 # Locate the nros-codegen tool

--- a/cmake/NanoRosLink.cmake
+++ b/cmake/NanoRosLink.cmake
@@ -98,9 +98,21 @@ function(nano_ros_link_rmw TARGET)
     #
     # Verify: the archive must appear under `|` (implicit), not `||`, in
     #   ninja -C <build-dir> -t query <exe>
-    if(TARGET nros_rmw_${_chosen})
+    #
+    # phase-439 W4 — the target is DECLARED, not guessed. This read
+    # `if(TARGET nros_rmw_${_chosen})`, an accidental generalisation of 0475's
+    # fix that nothing documented and nothing gated: a provider whose cmake
+    # target happened to be spelled `nros_rmw_<name>` got the file edge for
+    # free, and one that named it anything else silently got the 0475 defect
+    # back — build order without a file edge, i.e. museum binaries (issue 1216).
+    # `NROS_RMW_CMAKE_TARGET` is `[rmw.provides.cmake] target` from the
+    # backend's own descriptor, so the edge follows the declaration rather than
+    # a naming coincidence. A backend with NO cmake target (the `umbrella`
+    # strategy) correctly gets none: it has no separate archive to depend on.
+    nros_rmw_dispatch("${_chosen}")
+    if(NROS_RMW_CMAKE_TARGET AND TARGET ${NROS_RMW_CMAKE_TARGET})
         set_property(TARGET ${TARGET} APPEND PROPERTY
-            LINK_DEPENDS "$<TARGET_FILE:nros_rmw_${_chosen}>")
+            LINK_DEPENDS "$<TARGET_FILE:${NROS_RMW_CMAKE_TARGET}>")
     endif()
 
     # Issue 0837 — the SAME edge for every other file named in that flag.
@@ -161,11 +173,19 @@ function(nano_ros_link_rmw TARGET)
     # directory scope and is not visible from the leaf that builds the image, so
     # a `if(TARGET …)` here is silently false — the first cut of this block was,
     # and left the RUNPATH in place.
-    if(_chosen STREQUAL "cyclonedds" AND UNIX AND NOT APPLE
-       AND DEFINED NROS_RMW_CYCLONEDDS_DDSC_LIBRARY
-       AND NROS_RMW_CYCLONEDDS_DDSC_LIBRARY MATCHES "\\.so(\\.[0-9]+)*$")
-        set_property(TARGET ${TARGET} APPEND PROPERTY
-            LINK_OPTIONS "-Wl,--disable-new-dtags")
+    #
+    # phase-439 W4 — keyed on the backend's DECLARED companion archives rather
+    # than on `_chosen STREQUAL "cyclonedds"`. The predicate that matters is
+    # "this backend drags in a shared library by SONAME", which is a property
+    # any backend can have; the name test just happened to be the one that did.
+    if(UNIX AND NOT APPLE)
+        foreach(_companion IN LISTS NROS_RMW_COMPANION_LIBRARIES)
+            if(_companion MATCHES "\\.so(\\.[0-9]+)*$")
+                set_property(TARGET ${TARGET} APPEND PROPERTY
+                    LINK_OPTIONS "-Wl,--disable-new-dtags")
+                break()
+            endif()
+        endforeach()
     endif()
 
     # Phase 104.B.6 — accumulate the chosen RMW into the target's

--- a/cmake/NanoRosRmwDispatch.cmake
+++ b/cmake/NanoRosRmwDispatch.cmake
@@ -1,65 +1,367 @@
-# Generated from cargo-nano-ros `resolve_rmw()` — DO NOT EDIT.
-# Regenerate: `cargo test -p cargo-nano-ros rmw_cmake_dispatch_is_current -- --ignored`
-# (or run the bin helper). The SSoT is rmw_resolver.rs; this is its CMake lowering.
+# NanoRosRmwDispatch.cmake — phase-439 W4 (RFC-0094 D5)
 #
-# nros_rmw_dispatch(<rmw>) sets in the CALLER scope:
-#   NROS_RMW_UMBRELLA_CFFI_FEATURE  the nros-c/nros-cpp cffi feature (e.g. rmw-zenoh-cffi)
-#   NROS_RMW_RLIB_DEP               backend rlib crate bundled in the umbrella, or ""
-#   NROS_RMW_EXTRA_LINK_LIBS        ;-list of extra link libs (cyclonedds C++ path), or ""
-#   NROS_RMW_NEEDS_CXX_LINKER       ON/OFF — force the C++ linker driver (libstdc++)
+# WHAT THIS USED TO BE, AND WHY IT ISN'T
+#
+# This file was GENERATED. Its header read "Generated from cargo-nano-ros
+# `resolve_rmw()` — DO NOT EDIT", and its body was an `if/elseif` chain over the
+# four backends that happened to live in `packages/rmw/` when the `nros` binary
+# was compiled, re-emitting the eight values each backend's `nros-rmw.toml`
+# already carried. The chain closed on
+#
+#     else()
+#         message(FATAL_ERROR "nros_rmw_dispatch: unknown rmw '${rmw}' "
+#             "(known: cyclonedds uorb xrce zenoh)")
+#
+# — a closed set, and the reason issue 1214 exists. Both halves, measured
+# against one tree in one minute:
+#
+#     $ nros ws providers --resolve rmw:acme
+#     rmw:acme -> <ws>/src/acme_rmw   root[1] (workspace)     <- FOUND
+#     $ cmake -P probe.cmake
+#     CMake Error: nros_rmw_dispatch: unknown rmw 'acme'
+#
+# Discoverable, not dispatchable.
+#
+# THE SEAM
+#
+# cmake never parses a descriptor. It ASKS the CLI for a shape it can read,
+# exactly as `NanoRosProviders.cmake` does:
+#
+#     nros ws rmw-dispatch <name> --lines
+#     NROS_RMW_<KEY><TAB><value>
+#
+# and the answer comes from the provider SCAN, so a backend in the user's own
+# workspace resolves by the same code as an in-tree one. An unknown name is now
+# "no provider announced this", with the announced names listed from the same
+# scan that produced the refusal — not a hand-spelled list inside a generator,
+# which is how the old message came to omit `uorb` (issue 1215).
+#
+# CACHE INVALIDATION (RFC-0094 D6 / issue 1018)
+#
+# `execute_process()` has already run by the time ninja decides anything, so the
+# freshness of anything a configure-time query emits reduces to *does a
+# configure happen*. Every query below therefore goes through
+# `nros_codegen_tool_reconfigure()`, which appends the `nros` binary to
+# `CMAKE_CONFIGURE_DEPENDS`. The DESCRIPTORS and `package.xml` files are watched
+# too — a backend that changes its link strategy must re-run the configure that
+# baked the old one into `build.ninja`.
+#
+# MEMOISATION
+#
+# `nros_rmw_dispatch()` is called from inside a `foreach` in
+# `NanoRosLink.cmake`, so a query per call would be a process spawn per RMW per
+# target. Answers are cached in GLOBAL PROPERTIES rather than cache variables:
+# a global property lives for one configure run and dies with it, so a rebuilt
+# `nros` (or an edited descriptor) cannot be served a stale answer from
+# `CMakeCache.txt` on the configure that its own `CONFIGURE_DEPENDS` triggered.
+
+include_guard(GLOBAL)
+
+# CACHE INTERNAL, not a normal var — this file is `include()`d from inside
+# other functions, and a normal `set(_X ${CMAKE_CURRENT_LIST_DIR})` is dropped
+# when that frame pops (the `_NROS_ENTRY_DIR` pattern; 287-W6 broke every
+# freertos workspace member this way).
+set(_NROS_RMW_DISPATCH_DIR "${CMAKE_CURRENT_LIST_DIR}"
+    CACHE INTERNAL "dir of NanoRosRmwDispatch.cmake")
+
+# The variables `nros_rmw_dispatch()` sets in the CALLER's scope. Listed once,
+# here, so the setter and the cache replay cannot drift apart.
+#
+#   NROS_RMW_NAME                   the provider's canonical name
+#   NROS_RMW_PACKAGE                its `package.xml` <name>
+#   NROS_RMW_PACKAGE_DIR            the dir holding that package.xml
+#   NROS_RMW_CMAKE_DIR              the cmake project to add_subdirectory()
+#   NROS_RMW_LINK_STRATEGY          `umbrella` | `cmake` (RFC-0094 D5)
+#   NROS_RMW_UMBRELLA_CFFI_FEATURE  the nros-cpp cffi feature, or ""
+#   NROS_RMW_C_CFFI_FEATURE         the nros-c cffi feature, or ""
+#   NROS_RMW_RLIB_DEP               backend rlib bundled in the umbrella, or ""
+#   NROS_RMW_CARGO_FEATURE          the board crate's `rmw-<name>` feature
+#   NROS_RMW_C_DEFINE_TOKEN         the `NROS_SYSTEM_RMW_<TOKEN>` token
 #   NROS_RMW_CPP_DEFINE             the define nros-cpp puts on its INTERFACE
-#   NROS_RMW_CMAKE_TARGET           a cmake target to link when present, or ""
+#   NROS_RMW_CMAKE_TARGET           the backend's own cmake target, or ""
+#   NROS_RMW_NEEDS_CXX_LINKER       ON/OFF — force the C++ linker driver
 #   NROS_RMW_CAPABILITIES           ;-list of capabilities this backend declares
 #   NROS_RMW_PER_MESSAGE_HOOK       cmake command run per message type, or ""
-function(nros_rmw_dispatch rmw)
-    if(rmw STREQUAL "cyclonedds")
-        set(NROS_RMW_UMBRELLA_CFFI_FEATURE "rmw-cyclonedds-cffi" PARENT_SCOPE)
-        set(NROS_RMW_RLIB_DEP "" PARENT_SCOPE)
-        set(NROS_RMW_EXTRA_LINK_LIBS "nros_rmw_cyclonedds;ddsc;stdc++" PARENT_SCOPE)
-        set(NROS_RMW_NEEDS_CXX_LINKER ON PARENT_SCOPE)
-        set(NROS_RMW_CPP_DEFINE "NROS_RMW_CYCLONEDDS" PARENT_SCOPE)
-        set(NROS_RMW_CMAKE_TARGET "" PARENT_SCOPE)
-        set(NROS_RMW_CAPABILITIES "type-descriptors" PARENT_SCOPE)
-        set(NROS_RMW_PER_MESSAGE_HOOK "nros_rmw_cyclonedds_typesupport_for_target" PARENT_SCOPE)
-    elseif(rmw STREQUAL "uorb")
-        set(NROS_RMW_UMBRELLA_CFFI_FEATURE "rmw-uorb-cffi" PARENT_SCOPE)
-        set(NROS_RMW_RLIB_DEP "" PARENT_SCOPE)
-        set(NROS_RMW_EXTRA_LINK_LIBS "nros_rmw_uorb" PARENT_SCOPE)
-        set(NROS_RMW_NEEDS_CXX_LINKER ON PARENT_SCOPE)
-        set(NROS_RMW_CPP_DEFINE "NROS_RMW_UORB" PARENT_SCOPE)
-        set(NROS_RMW_CMAKE_TARGET "nros_rmw_uorb" PARENT_SCOPE)
-        set(NROS_RMW_CAPABILITIES "" PARENT_SCOPE)
-        set(NROS_RMW_PER_MESSAGE_HOOK "" PARENT_SCOPE)
-    elseif(rmw STREQUAL "xrce")
-        set(NROS_RMW_UMBRELLA_CFFI_FEATURE "rmw-xrce-cffi" PARENT_SCOPE)
-        set(NROS_RMW_RLIB_DEP "nros-rmw-xrce-cffi" PARENT_SCOPE)
-        set(NROS_RMW_EXTRA_LINK_LIBS "" PARENT_SCOPE)
-        set(NROS_RMW_NEEDS_CXX_LINKER OFF PARENT_SCOPE)
-        set(NROS_RMW_CPP_DEFINE "NROS_RMW_XRCE_CFFI" PARENT_SCOPE)
-        set(NROS_RMW_CMAKE_TARGET "" PARENT_SCOPE)
-        set(NROS_RMW_CAPABILITIES "" PARENT_SCOPE)
-        set(NROS_RMW_PER_MESSAGE_HOOK "" PARENT_SCOPE)
-    elseif(rmw STREQUAL "zenoh")
-        set(NROS_RMW_UMBRELLA_CFFI_FEATURE "rmw-zenoh-cffi" PARENT_SCOPE)
-        set(NROS_RMW_RLIB_DEP "nros-rmw-zenoh" PARENT_SCOPE)
-        set(NROS_RMW_EXTRA_LINK_LIBS "" PARENT_SCOPE)
-        set(NROS_RMW_NEEDS_CXX_LINKER OFF PARENT_SCOPE)
-        set(NROS_RMW_CPP_DEFINE "NROS_RMW_ZENOH_CFFI" PARENT_SCOPE)
-        set(NROS_RMW_CMAKE_TARGET "" PARENT_SCOPE)
-        set(NROS_RMW_CAPABILITIES "zero-copy-receive;safety" PARENT_SCOPE)
-        set(NROS_RMW_PER_MESSAGE_HOOK "" PARENT_SCOPE)
-    else()
-        message(FATAL_ERROR "nros_rmw_dispatch: unknown rmw '${rmw}' "
-            "(known: cyclonedds uorb xrce zenoh)")
+#
+# `NROS_RMW_EXTRA_LINK_LIBS` is GONE (issue 1216). It was read by nothing, and
+# its cyclonedds value — `nros_rmw_cyclonedds;ddsc;stdc++` — was a
+# plausible-looking name holding a plausible-looking value whose obvious use,
+# `target_link_libraries(${TARGET} ${NROS_RMW_EXTRA_LINK_LIBS})`, is precisely
+# what issue 0475 records as BREAKING the link with `undefined reference to
+# ddsrt_*`. A maintained, generated declaration of how to link a backend whose
+# only correct use was not to use it.
+set(_NROS_RMW_DISPATCH_VARS
+    NROS_RMW_NAME
+    NROS_RMW_PACKAGE
+    NROS_RMW_PACKAGE_DIR
+    NROS_RMW_CMAKE_DIR
+    NROS_RMW_LINK_STRATEGY
+    NROS_RMW_UMBRELLA_CFFI_FEATURE
+    NROS_RMW_C_CFFI_FEATURE
+    NROS_RMW_RLIB_DEP
+    NROS_RMW_CARGO_FEATURE
+    NROS_RMW_C_DEFINE_TOKEN
+    NROS_RMW_CPP_DEFINE
+    NROS_RMW_CMAKE_TARGET
+    NROS_RMW_NEEDS_CXX_LINKER
+    NROS_RMW_CAPABILITIES
+    NROS_RMW_PER_MESSAGE_HOOK
+    CACHE INTERNAL "variables nros_rmw_dispatch() sets")
+
+# ---------------------------------------------------------------------------
+# _nros_rmw_cli(<out_var>) — resolve the `nros` binary and register it as a
+# configure dependency.
+#
+# Resolve rather than demand: this module is included before a workspace's
+# subdirectories, so requiring the caller to have located `nros` first would
+# only move the failure. Same lazy bootstrap as `nano_ros_load_providers`.
+# ---------------------------------------------------------------------------
+function(_nros_rmw_cli out_var)
+    if(NOT _NANO_ROS_CODEGEN_TOOL)
+        include("${_NROS_RMW_DISPATCH_DIR}/NanoRosBootstrapCodegen.cmake")
+        nros_bootstrap_codegen()
     endif()
+    if(NOT _NANO_ROS_CODEGEN_TOOL OR NOT EXISTS "${_NANO_ROS_CODEGEN_TOOL}")
+        message(FATAL_ERROR
+            "nros_rmw_dispatch: no `nros` binary — an RMW backend's build facts "
+            "are read from its `nros-rmw.toml` THROUGH the CLI, never parsed "
+            "here (RFC-0094 D5). Run `./scripts/bootstrap.sh` (contributors: "
+            "`just setup-cli`) and `source ./activate.sh`.")
+    endif()
+    # RFC-0094 D6 / issue 1018 — the ONE spelling. A configure-time query has no
+    # `DEPENDS` to carry its tool, so its freshness is exactly "does a configure
+    # happen"; this is what makes a rebuilt `nros` cause one.
+    include("${_NROS_RMW_DISPATCH_DIR}/NanoRosCodegenCore.cmake")
+    nros_codegen_tool_reconfigure("${_NANO_ROS_CODEGEN_TOOL}")
+    set(${out_var} "${_NANO_ROS_CODEGEN_TOOL}" PARENT_SCOPE)
 endfunction()
 
-# Every rmw a descriptor in this checkout provides. DERIVED — see above.
-set(NROS_RMW_KNOWN "cyclonedds;uorb;xrce;zenoh" CACHE INTERNAL "rmw names provided by nros-rmw.toml descriptors")
+# ---------------------------------------------------------------------------
+# The nano-ros tree — search-path root 0.
+#
+# Derived from THIS FILE's location rather than read from `NANO_ROS_ROOT_DIR`,
+# because that variable is set partway down the root `CMakeLists.txt` and this
+# module is included above it (to populate the `NANO_ROS_RMW` cache entry's
+# choices). A module that answers differently depending on where in a configure
+# it is first called is the ordering trap `_NROS_ENTRY_DIR` documents; this file
+# always sits at `<nano-ros>/cmake/`, so its own directory is the one input that
+# is true at every point.
+# ---------------------------------------------------------------------------
+function(_nros_rmw_root out_var)
+    if(NANO_ROS_ROOT_DIR)
+        set(${out_var} "${NANO_ROS_ROOT_DIR}" PARENT_SCOPE)
+        return()
+    endif()
+    get_filename_component(_root "${_NROS_RMW_DISPATCH_DIR}" DIRECTORY)
+    set(${out_var} "${_root}" PARENT_SCOPE)
+endfunction()
 
-# nros_rmw_is_known(<name> <out_var>) — TRUE when a descriptor claims <name>.
+# The search-path arguments every query shares. The WORKSPACE is the consumer's
+# own project, so a backend the user ships beside their nodes is found by the
+# same scan that finds ours.
+function(_nros_rmw_scan_args out_var)
+    _nros_rmw_root(_root)
+    set(${out_var}
+        --workspace "${CMAKE_SOURCE_DIR}" --nano-ros-root "${_root}"
+        PARENT_SCOPE)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Watch every `package.xml` and `nros-rmw.toml` the scan could have read.
+#
+# The provider index records its inputs; this module does not write one, so it
+# watches the DIRECTORY globs instead. A best-effort watch list, exactly as
+# `_nano_ros_watch_provider_inputs` is: getting it wrong costs a missed
+# reconfigure on a descriptor edit, and the tool itself is always watched.
+# ---------------------------------------------------------------------------
+function(_nros_rmw_watch_descriptors)
+    _nros_rmw_root(_root)
+    file(GLOB_RECURSE _descriptors "${_root}/packages/rmw/*/nros-rmw.toml")
+    foreach(_d IN LISTS _descriptors)
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_d}")
+        get_filename_component(_dir "${_d}" DIRECTORY)
+        if(EXISTS "${_dir}/package.xml")
+            set_property(DIRECTORY APPEND PROPERTY
+                CMAKE_CONFIGURE_DEPENDS "${_dir}/package.xml")
+        endif()
+    endforeach()
+endfunction()
+
+# ---------------------------------------------------------------------------
+# nros_rmw_dispatch(<rmw>)
+#
+# Sets `_NROS_RMW_DISPATCH_VARS` in the caller's scope from the backend's own
+# descriptor. An unknown name is a FATAL_ERROR naming what the scan DID find.
+# ---------------------------------------------------------------------------
+function(nros_rmw_dispatch rmw)
+    if(rmw STREQUAL "")
+        message(FATAL_ERROR "nros_rmw_dispatch: empty rmw name")
+    endif()
+    string(MAKE_C_IDENTIFIER "${rmw}" _key)
+    get_property(_cached GLOBAL PROPERTY _NROS_RMW_DISPATCH_${_key}_SET)
+    if(_cached)
+        foreach(_v IN LISTS _NROS_RMW_DISPATCH_VARS)
+            get_property(_val GLOBAL PROPERTY _NROS_RMW_DISPATCH_${_key}_${_v})
+            set(${_v} "${_val}" PARENT_SCOPE)
+        endforeach()
+        return()
+    endif()
+
+    _nros_rmw_cli(_tool)
+    _nros_rmw_scan_args(_scan_args)
+    _nros_rmw_watch_descriptors()
+    execute_process(
+        COMMAND "${_tool}" ws rmw-dispatch "${rmw}" ${_scan_args} --lines
+        OUTPUT_VARIABLE _rows
+        ERROR_VARIABLE _err
+        RESULT_VARIABLE _rc)
+    if(NOT _rc EQUAL 0)
+        message(FATAL_ERROR
+            "nros_rmw_dispatch: no provider announces rmw '${rmw}'.\n${_err}\n"
+            "A backend announces itself with "
+            "`<nano_ros_provides kind=\"rmw\" name=\"${rmw}\"/>` in its "
+            "package.xml and declares its build facts in `nros-rmw.toml` "
+            "beside it (RFC-0071 D5 / RFC-0094 D5). Nothing central lists "
+            "backends, so there is nothing here to add it to.")
+    endif()
+
+    # NOT `OUTPUT_STRIP_TRAILING_WHITESPACE`: an EMPTY value is `KEY<TAB>`, and
+    # stripping eats the tab off the last row, which then reads as a malformed
+    # line rather than as an empty value. Trim newlines only.
+    string(REGEX REPLACE "\n+$" "" _rows "${_rows}")
+    # A VALUE may contain `;` — `NROS_RMW_CAPABILITIES` is a `;`-list by
+    # construction, because `IN_LIST` is what consumes it. Splitting the output
+    # on newlines with those semicolons live would make `zero-copy-receive` and
+    # `safety` two separate ROWS. Escape them first: an escaped `;` stays inside
+    # one list element and unescapes back to a literal `;` on expansion.
+    string(REPLACE ";" "\\;" _rows "${_rows}")
+    string(REPLACE "\n" ";" _lines "${_rows}")
+    foreach(_line IN LISTS _lines)
+        if(_line STREQUAL "")
+            continue()
+        endif()
+        # TAB-separated by construction; a value may contain almost anything
+        # else (a `;`-list of capabilities, an absolute path), so split on the
+        # FIRST tab only.
+        string(FIND "${_line}" "\t" _tab)
+        if(_tab EQUAL -1)
+            message(FATAL_ERROR
+                "nros_rmw_dispatch: expected KEY<TAB>VALUE, got: ${_line}")
+        endif()
+        string(SUBSTRING "${_line}" 0 ${_tab} _k)
+        math(EXPR _rest "${_tab} + 1")
+        string(SUBSTRING "${_line}" ${_rest} -1 _val)
+        if(NOT _k IN_LIST _NROS_RMW_DISPATCH_VARS)
+            message(FATAL_ERROR
+                "nros_rmw_dispatch: the CLI emitted ${_k}, which this module "
+                "does not know. The two lists must move together — add it to "
+                "`_NROS_RMW_DISPATCH_VARS`.")
+        endif()
+        set(${_k} "${_val}" PARENT_SCOPE)
+        set_property(GLOBAL PROPERTY _NROS_RMW_DISPATCH_${_key}_${_k} "${_val}")
+        list(APPEND _seen "${_k}")
+    endforeach()
+
+    # Fail on a MISSING key rather than leaving the caller's variable at
+    # whatever a previous dispatch left there. A silently-empty
+    # `NROS_RMW_CPP_DEFINE` compiles and means nothing.
+    foreach(_v IN LISTS _NROS_RMW_DISPATCH_VARS)
+        if(NOT _v IN_LIST _seen)
+            message(FATAL_ERROR
+                "nros_rmw_dispatch: the CLI emitted no ${_v} for '${rmw}'.")
+        endif()
+    endforeach()
+    set_property(GLOBAL PROPERTY _NROS_RMW_DISPATCH_${_key}_SET TRUE)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# nros_rmw_known(<out_var>) — every rmw a provider on the search path announces.
+#
+# Replaces the generated `NROS_RMW_KNOWN` cache variable, which was a literal
+# `"cyclonedds;uorb;xrce;zenoh"` written into this file at CLI compile time and
+# therefore blind to every out-of-tree provider.
+#
+# `SOFT` degrades to an empty list when no `nros` is reachable, for the two
+# callers whose use is COSMETIC — the cache variable's help string and the
+# cmake-gui drop-down. A configure that cannot list the choices is still a
+# configure; one that cannot dispatch the chosen backend is not, which is why
+# `nros_rmw_dispatch` has no such arm.
+# ---------------------------------------------------------------------------
+function(nros_rmw_known out_var)
+    cmake_parse_arguments(_RK "SOFT" "" "" ${ARGN})
+    get_property(_have GLOBAL PROPERTY _NROS_RMW_KNOWN_SET)
+    if(_have)
+        get_property(_names GLOBAL PROPERTY _NROS_RMW_KNOWN)
+        set(${out_var} "${_names}" PARENT_SCOPE)
+        return()
+    endif()
+    if(_RK_SOFT)
+        if(NOT _NANO_ROS_CODEGEN_TOOL)
+            include("${_NROS_RMW_DISPATCH_DIR}/NanoRosBootstrapCodegen.cmake")
+            nros_bootstrap_codegen()
+        endif()
+        if(NOT _NANO_ROS_CODEGEN_TOOL OR NOT EXISTS "${_NANO_ROS_CODEGEN_TOOL}")
+            message(STATUS
+                "nano-ros: no `nros` binary yet — the RMW choices cannot be "
+                "listed. Run ./scripts/bootstrap.sh (contributors: "
+                "just setup-cli) and `source ./activate.sh`.")
+            set(${out_var} "" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+    _nros_rmw_cli(_tool)
+    _nros_rmw_scan_args(_scan_args)
+    _nros_rmw_watch_descriptors()
+    execute_process(
+        COMMAND "${_tool}" ws rmw-dispatch --known ${_scan_args} --lines
+        OUTPUT_VARIABLE _row
+        ERROR_VARIABLE _err
+        RESULT_VARIABLE _rc
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _rc EQUAL 0)
+        message(FATAL_ERROR
+            "nros_rmw_known: `nros ws rmw-dispatch --known` failed (${_rc}).\n${_err}")
+    endif()
+    # One row, `NROS_RMW_KNOWN<TAB>a;b;c`. The `;`-list is what we want here, so
+    # no escaping — and a tab-less row means the list is EMPTY (no provider
+    # announced an rmw), which is a legal answer for a workspace with none.
+    if(_row MATCHES "^NROS_RMW_KNOWN\t(.*)$")
+        set(_names "${CMAKE_MATCH_1}")
+    else()
+        set(_names "")
+    endif()
+    set_property(GLOBAL PROPERTY _NROS_RMW_KNOWN "${_names}")
+    set_property(GLOBAL PROPERTY _NROS_RMW_KNOWN_SET TRUE)
+    set(${out_var} "${_names}" PARENT_SCOPE)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# nros_rmw_is_known(<name> <out_var>) — TRUE when a provider announces <name>.
+#
+# Aliases count: `rmw-zenoh` and `rmw-zenoh-cffi` reach the same backend, and
+# `nros_rmw_dispatch` accepts them, so a validator that refused them would
+# reject a name the dispatch handles. `nros_rmw_known` lists one CANONICAL name
+# per provider (a drop-down offering three spellings of one choice is worse than
+# useless), so membership is asked of the dispatch, not of that list.
+# ---------------------------------------------------------------------------
 function(nros_rmw_is_known name out_var)
-    if(name IN_LIST NROS_RMW_KNOWN)
+    if(name STREQUAL "")
+        set(${out_var} FALSE PARENT_SCOPE)
+        return()
+    endif()
+    string(MAKE_C_IDENTIFIER "${name}" _key)
+    get_property(_cached GLOBAL PROPERTY _NROS_RMW_DISPATCH_${_key}_SET)
+    if(_cached)
+        set(${out_var} TRUE PARENT_SCOPE)
+        return()
+    endif()
+    _nros_rmw_cli(_tool)
+    _nros_rmw_scan_args(_scan_args)
+    execute_process(
+        COMMAND "${_tool}" ws rmw-dispatch "${name}" ${_scan_args} --lines
+        OUTPUT_QUIET ERROR_QUIET
+        RESULT_VARIABLE _rc)
+    if(_rc EQUAL 0)
         set(${out_var} TRUE PARENT_SCOPE)
     else()
         set(${out_var} FALSE PARENT_SCOPE)

--- a/cmake/NanoRosRuntimeCrate.cmake
+++ b/cmake/NanoRosRuntimeCrate.cmake
@@ -23,12 +23,12 @@ if(DEFINED _NROS_RUNTIME_CRATE_INCLUDED)
 endif()
 set(_NROS_RUNTIME_CRATE_INCLUDED TRUE)
 
-# Phase 241 W13/R1 — the BACKEND → {cffi feature, rlib, extra link libs, needs-cxx}
-# dispatch is GENERATED from cargo-nano-ros `resolve_rmw()` (the RFC-0031 SSoT) into
-# `NanoRosRmwDispatch.cmake` (drift-guarded by `rmw_cmake_dispatch_is_current`). The
-# former hardcoded `_nros_runtime_backend_feature` map is replaced by the generated
-# `nros_rmw_dispatch(<rmw>)` so the synthesized runtime crate's cffi feature can never
-# drift from the Rust SSoT / the cmake link extras.
+# Phase 241 W13/R1 — the BACKEND → {cffi feature, rlib, needs-cxx} dispatch, which
+# replaced a hardcoded `_nros_runtime_backend_feature` map here. phase-439 W4: it is
+# no longer GENERATED from `resolve_rmw()`; `nros_rmw_dispatch()` asks the CLI, which
+# reads the backend's own `nros-rmw.toml` over the provider scan (RFC-0094 D5). The
+# synthesized runtime crate reaches it through `nros_feature_set` below rather than
+# calling it directly.
 include("${CMAKE_CURRENT_LIST_DIR}/NanoRosRmwDispatch.cmake")
 # phase-336 — the cargo-profile resolver. File scope, so the function below
 # does not include() inside its own frame.
@@ -216,7 +216,12 @@ function(nros_synth_runtime_umbrella)
     # riscv64-qemu (no_std), and it carried no capabilities at all — which meant
     # a MIXED workspace silently lost param-services while a pure C/C++ one kept
     # them (issue 0311 / phase-314 W1).
-    nros_rmw_dispatch("${_NRR_BACKEND}")
+    # phase-439 W4 — the bare `nros_rmw_dispatch("${_NRR_BACKEND}")` that stood
+    # here is GONE. It read none of the eight variables it set: the next line
+    # includes `NanoRosFeatureSet`, which computes the cffi feature from
+    # `_NRR_BACKEND` itself, so the call was a no-op that read as the SSoT
+    # (`grep NROS_RMW` over this file returned nothing). It is a process spawn
+    # now, which is a good reason to notice, but it was dead before.
     include("${NANO_ROS_ROOT}/cmake/NanoRosFeatureSet.cmake")
     set(_caps ${NANO_ROS_FEATURES})
     if(NANO_ROS_SAFETY_E2E)

--- a/docs/design/0094-resolve-before-configure.md
+++ b/docs/design/0094-resolve-before-configure.md
@@ -182,6 +182,14 @@ status quo.
 
 ### D5 — Descriptors become load-bearing; the closed lists go
 
+**LANDED, phase-439 W4 (2026-09-08).** `nros_rmw_dispatch()` asks
+`nros ws rmw-dispatch <name> --lines`, which resolves over the provider scan;
+the generated chain, its generator and the root's hand-written chain are all
+deleted, and the root dispatches on the DECLARED link strategy (`umbrella` /
+`cmake`) instead of on names. `NANO_ROS_RMW=uorb` configures. Issues 1214,
+1215 and 1216 are closed; 1219's gate is not written and the issue records the
+survey that says why.
+
 `cmake/NanoRosRmwDispatch.cmake` is GENERATED from `rmw_resolver.rs`'s
 `KNOWN_RMW` and re-emits, as an `if/elseif` chain, the same eight values that
 already live in each backend's `nros-rmw.toml`. Its `else()` arm is a
@@ -219,6 +227,12 @@ No build required.
 `nros_rmw_acme_register`. It must configure and link without editing
 `NanoRosRmwDispatch.cmake`, the root `CMakeLists.txt`, or recompiling the `nros`
 binary.
+
+*Met, phase-439 W4, with `uorb` as the in-tree proof: it announces itself, ships
+a descriptor and a `CMakeLists.txt`, has no `Cargo.toml`, and was refused by both
+closed lists. `NANO_ROS_RMW=uorb` now configures and `add_subdirectory` creates
+its target. A uorb IMAGE still does not link on a plain host — `orb_*` is PX4's
+uORB middleware, which is a property of that backend and not of the seam.*
 
 **A3 — the fixed point is gone.** No lane re-derives a knob during configure;
 `nros_reconfigure_settle` and the future-mtime arm are deleted, and Zephyr

--- a/docs/issues/1219-no-rmw-agnostic-gate.md
+++ b/docs/issues/1219-no-rmw-agnostic-gate.md
@@ -1,11 +1,11 @@
 ---
 id: 1219
-title: "RFC-0071's `check-rmw-agnostic` gate was never written, so the closed backend lists grew from three to at least five while the RFC's other waves landed"
+title: "RFC-0071's `check-rmw-agnostic` gate was never written, so the closed backend lists grew from three to at least five while the RFC's other waves landed (phase-439 W4 removed three of the five; the GATE is still unwritten)"
 status: open
 area: ci, rmw, api
 severity: medium
 found: 2026-09-08
-related: [1214, 1215, 1218, RFC-0071]
+related: [1214, 1215, 1216, 1218, RFC-0071, RFC-0094, phase-439]
 ---
 
 # The verification section is the part that did not land
@@ -116,3 +116,78 @@ two of the five closed lists are in neither Rust nor a manifest, which is why a
 manifest-only guard like `check-decoupling.sh` could never have caught them.
 Retire or rewrite `check-decoupling.sh` in the same change rather than leaving a
 gate that is documented as testing a goal the project abandoned.
+
+---
+
+## Status after phase-439 W4 (2026-09-08) — three of the five lists are gone; the GATE is not written
+
+**Still open, and deliberately so.** W4 was expected to close this issue. It
+removed most of what the issue counted and did not write the gate, and saying
+that plainly is worth more than a green check on a rule nobody calibrated.
+
+### What went
+
+| site | state |
+| --- | --- |
+| `CMakeLists.txt:267-402` (`if/elseif` → `FATAL_ERROR`, `uorb` fatal) | **gone** — dispatches on the DECLARED link strategy (issue 1215) |
+| `cmake/NanoRosRmwDispatch.cmake` (generated chain + `NROS_RMW_KNOWN` literal) | **gone** — the file asks the CLI (issue 1214) |
+| `cmake/NanoRosFeatureSet.cmake:135-146` (name → cffi feature, per crate) | **gone** — reads `[rmw.link] c_cffi_feature` / the derived `<cargo_feature>-cffi` (issue 1216) |
+| `cmake/NanoRosFeatureSet.cmake:239` (`safety` is zenoh-only) | **gone** — `"safety" IN_LIST NROS_RMW_CAPABILITIES`, which is what `nros-cpp` already did |
+
+That last one is the 0196-shaped half this issue named: the fix had landed at
+one of two sites, and a third-party backend declaring `safety` was honoured on
+one path and refused with a WRONG explanation on the other. Both sites now ask
+the descriptor.
+
+`scripts/check-entry-rmw-vocabulary.py` no longer regexes `NROS_RMW_KNOWN` out
+of a generated file — it reads the `<nano_ros_provides kind="rmw"/>`
+announcements, cross-checked against the CLI's own answer by
+`rmw_resolver::tests::every_announced_backend_resolves_through_the_scan`.
+
+### What did not: the gate, and why not — MEASURED
+
+`check-rmw-agnostic` was written and then deleted rather than shipped. The rule
+is easy to state ("code that enumerates two or more backend names") and the
+measurement is what killed the first version:
+
+* over every tracked build-logic file (cmake / rs / py / sh / just / Kconfig),
+  comments stripped, names matched only as quoted literals or regex
+  alternations: **93 files**;
+* narrowed to the build-DECISION surface (`cmake/`, `zephyr/`, `integrations/`,
+  `just/`, `packages/{api,boards,cli,core,rmw,platform,tooling}/`): **39 files**.
+
+Most of the excess is not a defect. `packages/testing/**` enumerates the
+backends a TEST MATRIX covers; `examples/bridges/tt-zenoh-to-cyclonedds` names
+two backends because bridging them is what it demonstrates;
+`scripts/build/fixtures-manifest.py`'s `KNOWN_RMWS` is a test-plan coordinate
+list. Even inside the 39, spot-checking found roughly 40 % noise from `#[cfg(test)]`
+TOML fixtures inside `cargo_metadata_schema.rs` — a shape the reader would have
+to learn to skip.
+
+A baseline of 39 (let alone 93) reasons written without verifying each one is a
+gate that reads as coverage, which this repo has paid for before. So the gate
+needs a classification pass — dispatch vs test-plan vs demo vs help text — and
+that is its own wave, not a side effect of W4.
+
+### What a next attempt should start from
+
+* The narrowing that worked: comments stripped per language; names matched only
+  where they open a quoted string or follow an alternation (`"zenoh"`,
+  `(zenoh|xrce)`), which drops `nros_rmw_zenoh_register` and `use
+  nros_rmw_zenoh::…`; a window (~320 chars) so two names at opposite ends of a
+  file are not "one construct"; a threshold of TWO names, because one is usually
+  a legitimate backend-specific site.
+* The name set from `check-entry-rmw-vocabulary.cmake_known()`, imported — a
+  gate against second spellings must not carry one.
+* What still needs a decision: skipping `#[cfg(test)]` bodies, and whether a
+  `Cargo.toml` feature table (`rmw-zenoh = [...]`, this issue's "api leaks")
+  belongs to this rule at all or is a separate one.
+
+### Unchanged by W4
+
+The api-manifest leaks (`packages/api/nros-{c,cpp}/Cargo.toml`), the core leaks
+(`main_macro.rs`'s `rmw_crate_ident` and its `cyclonedds` filter,
+`nros-orchestration-ir/src/cyclonedds_type_sizing.rs`), D8's
+`board.knobs.zenoh.tx`, `workspace_scaffold.rs`, `colcon_nano_ros`'s
+`RMW_BACKENDS`, and `scripts/check-decoupling.sh` (still documented as testing
+a goal the project abandoned).

--- a/docs/issues/1226-zephyr-native-sim-cpp-cyclonedds-row-has-no-matrix-cell.md
+++ b/docs/issues/1226-zephyr-native-sim-cpp-cyclonedds-row-has-no-matrix-cell.md
@@ -1,0 +1,82 @@
+---
+id: 1226
+title: "`just ci gate` is red on `main`: a `fixtures.toml` workspace row for zephyr-native-sim / cpp / cyclonedds has no `matrix::CELLS` cell"
+status: open
+area: testing, ci
+severity: medium
+found: 2026-09-08
+related: [0981, 0952, phase-206]
+---
+
+# The last step of the local push lane fails, and it is nobody's diff
+
+`just ci gate` step 6 of 6, `test-lane-contracts`:
+
+```
+FAIL nros-tests::matrix_fixture_coverage fixture_rows_all_modeled_by_matrix
+
+fixtures.toml coordinates outside the matrix (model them or delete the rows):
+orphan (platform_idx, lang_idx, rmw_idx, is_ws): [(1, 2, 1, true)]
+unmapped rows: []
+```
+
+Decoded against `packages/testing/nros-tests/src/matrix.rs`:
+
+| field | value | source |
+| --- | --- | --- |
+| `platform_idx` 1 | `PlatformId::ZephyrNativeSim` | `:93` |
+| `lang_idx` 2 | `Lang::Cpp` | `:307` |
+| `rmw_idx` 1 | `Rmw::Cyclonedds` | `:282` |
+| `is_ws` true | `Kind::Workspace` | |
+
+So `examples/fixtures.toml` carries a WORKSPACE row at
+(zephyr-native-sim, cpp, cyclonedds) that `matrix::CELLS` does not model.
+`fixture_rows_all_modeled_by_matrix` is the REVERSE direction the matrix gate
+added at W3-end — "an unmodeled row is either debt the table must model or an
+orphan to delete" — and it is the one firing.
+
+## Not from the branch that found it
+
+Bisected by inputs rather than by revision, which is sound here because the
+test is a pure function of three files:
+
+* `examples/fixtures.toml`
+* `packages/testing/nros-tests/src/matrix.rs` (`CELLS` + the index tables)
+* `scripts/build/fixtures-manifest.py` (the `coords` subcommand)
+
+The most recent commit touching any of them is
+`9ae271174 feat(phase-206 W2): the RTOS image that links Cyclone AND carries a
+bringup config` (2026-09-06), and it is an ancestor of every branch that has
+since reported this. Reproduced on `docs/rfc-0094-resolve-before-configure`
+with and without `NROS_REPO_ROOT` set, on a tree whose diff touches none of the
+three.
+
+## Why it survived
+
+`test-lane-contracts` is not in the required `CI` context on a pull request
+(that is `check-fast` + `check-submodule-commits-reachable` +
+`check-compile-smoke` + `check-cli-tests`), so nothing between the commit and a
+merge asks this question. It is asked by `just ci gate`, which is the lane
+contributors are told to run before every push — and because that lane stops at
+the FIRST failure, a red here also withdraws nothing, being last. What it does
+cost is the signal: every contributor who runs the documented lane now sees a
+red they must triage as not-theirs before they can trust the green above it,
+which is issue 0952's warning read from the other end.
+
+This is the fourth pre-existing red on `main` this week, after the two
+`docs/rfc-0094-resolve-before-configure` fixed in `5817d343e` and the
+`cli-clippy` dead-code one in `684e40ab3`.
+
+## Fix direction (not applied)
+
+Two candidates, and the choice belongs to whoever owns phase-206 W2:
+
+* **model the cell** — add
+  `cell(ZephyrNativeSim, Cpp, Cyclonedds, …, Workspace, …)` to `matrix::CELLS`,
+  if the image the row builds is meant to produce a runtime verdict;
+* **delete the row** — if the fixture is a build-only artifact that was never
+  meant to carry a cell.
+
+Not guessed here: the gate's own message says "model them or delete the rows",
+and picking wrong turns a missing cell into a permanently-skipped one, which is
+the shape issue 1127 is already about.

--- a/docs/issues/archived/1214-rmw-discoverable-not-dispatchable.md
+++ b/docs/issues/archived/1214-rmw-discoverable-not-dispatchable.md
@@ -1,10 +1,11 @@
 ---
 id: 1214
 title: "An out-of-tree RMW provider is DISCOVERABLE and not DISPATCHABLE — the D5 scan resolves it, and no build path can consume the answer"
-status: open
+status: resolved
 area: rmw, build, cli, cmake
 severity: high
 found: 2026-09-08
+resolved_in: phase-439 W4
 related: [1215, 1216, 1219, 0934, RFC-0071, RFC-0087, RFC-0088]
 ---
 
@@ -157,3 +158,48 @@ takes its rows from the scan rather than from `OUT_DIR`. Note that alone is not
 sufficient — see issue 1215 (the root `CMakeLists.txt` chain fatals on a name
 the dispatch accepts) and issue 1216 (the dispatch outputs that would carry an
 out-of-tree provider's link data are read by nothing).
+
+---
+
+## Fix (phase-439 W4, RFC-0094 D5)
+
+The scan half and the dispatch half are ONE mechanism now.
+
+* `cargo-nano-ros/src/rmw_descriptor.rs` — the `nros-rmw.toml` parser, `include!`d
+  by `build.rs` and compiled into the library, the arrangement
+  `serdes_descriptor.rs` already used. `build.rs`'s private `parse()` is gone, so
+  there is no second reader to drift.
+* `rmw_resolver::resolve_rmw_in(&ScanResult, name)` — the sibling of
+  `serdes_resolver::resolve_serdes_in` this issue asked for. It reads the winner's
+  descriptor at SELECTION time, applies the same RFC-0087 D4 derivations
+  `build.rs` applies, and returns the provider's DIRECTORY as well — the half a
+  compile-time table cannot have and the half `add_subdirectory()` needs.
+  `known_rmw_in` is the scan-based `known_rmw`.
+* `nros ws rmw-dispatch <name> --lines` / `--known` — the cmake seam, the same
+  "cmake asks the CLI for a shape it can read" pattern as `ws providers --lines`.
+* `cmake/NanoRosRmwDispatch.cmake` is HAND-WRITTEN and asks. Its
+  `if/elseif`-over-four-names chain, the `render_cmake_dispatch()` that generated
+  it, `CMAKE_DISPATCH_REL_PATH` and the `rmw_cmake_dispatch_is_current` /
+  `regenerate_cmake_dispatch` tests are deleted. Answers are memoised in GLOBAL
+  properties (they die with the configure, so a rebuilt `nros` cannot be served a
+  stale one), and every query registers the tool through
+  `nros_codegen_tool_reconfigure()` — `check-codegen-tool-reconfigure` now counts
+  `rmw-dispatch` as an emitting verb, with its own negative control.
+
+Two readers of one format that nobody compares is what this repo keeps paying
+for, so `rmw_resolver::tests::the_baked_table_and_the_scan_agree_on_every_in_tree_backend`
+asserts the compile-time table and the scan agree field for field, and
+`every_announced_backend_resolves_through_the_scan` asserts that what the scan
+FINDS, the resolver DISPATCHES — this issue's shape, as a test.
+
+Measured: `NANO_ROS_RMW=uorb` configures (see issue 1215), and all four backends
+configure and produce byte-identical cargo feature sets to the ones the deleted
+closed chains produced.
+
+## Not fixed here
+
+The BOARD axis is still not resolved through the scan (this issue's own "what
+would settle the remaining uncertainty"), and `nano_ros_load_providers()` still
+has no production caller — `nros_rmw_dispatch` runs its own scan through the CLI
+rather than sharing cmake's index. Both are follow-ups; neither blocks the rmw
+axis, which is what the acceptance test asked for.

--- a/docs/issues/archived/1215-root-cmake-rmw-list-fifth.md
+++ b/docs/issues/archived/1215-root-cmake-rmw-list-fifth.md
@@ -1,10 +1,11 @@
 ---
 id: 1215
 title: "The root CMakeLists is a FIFTH closed rmw list: `uorb` is offered by the cache UI and FATAL_ERRORs at configure"
-status: open
+status: resolved
 area: cmake, build, rmw
 severity: medium
 found: 2026-09-08
+resolved_in: phase-439 W4
 related: [1214, 1216, 1218, RFC-0071]
 ---
 
@@ -103,3 +104,57 @@ discarded — `packages/cli/cargo-nano-ros/build.rs:154` says
 `[rmw.provides.*]` and `[rmw.codegen]` "are for later waves and are **ignored**".
 Making the root chain read them is the shape of the fix; until then, note that
 the drop-down advertises a value the configure rejects.
+
+---
+
+## Fix (phase-439 W4, RFC-0094 D5)
+
+`NANO_ROS_RMW=uorb` configures.
+
+The root chain's three arms were never three backends — they were three LINK
+STRATEGIES, and this issue's own "fix direction" said so. A backend declares its
+strategy and the root dispatches on that:
+
+* `umbrella` — the backend is a Rust rlib bundled into `libnros_c.a` /
+  `libnros_cpp.a`; nothing separate reaches the link line. DERIVED from
+  `[rmw.link] rlib_dep` being non-empty, which is what naming an rlib means.
+* `cmake` — the backend is a CMake project: `add_subdirectory()` the dir it
+  declares and whole-archive the target it declares into both umbrellas.
+
+`_nros_link_cmake_rmw(<target>)` is the one implementation of the second, for
+both umbrellas; the block existed twice, ~45 lines apart, differing only in the
+target name, and its own comments said "one defect, two consumers". The
+`else()` arm is now a closed list of STRATEGIES — a property of the file that
+implements them — rather than of names.
+
+Two other things this cost:
+
+* `NROS_RMW_CYCLONEDDS_DDSC_LIBRARY` in the root became
+  `NROS_RMW_COMPANION_LIBRARIES`, a generic channel a backend appends to. The
+  root had to know that one backend has a companion archive; issue 0837 was the
+  price of that archive having no channel to be declared through.
+* The `CYCLONEDDS_SOURCE_DIR` pre-step moved to
+  `packages/rmw/cyclonedds/nros-rmw-cyclonedds/nros-rmw-provision.cmake`, a
+  fragment the selecting build includes when present. What a backend needs
+  provisioned is the backend's business; an `if(NANO_ROS_RMW STREQUAL
+  "cyclonedds")` pre-step at the root is the same closed list one line up.
+
+`NROS_RMW_KNOWN` — the generated literal at `NanoRosRmwDispatch.cmake:58` that
+the drop-down read — is gone too, replaced by `nros_rmw_known()`, a query. So
+the two lines 370 apart in one file now have ONE source: what a provider
+announces. `check-entry-rmw-vocabulary`, which regex'd that literal out of the
+generated file, reads the announcements instead.
+
+## Measured, and the honest limit
+
+`cmake -DNANO_ROS_RMW=uorb` configures, `add_subdirectory` runs, and
+`nros_rmw_uorb` is created — so `nros-cpp`'s `NROS_RMW_CMAKE_TARGET` guard,
+inert since it was written, finally has a producer.
+
+A uorb IMAGE still does not LINK on a plain host: `orb_advertise_multi`,
+`orb_subscribe_multi`, `orb_check`, `orb_copy`, `orb_publish`,
+`orb_unadvertise`, `orb_unsubscribe` are undefined. That is uORB itself — the
+middleware lives in PX4, which is why `NROS_RMW_UORB_LINK_PX4` exists and
+defaults OFF and why `integrations/px4/` is uorb's consumer. The nano-ros half
+of the link (`nros_rmw_cffi_register_named`) resolves. Recorded in the
+descriptor so the next person reads it before re-deriving it.

--- a/docs/issues/archived/1216-rmw-dispatch-outputs-unconsumed.md
+++ b/docs/issues/archived/1216-rmw-dispatch-outputs-unconsumed.md
@@ -1,10 +1,11 @@
 ---
 id: 1216
 title: "Three of the eight `nros_rmw_dispatch` outputs are set and read by nothing — including the one that carries a backend's link libraries"
-status: open
+status: resolved
 area: cmake, rmw, build
 severity: medium
 found: 2026-09-08
+resolved_in: phase-439 W4
 related: [1214, 1215, 0475, 0837, RFC-0071]
 ---
 
@@ -103,3 +104,58 @@ gate it, in the spirit of `just check cmake-support-library`
 class. Note there is no gate at all on the RMW link path today; verification is
 the manual `ninja -t query` recipe in the comments at
 `cmake/NanoRosLink.cmake:99-100`.
+
+---
+
+## Fix (phase-439 W4)
+
+Decided one at a time rather than as a batch, because they are three different
+things that happened to share a symptom.
+
+**`NROS_RMW_EXTRA_LINK_LIBS` — DELETED**, along with the `extra_link_libs`
+field in all four descriptors and in `RmwDispatch`. This issue's argument stands
+as written: a maintained, generated, documented declaration of how to link a
+backend whose only correct use is not to use it. Nothing read it, and the
+obvious consumption is what 0475 records as breaking the link. The reason is
+recorded IN the cyclonedds descriptor where the value used to be, so the next
+person finds the warning at the place they would reach for it.
+
+**`NROS_RMW_RLIB_DEP` — WIRED, and load-bearing.** Naming an rlib IS the
+statement that the backend arrives inside the C/C++ umbrella and nothing
+separate reaches the link line, so it now derives `[rmw.link] strategy` and
+decides which arm of the root `CMakeLists.txt` runs (issue 1215). It also gates
+the cffi feature below: without an rlib there is no umbrella feature to name.
+
+**`NROS_RMW_UMBRELLA_CFFI_FEATURE` — WIRED**, in `nros_feature_set`, together
+with a new `NROS_RMW_C_CFFI_FEATURE`. That deleted a fourth closed list:
+`NanoRosFeatureSet.cmake` mapped backend NAME to cffi feature with its own
+`if(_FS_RMW STREQUAL "zenoh")` chain per crate. `nros-cpp`'s spelling is regular
+(`<cargo_feature>-cffi`, derived); `nros-c`'s is not (`cffi-zenoh-cffi` but
+`cffi-xrce-c`), so it is AUTHORED in the descriptor for the same reason
+`cpp_define` is. Verified byte-for-byte against the deleted chain for all four
+backends × both crates × `none`.
+
+**The `nros_rmw_<name>` naming convention `LINK_DEPENDS` depended on — REPLACED,
+not documented.** `cmake/NanoRosLink.cmake` read `if(TARGET nros_rmw_${_chosen})`.
+This issue called that an accidental generalisation that nothing documented and
+nothing gated, and a provider naming its target anything else silently got the
+0475 defect back. It reads `NROS_RMW_CMAKE_TARGET` now — the backend's own
+`[rmw.provides.cmake] target` — so the edge follows the DECLARATION and there is
+no convention left to document or gate. A backend with no cmake target correctly
+gets no edge: it has no separate archive.
+
+The same file's cyclone-named `--disable-new-dtags` block is keyed on
+`NROS_RMW_COMPANION_LIBRARIES` now: "this backend drags in a shared library by
+SONAME" is a property any backend can have, and the name test just happened to
+be the one that did.
+
+Verified with `ninja -t query`, which is the recipe 0475 left in the comments:
+for a cyclonedds link, both `libnros_rmw_cyclonedds.a` and
+`libddsc.so.0.10.5` appear under `|` (implicit), not only under `||`.
+
+## Not fixed here
+
+Also unread and left alone: `NROS_RMW_CMAKE_TARGET`'s guard in
+`packages/api/nros-cpp/CMakeLists.txt` is still a guard rather than the link
+path — the root does the linking. It is no longer INERT, though (issue 1215),
+which was the part that made it a lie.

--- a/docs/roadmap/phase-439-resolve-before-configure.md
+++ b/docs/roadmap/phase-439-resolve-before-configure.md
@@ -2,8 +2,12 @@
 
 **Status (2026-09-08). Opened from RFC-0094. W0 and W1 are the routing diff and
 the digest key — both are PRECONDITIONS and neither changes behaviour. W2–W4 are
-the three landings. W0 has LANDED and corrected three of the RFC's numbers; W1
-is not started.**
+the three landings. W0 has LANDED and corrected three of the RFC's numbers; W4
+has LANDED; W1–W3 are not started.**
+
+W4 landed out of the stated order because it depends on none of the others: it
+is the RMW axis alone (descriptors, the cmake seam, the link strategies), while
+W0/W1's preconditions are about routing and cargo-directory keys.
 
 Implements [RFC-0094](../design/0094-resolve-before-configure.md). Read its
 "Design" section first; this doc carries work items and acceptance only.
@@ -143,7 +147,7 @@ needs.
 `Cargo.toml` that IS routed produces a loud error naming the package, where
 today it is silently skipped.
 
-## W4 — Descriptors become load-bearing
+## W4 — Descriptors become load-bearing — **LANDED 2026-09-08**
 
 `nros_rmw_dispatch` becomes a query against the provider index rather than a
 generated `if/elseif` chain, following `NanoRosProviders.cmake`'s existing
@@ -160,7 +164,48 @@ configures and links with ZERO edits to `NanoRosRmwDispatch.cmake`, the root
 `CMakeLists.txt`, or the `nros` binary. `uorb` becoming selectable is the
 in-tree proof.
 
-Closes issues 1214, 1215, 1216, 1219.
+Closes issues 1214, 1215, 1216. **1219 stays OPEN** — see below.
+
+### What landed
+
+* `rmw_descriptor.rs` — ONE `nros-rmw.toml` parser, `include!`d by `build.rs`
+  and compiled into the library. `resolve_rmw_in(&ScanResult, name)` reads a
+  descriptor at SELECTION time over the provider scan, so an out-of-tree
+  provider dispatches by the same code as an in-tree one (1214).
+* `nros ws rmw-dispatch <name> --lines` / `--known` — the cmake seam.
+  `NanoRosRmwDispatch.cmake` is hand-written and ASKS; `render_cmake_dispatch()`
+  and its two drift tests are deleted.
+* The root chain dispatches on the DECLARED link strategy (`umbrella` /
+  `cmake`), one helper for both umbrellas, a per-backend
+  `nros-rmw-provision.cmake` hook for what a backend needs resolved first, and
+  a generic `NROS_RMW_COMPANION_LIBRARIES` where the root used to name
+  cyclone's `libddsc` (1215).
+* The three unread dispatch outputs: `EXTRA_LINK_LIBS` deleted, `RLIB_DEP` and
+  `UMBRELLA_CFFI_FEATURE` wired — the latter deleting a fourth closed list in
+  `NanoRosFeatureSet.cmake`. `LINK_DEPENDS` keys on the declared cmake target
+  rather than the `nros_rmw_<name>` naming coincidence (1216).
+* `check-codegen-tool-reconfigure` counts `rmw-dispatch` as an emitting verb,
+  with its own negative control.
+
+### Measured
+
+`NANO_ROS_RMW=uorb` configures and reaches a correct link line — it had been
+advertised in the cache drop-down and fatal at the root. A uorb IMAGE still does
+not link on a plain host: `orb_*` is PX4's uORB middleware, not ours. All four
+backends configure; the cargo feature sets are byte-identical to the ones the
+deleted closed chains produced; cyclonedds and zenoh and xrce probes LINK, and
+`ninja -t query` shows both the backend archive and `libddsc` under `|`.
+
+### Why 1219 is not closed
+
+`check-rmw-agnostic` was written and deleted rather than shipped. W4 removed
+three of the five closed lists it counted and fixed the `safety` capability's
+two-site defect, but the GATE needs a classification pass the measurement made
+plain: repo-wide over build logic the rule reports 93 files, and 39 even
+narrowed to the build-decision surface, most of them test plans, demos and help
+text rather than dispatch. A 39-row baseline of unverified reasons reads as
+coverage. The survey, the narrowing that worked, and what a next attempt should
+decide are recorded in the issue.
 
 ## Out of scope
 

--- a/packages/api/nros-cpp/CMakeLists.txt
+++ b/packages/api/nros-cpp/CMakeLists.txt
@@ -270,9 +270,10 @@ cmake_language(DEFER DIRECTORY "${NANO_ROS_ROOT_DIR}" CALL
 if(NANO_ROS_RMW AND NOT NANO_ROS_RMW STREQUAL "none")
     nros_rmw_is_known("${NANO_ROS_RMW}" _nros_cpp_rmw_known)
     if(NOT _nros_cpp_rmw_known)
+        nros_rmw_known(_nros_cpp_rmw_names)
         message(FATAL_ERROR
             "nros-cpp: unknown RMW '${NANO_ROS_RMW}' "
-            "(provided by a descriptor: ${NROS_RMW_KNOWN})")
+            "(announced by a provider: ${_nros_cpp_rmw_names})")
     endif()
     nros_rmw_dispatch("${NANO_ROS_RMW}")
     if(NROS_RMW_CPP_DEFINE)

--- a/packages/cli/cargo-nano-ros/build.rs
+++ b/packages/cli/cargo-nano-ros/build.rs
@@ -58,6 +58,13 @@ const KIND: &str = "rmw";
 // why it is std-only.
 include!("src/serdes_descriptor.rs");
 
+// phase-439 W4 — same arrangement for the RMW descriptor, which until this wave
+// was parsed ONLY here, privately. That is what made the in-tree table the only
+// answer to "which backends exist" and left an out-of-tree provider discoverable
+// and not dispatchable (issue 1214). `resolve_rmw_in` reads a descriptor through
+// these same functions at selection time.
+include!("src/rmw_descriptor.rs");
+
 fn main() {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     // packages/cli/cargo-nano-ros -> packages
@@ -124,98 +131,38 @@ fn main() {
     fs::write(&out, render(&descriptors)).expect("write rmw_table.rs");
 }
 
+/// One in-tree backend, as the generated `RMW_ROWS` table sees it: what the
+/// descriptor STATES ([`RmwDescriptor`]) plus what convention DERIVES from the
+/// sibling `package.xml`.
 struct Descriptor {
     names: Vec<String>,
     cargo_feature: String,
     cmake_value: String,
     c_define_token: String,
     cffi_feature: String,
-    cpp_define: String,
-    cmake_target: String,
-    rlib_dep: String,
-    extra_link_libs: Vec<String>,
-    needs_cxx_linker: bool,
-    /// `[rmw.capabilities]` — capability name -> THIS backend's own feature.
-    capabilities: Vec<(String, String)>,
-    /// `[rmw.codegen].per_message` — a cmake command run per message type.
-    per_message_hook: String,
+    stated: RmwDescriptor,
 }
 
-/// Minimal line parser for the descriptor's flat `key = value` shape.
+/// Read one in-tree backend's descriptor into the shape `render` emits.
 ///
-/// Deliberately NOT the `toml` crate: it is a normal dependency, not a
-/// build-dependency, and adding one would move `Cargo.lock` — which this repo
-/// only permits through `just lock-update`. The descriptor format is flat and
-/// under our control, and `NanoRosCapabilities.cmake` already reads
-/// `nros-board.toml` exactly this way (`file(STRINGS ... REGEX ...)`), so this
-/// is the established idiom rather than a shortcut.
-///
-/// Only the `[rmw]` and `[rmw.link]` tables are read; `[rmw.capabilities]`,
-/// `[rmw.provides.*]` and `[rmw.codegen]` are for later waves and are ignored
-/// here rather than half-parsed.
-///
-/// phase-420 W5: what the file STATES is read here; what convention DERIVES is
-/// filled in by [`derive_fields`] afterwards, and a stated value that
-/// disagrees with the derived one is fatal.
+/// The PARSE is `rmw_descriptor::parse_rmw_descriptor`, shared verbatim with
+/// the library (phase-439 W4) — this script used to own a private copy, which
+/// is why the only readers of `nros-rmw.toml` were in-tree ones compiled into
+/// the binary. The DERIVATIONS below are phase-420 W5's: what convention can
+/// produce is produced here, and a descriptor that restates one must agree
+/// with it.
 fn parse(path: &Path, pkg_xml: &Path) -> Descriptor {
     let text = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    let mut section = String::new();
+    let stated =
+        parse_rmw_descriptor(&text, &path.display().to_string()).unwrap_or_else(|e| panic!("{e}"));
     let mut d = Descriptor {
-        names: Vec::new(),
-        cargo_feature: String::new(),
-        cmake_value: String::new(),
-        c_define_token: String::new(),
-        cffi_feature: String::new(),
-        cpp_define: String::new(),
-        cmake_target: String::new(),
-        rlib_dep: String::new(),
-        extra_link_libs: Vec::new(),
-        needs_cxx_linker: false,
-        capabilities: Vec::new(),
-        per_message_hook: String::new(),
+        names: stated.stated_names.clone(),
+        cargo_feature: stated.stated_cargo_feature.clone(),
+        cmake_value: stated.stated_cmake_value.clone(),
+        c_define_token: stated.stated_c_define_token.clone(),
+        cffi_feature: stated.stated_cffi_feature.clone(),
+        stated,
     };
-    for raw in text.lines() {
-        let line = raw.split('#').next().unwrap_or("").trim();
-        if line.is_empty() {
-            continue;
-        }
-        if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
-            section = name.to_string();
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        let (key, value) = (key.trim(), value.trim());
-        let scalar = || value.trim_matches('"').to_string();
-        let list = || {
-            value
-                .trim_start_matches('[')
-                .trim_end_matches(']')
-                .split(',')
-                .map(|x| x.trim().trim_matches('"').to_string())
-                .filter(|x| !x.is_empty())
-                .collect::<Vec<_>>()
-        };
-        match (section.as_str(), key) {
-            ("rmw", "names") => d.names = list(),
-            ("rmw", "cargo_feature") => d.cargo_feature = scalar(),
-            ("rmw", "cmake_value") => d.cmake_value = scalar(),
-            ("rmw", "c_define_token") => d.c_define_token = scalar(),
-            ("rmw", "cffi_feature") => d.cffi_feature = scalar(),
-            ("rmw", "cpp_define") => d.cpp_define = scalar(),
-            ("rmw", "cmake_target") => d.cmake_target = scalar(),
-            ("rmw.link", "rlib_dep") => d.rlib_dep = scalar(),
-            ("rmw.link", "extra_link_libs") => d.extra_link_libs = list(),
-            ("rmw.link", "needs_cxx_linker") => d.needs_cxx_linker = value == "true",
-            // Open vocabulary by design (RFC-0071 D6 / the platform
-            // descriptor's precedent): whatever the backend declares is a
-            // capability it offers, and core never learns the right-hand side.
-            ("rmw.capabilities", k) => d.capabilities.push((k.to_string(), scalar())),
-            ("rmw.codegen", "per_message") => d.per_message_hook = scalar(),
-            _ => {}
-        }
-    }
     derive_fields(path, pkg_xml, &mut d);
     d
 }
@@ -263,7 +210,7 @@ fn derive_fields(path: &Path, pkg_xml: &Path, d: &mut Descriptor) {
     agree(path, "cffi_feature", &d.cffi_feature, &cffi);
     d.cffi_feature = cffi;
 
-    if d.cpp_define.is_empty() {
+    if d.stated.cpp_define.is_empty() {
         // Not derivable — see the module header. An absent one would lower to
         // an empty `#define`, which compiles and means nothing.
         panic!(
@@ -277,18 +224,13 @@ fn derive_fields(path: &Path, pkg_xml: &Path, d: &mut Descriptor) {
 
 /// A descriptor may restate a derivable field; it may not disagree with it.
 ///
-/// Empty means "not stated" — the field's whole point after W5 is to be
-/// absent. `check-derived-descriptor-fields` is the buildless form of this
-/// same rule, with a ratchet for the rows history has pinned; this is the
-/// copy that fires for anyone who builds.
+/// One rule, one implementation: `rmw_descriptor::agree_with_convention` is the
+/// shared form, and this is the build script's panicking wrapper around it —
+/// the belt to `check-derived-descriptor-fields`'s braces, firing for anyone who
+/// builds rather than only for `check-fast`.
 fn agree(path: &Path, field: &str, stated: &str, derived: &str) {
-    if !stated.is_empty() && stated != derived {
-        panic!(
-            "{}: [rmw].{field} states {stated:?} but convention derives \
-             {derived:?} (RFC-0087 D4). Delete the field — it is derived from \
-             the provider's announced name — or fix the name it disagrees with.",
-            path.display()
-        );
+    if let Err(e) = agree_with_convention(&path.display().to_string(), field, stated, derived) {
+        panic!("{e}");
     }
 }
 
@@ -297,7 +239,7 @@ fn render(ds: &[(String, Descriptor)]) -> String {
         "// @generated by build.rs from packages/rmw/*/*/nros-rmw.toml — DO NOT EDIT.\n\
          // phase-347 W3: the descriptors are the source; this is their Rust lowering.\n\n",
     );
-    out.push_str("pub(crate) struct RmwRow {\n    pub declared: &'static str,\n    pub names: &'static [&'static str],\n    pub cargo_feature: &'static str,\n    pub cmake_value: &'static str,\n    pub c_define_token: &'static str,\n    pub cffi_feature: &'static str,\n    pub cpp_define: &'static str,\n    pub cmake_target: &'static str,\n    pub rlib_dep: &'static str,\n    pub extra_link_libs: &'static [&'static str],\n    pub needs_cxx_linker: bool,\n    pub capabilities: &'static [(&'static str, &'static str)],\n    pub per_message_hook: &'static str,\n}\n\n");
+    out.push_str("pub(crate) struct RmwRow {\n    pub declared: &'static str,\n    pub names: &'static [&'static str],\n    pub cargo_feature: &'static str,\n    pub cmake_value: &'static str,\n    pub c_define_token: &'static str,\n    pub cffi_feature: &'static str,\n    pub cpp_define: &'static str,\n    pub cmake_target: &'static str,\n    pub rlib_dep: &'static str,\n    pub link_strategy: &'static str,\n    pub c_cffi_feature: &'static str,\n    pub needs_cxx_linker: bool,\n    pub capabilities: &'static [(&'static str, &'static str)],\n    pub per_message_hook: &'static str,\n}\n\n");
     out.push_str("pub(crate) static RMW_ROWS: &[RmwRow] = &[\n");
     for (_, d) in ds {
         let names = d
@@ -307,29 +249,26 @@ fn render(ds: &[(String, Descriptor)]) -> String {
             .collect::<Vec<_>>()
             .join(", ");
         let caps = d
+            .stated
             .capabilities
             .iter()
             .map(|(k, v)| format!("({k:?}, {v:?})"))
             .collect::<Vec<_>>()
             .join(", ");
-        let libs = d
-            .extra_link_libs
-            .iter()
-            .map(|n| format!("{n:?}"))
-            .collect::<Vec<_>>()
-            .join(", ");
         out.push_str(&format!(
-            "    RmwRow {{\n        declared: {:?},\n        names: &[{names}],\n        cargo_feature: {:?},\n        cmake_value: {:?},\n        c_define_token: {:?},\n        cffi_feature: {:?},\n        cpp_define: {:?},\n        cmake_target: {:?},\n        rlib_dep: {:?},\n        extra_link_libs: &[{libs}],\n        needs_cxx_linker: {},\n        capabilities: &[{caps}],\n        per_message_hook: {:?},\n    }},\n",
+            "    RmwRow {{\n        declared: {:?},\n        names: &[{names}],\n        cargo_feature: {:?},\n        cmake_value: {:?},\n        c_define_token: {:?},\n        cffi_feature: {:?},\n        cpp_define: {:?},\n        cmake_target: {:?},\n        rlib_dep: {:?},\n        link_strategy: {:?},\n        c_cffi_feature: {:?},\n        needs_cxx_linker: {},\n        capabilities: &[{caps}],\n        per_message_hook: {:?},\n    }},\n",
             d.names[0],
             d.cargo_feature,
             d.cmake_value,
             d.c_define_token,
             d.cffi_feature,
-            d.cpp_define,
-            d.cmake_target,
-            d.rlib_dep,
-            d.needs_cxx_linker,
-            d.per_message_hook,
+            d.stated.cpp_define,
+            d.stated.cmake_target,
+            d.stated.rlib_dep,
+            d.stated.link_strategy,
+            d.stated.c_cffi_feature,
+            d.stated.needs_cxx_linker,
+            d.stated.per_message_hook,
             caps = caps,
         ));
     }

--- a/packages/cli/cargo-nano-ros/src/lib.rs
+++ b/packages/cli/cargo-nano-ros/src/lib.rs
@@ -53,6 +53,11 @@ pub mod derived_descriptor;
 pub mod package_discovery;
 pub mod package_xml;
 pub mod provider_scan;
+/// The `nros-rmw.toml` descriptor (phase-439 W4, RFC-0094 D5). `build.rs`
+/// shares this exact file via `include!`, so the compile-time table and the
+/// selection-time read of an out-of-tree provider cannot be two spellings of
+/// one format.
+pub mod rmw_descriptor;
 pub mod rmw_resolver;
 pub mod scaffold;
 /// The `nros-serdes.toml` descriptor and the derivations that make it almost

--- a/packages/cli/cargo-nano-ros/src/rmw_descriptor.rs
+++ b/packages/cli/cargo-nano-ros/src/rmw_descriptor.rs
@@ -1,0 +1,314 @@
+// phase-439 W4 — the `nros-rmw.toml` descriptor, read at RUNTIME as well as at
+// build time (RFC-0094 D5, issues 1214/1215/1216).
+//
+// **This module is `include!`d by `build.rs`** as well as compiled into the
+// library, exactly like its sibling `serdes_descriptor.rs`, and for the same
+// reason: `build.rs` may not use `toml`, which is an ordinary dependency rather
+// than a build-dependency, and adding a build-dependency would move
+// `Cargo.lock`.
+//
+// One parser, two callers, on purpose. Until this wave there were two answers
+// to "what does `nros-rmw.toml` say": `build.rs`'s private `parse()` (in-tree
+// backends only, baked into the binary at compile time) and nothing at all for
+// an out-of-tree one — which is issue 1214's whole shape, a provider the scan
+// FINDS and the dispatch calls unknown. `resolve_rmw_in` reads a descriptor
+// through this module at selection time; `build.rs` reads the in-tree ones
+// through it at compile time; there is no second spelling to drift.
+//
+// Everything here is std-only and dependency-free for that reason. A path is
+// never opened here — callers hand in TEXT — so the same functions serve a
+// build script walking `packages/rmw/` and a resolver holding a `ScanResult`.
+
+/// The provider kind these descriptors belong to.
+pub const RMW_KIND: &str = "rmw";
+
+/// How a backend reaches the final link (RFC-0094 D5).
+///
+/// This is the fact the root `CMakeLists.txt` used to encode as an `if/elseif`
+/// chain on backend NAMES — `zenoh OR xrce` in one arm, `cyclonedds` in the
+/// next, and a `FATAL_ERROR` naming a closed set for everything else, which is
+/// how `uorb` came to be advertised in the cache drop-down and rejected at
+/// configure (issue 1215). A backend declares its strategy; nothing central
+/// enumerates backends.
+pub const LINK_STRATEGIES: &[&str] = &[LINK_UMBRELLA, LINK_CMAKE];
+
+/// The backend is a Rust rlib BUNDLED into the C/C++ umbrella staticlib
+/// (`libnros_c.a` / `libnros_cpp.a`) and anchored there by a `#[used]` static.
+/// The root adds nothing to the link line — there is no separate archive.
+pub const LINK_UMBRELLA: &str = "umbrella";
+
+/// The backend is a CMake project. The root `add_subdirectory()`s the
+/// directory the descriptor names and whole-archives the target it names into
+/// both umbrellas, because the backend's registration object is referenced by
+/// nothing and a plain archive link would drop it.
+pub const LINK_CMAKE: &str = "cmake";
+
+/// What a backend's `nros-rmw.toml` says.
+///
+/// Split into what convention CANNOT produce (the fields below) and what it
+/// can (the `stated_*` fields, which exist only so a descriptor written
+/// against the older shape can be checked for agreement rather than silently
+/// preferred — RFC-0087 D4).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RmwDescriptor {
+    /// `[rmw].cpp_define` — the define `nros-cpp` puts on its INTERFACE.
+    /// NOT derivable: spellings are inconsistent across backends by history
+    /// (`_CFFI` on two, bare on two) and consumer headers `#if` on them.
+    pub cpp_define: String,
+    /// The cmake target the backend's own `CMakeLists.txt` creates —
+    /// `[rmw.provides.cmake].target`, or the legacy top-level
+    /// `[rmw].cmake_target`.
+    pub cmake_target: String,
+    /// `[rmw.provides.cmake].dir` — the backend's cmake project, relative to
+    /// the descriptor. `"."` in every in-tree backend; kept because a provider
+    /// may legitimately put its `CMakeLists.txt` in a subdirectory.
+    pub cmake_dir: String,
+    /// Whether a `[rmw.provides.cmake]` table was present at all.
+    pub has_cmake_provision: bool,
+    /// `[rmw.link].rlib_dep` — the Rust backend crate bundled into the
+    /// umbrella, or empty for a backend that is not Rust.
+    pub rlib_dep: String,
+    /// `[rmw.link].needs_cxx_linker` — force the C++ linker driver.
+    pub needs_cxx_linker: bool,
+    /// `[rmw.link].strategy`, or the derivation in [`derive_link_strategy`].
+    pub link_strategy: String,
+    /// `[rmw.link].c_cffi_feature` — the `nros-c` feature that bundles this
+    /// backend. AUTHORED, not derived: the two in-tree values are
+    /// `cffi-zenoh-cffi` and `cffi-xrce-c`, irregular by history in the same
+    /// way `cpp_define` is, and `nros-c`'s feature table is what a wrong guess
+    /// would break. Empty means "this backend is not bundled into `nros-c`",
+    /// which is correct for every non-Rust backend.
+    pub c_cffi_feature: String,
+    /// `[rmw.capabilities]` — capability name -> THIS backend's own feature.
+    /// An open vocabulary by design (RFC-0071 D6): core never learns the
+    /// right-hand side, so a third-party backend can offer a capability
+    /// nano-ros has never heard of.
+    pub capabilities: Vec<(String, String)>,
+    /// `[rmw.codegen].per_message` — a cmake command run per message type.
+    pub per_message_hook: String,
+
+    // ---- restatements of derivable facts (RFC-0087 D4) --------------------
+    /// `[rmw].names`, if the descriptor still restates the announcements.
+    pub stated_names: Vec<String>,
+    pub stated_cargo_feature: String,
+    pub stated_cmake_value: String,
+    pub stated_c_define_token: String,
+    pub stated_cffi_feature: String,
+}
+
+/// Parse an `nros-rmw.toml`.
+///
+/// Line-oriented, matching `serdes_descriptor::parse_serdes_descriptor` and
+/// `NanoRosCapabilities.cmake`'s `file(STRINGS … REGEX …)`: the descriptor
+/// shape is flat `key = value` under one table, and it is ours.
+///
+/// `origin` names the file in error messages; it is never opened here.
+///
+/// Unknown keys are IGNORED rather than rejected, deliberately — the four
+/// in-tree descriptors carry `[rmw.provides.cargo]` tables that no consumer
+/// reads yet, and a forward-compatible reader is what lets a wave add a field
+/// without every older descriptor becoming unparsable. An unknown value for a
+/// key that IS read is a different matter and errors below.
+pub fn parse_rmw_descriptor(text: &str, origin: &str) -> Result<RmwDescriptor, String> {
+    let mut d = RmwDescriptor {
+        cmake_dir: ".".to_string(),
+        ..RmwDescriptor::default()
+    };
+    let mut section = String::new();
+
+    for raw in text.lines() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            section = name.to_string();
+            if section == "rmw.provides.cmake" {
+                d.has_cmake_provision = true;
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let (key, value) = (key.trim(), value.trim());
+        let scalar = || value.trim_matches('"').to_string();
+        let list = || {
+            value
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .split(',')
+                .map(|x| x.trim().trim_matches('"').to_string())
+                .filter(|x| !x.is_empty())
+                .collect::<Vec<_>>()
+        };
+        match (section.as_str(), key) {
+            ("rmw", "cpp_define") => d.cpp_define = scalar(),
+            ("rmw", "cmake_target") => d.cmake_target = scalar(),
+            ("rmw", "names") => d.stated_names = list(),
+            ("rmw", "cargo_feature") => d.stated_cargo_feature = scalar(),
+            ("rmw", "cmake_value") => d.stated_cmake_value = scalar(),
+            ("rmw", "c_define_token") => d.stated_c_define_token = scalar(),
+            ("rmw", "cffi_feature") => d.stated_cffi_feature = scalar(),
+            ("rmw.provides.cmake", "target") => d.cmake_target = scalar(),
+            ("rmw.provides.cmake", "dir") => d.cmake_dir = scalar(),
+            ("rmw.link", "rlib_dep") => d.rlib_dep = scalar(),
+            ("rmw.link", "needs_cxx_linker") => d.needs_cxx_linker = value == "true",
+            ("rmw.link", "strategy") => d.link_strategy = scalar(),
+            ("rmw.link", "c_cffi_feature") => d.c_cffi_feature = scalar(),
+            ("rmw.capabilities", k) => d.capabilities.push((k.to_string(), scalar())),
+            ("rmw.codegen", "per_message") => d.per_message_hook = scalar(),
+            _ => {}
+        }
+    }
+
+    if !d.link_strategy.is_empty() && !LINK_STRATEGIES.contains(&d.link_strategy.as_str()) {
+        return Err(format!(
+            "{origin}: [rmw.link].strategy is {:?}, which is not one of {} — a typo \
+             here would produce a build that links no backend and says nothing",
+            d.link_strategy,
+            LINK_STRATEGIES.join(" | ")
+        ));
+    }
+    if d.link_strategy.is_empty() {
+        d.link_strategy = derive_link_strategy(&d.rlib_dep, &d.cmake_target)
+            .ok_or_else(|| {
+                format!(
+                    "{origin}: cannot tell how this backend reaches the link. Declare \
+                     `[rmw.link] rlib_dep = \"<crate>\"` (bundled into the C/C++ \
+                     umbrella), or `[rmw.provides.cmake] target = \"<cmake target>\"` \
+                     (a CMake project the build add_subdirectory()s), or state \
+                     `[rmw.link] strategy` outright."
+                )
+            })?
+            .to_string();
+    }
+
+    Ok(d)
+}
+
+/// The link strategy a descriptor gets when it states none.
+///
+/// A Rust backend names the rlib the umbrella bundles, which IS the statement
+/// that nothing separate reaches the link line. Anything else that names a
+/// cmake target is a CMake project the build must add and whole-archive.
+/// Neither: there is no answer, and guessing one produces an image with no
+/// backend registered and no diagnostic (issue 0155's failure mode).
+#[must_use]
+pub fn derive_link_strategy(rlib_dep: &str, cmake_target: &str) -> Option<&'static str> {
+    if !rlib_dep.is_empty() {
+        Some(LINK_UMBRELLA)
+    } else if !cmake_target.is_empty() {
+        Some(LINK_CMAKE)
+    } else {
+        None
+    }
+}
+
+/// A descriptor may restate a derivable field; it may not disagree with it.
+///
+/// Empty means "not stated" — after phase-420 W5 the field's whole point is to
+/// be absent. `check-derived-descriptor-fields` is the buildless form of this
+/// same rule; this is the copy that fires for anyone who builds or resolves.
+pub fn agree_with_convention(
+    origin: &str,
+    field: &str,
+    stated: &str,
+    derived: &str,
+) -> Result<(), String> {
+    if !stated.is_empty() && stated != derived {
+        return Err(format!(
+            "{origin}: [rmw].{field} states {stated:?} but convention derives \
+             {derived:?} (RFC-0087 D4). Delete the field — it is derived from the \
+             provider's announced name — or fix the name it disagrees with."
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_rust_backend_defaults_to_the_umbrella_strategy() {
+        let d = parse_rmw_descriptor(
+            "[rmw]\ncpp_define = \"NROS_RMW_ACME\"\n[rmw.link]\nrlib_dep = \"nros-rmw-acme\"\n",
+            "acme",
+        )
+        .unwrap();
+        assert_eq!(d.link_strategy, LINK_UMBRELLA);
+        assert_eq!(d.rlib_dep, "nros-rmw-acme");
+        assert!(!d.has_cmake_provision);
+    }
+
+    #[test]
+    fn a_cmake_backend_defaults_to_the_cmake_strategy() {
+        let d = parse_rmw_descriptor(
+            "[rmw]\ncpp_define = \"NROS_RMW_ACME\"\n\
+             [rmw.provides.cmake]\ndir = \".\"\ntarget = \"nros_rmw_acme\"\n\
+             [rmw.link]\nrlib_dep = \"\"\nneeds_cxx_linker = true\n",
+            "acme",
+        )
+        .unwrap();
+        assert_eq!(d.link_strategy, LINK_CMAKE);
+        assert_eq!(d.cmake_target, "nros_rmw_acme");
+        assert_eq!(d.cmake_dir, ".");
+        assert!(d.has_cmake_provision);
+        assert!(d.needs_cxx_linker);
+    }
+
+    #[test]
+    fn a_backend_that_names_no_route_to_the_link_is_refused() {
+        let err = parse_rmw_descriptor("[rmw]\ncpp_define = \"X\"\n", "acme").unwrap_err();
+        assert!(
+            err.contains("cannot tell how this backend reaches the link"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_typoed_strategy_is_refused_rather_than_defaulted() {
+        let err = parse_rmw_descriptor(
+            "[rmw]\ncpp_define = \"X\"\n[rmw.link]\nrlib_dep = \"a\"\nstrategy = \"umbrela\"\n",
+            "acme",
+        )
+        .unwrap_err();
+        assert!(err.contains("umbrela"), "{err}");
+    }
+
+    #[test]
+    fn capabilities_are_an_open_vocabulary() {
+        let d = parse_rmw_descriptor(
+            "[rmw]\ncpp_define = \"X\"\n[rmw.link]\nrlib_dep = \"a\"\n\
+             [rmw.capabilities]\nnever-heard-of-it = \"acme-feature\"\n",
+            "acme",
+        )
+        .unwrap();
+        assert_eq!(
+            d.capabilities,
+            vec![("never-heard-of-it".to_string(), "acme-feature".to_string())]
+        );
+    }
+
+    #[test]
+    fn an_unread_table_does_not_make_a_descriptor_unparsable() {
+        // `[rmw.provides.cargo]` is read by nothing today. A reader that
+        // rejected it would make every in-tree descriptor unparsable.
+        let d = parse_rmw_descriptor(
+            "[rmw]\ncpp_define = \"X\"\n[rmw.provides.cargo]\ncrate = \"nros-rmw-acme\"\n\
+             [rmw.link]\nrlib_dep = \"nros-rmw-acme\"\n",
+            "acme",
+        )
+        .unwrap();
+        assert_eq!(d.link_strategy, LINK_UMBRELLA);
+    }
+
+    #[test]
+    fn a_restatement_that_disagrees_is_refused() {
+        assert!(agree_with_convention("acme", "cmake_value", "acme", "acme").is_ok());
+        assert!(agree_with_convention("acme", "cmake_value", "", "acme").is_ok());
+        let err = agree_with_convention("acme", "cmake_value", "acme-rmw", "acme").unwrap_err();
+        assert!(err.contains("RFC-0087 D4"), "{err}");
+    }
+}

--- a/packages/cli/cargo-nano-ros/src/rmw_resolver.rs
+++ b/packages/cli/cargo-nano-ros/src/rmw_resolver.rs
@@ -16,7 +16,12 @@
 //! It lives in `cargo-nano-ros` (the lower crate) so both the scaffolder here
 //! and the orchestration loader in `nros-cli-core` share one mapping.
 
-use std::fmt;
+use std::{fmt, path::PathBuf};
+
+use crate::{
+    provider_scan::{ResolveError, ScanResult, resolve_unique},
+    rmw_descriptor::{RMW_KIND, RmwDescriptor, agree_with_convention, parse_rmw_descriptor},
+};
 
 include!(concat!(env!("OUT_DIR"), "/rmw_table.rs"));
 
@@ -46,6 +51,12 @@ pub struct ResolvedRmw {
     pub cmake_value: &'static str,
     /// The C `#define NROS_SYSTEM_RMW_<TOKEN>` token, e.g. `"ZENOH"`.
     pub c_define_token: &'static str,
+    /// `[rmw].cpp_define` — the define `nros-cpp` puts on its INTERFACE.
+    pub cpp_define: &'static str,
+    /// The cmake target the backend's own `CMakeLists.txt` creates, or empty.
+    pub cmake_target: &'static str,
+    /// `[rmw.codegen].per_message` — a cmake command run per message type.
+    pub per_message_hook: &'static str,
     /// Phase 241 W13/R1 (RFC-0042 §D3 bullet 2) — the **link dispatch** data,
     /// the one place that records how each backend reaches the final link.
     /// Consumed by both the W11 synthesized `nros_ws_runtime` crate's nros-cpp
@@ -63,14 +74,23 @@ pub struct RmwDispatch {
     /// `nros_ws_runtime` crate sets this on its `nros-cpp` dep.
     pub umbrella_cffi_feature: &'static str,
     /// The pure-Rust backend crate force-linked **into** the umbrella as an rlib
-    /// dep, e.g. `Some("nros-rmw-zenoh")`. `None` for cyclonedds — it is a C++
-    /// library linked separately (see `extra_link_libs`), not a Rust rlib.
+    /// dep, e.g. `Some("nros-rmw-zenoh")`. `None` for a backend that is not a
+    /// Rust crate — cyclonedds and uorb are C/C++ CMake projects.
+    ///
+    /// phase-439 W4 — this used to be read by NOTHING (issue 1216) and is now
+    /// the discriminator: naming an rlib IS the statement that the backend
+    /// arrives inside the umbrella staticlib and nothing separate reaches the
+    /// link line. See [`RmwDispatch::link_strategy`].
     pub rlib_dep: Option<&'static str>,
-    /// Extra non-umbrella link libraries the final binary needs for this backend.
-    /// Empty for the pure-Rust backends (zenoh/xrce); cyclonedds pulls its C++
-    /// RMW wrapper + Cyclone + the C++ runtime (incl. for C binaries — the locked
-    /// design choice). Names are cmake link targets / `-l` stems.
-    pub extra_link_libs: &'static [&'static str],
+    /// `umbrella` | `cmake` — see `rmw_descriptor::LINK_STRATEGIES`.
+    pub link_strategy: &'static str,
+    /// The `nros-c` feature that bundles this backend, or empty.
+    ///
+    /// AUTHORED per backend rather than derived: the two in-tree values are
+    /// `cffi-zenoh-cffi` and `cffi-xrce-c`, irregular by history in the same way
+    /// `cpp_define` is. `umbrella_cffi_feature` is the `nros-cpp` half, which IS
+    /// regular (`<cargo_feature>-cffi`).
+    pub c_cffi_feature: &'static str,
     /// Whether the final link must use the C++ linker driver (libstdc++ on the
     /// line). True for cyclonedds (its wrapper is C++), even for C binaries.
     pub needs_cxx_linker: bool,
@@ -157,10 +177,14 @@ pub fn resolve_rmw(declared: &str) -> Result<ResolvedRmw, UnknownRmw> {
             cargo_feature: r.cargo_feature,
             cmake_value: r.cmake_value,
             c_define_token: r.c_define_token,
+            cpp_define: r.cpp_define,
+            cmake_target: r.cmake_target,
+            per_message_hook: r.per_message_hook,
             dispatch: RmwDispatch {
                 umbrella_cffi_feature: r.cffi_feature,
                 rlib_dep: (!r.rlib_dep.is_empty()).then_some(r.rlib_dep),
-                extra_link_libs: r.extra_link_libs,
+                link_strategy: r.link_strategy,
+                c_cffi_feature: r.c_cffi_feature,
                 needs_cxx_linker: r.needs_cxx_linker,
             },
         })
@@ -169,102 +193,194 @@ pub fn resolve_rmw(declared: &str) -> Result<ResolvedRmw, UnknownRmw> {
         })
 }
 
-/// Phase 241 W13/R1 — render the per-backend link dispatch ([`RmwDispatch`]) as a
-/// CMake-includable `nros_rmw_dispatch(<rmw>)` function, the **generated** form of the
-/// formerly hand-maintained "RMW backend dispatch" prose (RFC-0042 §D3 bullet 2). The
-/// output is committed at `cmake/NanoRosRmwDispatch.cmake`; `rmw_cmake_dispatch_is_current`
-/// asserts the committed copy matches this renderer, so the SSoT is `resolve_rmw()` and
-/// drift fails the build. Consumed by `NanoRosRuntimeCrate.cmake` (the W11 synthesized
-/// runtime crate's nros-cpp cffi feature) and the cmake Cyclone link block.
-pub fn render_cmake_dispatch() -> String {
-    let mut out = String::new();
-    out.push_str(
-        "# Generated from cargo-nano-ros `resolve_rmw()` — DO NOT EDIT.\n\
-         # Regenerate: `cargo test -p cargo-nano-ros rmw_cmake_dispatch_is_current -- --ignored`\n\
-         # (or run the bin helper). The SSoT is rmw_resolver.rs; this is its CMake lowering.\n\
-         #\n\
-         # nros_rmw_dispatch(<rmw>) sets in the CALLER scope:\n\
-         #   NROS_RMW_UMBRELLA_CFFI_FEATURE  the nros-c/nros-cpp cffi feature (e.g. rmw-zenoh-cffi)\n\
-         #   NROS_RMW_RLIB_DEP               backend rlib crate bundled in the umbrella, or \"\"\n\
-         #   NROS_RMW_EXTRA_LINK_LIBS        ;-list of extra link libs (cyclonedds C++ path), or \"\"\n\
-         #   NROS_RMW_NEEDS_CXX_LINKER       ON/OFF — force the C++ linker driver (libstdc++)\n\
-         #   NROS_RMW_CPP_DEFINE             the define nros-cpp puts on its INTERFACE\n\
-         #   NROS_RMW_CMAKE_TARGET           a cmake target to link when present, or \"\"\n\
-         #   NROS_RMW_CAPABILITIES           ;-list of capabilities this backend declares\n\
-         #   NROS_RMW_PER_MESSAGE_HOOK       cmake command run per message type, or \"\"\n\
-         function(nros_rmw_dispatch rmw)\n",
-    );
-    let mut first = true;
-    for name in known_rmw() {
-        let row = RMW_ROWS
-            .iter()
-            .find(|x| x.declared == name)
-            .expect("known_rmw() names come from RMW_ROWS");
-        let r = resolve_rmw(name).expect("a descriptor-provided name resolves");
-        let d = &r.dispatch;
-        let branch = if first { "if" } else { "elseif" };
-        first = false;
-        let rlib = d.rlib_dep.unwrap_or("");
-        let extra = d.extra_link_libs.join(";");
-        let needs_cxx = if d.needs_cxx_linker { "ON" } else { "OFF" };
-        out.push_str(&format!(
-            "    {branch}(rmw STREQUAL \"{decl}\")\n\
-             \x20       set(NROS_RMW_UMBRELLA_CFFI_FEATURE \"{feat}\" PARENT_SCOPE)\n\
-             \x20       set(NROS_RMW_RLIB_DEP \"{rlib}\" PARENT_SCOPE)\n\
-             \x20       set(NROS_RMW_EXTRA_LINK_LIBS \"{extra}\" PARENT_SCOPE)\n\
-             \x20       set(NROS_RMW_NEEDS_CXX_LINKER {needs_cxx} PARENT_SCOPE)\n\
-             \x20       set(NROS_RMW_CPP_DEFINE \"{cpp_define}\" PARENT_SCOPE)\n\
-             \x20       set(NROS_RMW_CMAKE_TARGET \"{cmake_target}\" PARENT_SCOPE)\n\
-             \x20       set(NROS_RMW_CAPABILITIES \"{caps}\" PARENT_SCOPE)\n\
-             \x20       set(NROS_RMW_PER_MESSAGE_HOOK \"{hook}\" PARENT_SCOPE)\n",
-            decl = r.declared,
-            feat = d.umbrella_cffi_feature,
-            cpp_define = row.cpp_define,
-            cmake_target = row.cmake_target,
-            hook = row.per_message_hook,
-            caps = row
-                .capabilities
-                .iter()
-                .map(|(k, _)| *k)
-                .collect::<Vec<_>>()
-                .join(";"),
-        ));
+/// Lower a declared RMW string against a PROVIDER SCAN.
+///
+/// The sibling of [`resolve_rmw`], and the answer to issue 1214. `resolve_rmw`
+/// reads a table baked into this binary at COMPILE time from `packages/rmw/`,
+/// so the set of resolvable names is structurally the contents of one checkout:
+/// an out-of-tree provider that `nros ws providers --resolve rmw:acme` FINDS is
+/// then reported unknown by every build path. This reads the descriptor at
+/// SELECTION time, through the same scan, so discovery and dispatch are one
+/// mechanism.
+///
+/// Modelled on `serdes_resolver::resolve_serdes_in`, which is the shape RFC-0088
+/// D6 established and RFC-0094 D5 extends to this axis. Owned `String`s for the
+/// same reason it gives: an out-of-repo provider's name is read from a file at
+/// selection time and cannot be `'static`.
+///
+/// A provider with NO `nros-rmw.toml` is an error here, unlike serdes: a serdes
+/// provider with nothing non-derivable to say gets every default, while an RMW
+/// backend must at minimum say how it reaches the link and what `cpp_define`
+/// consumers `#if` on. Both are non-derivable, so silence is not a default.
+pub fn resolve_rmw_in(scan: &ScanResult, declared: &str) -> Result<ResolvedRmwIn, RmwResolveError> {
+    let resolution = resolve_unique(scan, RMW_KIND, declared).map_err(RmwResolveError::Scan)?;
+    let pkg = resolution.winner;
+
+    // The CANONICAL name is the provider's first `rmw` announcement, not the
+    // string the consumer typed: a provider announcing `zenoh`, `rmw-zenoh` and
+    // `rmw-zenoh-cffi` has one canonical spelling, and the lowering must not
+    // depend on which alias the consumer reached it by.
+    let canonical = pkg
+        .provides
+        .iter()
+        .find(|p| p.kind == RMW_KIND)
+        .map(|p| p.name.clone())
+        .ok_or_else(|| RmwResolveError::Provider {
+            dir: pkg.dir.clone(),
+            message: "resolved as an rmw provider but announces no rmw provision".to_string(),
+        })?;
+
+    let fail = |message: String| RmwResolveError::Provider {
+        dir: pkg.dir.clone(),
+        message,
+    };
+
+    let descriptor_path = pkg.descriptor_path(RMW_KIND);
+    if !descriptor_path.is_file() {
+        return Err(fail(format!(
+            "no {} beside the announcement. An rmw provider must declare at least \
+             `[rmw] cpp_define` and how it reaches the link — neither is derivable \
+             from the name, so there is no default that could be right.",
+            descriptor_path.file_name().map_or_else(
+                || descriptor_path.display().to_string(),
+                |f| f.to_string_lossy().into_owned()
+            )
+        )));
     }
-    out.push_str(
-        "    else()\n\
-         \x20       message(FATAL_ERROR \"nros_rmw_dispatch: unknown rmw '${rmw}' \"\n\
-         \x20           \"(known: KNOWN_PLACEHOLDER)\")\n\
-         \x20   endif()\n\
-         endfunction()\n",
-    );
-    // phase-347 W3 — the "known:" list in the FATAL_ERROR is DERIVED. It used to
-    // be the literal "zenoh xrce cyclonedds", which is how the message came to
-    // omit `uorb`: a hand-written list inside a generator is still a hand-written
-    // list.
-    out = out.replace("KNOWN_PLACEHOLDER", &known_rmw().join(" "));
-    // phase-347 W3 — one derived list every cmake consumer shares, so
-    // `NanoRosFeatureSet`'s validator and `nros-cpp`'s dispatch stop keeping
-    // their own. Those two accepted `uorb` while `nros_rmw_dispatch` fatal'd on
-    // it: three lists, two of which were right.
-    out.push_str(&format!(
-        "\n# Every rmw a descriptor in this checkout provides. DERIVED — see above.\n\
-         set(NROS_RMW_KNOWN \"{}\" CACHE INTERNAL \"rmw names provided by nros-rmw.toml descriptors\")\n\
-         \n\
-         # nros_rmw_is_known(<name> <out_var>) — TRUE when a descriptor claims <name>.\n\
-         function(nros_rmw_is_known name out_var)\n\
-         \x20   if(name IN_LIST NROS_RMW_KNOWN)\n\
-         \x20       set(${{out_var}} TRUE PARENT_SCOPE)\n\
-         \x20   else()\n\
-         \x20       set(${{out_var}} FALSE PARENT_SCOPE)\n\
-         \x20   endif()\n\
-         endfunction()\n",
-        known_rmw().join(";")
-    ));
-    out
+    let text = std::fs::read_to_string(&descriptor_path)
+        .map_err(|e| fail(format!("read {}: {e}", descriptor_path.display())))?;
+    let origin = descriptor_path.display().to_string();
+    let d = parse_rmw_descriptor(&text, &origin).map_err(fail)?;
+
+    // The same convention half `build.rs` applies to an in-tree descriptor, and
+    // the same refusal of a restatement that disagrees (RFC-0087 D4).
+    let cargo_feature = crate::derived_descriptor::cargo_feature(RMW_KIND, &canonical);
+    let cmake_value = crate::derived_descriptor::cmake_value(&canonical);
+    let c_define_token = crate::derived_descriptor::c_define_token(&canonical);
+    let cffi_feature = crate::derived_descriptor::cffi_feature(&cargo_feature);
+    for (field, stated, derived) in [
+        ("cargo_feature", &d.stated_cargo_feature, &cargo_feature),
+        ("cmake_value", &d.stated_cmake_value, &cmake_value),
+        ("c_define_token", &d.stated_c_define_token, &c_define_token),
+        ("cffi_feature", &d.stated_cffi_feature, &cffi_feature),
+    ] {
+        agree_with_convention(&origin, field, stated, derived).map_err(fail)?;
+    }
+    if !d.stated_names.is_empty() {
+        let announced: Vec<String> = pkg
+            .provides
+            .iter()
+            .filter(|p| p.kind == RMW_KIND)
+            .map(|p| p.name.clone())
+            .collect();
+        agree_with_convention(
+            &origin,
+            "names",
+            &d.stated_names.join(","),
+            &announced.join(","),
+        )
+        .map_err(fail)?;
+    }
+    if d.cpp_define.is_empty() {
+        return Err(fail(format!(
+            "{origin}: [rmw].cpp_define is missing — it is the one non-derivable \
+             lowering (spellings are inconsistent across backends by history and \
+             consumers `#if` on them), so it must be authored"
+        )));
+    }
+
+    // The cmake project directory is descriptor-relative, so a provider may put
+    // its `CMakeLists.txt` in a subdirectory. Normalised here rather than in
+    // cmake: a `dir` of `"."` must come back as the package dir itself, not as
+    // `<dir>/.`, because the value is compared against build paths.
+    let cmake_dir = if d.cmake_dir == "." || d.cmake_dir.is_empty() {
+        pkg.dir.clone()
+    } else {
+        pkg.dir.join(&d.cmake_dir)
+    };
+
+    Ok(ResolvedRmwIn {
+        declared: canonical,
+        cargo_feature,
+        cmake_value,
+        c_define_token,
+        cffi_feature,
+        package: pkg.package.clone(),
+        package_dir: pkg.dir.clone(),
+        cmake_dir,
+        descriptor: d,
+    })
 }
 
-/// Repo-relative path of the committed CMake lowering of [`render_cmake_dispatch`].
-pub const CMAKE_DISPATCH_REL_PATH: &str = "cmake/NanoRosRmwDispatch.cmake";
+/// A declared RMW value lowered against a provider scan ([`resolve_rmw_in`]).
+///
+/// Everything [`ResolvedRmw`] carries plus WHERE the provider is — which is the
+/// half the compile-time table cannot have, and the half a `add_subdirectory()`
+/// needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRmwIn {
+    /// The provider's first `rmw` announcement — its canonical name.
+    pub declared: String,
+    pub cargo_feature: String,
+    pub cmake_value: String,
+    pub c_define_token: String,
+    pub cffi_feature: String,
+    /// The `package.xml` `<name>`.
+    pub package: String,
+    /// The directory holding the provider's `package.xml`.
+    pub package_dir: PathBuf,
+    /// The cmake project to `add_subdirectory()`, resolved absolute.
+    pub cmake_dir: PathBuf,
+    /// Everything the descriptor itself declares.
+    pub descriptor: RmwDescriptor,
+}
+
+/// Why [`resolve_rmw_in`] could not lower a name.
+#[derive(Debug)]
+pub enum RmwResolveError {
+    /// No provider announced it, or several did ambiguously.
+    Scan(ResolveError),
+    /// A provider WAS resolved and its descriptor is unusable.
+    Provider { dir: PathBuf, message: String },
+}
+
+impl fmt::Display for RmwResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Scan(e) => write!(f, "{e}"),
+            Self::Provider { dir, message } => {
+                write!(f, "rmw provider at {}: {message}", dir.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for RmwResolveError {}
+
+/// Every rmw backend a provider on this scan announces, by CANONICAL name.
+///
+/// The scan-based sibling of [`known_rmw`], and the producer of the cmake
+/// `NROS_RMW_KNOWN` list. One entry per provider — its FIRST `rmw` provision —
+/// not one per announcement: `zenoh`, `rmw-zenoh` and `rmw-zenoh-cffi` are
+/// three ways to reach one backend, and listing all three in the cache
+/// drop-down would offer a user three choices that are one choice.
+/// [`resolve_rmw_in`] still accepts every alias.
+///
+/// Sorted rather than in scan order so the list does not reorder when an
+/// unrelated package is added — the same reason `nano_ros_load_providers` sorts
+/// its kinds.
+#[must_use]
+pub fn known_rmw_in(scan: &ScanResult) -> Vec<String> {
+    let mut names: Vec<String> = scan
+        .providers
+        .iter()
+        .filter_map(|p| p.provides.iter().find(|x| x.kind == RMW_KIND))
+        .map(|p| p.name.clone())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
 
 #[cfg(test)]
 mod tests {
@@ -330,40 +446,97 @@ mod tests {
         }
     }
 
-    fn cmake_dispatch_path() -> std::path::PathBuf {
+    /// The repo root, from this crate's manifest dir.
+    fn repo_root() -> std::path::PathBuf {
         // CARGO_MANIFEST_DIR = packages/cli/cargo-nano-ros → repo root is ../../..
         std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../..")
-            .join(CMAKE_DISPATCH_REL_PATH)
+            .canonicalize()
+            .expect("the repo root exists relative to this manifest")
     }
 
+    /// The compile-time table and the scan-time read must agree, field for
+    /// field, for every backend in this checkout.
+    ///
+    /// Two readers of one file format that nobody compares is how the RMW
+    /// parity map came to disagree with the vtable by 25 symbols, and it is the
+    /// exact risk `resolve_rmw_in` introduces: `build.rs` bakes `RMW_ROWS` from
+    /// `packages/rmw/`, `resolve_rmw_in` reads the same descriptors through the
+    /// provider scan, and nothing else would notice them drifting. They share
+    /// `rmw_descriptor::parse_rmw_descriptor`, so this asserts the DERIVATIONS
+    /// around it agree too.
     #[test]
-    fn rmw_cmake_dispatch_is_current() {
-        let want = render_cmake_dispatch();
-        let path = cmake_dispatch_path();
-        let got = std::fs::read_to_string(&path).unwrap_or_else(|e| {
-            panic!(
-                "cannot read {} ({e}); regenerate with `cargo test -p cargo-nano-ros \
-                 regenerate_cmake_dispatch -- --ignored`",
-                path.display()
-            )
-        });
-        assert_eq!(
-            got, want,
-            "{} is stale — resolve_rmw() changed. Regenerate: `cargo test -p cargo-nano-ros \
-             regenerate_cmake_dispatch -- --ignored`",
-            CMAKE_DISPATCH_REL_PATH
+    fn the_baked_table_and_the_scan_agree_on_every_in_tree_backend() {
+        let root = repo_root();
+        let scan = crate::provider_scan::scan_roots(&[root]).expect("the nano-ros tree scans");
+        for name in known_rmw() {
+            let baked = resolve_rmw(name).expect("a baked name resolves");
+            let scanned = resolve_rmw_in(&scan, name)
+                .unwrap_or_else(|e| panic!("{name} resolves through the scan: {e}"));
+            assert_eq!(scanned.declared, baked.declared, "{name}: declared");
+            assert_eq!(
+                scanned.cargo_feature, baked.cargo_feature,
+                "{name}: cargo_feature"
+            );
+            assert_eq!(
+                scanned.cmake_value, baked.cmake_value,
+                "{name}: cmake_value"
+            );
+            assert_eq!(
+                scanned.c_define_token, baked.c_define_token,
+                "{name}: c_define_token"
+            );
+            assert_eq!(
+                scanned.cffi_feature, baked.dispatch.umbrella_cffi_feature,
+                "{name}: cffi"
+            );
+            let d = &scanned.descriptor;
+            assert_eq!(d.cpp_define, baked.cpp_define, "{name}: cpp_define");
+            assert_eq!(
+                d.per_message_hook, baked.per_message_hook,
+                "{name}: per_message_hook"
+            );
+            assert_eq!(
+                d.link_strategy, baked.dispatch.link_strategy,
+                "{name}: link_strategy"
+            );
+            assert_eq!(
+                d.c_cffi_feature, baked.dispatch.c_cffi_feature,
+                "{name}: c_cffi_feature"
+            );
+            assert_eq!(
+                d.needs_cxx_linker, baked.dispatch.needs_cxx_linker,
+                "{name}: cxx_linker"
+            );
+            assert_eq!(
+                d.rlib_dep.as_str(),
+                baked.dispatch.rlib_dep.unwrap_or(""),
+                "{name}: rlib_dep"
+            );
+            // `cmake_target` is the one field whose SOURCE differs: the baked
+            // row reads only the legacy top-level `[rmw].cmake_target` (uorb's),
+            // while the scan also reads `[rmw.provides.cmake].target`. So the
+            // scan is a SUPERSET, and the assertion is one-directional.
+            if !baked.cmake_target.is_empty() {
+                assert_eq!(d.cmake_target, baked.cmake_target, "{name}: cmake_target");
+            }
+        }
+    }
+
+    /// Every backend a provider announces must be dispatchable, not merely
+    /// discoverable — issue 1214's exact shape, as a test.
+    #[test]
+    fn every_announced_backend_resolves_through_the_scan() {
+        let root = repo_root();
+        let scan = crate::provider_scan::scan_roots(&[root]).expect("the nano-ros tree scans");
+        let announced = known_rmw_in(&scan);
+        assert!(
+            announced.iter().any(|n| n == "uorb"),
+            "uorb announces `kind=\"rmw\"` and must be in the scan's answer: {announced:?}"
         );
-    }
-
-    /// Writes the committed CMake lowering from `resolve_rmw()`. Ignored by default
-    /// (it mutates a tracked file); run explicitly to regenerate after editing the
-    /// dispatch data: `cargo test -p cargo-nano-ros regenerate_cmake_dispatch -- --ignored`.
-    #[test]
-    #[ignore = "writes a tracked file; run explicitly to regenerate"]
-    fn regenerate_cmake_dispatch() {
-        let path = cmake_dispatch_path();
-        std::fs::write(&path, render_cmake_dispatch())
-            .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+        for name in &announced {
+            resolve_rmw_in(&scan, name)
+                .unwrap_or_else(|e| panic!("{name} is announced but does not dispatch: {e}"));
+        }
     }
 }

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -185,6 +185,58 @@ pub enum Sub {
     /// dependency cycle is an error naming every package on it.
     #[command(name = "order")]
     Order(OrderArgs),
+
+    /// phase-439 W4 (RFC-0094 D5) — lower one declared RMW name to the build
+    /// facts its descriptor declares, over the SAME provider scan `providers`
+    /// uses.
+    ///
+    /// This is the seam that makes a backend's `nros-rmw.toml` load-bearing.
+    /// `cmake/NanoRosRmwDispatch.cmake` used to be GENERATED from the table
+    /// baked into this binary — an `if/elseif` chain over the four backends in
+    /// one checkout, with an `else()` `FATAL_ERROR` naming a closed set. So an
+    /// out-of-tree provider that `providers --resolve rmw:acme` found was then
+    /// reported unknown by the very next step (issue 1214). cmake now ASKS,
+    /// exactly as `nano_ros_load_providers` does, and an unknown name is "no
+    /// provider announced this" rather than "not one of the four we compiled".
+    #[command(name = "rmw-dispatch")]
+    RmwDispatch(RmwDispatchArgs),
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct RmwDispatchArgs {
+    /// The declared RMW name — canonical (`zenoh`) or any announced alias
+    /// (`rmw-zenoh`, `rmw-zenoh-cffi`). Omit it with `--known`.
+    pub name: Option<String>,
+
+    /// Workspace to scan as the second search root. Defaults to the cwd.
+    #[arg(long)]
+    pub workspace: Option<PathBuf>,
+
+    /// nano-ros source tree to scan as the FIRST search root.
+    #[arg(long)]
+    pub nano_ros_root: Option<PathBuf>,
+
+    /// Read this provider index instead of scanning. Same identity rule as
+    /// `providers --index`: an index built for other roots is rejected.
+    #[arg(long, value_name = "PATH")]
+    pub index: Option<PathBuf>,
+
+    /// Scan, and leave the index current for the next reader.
+    #[arg(long, value_name = "PATH", conflicts_with = "index")]
+    pub write_index: Option<PathBuf>,
+
+    /// Emit `KEY<TAB>VALUE` rows cmake can read with `string(REPLACE)`.
+    ///
+    /// The cmake seam, same shape and same reason as `providers --lines`:
+    /// cmake has no JSON parser, and a second parser of the descriptor is the
+    /// drift class this wave exists to delete.
+    #[arg(long)]
+    pub lines: bool,
+
+    /// List every rmw name a provider on the search path announces, instead of
+    /// dispatching one. This is what feeds `NROS_RMW_KNOWN`.
+    #[arg(long)]
+    pub known: bool,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -442,7 +494,153 @@ pub fn run(args: Args) -> Result<()> {
         Sub::EntityInventory(a) => crate::cmd::entity_inventory::run(a),
         Sub::Providers(a) => run_providers(a),
         Sub::Order(a) => run_order(a),
+        Sub::RmwDispatch(a) => run_rmw_dispatch(a),
     }
+}
+
+// =============================================================================
+// `nros ws rmw-dispatch` — phase-439 W4 (RFC-0094 D5)
+// =============================================================================
+
+/// Build the provider search path and scan (or read the index) the way
+/// `run_providers` does.
+///
+/// Shared rather than copied: the roots are part of an index's IDENTITY —
+/// `is_valid_for` REJECTS an index written against a different root list — so
+/// two spellings of "which roots" would make every cached read fail, which is
+/// exactly the failure `provider_search_path` was factored out to prevent one
+/// level up.
+fn scan_providers_for(
+    workspace: Option<PathBuf>,
+    nano_ros_root: Option<PathBuf>,
+    index: Option<&Path>,
+    write_index: Option<&Path>,
+) -> Result<provider_scan::ScanResult> {
+    let workspace = match workspace {
+        Some(w) => w,
+        None => std::env::current_dir().wrap_err("resolving cwd as the workspace root")?,
+    };
+    let workspace = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.clone());
+    let search_path = match nano_ros_root {
+        Some(r) => {
+            let r = r.canonicalize().unwrap_or(r);
+            provider_search_path_with(Some(&r), &workspace)?
+        }
+        None => provider_search_path(&workspace)?,
+    };
+    warn_missing_roots(&search_path);
+    let roots = search_path.paths();
+
+    let result = match index {
+        Some(path) => {
+            let idx = provider_scan::ProviderIndex::read(path)?;
+            if !idx.is_valid_for(&roots) {
+                bail!(
+                    "provider index {} was built for roots {:?}, not {:?} — \
+                     an index for other roots is wrong, not merely stale",
+                    path.display(),
+                    idx.roots,
+                    roots
+                );
+            }
+            provider_scan::ScanResult {
+                providers: idx.providers,
+                errors: Vec::new(),
+                inputs: idx.inputs,
+            }
+        }
+        None => provider_scan::scan_roots(&roots)?,
+    };
+    // A package.xml that could not be parsed is the reason a provider the user
+    // expected is missing; never bury it.
+    for e in &result.errors {
+        eprintln!("warning: {}: {}", e.path.display(), e.message);
+    }
+    if let Some(path) = write_index {
+        provider_scan::ProviderIndex::from_scan(&roots, &result).write(path)?;
+    }
+    Ok(result)
+}
+
+fn run_rmw_dispatch(args: RmwDispatchArgs) -> Result<()> {
+    use cargo_nano_ros::rmw_resolver::{known_rmw_in, resolve_rmw_in};
+
+    let scan = scan_providers_for(
+        args.workspace,
+        args.nano_ros_root,
+        args.index.as_deref(),
+        args.write_index.as_deref(),
+    )?;
+
+    if args.known {
+        let names = known_rmw_in(&scan);
+        if args.lines {
+            println!("NROS_RMW_KNOWN\t{}", names.join(";"));
+        } else {
+            for n in &names {
+                println!("{n}");
+            }
+        }
+        return Ok(());
+    }
+
+    let name = args.name.ok_or_else(|| {
+        eyre!("`nros ws rmw-dispatch` takes an rmw NAME, or `--known` to list them")
+    })?;
+    let r = resolve_rmw_in(&scan, &name).map_err(|e| {
+        // The known list is part of the DIAGNOSTIC, never part of the decision:
+        // it is derived from this same scan, so it cannot go stale against the
+        // answer the way the generated `FATAL_ERROR`'s hand-spelled one did.
+        eyre!(
+            "{e}\n\nnames announced on this search path: {}",
+            known_rmw_in(&scan).join(", ")
+        )
+    })?;
+    let d = &r.descriptor;
+
+    // ON/OFF rather than true/false: the value is consumed by `if()` in cmake,
+    // where both spellings work but only one reads as a cmake boolean.
+    let bool_cmake = |b: bool| if b { "ON" } else { "OFF" };
+    let rows: Vec<(&str, String)> = vec![
+        ("NROS_RMW_NAME", r.declared.clone()),
+        ("NROS_RMW_PACKAGE", r.package.clone()),
+        ("NROS_RMW_PACKAGE_DIR", r.package_dir.display().to_string()),
+        ("NROS_RMW_CMAKE_DIR", r.cmake_dir.display().to_string()),
+        ("NROS_RMW_LINK_STRATEGY", d.link_strategy.clone()),
+        ("NROS_RMW_UMBRELLA_CFFI_FEATURE", r.cffi_feature.clone()),
+        ("NROS_RMW_C_CFFI_FEATURE", d.c_cffi_feature.clone()),
+        ("NROS_RMW_RLIB_DEP", d.rlib_dep.clone()),
+        ("NROS_RMW_CARGO_FEATURE", r.cargo_feature.clone()),
+        ("NROS_RMW_C_DEFINE_TOKEN", r.c_define_token.clone()),
+        ("NROS_RMW_CPP_DEFINE", d.cpp_define.clone()),
+        ("NROS_RMW_CMAKE_TARGET", d.cmake_target.clone()),
+        (
+            "NROS_RMW_NEEDS_CXX_LINKER",
+            bool_cmake(d.needs_cxx_linker).to_string(),
+        ),
+        (
+            "NROS_RMW_CAPABILITIES",
+            d.capabilities
+                .iter()
+                .map(|(k, _)| k.as_str())
+                .collect::<Vec<_>>()
+                .join(";"),
+        ),
+        ("NROS_RMW_PER_MESSAGE_HOOK", d.per_message_hook.clone()),
+    ];
+
+    if args.lines {
+        for (k, v) in &rows {
+            println!("{k}\t{v}");
+        }
+    } else {
+        for (k, v) in &rows {
+            println!("{k} = {v}");
+        }
+    }
+    Ok(())
 }
 
 // =============================================================================

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
@@ -178,6 +178,12 @@ if(NROS_CYCLONEDDS_PROVENANCE STREQUAL "source")
     # drops every dds_*/ddsrt_* symbol. Phase 186.
     set(NROS_RMW_CYCLONEDDS_DDSC_LIBRARY "$<TARGET_FILE:CycloneDDS::ddsc>"
         CACHE STRING "Resolved Cyclone DDS ddsc library (source path)" FORCE)
+    # phase-439 W4 — the GENERIC channel the selecting build reads. The root's
+    # link helper knows "a backend may name companion archives that ride the
+    # same whole-archive flag"; it does not know that one backend's companion is
+    # called libddsc. Same value, declared under the name the seam uses.
+    set(NROS_RMW_COMPANION_LIBRARIES "${NROS_RMW_CYCLONEDDS_DDSC_LIBRARY}"
+        CACHE STRING "Archives that ride this backend's whole-archive flag" FORCE)
 endif()
 
 if(DEFINED NANO_ROS_PLATFORM
@@ -278,6 +284,10 @@ if(_ddsc_loc)
     get_filename_component(_ddsc_libdir "${_ddsc_loc}" DIRECTORY)
     set(NROS_RMW_CYCLONEDDS_DDSC_LIBRARY "${_ddsc_loc}"
         CACHE FILEPATH "Resolved Cyclone DDS ddsc library path")
+    # phase-439 W4 — see the source-path arm above; the generic name is what the
+    # selecting build's whole-archive helper consumes.
+    set(NROS_RMW_COMPANION_LIBRARIES "${_ddsc_loc}"
+        CACHE STRING "Archives that ride this backend's whole-archive flag" FORCE)
     set_property(TARGET nros_rmw_cyclonedds APPEND PROPERTY
         INTERFACE_LINK_OPTIONS "LINKER:-rpath,${_ddsc_libdir}")
 endif()

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/nros-rmw-provision.cmake
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/nros-rmw-provision.cmake
@@ -1,0 +1,36 @@
+# nros-rmw-provision.cmake — what this backend needs resolved BEFORE its own
+# `add_subdirectory()` (phase-439 W4, RFC-0094 D5).
+#
+# Included by the selecting build, in ITS scope, when this backend is chosen.
+# The hook exists so the root `CMakeLists.txt` does not need an
+# `if(NANO_ROS_RMW STREQUAL "cyclonedds")` pre-step — which is exactly the
+# closed-list shape W4 deleted one block down. What a backend needs provisioned
+# is the backend's business.
+#
+# Phase 186 — `nros_provide_cyclonedds()` resolves Cyclone: a prebuilt install
+# on `CMAKE_PREFIX_PATH` wins; otherwise it self-provisions from
+# `CYCLONEDDS_SOURCE_DIR`. As the project root we own `third-party/`, so default
+# that to the pinned submodule — a bare cmake build then needs no
+# `just cyclonedds` pre-step. A user overrides with `-DCMAKE_PREFIX_PATH` (their
+# install) or `-DCYCLONEDDS_SOURCE_DIR` (their checkout).
+#
+# `NANO_ROS_ROOT_DIR` rather than `CMAKE_CURRENT_SOURCE_DIR`: an `include()`
+# evaluates in the INCLUDING file's directory scope, so the latter would name
+# the consumer's project, not this checkout. Falls back to walking up from this
+# file (packages/rmw/cyclonedds/nros-rmw-cyclonedds -> the tree root) for a
+# consumer that reaches the descriptor without the root having run.
+
+if(NOT DEFINED CYCLONEDDS_SOURCE_DIR)
+    if(NANO_ROS_ROOT_DIR)
+        set(_nros_cyclone_tree "${NANO_ROS_ROOT_DIR}")
+    else()
+        get_filename_component(_nros_cyclone_tree
+            "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)
+    endif()
+    if(EXISTS "${_nros_cyclone_tree}/third-party/dds/cyclonedds/CMakeLists.txt")
+        set(CYCLONEDDS_SOURCE_DIR
+            "${_nros_cyclone_tree}/third-party/dds/cyclonedds"
+            CACHE PATH "CycloneDDS source tree for self-provisioning (Phase 186)")
+    endif()
+    unset(_nros_cyclone_tree)
+endif()

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/nros-rmw.toml
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/nros-rmw.toml
@@ -39,8 +39,18 @@ sys_crate = "cyclonedds-sys"
 
 [rmw.link]
 rlib_dep = ""                       # none — it is a C++ library, not an rlib
-extra_link_libs = ["nros_rmw_cyclonedds", "ddsc", "stdc++"]
+# No rlib and a cmake target above ⇒ `strategy = "cmake"` (RFC-0094 D5): the
+# build `add_subdirectory()`s `[rmw.provides.cmake].dir` and whole-archives
+# `[rmw.provides.cmake].target` into both umbrellas. `nros-c`/`nros-cpp` bundle
+# nothing for it, so it names no cffi feature and both fall back to `rmw-cffi`.
 needs_cxx_linker = true
+# `extra_link_libs = ["nros_rmw_cyclonedds", "ddsc", "stdc++"]` was DELETED in
+# phase-439 W4 (issue 1216). Nothing read it, and consuming it the obvious way —
+# `target_link_libraries(${TARGET} ${NROS_RMW_EXTRA_LINK_LIBS})` — is precisely
+# what issue 0475 records as BREAKING the link (`undefined reference to
+# ddsrt_*`): the archives must ride ONE `-Wl,--whole-archive` group, and adding
+# them to the link LINE reorders ld's single pass. The real link is that flag
+# plus `LINK_DEPENDS` for the rebuild edge.
 
 # The per-message IDL descriptor step no other backend needs. W5 consumes this;
 # W2/W3 only record it.

--- a/packages/rmw/uorb/nros-rmw-uorb/nros-rmw.toml
+++ b/packages/rmw/uorb/nros-rmw-uorb/nros-rmw.toml
@@ -33,18 +33,33 @@ cmake_target = "nros_rmw_uorb"
 # through the `integrations/px4/` shell rather than a nano-ros entry, which is a
 # property of the deployment, not of the backend.
 #
-# It is absent from `resolve_rmw()`/`nros_rmw_dispatch()` today while being a
-# first-class value in `NanoRosFeatureSet.cmake` and `nros-cpp/CMakeLists.txt` —
-# the three-disagreeing-lists bug W3 retires. `check-rmw-descriptors` therefore
-# EXEMPTS uorb from the agreement check and says why, rather than pretending the
-# dispatch has a row it does not.
+# phase-439 W4 — it is now SELECTABLE. `NANO_ROS_RMW=uorb` was advertised by the
+# cache drop-down (`NROS_RMW_KNOWN`), accepted by `NanoRosFeatureSet` and by
+# `nros-cpp`, and a configure-time FATAL_ERROR at the repo root, because the root
+# chain had arms for three names and no descriptor could add a fourth
+# (issue 1215). The root now dispatches on the DECLARED strategy below, so this
+# backend reaches a link through the same path every other one does, and the
+# `NROS_RMW_CMAKE_TARGET` guard in `nros-cpp` — inert since it was written,
+# because nothing ever created the target — finally has a producer.
+#
+# MEASURED, and worth stating so nobody reads more into it: a `NANO_ROS_RMW=uorb`
+# image CONFIGURES and reaches a correct link line, and on a plain host it then
+# fails to LINK on `orb_advertise_multi` / `orb_subscribe_multi` / `orb_check` /
+# `orb_copy` / `orb_publish` / `orb_unadvertise` / `orb_unsubscribe`. That is
+# uORB itself: the middleware lives in PX4, not here, which is why
+# `NROS_RMW_UORB_LINK_PX4` exists and defaults OFF (the archive builds anywhere;
+# an image needs PX4). `nros_rmw_cffi_register_named` — the nano-ros half of that
+# link — resolves.
 [rmw.provides.cmake]
 dir = "."
 target = "nros_rmw_uorb"
 
 [rmw.link]
 rlib_dep = ""
-extra_link_libs = ["nros_rmw_uorb"]
+# Same shape as cyclonedds: a CMake project, whole-archived. phase-439 W4 is
+# what makes `NANO_ROS_RMW=uorb` reach a link at all — the root chain had no
+# uorb arm and hard-failed on the value its own cache drop-down offered
+# (issue 1215). `extra_link_libs` deleted with the class (issue 1216).
 needs_cxx_linker = true             # C++ port
 
 [rmw.capabilities]

--- a/packages/rmw/xrce/nros-rmw-xrce/nros-rmw.toml
+++ b/packages/rmw/xrce/nros-rmw-xrce/nros-rmw.toml
@@ -38,7 +38,9 @@ target = "nros_rmw_xrce"
 
 [rmw.link]
 rlib_dep = "nros-rmw-xrce-cffi"
-extra_link_libs = []
+# Irregular by history — see the zenoh descriptor's note. `nros-c` spells this
+# `cffi-xrce-c`, not `cffi-xrce-cffi`, so no convention produces it.
+c_cffi_feature = "cffi-xrce-c"
 needs_cxx_linker = false
 
 [rmw.capabilities]

--- a/packages/rmw/zenoh/nros-rmw-zenoh/nros-rmw.toml
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/nros-rmw.toml
@@ -32,9 +32,20 @@ cpp_define = "NROS_RMW_ZENOH_CFFI"
 crate = "nros-rmw-zenoh"
 
 [rmw.link]
+# Naming an rlib IS the statement that this backend arrives INSIDE the C/C++
+# umbrella staticlib and nothing separate reaches the link line — phase-439 W4
+# reads it as `strategy = "umbrella"` (RFC-0094 D5), which is what retired the
+# root `CMakeLists.txt`'s `if(NANO_ROS_RMW STREQUAL "zenoh" OR ... "xrce")` arm.
 rlib_dep = "nros-rmw-zenoh"
-extra_link_libs = []
+# The `nros-c` feature that bundles it. AUTHORED, like `cpp_define`: `nros-c`
+# spells this `cffi-zenoh-cffi` and xrce's `cffi-xrce-c`, which no convention
+# produces. The `nros-cpp` half IS regular and is derived (`rmw-zenoh-cffi`).
+c_cffi_feature = "cffi-zenoh-cffi"
 needs_cxx_linker = false
+# `extra_link_libs` was DELETED in phase-439 W4 (issue 1216). It was read by
+# NOTHING, and its cyclonedds value named the archives whose only correct use is
+# NOT to be passed to `target_link_libraries` — doing so is what issue 0475
+# records as breaking the link with `undefined reference to ddsrt_*`.
 
 # Optional capabilities a user may select (RFC-0071 D6). The KEY is the
 # capability; the VALUE is this backend's own feature. Core never learns the

--- a/scripts/check-codegen-tool-reconfigure.py
+++ b/scripts/check-codegen-tool-reconfigure.py
@@ -79,9 +79,24 @@ REPO = Path(__file__).resolve().parent.parent
 
 HELPER = "nros_codegen_tool_reconfigure"
 
-# Verbs whose emitted files outlive the configure. See the module docstring for
-# why `resolve-deps` and the fact verbs are not here.
-EMITTING_VERBS = ("codegen", "codegen-system")
+# Verbs whose answer outlives the configure. See the module docstring for why
+# `resolve-deps` and the fact verbs are not here.
+#
+# `rmw-dispatch` joined in phase-439 W4 (RFC-0094 D6). It emits no FILE, so it
+# is not an emitter in the `codegen` sense — but its answer is BAKED INTO
+# `build.ninja`: which cmake project is add_subdirectory'd, which archive rides
+# the whole-archive flag, which cffi feature the umbrella is built with, which
+# `#define` the C++ INTERFACE carries. That outlives the configure exactly the
+# way generated code does, and it is decided by a query whose only input the
+# build graph can see is the `nros` binary itself.
+#
+# The fact verbs' exemption reads "they still get the tool change the moment any
+# configure runs, and the emitters above are what make one run" — which assumes
+# the same directory ALSO reaches an emitter. That assumption is what issue 1018
+# was: `nano_ros_entry()` registered inline and three siblings inherited nothing.
+# A build dir that reaches no codegen emitter (a C++ leaf whose messages are
+# pre-generated) reaches this query, so it does not get to inherit.
+EMITTING_VERBS = ("codegen", "codegen-system", "rmw-dispatch")
 
 # `codegen` with this argument is the same-configure fragment writer, not an
 # emitter of anything a later build step compiles.
@@ -287,6 +302,13 @@ def selftest(verbose=False):
             '    RESULT_VARIABLE _rc)\n'
         ),
         "both.cmake": emit + resolve,
+        # phase-439 W4 — the RMW dispatch query. It writes no file; what it
+        # bakes into `build.ninja` is which backend project is added and which
+        # archive rides the whole-archive flag.
+        "rmwdispatch.cmake": 'execute_process(COMMAND "${_tool}" ws rmw-dispatch zenoh --lines)\n',
+        "rmwdispatch_reg.cmake": (
+            reg + 'execute_process(COMMAND "${_tool}" ws rmw-dispatch zenoh --lines)\n'
+        ),
         "cmdvar.cmake": via_cmd_var,
         "argsvar.cmake": via_args_var,
         "prose.cmake": (
@@ -304,6 +326,10 @@ def selftest(verbose=False):
     chk("`codegen-system` is not reported as `codegen`",
         run(["system.cmake"])[0][1] == ["codegen-system"])
     chk("`codegen resolve-deps` is not an emitter", run(["resolve.cmake"]) == [])
+    chk("an unregistered `ws rmw-dispatch` FAILS",
+        run(["rmwdispatch.cmake"]) == [("rmwdispatch.cmake", ["rmw-dispatch"])])
+    chk("registering the rmw dispatch query passes",
+        run(["rmwdispatch_reg.cmake"]) == [])
     chk("a BUILD-time add_custom_command is out of scope (it carries DEPENDS)",
         run(["custom.cmake"]) == [])
     chk("a commented-out emitter is not a finding", run(["commented.cmake"]) == [])

--- a/scripts/check-entry-rmw-vocabulary.py
+++ b/scripts/check-entry-rmw-vocabulary.py
@@ -10,8 +10,10 @@ That resolution is a LOOKUP, and a miss is `BackendResolution::Unknown` — a ha
 error, not a fallback to the registry default. So the two vocabularies have to
 agree exactly:
 
-  * what cmake can bake — `NROS_RMW_KNOWN` in `cmake/NanoRosRmwDispatch.cmake`,
-    which is also the set `NANO_ROS_RMW` may take;
+  * what cmake can bake — the canonical `<nano_ros_provides kind="rmw"/>`
+    announcement of each in-tree backend, which is also the set `NANO_ROS_RMW`
+    may take (phase-439 W4: `NROS_RMW_KNOWN` is no longer a generated literal
+    in `cmake/NanoRosRmwDispatch.cmake`, it is a query);
   * what the registry answers to — the name each backend passes to
     `nros_rmw_cffi_register_named`.
 
@@ -32,8 +34,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
-DISPATCH = ROOT / "cmake" / "NanoRosRmwDispatch.cmake"
 BACKEND_ROOT = ROOT / "packages" / "rmw"
+
+# The announcement each backend's `package.xml` carries. Same regex shape as
+# `check-rmw-descriptors.py`'s, and the FIRST match per package is the canonical
+# name (the rule `rmw_resolver::known_rmw_in` applies).
+PROVIDES_RE = re.compile(r'<nano_ros_provides\s+kind="rmw"\s+name="([^"]+)"\s*/?>')
 
 # `nros_rmw_cffi_register_named("uorb", …)` in C/C++, `c"zenoh".as_ptr()` in
 # Rust, and — cyclone — a named constant, which is why a bare literal scan is
@@ -83,7 +89,7 @@ def compare(known: set[str], registered: dict[str, set[str]]) -> list[str]:
     errors = []
     for name in sorted(known - set(registered)):
         errors.append(
-            f'cmake can bake NROS_ENTRY_RMW="{name}" (it is in NROS_RMW_KNOWN), '
+            f'cmake can bake NROS_ENTRY_RMW="{name}" (a package.xml announces it), '
             f"but no backend under packages/rmw/ registers under that name.\n"
             f"      A baked selector that names no registered backend resolves "
             f"to `Unknown`, which FAILS the session open — it does not fall "
@@ -93,11 +99,12 @@ def compare(known: set[str], registered: dict[str, set[str]]) -> list[str]:
     for name in sorted(set(registered) - known - NOT_A_CMAKE_RMW):
         where = ", ".join(sorted(registered[name]))
         errors.append(
-            f"'{name}' is registered ({where}) but is not in NROS_RMW_KNOWN, "
-            f"so no entry can select it.\n"
-            f"      Add it to the descriptor set (and regenerate "
-            f"cmake/NanoRosRmwDispatch.cmake), or add it to NOT_A_CMAKE_RMW in "
-            f"this script if it is a stub that ships in no image."
+            f"'{name}' is registered ({where}) but no package.xml announces it "
+            f"as an rmw provision, so no entry can select it.\n"
+            f"      Add `<nano_ros_provides kind=\"rmw\" name=\"{name}\"/>` to the "
+            f"backend's package.xml (with an nros-rmw.toml beside it), or add it "
+            f"to NOT_A_CMAKE_RMW in this script if it is a stub that ships in no "
+            f"image."
         )
     return errors
 
@@ -139,11 +146,49 @@ def self_test() -> None:
 
 
 def cmake_known() -> set[str]:
-    text = DISPATCH.read_text()
-    m = re.search(r'set\(NROS_RMW_KNOWN\s+"([^"]*)"', text)
-    if not m:
-        sys.exit(f"{DISPATCH}: no NROS_RMW_KNOWN — has the dispatch file moved?")
-    return {n for n in m.group(1).split(";") if n}
+    """Every rmw name `NANO_ROS_RMW` may take, from the ANNOUNCEMENTS.
+
+    phase-439 W4 — this used to regex `set(NROS_RMW_KNOWN "…")` out of
+    `cmake/NanoRosRmwDispatch.cmake`, which was a GENERATED literal listing the
+    backends present when the `nros` binary was compiled. That file is now a
+    query against the provider scan and holds no list, so there is nothing left
+    to grep.
+
+    The same rule the CLI applies (`rmw_resolver::known_rmw_in`): one CANONICAL
+    name per provider — its FIRST `<nano_ros_provides kind="rmw"/>` — not one
+    per announcement, because `zenoh` / `rmw-zenoh` / `rmw-zenoh-cffi` are three
+    spellings of one backend and only the first is a `NANO_ROS_RMW` value.
+
+    Read from source rather than by asking the CLI on purpose: this gate is on
+    the buildless, source-free `check-fast` line, where no `nros` binary exists.
+    That makes it a SECOND reader of the announcements, which this repo
+    normally refuses — the mitigation is that it reads the same files by the
+    same rule and that `check-rmw-descriptors` already parses them this way, and
+    the cross-check is
+    `rmw_resolver::tests::every_announced_backend_resolves_through_the_scan`,
+    which fails if the CLI's answer and the announcements ever diverge.
+
+    Out-of-tree providers are deliberately out of scope: this gate is about
+    whether THIS tree's bakeable names and THIS tree's registrations agree.
+    """
+    known: set[str] = set()
+    for pkg_xml in sorted(BACKEND_ROOT.glob("*/*/package.xml")):
+        if not (pkg_xml.parent / "nros-rmw.toml").is_file():
+            continue
+        m = PROVIDES_RE.search(pkg_xml.read_text(errors="replace"))
+        if not m:
+            sys.exit(
+                f"{pkg_xml}: an rmw backend with a descriptor announces no "
+                f'<nano_ros_provides kind="rmw" name="…"/> — nothing could '
+                f"select it."
+            )
+        known.add(m.group(1))
+    if not known:
+        sys.exit(
+            f"{BACKEND_ROOT}: no rmw provider announcements found — refusing to "
+            f"compare an EMPTY bakeable set, which would pass vacuously."
+        )
+    return known
 
 
 def registered_names() -> dict[str, set[str]]:


### PR DESCRIPTION
**Stacked on #747** (`docs/rfc-0094-resolve-before-configure`), which carries RFC-0094, phase-439 W0 and three pre-existing-red fixes. Base this at that branch; it merges after #747.

Implements **phase-439 W4** (RFC-0094 D5/D6). Closes #1214, #1215, #1216. **Does not close #1219** — see below.

## The defect

`cmake/NanoRosRmwDispatch.cmake` was GENERATED from a table baked into the `nros` binary at CLI-compile time: an `if/elseif` chain over the four backends that happened to be in `packages/rmw/` when the binary was built, re-emitting the eight values each backend's `nros-rmw.toml` already carried, closing on a `FATAL_ERROR` naming a closed set.

Both halves, one tree, one minute:

```
$ nros ws providers --resolve rmw:acme
rmw:acme -> <ws>/src/acme_rmw   root[1] (workspace)        ← found
$ cmake -P probe.cmake
CMake Error: nros_rmw_dispatch: unknown rmw 'acme' (known: cyclonedds uorb xrce zenoh)
```

Discoverable, not dispatchable. And there was a **second** closed list, hand-written at the root `CMakeLists.txt`, which hard-failed on `uorb` — an in-tree, zero-Rust C++ backend that the same file's cache drop-down advertised, 370 lines up.

## The change

cmake asks the CLI for a shape it can read, the pattern `NanoRosProviders.cmake` already used, and the answer comes from the provider **scan** — so a backend in the user's workspace resolves by the same code as ours.

```
nros ws rmw-dispatch <name> --lines   →  NROS_RMW_<KEY><TAB><value>
nros ws rmw-dispatch --known --lines  →  NROS_RMW_KNOWN<TAB>a;b;c
```

- **One parser, two callers.** `cargo-nano-ros/src/rmw_descriptor.rs` is `include!`d by `build.rs` and compiled into the library — the arrangement `serdes_descriptor.rs` already used. `build.rs`'s private `parse()` is deleted. `resolve_rmw_in(&ScanResult, name)` is the sibling of `resolve_serdes_in` that #1214 asked for.
- **The root's three arms were three LINK STRATEGIES, not three backends,** and a backend can declare which: `umbrella` (a Rust rlib bundled into the umbrella staticlib — DERIVED from `[rmw.link] rlib_dep`) or `cmake` (`add_subdirectory` the declared dir, whole-archive the declared target). `_nros_link_cmake_rmw()` is one implementation for both umbrellas; that block existed twice, ~45 lines apart, and its own comments said "one defect, two consumers".
- **A backend that needs something resolved first ships `nros-rmw-provision.cmake`** beside its descriptor (cyclonedds defaults `CYCLONEDDS_SOURCE_DIR` there), and `NROS_RMW_COMPANION_LIBRARIES` replaces the root naming cyclone's `libddsc` — #0837 was the price of an archive in a flag with no channel to be declared through.

### The three unread outputs (#1216), decided one at a time

| variable | decision |
| --- | --- |
| `NROS_RMW_EXTRA_LINK_LIBS` | **deleted.** Nothing read it, and consuming it the obvious way is what #0475 records as *breaking* the link. The warning now lives in the cyclonedds descriptor where the value was. |
| `NROS_RMW_RLIB_DEP` | **wired** — it derives the link strategy. |
| `NROS_RMW_UMBRELLA_CFFI_FEATURE` | **wired** in `nros_feature_set`, with a new authored `c_cffi_feature` (`nros-c` spells xrce's `cffi-xrce-c`, which no convention produces). That deleted a **fourth** closed list. |

`NanoRosLink.cmake`'s `LINK_DEPENDS` keyed on `TARGET nros_rmw_${_chosen}` — an accidental generalisation of #0475's fix that nothing documented or gated, so a provider naming its target anything else silently got museum binaries. It reads the **declared** `NROS_RMW_CMAKE_TARGET` now.

`NanoRosFeatureSet.cmake`'s `safety` capability read `if(_FS_RMW STREQUAL "zenoh")` while `nros-cpp` had already moved to `IN_LIST NROS_RMW_CAPABILITIES` — #1219's 0196-shaped half, where a third-party backend declaring `safety` was honoured on one path and refused with a *wrong explanation* on the other.

### D6 / #1018

Every query goes through `nros_codegen_tool_reconfigure()`, and `check-codegen-tool-reconfigure` now counts `rmw-dispatch` as an emitting verb, with its own negative control. Answers are memoised in **GLOBAL properties**, which die with the configure — so a rebuilt `nros` cannot be served a stale one out of `CMakeCache.txt`.

Two readers of one format that nobody compares is what this repo keeps paying for, so `the_baked_table_and_the_scan_agree_on_every_in_tree_backend` asserts they agree field for field, and `every_announced_backend_resolves_through_the_scan` asserts that what the scan *finds*, the resolver *dispatches*.

## Measured

- **`cmake -DNANO_ROS_RMW=uorb` configures.** `add_subdirectory` creates `nros_rmw_uorb`, so `nros-cpp`'s `NROS_RMW_CMAKE_TARGET` guard — inert since it was written — finally has a producer. A uorb *image* still does not link on a plain host: `orb_advertise_multi`, `orb_subscribe_multi`, `orb_check`, `orb_copy`, `orb_publish`, `orb_unadvertise`, `orb_unsubscribe` are PX4's uORB middleware, not ours (which is why `NROS_RMW_UORB_LINK_PX4` exists and defaults OFF). `nros_rmw_cffi_register_named` — the nano-ros half — resolves. Recorded in the descriptor.
- **All four backends configure**, and the cargo feature sets are **byte-identical** to what the deleted closed chains produced, for both crates and for `none`.
- **A C and a C++ binary LINK** against zenoh, xrce and cyclonedds through `nano_ros_link_rmw`. `ninja -t query` shows both `libnros_rmw_cyclonedds.a` and `libddsc.so.0.10.5` under `|` (implicit), which is #0475's own verification recipe.

## Tier run

`just ci gate` — `check::cli-fresh`, `check::fast`, `check::build`, `check::api-parity` and `test-unit` all green; `check::build` is where the C/C++ backends compile. Plus the link probes above, which are more than the lane asks for because this change touches the link path. Not run: tier 2/3 (no fixture build).

`test-lane-contracts` is red, and it is **not this diff** — `fixture_rows_all_modeled_by_matrix` reports an orphan `(ZephyrNativeSim, Cpp, Cyclonedds, Workspace)` `fixtures.toml` row, from `9ae271174` (phase-206 W2, 2026-09-06), on inputs this diff does not touch. Filed as **#1226** in the second commit rather than guessed at.

Six other lanes were red on the first run and all six were environmental, not code: four (`rmw-uorb`, `rmw-xrce`, `borrowed-e2e`, `staticlib-symbols`) because a `NROS_REPO_DIR` inherited from the parent shell points the shared build root at the main checkout while the tests look in the worktree — the case `scripts/build/build-root.sh:55` describes in its own comment; two were uninitialised submodules and an unbuilt `nros-launch-resolve`. All six pass with `NROS_REPO_ROOT` set and the preconditions met.

## Why #1219 stays open

`check-rmw-agnostic` was written and then **deleted rather than shipped**. W4 removed three of the five closed lists it counts and fixed its `safety` two-site defect, but the gate needs a classification pass the measurement made plain: repo-wide over build logic the rule reports **93 files**, and **39** even narrowed to the build-decision surface — mostly test plans (`packages/testing/**` enumerates the backends a matrix covers), demos (`tt-zenoh-to-cyclonedds` names two backends because bridging them is the point) and help text. A 39-row baseline of reasons nobody verified reads as coverage and is worth less than no gate.

The survey, the narrowing that *did* work (comments stripped per language; names matched only as quoted literals or regex alternations; a ~320-char window; a threshold of two names), and the two decisions a next attempt still has to make are all recorded in the issue so it starts from data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5
