### PR TITLE
fix(box-sync): `target/` ate Zephyr source, and zephyr-qos has its first verdict

### DIFF
--- a/.config/interop-verdicts.toml
+++ b/.config/interop-verdicts.toml
@@ -163,3 +163,12 @@ tests = ["interop::case_4_zenoh_service_nano_server", "interop::case_5_zenoh_ser
 run = "cargo nextest run -p nros-tests --test interop_e2e"
 where = "ros2 distrobox, Humble, tree with #684 + #692"
 evidence = "2 case(s) produced a result in interop_e2e.xml"
+
+[[verdict]]
+cell = "zephyr-qos-rust-zenoh"
+date = "2026-09-08"
+verdict = "pass"
+tests = ["nros_zephyr_publisher_reaches_ros2_topic_echo"]
+run = "cargo nextest run -p nros-tests --test qos_zephyr_ros2_interop_e2e"
+where = "ros2 distrobox, Humble, zephyr native_sim"
+evidence = "2/2: an nros zenoh-pico publisher on a Zephyr native_sim image reaches a stock rmw_zenoh_cpp subscriber via ros2 topic echo. First Zephyr build this host has ever produced."

--- a/scripts/check-prose-issue-refs.py
+++ b/scripts/check-prose-issue-refs.py
@@ -61,6 +61,7 @@ the baseline when their issue lands. Same shape as
 """
 
 import os
+import subprocess
 import re
 import sys
 
@@ -120,7 +121,39 @@ def candidate_files():
             for name in filenames:
                 if name.endswith((".md", ".sh", ".py", ".cmake", ".just", ".txt")):
                     out.append(os.path.relpath(os.path.join(dirpath, name), ROOT))
-    return sorted(set(out))
+    return sorted(_drop_ignored(set(out)))
+
+
+def _drop_ignored(paths):
+    """Everything git does not ignore.
+
+    The walk above is deliberate — an id and the doc citing it must be able to
+    land in one commit, so `git ls-files` is the wrong index. But "not in the
+    index" and "not ours" are different things, and the walk could not tell
+    them apart: `scripts/zephyr/.venv/` is gitignored, holds pip's vendored
+    third-party sources, and those cite THEIR OWN upstream issue numbers —
+    `pip/_vendor/requests/sessions.py` cites 1704, `distro.py` cites 1322. The
+    gate reported them as references to nano-ros issues that do not exist.
+
+    It fires only for someone who HAS such a directory, so it is red on a
+    developer's machine and green in CI, where a fresh clone has no venv. That
+    is the worst shape for a gate: the person who can see it is the person
+    least able to believe it.
+
+    One `git check-ignore` over the batch, not one per file.
+    """
+    if not paths:
+        return paths
+    try:
+        r = subprocess.run(
+            ["git", "-C", ROOT, "check-ignore", "--stdin"],
+            input="\n".join(sorted(paths)),
+            capture_output=True, text=True, check=False,
+        )
+    except OSError:
+        return paths  # no git: keep the walk's answer rather than lose coverage
+    ignored = {ln for ln in r.stdout.splitlines() if ln}
+    return {p for p in paths if p not in ignored}
 
 
 def refs_in(text):

--- a/scripts/dev/ros2-box-sync.sh
+++ b/scripts/dev/ros2-box-sync.sh
@@ -106,6 +106,27 @@ exclusions=(
     # `third-party/` needs no equivalent: it has no directory named `build` at
     # all, measured, and if one appears it will be output.
     --include '/zephyr-workspace/**/build/***'
+    # issue: `target/` is a RUST BUILD-OUTPUT pattern and Zephyr has two
+    # directories of SOURCE with that name — `drivers/i2c/target/` and
+    # `include/zephyr/drivers/i2c/target/`, five files, I2C target (slave) mode.
+    # Excluding them left the mirror unable to CONFIGURE any Zephyr image:
+    #
+    #   drivers/i2c/Kconfig:101: 'drivers/i2c/target/Kconfig' not found
+    #
+    # which reads as a broken Zephyr checkout rather than as a sync rule.
+    #
+    # This is the FIFTH time this exclusion has eaten tracked source; the
+    # comment on `build-*/` below records the first four and the fix each time.
+    # It survived `check-box-sync-covers-tracked-source` because that gate
+    # sweeps the SUPERPROJECT's `git ls-files`, and `zephyr-workspace/zephyr`
+    # is a nested repo — `git ls-files | grep -cE '(^|/)target/'` is 0 while
+    # two such directories exist on disk. A sweep scoped to one repo cannot see
+    # a sibling's source.
+    #
+    # Re-included AHEAD of the exclusion, the same shape as
+    # `/zephyr-workspace/**/build/***` above, and scoped to the zephyr tree so
+    # a genuine Rust `target/` anywhere else is still excluded.
+    --include '/zephyr-workspace/zephyr/**/target/***'
     --exclude 'target/'
     --exclude 'target-*/'
     --exclude 'build/'


### PR DESCRIPTION
**`zephyr-qos-rust-zenoh` PASSES live — 2/2.** An nros zenoh-pico publisher on a Zephyr `native_sim` image reaches a stock `rmw_zenoh_cpp` subscriber through `ros2 topic echo`. The only on-target cell in the matrix, and the last one that had never produced a verdict. **Ledger: 18 of 20.**

Getting there needed five distinct blockers cleared, each invisible until the one above it was fixed — which is why this cell's status was "never run" rather than "cannot run".

## The defect in this repo

`ros2-box-sync.sh` excludes `target/` — a **Rust build-output** pattern. Zephyr has two directories of **source** with that name:

```
zephyr-workspace/zephyr/drivers/i2c/target/
zephyr-workspace/zephyr/include/zephyr/drivers/i2c/target/
```

Five files, I²C target (slave) mode. The mirror could not **configure any Zephyr image at all**:

```
drivers/i2c/Kconfig:101: 'drivers/i2c/target/Kconfig' not found
```

— which reads as a broken Zephyr checkout, not as a sync rule. This is the **fifth** time this exclusion has eaten tracked source; the `build-*/` comment beside it records the first four.

**`check-box-sync-covers-tracked-source` could not see it.** That gate sweeps the *superproject's* `git ls-files`, and `zephyr-workspace/zephyr` is a nested repo: `git ls-files | grep -cE '(^|/)target/'` returns **0** while two such directories sit on disk. A sweep scoped to one repo is blind to a sibling's source. Fixed with the re-include shape the script already uses for `build/`, scoped to the zephyr tree; the gate's own blind spot is noted at the site and wants its own change.

## A gate that is red locally and green in CI

`check-prose-issue-refs` walks the filesystem deliberately — an id and the doc citing it must land in one commit, so `git ls-files` is the wrong index. But *"not in the index"* and *"not ours"* are different things. `scripts/zephyr/.venv/` is gitignored and holds pip's vendored sources, which cite **their own** upstream issue numbers: `requests/sessions.py` cites 1704, `distro.py` cites 1322. The gate reported them as references to nano-ros issues that don't exist.

It fires only for someone who *has* such a directory — red on a developer's machine, green in CI where a fresh clone has none. That's the worst shape for a gate: the person who can see it is the person least able to believe it. Now one `git check-ignore` over the batch, keeping the walk.

## The three that were environment

Recorded for the next person: no Zephyr SDK (provisioned 0.16.8 via `nros setup --tool zephyr-sdk` — needs ~10 GB, and the SDK store lives on `$HOME`, not the big disk; the first attempt filled the root filesystem); no `west`; and no Zephyr Python requirements (`ModuleNotFoundError: No module named 'elftools'` — install `zephyr/scripts/requirements-base.txt`, not the one module).

## Seen but not fixed

`ws-cpp-entry` fails because `[image.zephyr]` matches two entry packages (`zephyr_cyclonedds_entry`, `zephyr_entry`) and cannot derive the application. Different fixture, different problem.

## Verification

`just check fast` — 278 ran, 1 skipped (unprovisioned NVIDIA FSP tree) · cell 2/2 live · verdict recorded from junit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA