### PR TITLE
feat(phase-439 W2, RFC-0094 D1/D2): the resolve phase, and the one comment line that stops it saving a pass

### DIFF
--- a/cmake/NanoRosCodegenCore.cmake
+++ b/cmake/NanoRosCodegenCore.cmake
@@ -30,6 +30,11 @@ include("${CMAKE_CURRENT_LIST_DIR}/NanoRosMessageBounds.cmake")
 # helpers (`nros_entity_inventory_knobs_file`, `..._seed_knobs_file`) here. The
 # include is a no-op when `nano_ros_entry()` has already pulled it in.
 include("${CMAKE_CURRENT_LIST_DIR}/NanoRosEntityInventory.cmake")
+# phase-439 W2 (RFC-0094 D1) -- `nros_resolved_seed_entity_inventory`, the
+# configure-side reader for `nros build`'s resolve phase. Beside its sibling for
+# the same reason: this file is reachable from inside a function frame, so both
+# must be included at FILE scope.
+include("${CMAKE_CURRENT_LIST_DIR}/NanoRosResolved.cmake")
 
 # Issue 0991 -- both fragments above are written LATER in a configure than they
 # are read, and the `CMAKE_CONFIGURE_DEPENDS` recovery every comment in this
@@ -928,6 +933,11 @@ function(nros_find_interfaces)
     #    classes, re-configures, and builds at the derived ones -- and it is
     #    never silent, since the status line says which basis was used.
     nros_entity_inventory_knobs_file(_entity_knobs)
+    # phase-439 W2 (RFC-0094 D1) -- prefer the resolve phase's answer over a
+    # placeholder. Same reason as the Zephyr loader: this reader runs before the
+    # producer, so on a clean build dir the placeholder is what costs the extra
+    # configure. No-op when no resolve phase ran.
+    nros_resolved_seed_entity_inventory("${_entity_knobs}")
     nros_entity_inventory_seed_knobs_file("${_entity_knobs}")
     set_property(DIRECTORY APPEND PROPERTY
         CMAKE_CONFIGURE_DEPENDS "${_entity_knobs}")

--- a/cmake/NanoRosResolved.cmake
+++ b/cmake/NanoRosResolved.cmake
@@ -1,0 +1,163 @@
+# NanoRosResolved.cmake -- phase-439 W2 (RFC-0094 D1/D2): the CONFIGURE-SIDE
+# READER for `nros build`'s resolve phase.
+#
+# =============================================================================
+# What stage 3.5 is, from this side
+# =============================================================================
+#
+# `nros build` gains a phase between "is the toolchain present" (stage 3) and
+# "emit a root build file" (stage 4). It reads DECLARATIONS -- the descriptors,
+# the image block, and the wiring the launch tree states through its contract
+# sidecar -- runs `EntityInventory::derive` once for the whole image, and writes
+#
+#   <NROS_RESOLVED_DIR>/resolved.toml    the answer, with [provenance]
+#   <NROS_RESOLVED_DIR>/resolved.cmake   the same answer, include()able
+#
+# BEFORE any configure. `nros build` passes the directory as
+# `-DNROS_RESOLVED_DIR=<dir>` on the cmake and west handoffs.
+#
+# =============================================================================
+# Why a reader wants it: the producer-after-reader lag
+# =============================================================================
+#
+# `${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake` is written by
+# `nano_ros_entry()`, which must run after every `nano_ros_node_register()` --
+# and is READ by `nros_resolve_knobs()` inside `find_package(Zephyr)` and by
+# `nros_find_interfaces()`, both of which run earlier. On a clean build dir the
+# earliest reader therefore finds a PLACEHOLDER, and issue 0991's future-mtime
+# arm exists to buy a second configure in which it finds the answer.
+#
+# A file written before the configure has no such lag. Seeding the fragment from
+# it means the earliest reader of the FIRST pass sees a real number, which is
+# the pass that arm was buying.
+#
+# =============================================================================
+# It is a SEED, not an OVERRIDE -- and that is the safety property
+# =============================================================================
+#
+# `nros_resolved_seed_entity_inventory` writes ONLY where
+# `nros_entity_inventory_seed_knobs_file` would have written a placeholder: a
+# fragment that does not exist yet. The mid-configure producer still runs, still
+# composes over `nros-metadata.json` AND the model, and still arms a
+# re-configure through `nros_reconfigure_on_change` if its answer differs.
+#
+# That ordering is deliberate and it is what makes this safe to land before the
+# fixed point is deleted. The two composers do not have the same INPUTS:
+#
+#   * this phase reads the model alone, since `nros-metadata.json` is written
+#     DURING a configure and reading it here would recreate the lag;
+#   * the mid-configure producer also reads that metadata, whose component set
+#     is what makes `derive()` REFUSE when a registered component is absent from
+#     the launch declaration.
+#
+# So the seed can only be equal to, or more optimistic than, the producer's
+# answer -- and when it is more optimistic the producer overwrites it and arms,
+# exactly as it does today over a placeholder. Nothing here can make a build
+# quieter than it is now.
+#
+# =============================================================================
+# A lane that ran no resolve phase is UNCHANGED
+# =============================================================================
+#
+# `NROS_RESOLVED_DIR` unset -- a bare `west build`, `just zephyr
+# build-fixtures`, a user's own `cmake -S` -- means every function here is a
+# no-op and the placeholder is written as before. That is the whole reason the
+# seam is a passed variable rather than a search: a reader that GUESSED where a
+# resolve might live would silently pick up another image's answer, which is
+# issue 0616's shape one directory over.
+
+include_guard(GLOBAL)
+
+# nros_resolved_dir(<out_var>)
+#
+# The directory stage 3.5 wrote this image's answer into, or empty.
+#
+# Read from the cache/normal variable first and the ENVIRONMENT second, because
+# the two carriers reach different lanes: `-D` reaches a configure `nros build`
+# spawned directly, and the environment reaches one it spawned through a tool
+# that owns its own command line. Never GUESSED from `CMAKE_BINARY_DIR` -- see
+# the header.
+function(nros_resolved_dir _out_var)
+    if(DEFINED NROS_RESOLVED_DIR AND NOT "${NROS_RESOLVED_DIR}" STREQUAL "")
+        set(${_out_var} "${NROS_RESOLVED_DIR}" PARENT_SCOPE)
+        return()
+    endif()
+    if(DEFINED ENV{NROS_RESOLVED_DIR} AND NOT "$ENV{NROS_RESOLVED_DIR}" STREQUAL "")
+        set(${_out_var} "$ENV{NROS_RESOLVED_DIR}" PARENT_SCOPE)
+        return()
+    endif()
+    set(${_out_var} "" PARENT_SCOPE)
+endfunction()
+
+# nros_resolved_entity_fragment(<out_var>)
+#
+# The include()able projection stage 3.5 wrote, or empty when there is none.
+#
+# EMPTY rather than a path-that-does-not-exist, so a caller cannot accidentally
+# `include()` a missing file and get cmake's own error about a name that means
+# nothing to the reader. The file name is spelled ONCE, here, matching
+# `nros_cli_core::resolve::RESOLVED_CMAKE_NAME`.
+function(nros_resolved_entity_fragment _out_var)
+    nros_resolved_dir(_dir)
+    if("${_dir}" STREQUAL "")
+        set(${_out_var} "" PARENT_SCOPE)
+        return()
+    endif()
+    set(_frag "${_dir}/resolved.cmake")
+    if(NOT EXISTS "${_frag}")
+        # A resolve that REFUSED writes `resolved.toml` and no projection, on
+        # purpose: an empty projection would publish "every count is zero",
+        # which is a substituted default wearing an answer's clothes.
+        set(${_out_var} "" PARENT_SCOPE)
+        return()
+    endif()
+    set(${_out_var} "${_frag}" PARENT_SCOPE)
+endfunction()
+
+# nros_resolved_seed_entity_inventory(<path> [<out_used>])
+#
+# Seed the image's entity-inventory fragment from the resolve phase's answer,
+# if there is one and the fragment does not exist yet.
+#
+# Call it IMMEDIATELY BEFORE `nros_entity_inventory_seed_knobs_file(<path>)`,
+# which is a no-op on a file that now exists. Both are then correct in either
+# order of arrival, and a lane with no resolve keeps today's placeholder.
+#
+# Call it from a READER only. The three call sites inside
+# `nros_derive_entity_inventory_knobs()` are a PRODUCER recording its own
+# refusal ("I could not compose here"), and seeding those with a different
+# composer's answer would publish a number the producer did not stand behind.
+# Two roles, two behaviours -- the sites are not siblings even though they call
+# one function.
+function(nros_resolved_seed_entity_inventory _path)
+    if(ARGC GREATER 1)
+        set(${ARGV1} FALSE PARENT_SCOPE)
+    endif()
+    if(EXISTS "${_path}")
+        return()
+    endif()
+    nros_resolved_entity_fragment(_frag)
+    if("${_frag}" STREQUAL "")
+        return()
+    endif()
+    get_filename_component(_dir "${_path}" DIRECTORY)
+    file(MAKE_DIRECTORY "${_dir}")
+    # VERBATIM. Not a copy with a "seeded from ..." banner on top, which is what
+    # this did first and which MEASURED as buying nothing: `nros_reconfigure_
+    # snapshot` hashes CONTENT, so a seed that differs from the producer's
+    # answer by one comment line arms exactly the re-configure the seed exists
+    # to remove. Case B of `tests/cmake-resolved-seed-tests.sh` is that
+    # measurement, and it reported `re-runs=1` until the banner came off.
+    #
+    # The provenance is not lost, it is somewhere a byte comparison cannot
+    # reach: the STATUS line below, and `resolved.toml`'s `[provenance]` table
+    # beside the file this reads.
+    file(READ "${_frag}" _body)
+    file(WRITE "${_path}" "${_body}")
+    if(ARGC GREATER 1)
+        set(${ARGV1} TRUE PARENT_SCOPE)
+    endif()
+    message(STATUS
+        "nros: entity inventory seeded from the resolve phase (${_frag}); this "
+        "configure's first reader sees a derived answer rather than a placeholder")
+endfunction()

--- a/docs/design/0094-resolve-before-configure.md
+++ b/docs/design/0094-resolve-before-configure.md
@@ -88,7 +88,15 @@ Between stage 3 (preflight) and stage 4 (emit root):
 
     reads   nros-{rmw,board,platform,serdes}.toml   (the descriptors)
             [package.metadata.nros.component] entities
-            nano_ros_node_register(… ENTITIES …)     (the cmake declaration)
+            the contract sidecar, via `EntityInventory::from_model`
+
+**Correction, from phase-439 W2.** An earlier draft named
+`nano_ros_node_register(… ENTITIES …)` as the cmake-side declaration. That
+argument was RETIRED by phase-412 and is now a `FATAL_ERROR`
+(`cmake/NanoRosNodeRegister.cmake:1229`); it stays PARSED only so the refusal can
+name it. The live declarative source is the contract sidecar folded into the
+SystemModel, which is what stage 3.5 reads — still no compiled artifact, which is
+the property that matters.
     runs    EntityInventory::derive                  ONCE, for the whole image
     writes  build/<image>/resolved.toml
 

--- a/docs/issues/1228-resolve-phase-does-not-yet-delete-the-fixed-point.md
+++ b/docs/issues/1228-resolve-phase-does-not-yet-delete-the-fixed-point.md
@@ -1,0 +1,114 @@
+---
+id: 1228
+title: "phase-439 W2 landed the resolve phase; the three-pass fixed point is still authoritative and RFC-0094 A3 is not met"
+status: open
+area: build, cmake, cli
+severity: medium
+found: 2026-09-08
+related: [0940, 0965, 0991, 1002, 1119, 1061, 1125, phase-439, phase-403, phase-412]
+---
+
+# What landed, what did not, and the one measurement that decides the rest
+
+phase-439 W2 landed stage 3.5 of `nros build` — the resolve phase — as
+RFC-0094 D1/D2 specifies it: it reads declarations, runs
+`EntityInventory::derive` once per image, and writes
+`build/<image>/resolved.toml` with `[provenance]` and a digest, before any
+configure. `cmake/NanoRosResolved.cmake` is the configure-side reader, wired at
+the two sites that READ the entity-inventory fragment.
+
+It did **not** meet RFC-0094 **A3**, and this issue is the remainder.
+
+    A3 — the fixed point is gone. No lane re-derives a knob during configure;
+    `nros_reconfigure_settle` and the future-mtime arm are deleted, and Zephyr
+    converges in one pass.
+
+`nros_reconfigure_settle` and the future-mtime arm in
+`cmake/NanoRosReconfigure.cmake` are **still present and still authoritative**.
+Nothing about the pass count on a real Zephyr image changed.
+
+## The measurement that says why, and it is one comment line
+
+`nros_reconfigure_snapshot` hashes **content**. So the seed removes a configure
+pass only when the mid-configure producer that follows it writes byte-for-byte
+what the seed already wrote. Case B of `tests/cmake-resolved-seed-tests.sh`
+measures exactly that on a five-line project — with an agreeing seed the chain
+goes from 1 re-configure to 0.
+
+The two composers in the real tree do **not** agree byte-for-byte, and the whole
+difference is one line:
+
+| | stage 3.5 | the mid-configure producer |
+| --- | --- | --- |
+| component set | the resolved SystemModel | `nros-metadata.json` merged with the model |
+| derived numbers | — | **identical**, measured |
+| `NROS_ENTITY_INVENTORY_SOURCE` | `<model path>` | `<metadata path> + <model path>` |
+
+`resolve::tests::stage_3_5_and_the_mid_configure_producer_agree_on_every_number`
+asserts both halves: every value equal, and the byte difference confined to the
+source line. It is written to red if the numbers ever diverge — that direction
+would make the seed unsafe, not merely inert.
+
+So today the seed makes pass 1 read a **real number instead of a placeholder**,
+which is a real improvement in what a first-pass reader sees, and the producer
+still arms one re-configure over a provenance comment.
+
+## Why the source line is not simply deleted
+
+It is provenance, and RFC-0094 D2 makes provenance normative. The honest fixes
+are one of:
+
+1. **Make the producer read the resolve rather than recompose.** Then there is
+   one composer and the question does not arise. This is what RFC-0094 actually
+   asks for and it is blocked on the next item.
+2. **Give the resolve phase the refusal guard the producer has.** The producer's
+   `nros-metadata.json` component set is what makes `derive()` REFUSE when a
+   registered component is absent from the launch declaration; stage 3.5 reads
+   the model alone (the metadata is written DURING a configure, which is the lag
+   the phase exists to remove), so it cannot see that case and would derive a
+   number for an image the producer correctly refuses. **Do not skip this**:
+   `tests/cmake-resolved-seed-tests.sh` case C exists because a seed that can
+   override the producer is how stage 3.5 would ship a count nothing stood
+   behind.
+3. **Move the source string out of the hashed fragment**, into `resolved.toml`
+   where the rest of `[provenance]` already lives. Cheapest, and it makes 1
+   possible without 2 — but only if a reader that wants the source is left able
+   to find it.
+
+## The other half of the chain, untouched
+
+Even with the entity link closed, Zephyr's chain has a second link:
+`message_bound_knobs.cmake` is derived by `nros_find_interfaces()` mid-configure
+from codegen-produced bound FRAGMENTS, and is read by `nros_resolve_knobs()`
+earlier still. Stage 3.5 does not compute it — `nros_derive_message_bound_knobs`
+is a pure-CMake composer over per-package fragments, and there is no Rust twin
+to call before a configure. One pass more.
+
+So A3 needs both links, and the honest ordering is: (3) then (1), measured with
+`tests/cmake-resolved-seed-tests.sh`; then the bound half; then the deletion.
+
+## Not measured here, deliberately
+
+**No claim is made about a real Zephyr image.** This host has no
+`zephyr-workspace` and no Zephyr SDK, so "converges in one pass" and "a named
+image's knobs are byte-identical before and after" were not run and are not
+claimed. phase-392 W5 had to withdraw a causal claim from a before/after that
+accidentally built the same configuration twice; the acceptance for the deletion
+must be a real `west build` on a real image with `check-knob-delivery
+<build-dir>` green on both sides, and the unrelated knob values asserted
+UNCHANGED as the control.
+
+## What exists to build on
+
+* `packages/cli/nros-cli-core/src/resolve.rs` — the phase, the artifact, the
+  digest, `[provenance]`, and `HAND_SET_KNOBS` (the two knobs with no
+  declarative derivation now SAY they are hand-set, which was W2's stated
+  known-gap deliverable).
+* `packages/cli/nros-cli-core/src/cmd/build.rs` — `resolve_image()`, stage 3.5,
+  between the preflight bail and the driver match. It cannot fail a build.
+* `cmake/NanoRosResolved.cmake` — `nros_resolved_dir`,
+  `nros_resolved_entity_fragment`, `nros_resolved_seed_entity_inventory`.
+* `-DNROS_RESOLVED_DIR=<dir>` on the cmake and west handoffs; unset elsewhere,
+  so a bare `west build` or `just zephyr build-fixtures` is unchanged.
+* `just check resolved-seed` — the pass-count measurement, with its negative
+  controls.

--- a/docs/roadmap/phase-439-resolve-before-configure.md
+++ b/docs/roadmap/phase-439-resolve-before-configure.md
@@ -170,6 +170,45 @@ future-mtime arm in `cmake/NanoRosReconfigure.cmake`.
 answers for a built dir; a named image's knobs are byte-identical to today's
 before the deletion and after it.
 
+**PARTIALLY LANDED 2026-09-08 (PR #759).** The phase and `resolved.toml` are in
+and READ; the three-pass fixed point is NOT deleted and **A3 is not met**.
+Remainder is issue 1228.
+
+What landed: stage 3.5 in `plan_builds`, between the preflight bail and the
+driver match, writing `build/<bringup>__<image>/resolved.toml` with
+`schema_version`, `[image]` (incl. a 16-hex digest over every resolved value),
+`[executor]`, `[pools]`, `[entities]` and `[provenance]`. A refusal publishes
+prose and NO numbers. `[executor]`/`[pools]` carry raw demand INCLUDING ZERO —
+the floor stays at the consumer (issues 1015/1033) — and the two hand-set knobs
+name themselves in `[provenance]` with their reason.
+
+The read is `cmake/NanoRosResolved.cmake`, wired at the two sites that READ the
+entity-inventory fragment and deliberately not at the three inside
+`nros_derive_entity_inventory_knobs()`, which is a producer recording its own
+refusal. A lane that ran no resolve phase is unchanged.
+
+Evidence, by pass count rather than by assertion — `just check resolved-seed`,
+9/9:
+
+    A  no resolve        1 re-configure   real answer (baseline unchanged)
+    B  resolve agrees    0 re-configures  real answer
+    C  resolve DISAGREES 1 re-configure   the PRODUCER's answer wins
+    D  resolve refused   1 re-configure   byte-for-byte case A
+
+Case B corrected the implementation: the seed first carried a "seeded from …"
+banner and measured 1 re-configure, because `nros_reconfigure_snapshot` hashes
+CONTENT and one comment line arms the very re-configure the seed exists to
+remove. C is the control — a wrong seed must lose.
+
+**A3 is explicitly NOT claimed.** This host has no `zephyr-workspace` and no
+Zephyr SDK, so neither "one pass" nor "byte-identical knobs" was measured. Given
+phase-392 W5's withdrawn causal claim, saying nothing beats saying it from a
+synthetic. Issue 1228 records what the real acceptance is: a `west build` with
+`check-knob-delivery <build-dir>` green both sides and unrelated values asserted
+unchanged as the control. Its headline is the one differing line between stage
+3.5 and the mid-configure producer — `NROS_ENTITY_INVENTORY_SOURCE` — which is
+why the pass is not yet saved in the real tree.
+
 **Known gap, not a blocker:** `ZPICO_MAX_QUERYABLES` and
 `ZPICO_MAX_LARGE_SUBSCRIBERS` have no declarative derivation (issues 0827, 1061,
 1125). They stay hand-set and `[provenance]` says so, which is strictly better

--- a/docs/roadmap/phase-439-resolve-before-configure.md
+++ b/docs/roadmap/phase-439-resolve-before-configure.md
@@ -2,7 +2,8 @@
 
 **Status (2026-09-08). Opened from RFC-0094. W0 and W1 are the routing diff and
 the digest key — both are PRECONDITIONS and neither changes behaviour. W2–W4 are
-the three landings. **W0, W1 and W4 have LANDED; W2 and W3 are not started.**
+the three landings. **W0, W1 and W4 have LANDED; W2 is PARTIALLY landed (the phase and its
+artifact, not the deletion — issue 1228); W3 is not started.**
 
 W0 corrected three of RFC-0094's own numbers — the count of `package.xml`, the
 size of the declare-but-no-file class, and how many of the 21 side-changers are
@@ -155,7 +156,7 @@ Gate: `check-cargo-dir-knob-key`, which drives the production cmake through
 the normal path — with the knob fields removed the two images must COLLIDE, so a
 green verdict is a demonstration rather than an assertion.
 
-## W2 — Stage 3.5, the resolve phase
+## W2 — Stage 3.5, the resolve phase — **PARTIALLY LANDED 2026-09-08**
 
 The phase itself: read descriptors and declared entities, run
 `EntityInventory::derive` once, write `build/<image>/resolved.toml` with
@@ -173,6 +174,84 @@ before the deletion and after it.
 `ZPICO_MAX_LARGE_SUBSCRIBERS` have no declarative derivation (issues 0827, 1061,
 1125). They stay hand-set and `[provenance]` says so, which is strictly better
 than being hand-set and silent.
+
+### What landed
+
+The **phase and its artifact**, plus the configure-side reader. Not the
+deletion — see "What did not", and issue **1228**, which carries the remainder
+with the measurement that decides it.
+
+* `packages/cli/nros-cli-core/src/resolve.rs` — `Resolved`, `resolved.toml`
+  (D2's shape: `[image]` with a digest, `[executor]`, `[pools]`, `[entities]`,
+  `[provenance]`), and `write()`, which renders the TOML and the `include()`able
+  `resolved.cmake` from ONE composition. `[provenance]` is normative and carries
+  a line per value; `HAND_SET_KNOBS` puts the two undeliverable knobs in it
+  BY NAME with the reason, which is the stated known-gap deliverable.
+* **Stage 3.5** in `cmd/build.rs`'s `plan_builds`, between the preflight bail and
+  the driver match: `resolve_image()`. It reads the image block, the board the
+  catalog resolved, and the launch tree's wiring through the resolved
+  SystemModel — no compile, no configure, no cargo — and runs
+  `EntityInventory::derive` once. **It cannot fail a build:** an image it cannot
+  answer for gets a `resolved.toml` recording the refusal and NO projection, so
+  every downstream lane behaves as it did before the phase existed.
+* `cmake/NanoRosResolved.cmake` — the reader. `nros_resolved_seed_entity_inventory()`
+  seeds the entity-inventory fragment from the resolve where the build would
+  otherwise write a placeholder, at the two sites that READ it
+  (`_nros_load_derived_entity_inventory` in the Zephyr lane, and the
+  entity→bounds join in `NanoRosCodegenCore.cmake`). NOT at the three sites
+  inside `nros_derive_entity_inventory_knobs`, which are a PRODUCER recording its
+  own refusal — seeding those with another composer's answer would publish a
+  number the producer did not stand behind.
+* `-DNROS_RESOLVED_DIR=<dir>` on the cmake and west handoffs. Passed, never
+  guessed: a reader that inferred where a resolve might live would silently pick
+  up another image's answer, which is issue 0616 one directory over. A lane that
+  ran no resolve phase (a bare `west build`, `just zephyr build-fixtures`) sets
+  nothing and is unchanged.
+* `just check resolved-seed` / `tests/cmake-resolved-seed-tests.sh`.
+
+### Measured
+
+**The pass count, on a five-line cmake project** (`just check resolved-seed`,
+9/9). Its subject is the thing `NanoRosReconfigure.cmake` spends:
+
+| case | re-configures | built with |
+| --- | --- | --- |
+| A no resolve phase | 1 | the real answer — today's baseline, unchanged |
+| B resolve AGREES | **0** | the real answer — the pass this phase removes |
+| C resolve DISAGREES | 1 | the **producer's** answer — the safety property |
+| D resolve REFUSED | 1 | byte-for-byte case A |
+
+C is what makes it a test. The two composers do not read the same inputs, so a
+seed that is wrong must lose; a green A and B with a red C would mean stage 3.5
+can ship a number nothing stood behind.
+
+Case B also **corrected the implementation**: the seed first copied the fragment
+under a "seeded from …" banner, and measured `re-runs=1` — `nros_reconfigure_snapshot`
+hashes CONTENT, so a seed differing by one comment line arms exactly the
+re-configure it exists to remove. The seed is verbatim now and the provenance
+lives where a byte comparison cannot reach it.
+
+**The two composers agree on every NUMBER and differ by one LINE**
+(`resolve::tests::stage_3_5_and_the_mid_configure_producer_agree_on_every_number`,
+over the production `merged_per_kind_max` / `to_cmake`): identical values,
+identical bytes except `NROS_ENTITY_INVENTORY_SOURCE`, which names the metadata
+file on the producer's side and the model alone on stage 3.5's. That one line is
+why the pass is not yet saved in the real tree, and it is issue 1228's headline.
+
+### What did NOT land, and what is NOT claimed
+
+* **`nros_reconfigure_settle` and the future-mtime arm are still present and
+  still authoritative.** A3 is not met. Issue 1228.
+* **The message-bound half of the chain is untouched** — it is derived
+  mid-configure from codegen fragments by a pure-CMake composer with no Rust
+  twin, so a second pass survives even once the entity link closes.
+* **No claim about a real Zephyr image.** This host has no `zephyr-workspace`
+  and no Zephyr SDK, so "converges in one pass" and "a named image's knobs are
+  byte-identical" were NOT RUN. phase-392 W5 had to withdraw a causal claim from
+  a before/after that accidentally built the same configuration twice; the
+  deletion's acceptance must be a real `west build` with `check-knob-delivery
+  <build-dir>` green on both sides and the unrelated values asserted UNCHANGED
+  as the control.
 
 ## W3 — `build_type` selects the driver
 

--- a/just/check/cmake.just
+++ b/just/check/cmake.just
@@ -187,6 +187,31 @@ reconfigure-on-change:
     fi
     ./tests/cmake-reconfigure-tests.sh
 
+# phase-439 W2 (RFC-0094 D1) -- the resolve phase's CMake seam, measured.
+#
+# Its subject is the PASS COUNT, which is the thing `NanoRosReconfigure.cmake`
+# spends and the thing RFC-0094 A3 wants back. Its case C is the safety
+# property: a seed that DISAGREES with the mid-configure producer must lose, or
+# stage 3.5 could ship a number nothing stood behind.
+#
+# Same skip ledger and the same reason as its sibling above: "the tool is
+# absent" is a different claim from "it passed", and a gate that says the second
+# when it means the first is worth less than no gate.
+resolved-seed:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    _missing=""
+    for _t in cmake ninja; do
+        command -v "$_t" >/dev/null 2>&1 || _missing="$_missing $_t"
+    done
+    if [ -n "$_missing" ]; then
+        # shellcheck source=scripts/build/check-skip.sh
+        source scripts/build/check-skip.sh
+        nros_check_skip resolved-seed "missing host tool(s):$_missing"
+        exit 0
+    fi
+    ./tests/cmake-resolved-seed-tests.sh
+
 # Root-workspace rustfmt. `check-example-fmt` and `check-cli-fmt` already sit in
 # the fast tier; the ROOT workspace's `fmt --check` was the one left in the build
 # tier, so an unformatted file you just wrote survived `check-fast` — which is

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -324,6 +324,34 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
             eyre::bail!("{}", crate::builder::preflight::report(&missing));
         }
 
+        // ---- stage 3.5 — the RESOLVE phase (RFC-0094 D1, phase-439 W2) ---
+        //
+        // ONE PLACE DECIDES A KNOB, every other place reads it. Between "is the
+        // toolchain present" and "emit a root build file", because that is the
+        // last point at which nothing has been generated and the first at which
+        // the image is fully identified.
+        //
+        // It reads DECLARATIONS and never a compiled artifact. That is the
+        // whole point: `nros-rmw-zenoh` is a DEPENDENCY of the leaf, so the
+        // crate that must know the entity counts compiles before the crate
+        // whose source declares them, and no build script, proc macro or
+        // manifest key reaches backwards across that edge (issue 0827).
+        //
+        // It cannot FAIL a build. An image whose declarations this phase cannot
+        // reach gets a `resolved.toml` that says so and no CMake projection, so
+        // every downstream lane behaves exactly as it does today. Making the
+        // resolve phase a new way for a build to stop would be a regression
+        // paid by every image for the benefit of the few that derive.
+        let resolved_dir = resolve_image(
+            &root,
+            &bringup,
+            &bringup_dir,
+            &image_id,
+            &image,
+            &platform,
+            &board,
+        );
+
         // ---- stage 4 ----------------------------------------------------
         let mut cmake_configure: Option<Handoff> = None;
         let mut cargo_prepare: Option<Handoff> = None;
@@ -643,6 +671,18 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
                 if preamble.is_file() {
                     a.push(format!("-DNROS_WS_PREAMBLE={}", preamble.display()));
                 }
+                // RFC-0094 D1 — where stage 3.5 put this image's answer. The
+                // configure READS it; it does not re-derive it.
+                //
+                // Passed rather than discovered, for the reason the preamble
+                // above is: a generated build file that computes a path into
+                // the caller's tree stops being workspace-agnostic. It is also
+                // what keeps the seam HONEST — a lane that did not run stage
+                // 3.5 (a bare `west build`, `just zephyr build-fixtures`) sets
+                // nothing, finds nothing, and behaves exactly as it does today.
+                if let Some(d) = &resolved_dir {
+                    a.push(format!("-DNROS_RESOLVED_DIR={}", d.display()));
+                }
                 a.extend(args.native_args.iter().cloned());
                 cmake_configure = Some(Handoff::new("cmake", a).in_dir(&root));
                 Some(
@@ -716,10 +756,17 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
                 // arities, and west accepts options after the positional.
                 a.extend(west_extra);
                 let west_opts = crate::builder::zephyr::west_args(&overlays);
-                if !west_opts.is_empty() || !cmake_extra.is_empty() {
+                // RFC-0094 D1 — same seam as the cmake driver, in west's
+                // second argument zone. See the note there.
+                let resolved_opt: Vec<String> = resolved_dir
+                    .as_ref()
+                    .map(|d| vec![format!("-DNROS_RESOLVED_DIR={}", d.display())])
+                    .unwrap_or_default();
+                if !west_opts.is_empty() || !cmake_extra.is_empty() || !resolved_opt.is_empty() {
                     // Everything after `--` is a cmake option for the app.
                     a.push("--".to_string());
                     a.extend(west_opts);
+                    a.extend(resolved_opt);
                     a.extend(cmake_extra);
                 }
                 // Resolved here, ENFORCED at exec. A plan is an answer to
@@ -1655,6 +1702,150 @@ fn entries_for_other_boards(
         }
     }
     out
+}
+
+/// Stage 3.5 for ONE image — RFC-0094 D1, phase-439 W2.
+///
+/// Reads the declarations, runs [`EntityInventory::derive`] once through
+/// [`crate::resolve::write`], and returns the directory the artifacts landed in
+/// so stage 4 can hand it to a configure. `None` means the phase wrote nothing
+/// AT ALL, which happens only when the filesystem refused — a declaration this
+/// phase cannot READ still produces a `resolved.toml` saying so.
+///
+/// # Why this never bails
+///
+/// A `nros build` that worked yesterday must not stop working because a new
+/// phase could not answer for an image. Every failure mode here is a WARNING
+/// plus a refusal recorded in the artifact; the downstream lanes then behave
+/// exactly as they did before this phase existed, because the CMake projection
+/// — the only thing a build READS — is written only for a derived answer.
+///
+/// # What it does NOT read
+///
+/// `${CMAKE_BINARY_DIR}/nros-metadata.json`, which today's
+/// `nros ws entity-inventory` call takes as its component set. That file is
+/// written DURING a configure by `nano_ros_node_register()`, so reading it here
+/// would recreate the producer-after-reader lag this phase exists to remove.
+/// The declaration this phase reads instead is the contract sidecar beside the
+/// launch file (`<bringup>/launch/<stem>.contract.yaml`), folded into the
+/// resolved SystemModel — which is where phase-412 already put the statement of
+/// what an image creates when it retired the `ENTITIES` argument.
+fn resolve_image(
+    root: &std::path::Path,
+    bringup: &str,
+    bringup_dir: &std::path::Path,
+    image_id: &str,
+    image: &crate::orchestration::image::ImageBlock,
+    platform: &str,
+    board: &str,
+) -> Option<std::path::PathBuf> {
+    use crate::{
+        entity_inventory::EntityInventory,
+        orchestration::model_location,
+        resolve::{ImageIdent, write as write_resolved},
+    };
+
+    let ident = ImageIdent {
+        bringup: bringup.to_string(),
+        entry: image_id.to_string(),
+        board: board.to_string(),
+        platform: platform.to_string(),
+        rmw: image.rmw.clone().unwrap_or_default(),
+    };
+    let dir = root.join("build").join(ident.dir_name());
+
+    // (launch, args) → the resolved model, exactly as `generate_entry` reaches
+    // it. `ensure_model` resolves from `system.toml` + the launch file when no
+    // build has produced one, so this needs no build system to have run.
+    let args_vec: Vec<(String, String)> = image
+        .args
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    let inventory: Result<EntityInventory, String> = (|| {
+        let model_rel =
+            model_location::launch_to_model_rel(bringup_dir, image.launch.as_deref(), &args_vec)
+                .map_err(|e| format!("cannot resolve the launch for this image: {e}"))?;
+        let (model_path, _inputs) = model_location::ensure_model(bringup_dir, &model_rel)
+            .map_err(|e| format!("cannot resolve the SystemModel: {e}"))?;
+        let raw = std::fs::read_to_string(&model_path)
+            .map_err(|e| format!("reading {}: {e}", model_path.display()))?;
+        let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(&raw)
+            .map_err(|e| format!("parsing {}: {e}", model_path.display()))?;
+        // `None` is "no wiring described", which is a DECLARATION GAP and not
+        // an error: 5 of the tree's 114 resolvable models describe wiring, and
+        // they are exactly the 5 with a contract sidecar (issue 0973).
+        EntityInventory::from_model(model_path.display().to_string(), &model).ok_or_else(|| {
+            format!(
+                "the launch tree resolved, and it describes no wiring. Nothing here can \
+                 derive a count. State what each node creates in the contract sidecar \
+                 beside the launch file ({}/launch/<stem>.contract.yaml); until then this \
+                 image keeps its configured pool knobs.",
+                bringup_dir.display()
+            )
+        })
+    })();
+
+    let written = match inventory {
+        Ok(inv) => write_resolved(&dir, ident, &inv),
+        Err(reason) => {
+            let r = crate::resolve::Resolved::unresolvable(
+                ident,
+                bringup_dir.join("launch").display().to_string(),
+                reason,
+            );
+            // Same two writes as the derived path, minus the projection — kept
+            // inline rather than routed through `write` because there is no
+            // inventory to render one from.
+            match std::fs::create_dir_all(&dir)
+                .and_then(|()| {
+                    let stale = dir.join(crate::resolve::RESOLVED_CMAKE_NAME);
+                    if stale.exists() {
+                        std::fs::remove_file(&stale)?;
+                    }
+                    Ok(())
+                })
+                .and_then(|()| {
+                    let p = dir.join(crate::resolve::RESOLVED_TOML_NAME);
+                    crate::atomic_file::atomic_write(&p, &r.to_toml())
+                        .map_err(|e| std::io::Error::other(e.to_string()))
+                        .map(|()| p)
+                }) {
+                Ok(toml_path) => Ok(crate::resolve::Written {
+                    resolved: r,
+                    toml_path,
+                    cmake_path: None,
+                }),
+                Err(e) => Err(e),
+            }
+        }
+    };
+
+    match written {
+        Err(e) => {
+            eprintln!("nros build: warning: stage 3.5 could not write `{image_id}`'s resolve: {e}");
+            None
+        }
+        Ok(w) => {
+            match w.resolved.knobs() {
+                Some(k) => eprintln!(
+                    "nros build:   resolved → {} (max_cbs {}, nodes {}, digest {})",
+                    w.toml_path.display(),
+                    k.max_cbs,
+                    k.max_nodes,
+                    w.resolved.digest()
+                ),
+                // Says WHY, once, at the same volume as the success line. A
+                // refusal that only lives in a file nobody opens is the silent
+                // shape RFC-0094 exists to remove.
+                None => eprintln!(
+                    "nros build:   resolved → {} (no count derived; see [provenance].refused)",
+                    w.toml_path.display()
+                ),
+            }
+            Some(dir)
+        }
+    }
 }
 
 /// The build-tree coordinate for an image — RFC-0070 R2's vocabulary

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -38,6 +38,10 @@ pub mod leaf_entity_env;
 /// need the message-bound inventory as well as the entity one. The cargo-leaf
 /// twin of `_nros_bounds_join_subscribed` in `cmake/NanoRosMessageBounds.cmake`.
 pub mod leaf_payload_classes;
+/// phase-439 W2 (RFC-0094 D1/D2) — stage 3.5, the resolve phase: the one place
+/// that decides an image's declared counts, run BEFORE any configure so a
+/// reader early in one sees the final answer on its first pass.
+pub mod resolve;
 // Issue 0363 — the freshness predicate, shared verbatim with `build.rs` via
 // `include!`. One implementation: the build embeds a stamp, the runtime
 // recomputes it. Replaces the mtime comparison that fired on every rebase.

--- a/packages/cli/nros-cli-core/src/resolve.rs
+++ b/packages/cli/nros-cli-core/src/resolve.rs
@@ -1,0 +1,815 @@
+//! phase-439 W2 (RFC-0094 D1/D2) — stage 3.5, the resolve phase.
+//!
+//! `nros build` has five stages: discover, plan, preflight, emit root, exec.
+//! This is the phase between preflight and emit-root. It
+//!
+//!   reads   the board / platform descriptor the image resolved to,
+//!           the image declaration (`[image.*]` in the bringup's `system.toml`),
+//!           and the wiring the launch tree states (the resolved SystemModel,
+//!           which folds in the `<stem>.contract.yaml` sidecar),
+//!   runs    [`EntityInventory::derive`] ONCE, for the whole image,
+//!   writes  `build/<image>/resolved.toml`.
+//!
+//! **No compile. No configure. No cargo invocation.** Everything above is a
+//! declaration on disk. That is not a stylistic preference, it is the reason
+//! the phase can exist at all — see "the direction problem" below.
+//!
+//! # The direction problem, which is why this is a phase and not more forwarding
+//!
+//! `nros-rmw-zenoh` is a DEPENDENCY of the leaf, so the crate that must know the
+//! entity counts compiles BEFORE the crate whose source declares them. No build
+//! script, proc macro or manifest key reaches backwards across that edge. Issue
+//! 0827 already moved the derivation out of the cargo graph for this reason;
+//! RFC-0094 finishes the move by putting it before the build system rather than
+//! inside it.
+//!
+//! The same shape, one layer over, is what the three-pass convergence in
+//! `zephyr/cmake/nros_cargo_build.cmake` exists to paper over: the entity
+//! inventory's producer (`nano_ros_entry()`) runs LATER in a configure than its
+//! reader (`nros_resolve_knobs()`, inside `find_package(Zephyr)`). A producer
+//! that runs BEFORE the configure has no such lag, which is what makes the
+//! future-mtime arm in `cmake/NanoRosReconfigure.cmake` deletable.
+//!
+//! # Why the metadata probe cannot be the source
+//!
+//! `nros metadata` compiles a harness and RUNS it; on `qemu-arm-baremetal` that
+//! is a Cortex-M cross build executed under QEMU over semihosting, and issue
+//! 1061 measured that it cannot run at all for pure-cargo leaves. It may remain
+//! as a cross-check. It must not be what this phase depends on, and it is not:
+//! nothing here executes anything it built.
+//!
+//! `${CMAKE_BINARY_DIR}/nros-metadata.json` is out for a different reason — it
+//! is written DURING a configure by `nano_ros_node_register()`, so a phase that
+//! runs before the configure cannot read it without recreating the very lag it
+//! exists to remove.
+//!
+//! # DEMAND, not size — the floor belongs to the consumer
+//!
+//! Everything under `[executor]` and `[pools]` is the image's raw DEMAND,
+//! ZERO INCLUDED. Whether zero is a legal SIZE is a property of the STORAGE the
+//! knob reaches, not of the count:
+//!
+//! * `ZPICO_MAX_QUERYABLES` sizes a fixed C array. At 0 a board transmitted
+//!   nothing for 15 s with no diagnostic (issue 1015).
+//! * `XRCE_MAX_SUBSCRIBERS` at 0 is 33,296 bytes of heap the image gets back,
+//!   and is the correct answer (issue 1033).
+//!
+//! One [`EntityInventory::derive`] feeds both. A floor applied here silently
+//! defeated 1033 the day after it landed, and every knob gate stayed green
+//! because the number was derived correctly and delivered faithfully. So this
+//! file publishes demand and the consumers floor it
+//! ([`crate::entity_inventory::c_array_pool_floor`] on the Rust lane,
+//! `_nros_c_array_pool_floor` on the CMake one).
+//!
+//! # `[provenance]` is normative
+//!
+//! Today "which number did this image build at, and why?" is answered by
+//! cache-variable archaeology. Every value this file publishes carries a line
+//! saying where it came from — and every knob that has NO declarative
+//! derivation carries a line saying THAT, which is strictly better than being
+//! hand-set and silent.
+
+use std::{collections::BTreeMap, fmt::Write as _};
+
+use sha2::{Digest, Sha256};
+
+use crate::entity_inventory::{Derivation, DerivedEntityKnobs, EntityInventory};
+
+/// The `resolved.toml` schema this writer emits and its readers understand.
+///
+/// A reader that finds anything else REFUSES rather than reading field by field
+/// on the hope that nothing moved — the same rule
+/// `NROS_MESSAGE_BOUNDS_SCHEMA_SUPPORTED` states for the bound inventory.
+pub const RESOLVED_SCHEMA_VERSION: u32 = 1;
+
+/// The canonical file name, so no reader hand-derives it.
+pub const RESOLVED_TOML_NAME: &str = "resolved.toml";
+
+/// The CMake projection's file name, beside it.
+///
+/// A second FILE, not a second DERIVATION: both are rendered from one
+/// [`Resolved`] in one call to [`write`], exactly as
+/// `EntityInventory` already renders JSON, CMake and env from one data model.
+/// `resolved_toml_and_cmake_agree` is the test that holds them together.
+pub const RESOLVED_CMAKE_NAME: &str = "resolved.cmake";
+
+/// Which knobs have NO declarative derivation, and why.
+///
+/// RFC-0094 and phase-439 W2 both name these two explicitly as a KNOWN GAP
+/// rather than a defect. Stating the gap in the artifact is the deliverable:
+/// a hand-set knob that says it is hand-set can be audited, and one that does
+/// not cannot.
+///
+/// Do not invent a derivation for either without measuring one. `ZPICO_MAX_
+/// QUERYABLES` in particular has an addend this inventory cannot see — the ROS
+/// parameter services claim 6 queryables and the REP-2002 lifecycle services 5,
+/// before the application declares anything, and whether they are in the image
+/// is a FEATURE of another crate that cargo exposes to nobody.
+pub const HAND_SET_KNOBS: &[(&str, &str)] = &[
+    (
+        "ZPICO_MAX_QUERYABLES",
+        "HAND-SET: no declarative derivation. The entity inventory counts the \
+         APPLICATION's service servers and action servers; it cannot see the \
+         infrastructure addend (param_services 6 + lifecycle 5), which an \
+         image-level FEATURE enables and cargo exposes to no other crate. \
+         Issues 0827, 1061, 1125.",
+    ),
+    (
+        "ZPICO_MAX_LARGE_SUBSCRIBERS",
+        "HAND-SET: no declarative derivation. It is a count of payload BLOCKS, \
+         which needs the message-bound inventory (a TYPE's size) joined to the \
+         subscribed-type set — and the bound half is produced by codegen, not \
+         by a declaration this phase reads. Issues 0827, 1061, 1125.",
+    ),
+];
+
+/// The identity of the image whose knobs these are.
+///
+/// Every field is a DECLARATION: `entry` and `board` are what the bringup's
+/// `[image.*]` states, `platform` is what the board catalog resolved it to.
+/// None of them is read back off a compiled artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageIdent {
+    /// The bringup package that declares this image.
+    pub bringup: String,
+    /// The `[image.<id>]` key.
+    pub entry: String,
+    /// The nano-ros board id, or empty when the image names none.
+    pub board: String,
+    /// The platform the board catalog resolved the board to.
+    pub platform: String,
+    /// The RMW backend, or empty when the image inherits the system header's.
+    pub rmw: String,
+}
+
+impl ImageIdent {
+    /// The directory name this image's artifacts live under.
+    ///
+    /// `<bringup>__<entry>`, which is RFC-0094 D1's `build/<image>/` with the
+    /// bringup carried so two bringups declaring the same image id cannot land
+    /// in one directory. Path-safe by construction: every character outside
+    /// `[A-Za-z0-9_-]` becomes `-`, so a launch-argument-bearing id cannot
+    /// escape the build tree. `.` is NOT in the allowed set even though it is a
+    /// legal filename character — keeping it would let a `..` survive intact,
+    /// and this string is joined onto a build root.
+    #[must_use]
+    pub fn dir_name(&self) -> String {
+        let sanitize = |s: &str| -> String {
+            s.chars()
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() || matches!(c, '_' | '-') {
+                        c
+                    } else {
+                        '-'
+                    }
+                })
+                .collect()
+        };
+        format!("{}__{}", sanitize(&self.bringup), sanitize(&self.entry))
+    }
+}
+
+/// One image's resolved answer, plus how it got there.
+///
+/// `Refused` carries prose and NO numbers, which is [`Derivation`]'s own
+/// discipline and for its own reason: a consumer either reads a value this
+/// phase derived or reads nothing at all. A substituted default that looks like
+/// an answer is the silent shape this whole campaign exists to remove.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolved {
+    pub image: ImageIdent,
+    /// Where the declarations were read from — the model path, for the
+    /// provenance line.
+    pub source: String,
+    /// The composed inventory's answer, run ONCE.
+    pub derivation: Derivation,
+    /// Per-kind entity counts, when derived.
+    pub per_kind: BTreeMap<String, usize>,
+    /// Per-component `(pkg, component, entities, slots)`, when derived — the
+    /// provenance a reader needs to attribute a number to a declaration.
+    pub per_component: Vec<(String, String, usize, usize)>,
+}
+
+impl Resolved {
+    /// Compose one image's answer. [`EntityInventory::derive`] runs exactly
+    /// once here and the result is carried, not re-derived per renderer.
+    #[must_use]
+    pub fn compose(image: ImageIdent, inventory: &EntityInventory) -> Self {
+        let derivation = inventory.derive();
+        let (per_kind, per_component) = match &derivation {
+            Derivation::Derived(k) => (
+                k.per_kind
+                    .iter()
+                    .map(|(name, n)| ((*name).to_string(), *n))
+                    .collect(),
+                k.per_component.clone(),
+            ),
+            Derivation::Refused { .. } => (BTreeMap::new(), Vec::new()),
+        };
+        Self {
+            image,
+            source: inventory.source.clone(),
+            derivation,
+            per_kind,
+            per_component,
+        }
+    }
+
+    /// An image whose declarations could not be reached at all.
+    ///
+    /// Distinct from a refusal the inventory itself raised: this one says the
+    /// phase never got as far as an inventory (no launch, no model, no
+    /// contract). Both write a file, and neither writes a number.
+    #[must_use]
+    pub fn unresolvable(image: ImageIdent, source: impl Into<String>, reason: String) -> Self {
+        Self {
+            image,
+            source: source.into(),
+            derivation: Derivation::Refused { reason },
+            per_kind: BTreeMap::new(),
+            per_component: Vec::new(),
+        }
+    }
+
+    /// The knobs, when this image derived any.
+    #[must_use]
+    pub fn knobs(&self) -> Option<&DerivedEntityKnobs> {
+        self.derivation.knobs()
+    }
+
+    /// `derived` | `refused`.
+    #[must_use]
+    pub fn status(&self) -> &'static str {
+        self.derivation.tag()
+    }
+
+    /// A digest over every RESOLVED VALUE — not over the file, which carries
+    /// comments and provenance prose that must be free to improve.
+    ///
+    /// RFC-0094 D2. The point is that two images whose knobs agree share a
+    /// digest and two whose knobs differ do not, so the digest can key a shared
+    /// artifact directory (D4) without the key depending on wording.
+    ///
+    /// 16 hex digits rather than the RFC's illustrative 8: a 32-bit digest over
+    /// a whole tree's images collides at a few tens of thousands by the
+    /// birthday bound, and a collision here silently hands one image another's
+    /// numbers — issue 0616's shape, which is the failure D4 exists to prevent.
+    #[must_use]
+    pub fn digest(&self) -> String {
+        let mut h = Sha256::new();
+        h.update(RESOLVED_SCHEMA_VERSION.to_string());
+        h.update(b"\x1fimage\x1f");
+        for field in [
+            &self.image.bringup,
+            &self.image.entry,
+            &self.image.board,
+            &self.image.platform,
+            &self.image.rmw,
+        ] {
+            h.update(field.as_bytes());
+            h.update(b"\x1f");
+        }
+        h.update(b"\x1fstatus\x1f");
+        h.update(self.status().as_bytes());
+        // The VALUES, in a fixed order. A refusal contributes none, so every
+        // refused image of one identity shares a digest — which is correct: it
+        // is the same answer, namely none.
+        if let Some(k) = self.knobs() {
+            for (name, v) in self.value_rows() {
+                h.update(b"\x1f");
+                h.update(name.as_bytes());
+                h.update(b"=");
+                h.update(v.to_string().as_bytes());
+            }
+            // per-kind is provenance for the values above, but it is also the
+            // only place a declaration change with no knob effect shows up, and
+            // a consumer keyed on this digest wants to notice that.
+            for (kind, n) in &self.per_kind {
+                h.update(b"\x1f");
+                h.update(kind.as_bytes());
+                h.update(b"#");
+                h.update(n.to_string().as_bytes());
+            }
+            let _ = k;
+        }
+        let out = h.finalize();
+        out.iter().take(8).fold(String::new(), |mut s, b| {
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+    }
+
+    /// The resolved values, in emission order. ONE list, so the TOML body, the
+    /// CMake projection and the digest cannot disagree about what was resolved.
+    #[must_use]
+    pub fn value_rows(&self) -> Vec<(&'static str, usize)> {
+        match self.knobs() {
+            None => Vec::new(),
+            Some(k) => vec![
+                ("max_cbs", k.max_cbs),
+                ("action_clients", k.heavy_slots),
+                ("max_nodes", k.max_nodes),
+                ("entity_total", k.entity_total),
+                ("max_subscribers", k.max_subscribers),
+                ("rmw_subscriber_slots", k.max_subscribers),
+                ("max_publishers", k.max_publishers),
+                ("max_queryables", k.max_queryables),
+            ],
+        }
+    }
+
+    /// `resolved.toml` — RFC-0094 D2's artifact.
+    #[must_use]
+    pub fn to_toml(&self) -> String {
+        let mut s = String::new();
+        s.push_str(
+            "# GENERATED by `nros build` stage 3.5, the resolve phase (RFC-0094 D1/D2,\n\
+             # phase-439 W2). Do not edit: the next build overwrites it.\n\
+             #\n\
+             # ONE PLACE DECIDES A KNOB, EVERY OTHER PLACE READS IT. This is that place\n\
+             # for the counts an image's DECLARATIONS answer. It is written BEFORE any\n\
+             # configure, from declarations only — no compile, no cargo, no cmake — which\n\
+             # is what lets a reader that runs early in a configure see the final answer\n\
+             # on its first pass.\n\
+             #\n\
+             # THESE NUMBERS ARE DEMAND, NOT SIZE. Zero is a legitimate demand. Whether\n\
+             # zero is a legal size is a property of the storage the knob reaches, so the\n\
+             # FLOOR belongs to the consumer that names the knob and never here: issue\n\
+             # 1015 (a fixed C array at 0 = a board transmitting nothing for 15 s) and\n\
+             # issue 1033 (heap at 0 = 33,296 bytes returned, and correct) are the same\n\
+             # derived number answered two different ways.\n\
+             #\n\
+             # A derived value is a DEFAULT. An environment value or a Kconfig / board\n\
+             # `.conf` value states a number and WINS.\n\n",
+        );
+        let _ = writeln!(s, "schema_version = {RESOLVED_SCHEMA_VERSION}");
+        s.push('\n');
+
+        s.push_str("[image]\n");
+        let _ = writeln!(s, "bringup = {}", toml_str(&self.image.bringup));
+        let _ = writeln!(s, "entry = {}", toml_str(&self.image.entry));
+        let _ = writeln!(s, "board = {}", toml_str(&self.image.board));
+        let _ = writeln!(s, "platform = {}", toml_str(&self.image.platform));
+        let _ = writeln!(s, "rmw = {}", toml_str(&self.image.rmw));
+        let _ = writeln!(s, "status = {}", toml_str(self.status()));
+        let _ = writeln!(s, "digest = {}", toml_str(&self.digest()));
+        s.push('\n');
+
+        match &self.derivation {
+            Derivation::Refused { reason } => {
+                s.push_str(
+                    "# REFUSED. No knob is derived and NO NUMBER is published: every one\n\
+                     # keeps its configured value. A substituted default here would be\n\
+                     # indistinguishable from an answer, which is the failure this file\n\
+                     # exists to remove.\n",
+                );
+                s.push_str("[provenance]\n");
+                let _ = writeln!(s, "source = {}", toml_str(&self.source));
+                let _ = writeln!(s, "refused = {}", toml_str(reason));
+                for (knob, why) in HAND_SET_KNOBS {
+                    let _ = writeln!(s, "{} = {}", knob.to_ascii_lowercase(), toml_str(why));
+                }
+            }
+            Derivation::Derived(k) => {
+                s.push_str(
+                    "# The executor's own table. A PUBLISHER CLAIMS NO SLOT — it writes an\n\
+                     # RmwPublisher into caller storage and never reaches\n\
+                     # Executor::next_entry_slot — so `entity_total` is larger than\n\
+                     # `max_cbs`, and the gap is the finding rather than a discrepancy.\n",
+                );
+                s.push_str("[executor]\n");
+                let _ = writeln!(s, "max_cbs = {}", k.max_cbs);
+                let _ = writeln!(s, "action_clients = {}", k.heavy_slots);
+                let _ = writeln!(s, "max_nodes = {}", k.max_nodes);
+                let _ = writeln!(s, "entity_total = {}", k.entity_total);
+                s.push('\n');
+
+                s.push_str(
+                    "# The RMW SESSION pools, which count what the executor's table does\n\
+                     # not: a publisher claims a session slot but no callback slot, and a\n\
+                     # declared action is ONE entity that costs SEVERAL session slots (a\n\
+                     # server opens 3 queryables and 2 publishers, a client 1\n\
+                     # subscription).\n",
+                );
+                s.push_str("[pools]\n");
+                let _ = writeln!(s, "max_subscribers = {}", k.max_subscribers);
+                let _ = writeln!(s, "rmw_subscriber_slots = {}", k.max_subscribers);
+                let _ = writeln!(s, "max_publishers = {}", k.max_publishers);
+                let _ = writeln!(s, "max_queryables = {}", k.max_queryables);
+                s.push('\n');
+
+                s.push_str("[entities]\n");
+                for (kind, n) in &self.per_kind {
+                    let _ = writeln!(s, "{kind} = {n}");
+                }
+                s.push('\n');
+
+                s.push_str(
+                    "# NORMATIVE, not decoration. Without it \"which number did this image\n\
+                     # build at, and why?\" is answered by cache-variable archaeology.\n",
+                );
+                s.push_str("[provenance]\n");
+                let _ = writeln!(s, "source = {}", toml_str(&self.source));
+                let _ = writeln!(
+                    s,
+                    "max_cbs = {}",
+                    toml_str(&format!(
+                        "{} → {} declared entities over {} components, {} of them claiming a \
+                         callback slot",
+                        self.source,
+                        k.entity_total,
+                        k.per_component.len(),
+                        k.max_cbs
+                    ))
+                );
+                let _ = writeln!(
+                    s,
+                    "action_clients = {}",
+                    toml_str(
+                        "of those slots, the ones the arena must budget at the ACTION entry \
+                         size rather than the pub/sub one — action clients AND action \
+                         servers, since the arena stores ActionServerArenaEntry too (issue \
+                         0900)"
+                    )
+                );
+                let _ = writeln!(
+                    s,
+                    "max_nodes = {}",
+                    toml_str(
+                        "one node per declared component; over-counts when two share a name \
+                         (slots are keyed by name), which is the safe direction"
+                    )
+                );
+                let _ = writeln!(
+                    s,
+                    "max_queryables = {}",
+                    toml_str(
+                        "APPLICATION service servers + 3 per action server. Does NOT include \
+                         the parameter (6) or lifecycle (5) service families: an image-level \
+                         FEATURE enables those and this inventory cannot see it, so an image \
+                         carrying them must state the knob. That is why this is a DEFAULT and \
+                         not a ceiling."
+                    )
+                );
+                for (pkg, comp, count, slots) in &k.per_component {
+                    let _ = writeln!(
+                        s,
+                        "component_{} = {}",
+                        sanitize_key(&format!("{pkg}_{comp}")),
+                        toml_str(&format!("{count} entities, {slots} callback slots"))
+                    );
+                }
+                for (knob, why) in HAND_SET_KNOBS {
+                    let _ = writeln!(s, "{} = {}", knob.to_ascii_lowercase(), toml_str(why));
+                }
+            }
+        }
+        s
+    }
+}
+
+/// What one image's resolve phase wrote.
+#[derive(Debug, Clone)]
+pub struct Written {
+    pub resolved: Resolved,
+    /// `<dir>/resolved.toml` — RFC-0094 D2's artifact, always written.
+    pub toml_path: std::path::PathBuf,
+    /// `<dir>/resolved.cmake` — written ONLY when the phase derived something.
+    ///
+    /// Absent on a refusal, deliberately. A configure that finds no projection
+    /// falls through to exactly the behaviour it has today, so an image this
+    /// phase cannot answer for is never made WORSE by the phase existing. An
+    /// empty projection would instead publish "every count is zero", which is
+    /// the substituted-default failure in a new place.
+    pub cmake_path: Option<std::path::PathBuf>,
+}
+
+/// Run the resolve phase for one image and write its artifacts.
+///
+/// [`EntityInventory`] is composed by the caller from declarations; this
+/// function is the one place that turns it into files. Both transports are
+/// rendered from the SAME inventory in one call — a second derivation for a
+/// second file is how two artifacts of one answer come to disagree, which is
+/// the defect RFC-0094 exists to remove rather than to reproduce.
+pub fn write(
+    dir: &std::path::Path,
+    image: ImageIdent,
+    inventory: &EntityInventory,
+) -> std::io::Result<Written> {
+    let resolved = Resolved::compose(image, inventory);
+    std::fs::create_dir_all(dir)?;
+    let toml_path = dir.join(RESOLVED_TOML_NAME);
+    let map = |e: eyre::Report| std::io::Error::other(e.to_string());
+    crate::atomic_file::atomic_write(&toml_path, &resolved.to_toml()).map_err(map)?;
+
+    let cmake_path = match resolved.knobs() {
+        None => {
+            // Never leave a STALE projection beside a fresh refusal: a
+            // configure reading last build's numbers for this build's
+            // declarations is the museum-binary shape one directory over.
+            let stale = dir.join(RESOLVED_CMAKE_NAME);
+            if stale.exists() {
+                std::fs::remove_file(&stale)?;
+            }
+            None
+        }
+        Some(_) => {
+            let p = dir.join(RESOLVED_CMAKE_NAME);
+            crate::atomic_file::atomic_write(&p, &inventory.to_cmake()).map_err(map)?;
+            Some(p)
+        }
+    };
+    Ok(Written {
+        resolved,
+        toml_path,
+        cmake_path,
+    })
+}
+
+/// A TOML basic string. Hand-rolled rather than `toml::to_string` because the
+/// document above is a TEMPLATE with comments in load-bearing positions, and a
+/// serializer would drop every one of them.
+fn toml_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// A bare TOML key. `pkg::component` carries characters a bare key may not.
+fn sanitize_key(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity_inventory::{ComponentEntities, Declaration, EntityDecl};
+
+    fn ident() -> ImageIdent {
+        ImageIdent {
+            bringup: "demo_bringup".into(),
+            entry: "talker".into(),
+            board: "mps2-an385-freertos".into(),
+            platform: "freertos".into(),
+            rmw: "zenoh".into(),
+        }
+    }
+
+    fn inventory(entities: &[&str]) -> EntityInventory {
+        inventory_from("test://model", entities)
+    }
+
+    fn inventory_from(source: &str, entities: &[&str]) -> EntityInventory {
+        let mut inv = EntityInventory::new(source);
+        inv.insert(ComponentEntities {
+            pkg: "talker_pkg".into(),
+            component: "talker".into(),
+            class: "TalkerNode".into(),
+            declaration: Declaration::Stated(
+                entities
+                    .iter()
+                    .flat_map(|s| EntityDecl::parse(s).expect("parses"))
+                    .collect(),
+            ),
+        });
+        inv
+    }
+
+    #[test]
+    fn derived_image_publishes_demand_and_names_its_source() {
+        let r = Resolved::compose(ident(), &inventory(&["pub:std_msgs/msg/String", "timer"]));
+        assert_eq!(r.status(), "derived");
+        let toml = r.to_toml();
+        // A timer claims a callback slot, a publisher does not.
+        assert!(toml.contains("max_cbs = 1"), "{toml}");
+        assert!(toml.contains("entity_total = 2"), "{toml}");
+        assert!(toml.contains("max_publishers = 1"), "{toml}");
+        // DEMAND, unfloored: this image declares no service server.
+        assert!(toml.contains("max_queryables = 0"), "{toml}");
+        assert!(toml.contains("[provenance]"), "{toml}");
+        assert!(toml.contains("test://model"), "{toml}");
+    }
+
+    #[test]
+    fn a_refusal_publishes_prose_and_no_number() {
+        let mut inv = EntityInventory::new("test://model");
+        inv.insert(ComponentEntities {
+            pkg: "talker_pkg".into(),
+            component: "talker".into(),
+            class: "TalkerNode".into(),
+            declaration: Declaration::Absent,
+        });
+        let r = Resolved::compose(ident(), &inv);
+        assert_eq!(r.status(), "refused");
+        let toml = r.to_toml();
+        assert!(!toml.contains("[executor]"), "{toml}");
+        assert!(!toml.contains("[pools]"), "{toml}");
+        assert!(toml.contains("refused = "), "{toml}");
+        assert!(r.value_rows().is_empty());
+    }
+
+    #[test]
+    fn hand_set_knobs_say_so_in_both_outcomes() {
+        let derived = Resolved::compose(ident(), &inventory(&["timer"])).to_toml();
+        let refused = Resolved::unresolvable(ident(), "test://none", "no launch".into()).to_toml();
+        for (knob, _) in HAND_SET_KNOBS {
+            let key = knob.to_ascii_lowercase();
+            assert!(
+                derived.contains(&key),
+                "{knob} missing from a derived answer"
+            );
+            assert!(refused.contains(&key), "{knob} missing from a refusal");
+            assert!(derived.contains("HAND-SET"), "the reason must say hand-set");
+        }
+    }
+
+    #[test]
+    fn the_digest_moves_with_a_value_and_not_with_prose() {
+        let a = Resolved::compose(ident(), &inventory(&["timer"]));
+        let b = Resolved::compose(ident(), &inventory(&["timer"]));
+        assert_eq!(a.digest(), b.digest(), "same declarations, same digest");
+
+        let c = Resolved::compose(ident(), &inventory(&["timer", "timer"]));
+        assert_ne!(a.digest(), c.digest(), "a moved knob must move the digest");
+
+        // The identity is part of it: two boards at the same counts are two
+        // images, and D4 keys a cargo directory on this.
+        let mut other = ident();
+        other.board = "mps2-an385".into();
+        let d = Resolved::compose(other, &inventory(&["timer"]));
+        assert_ne!(a.digest(), d.digest(), "a moved board must move the digest");
+
+        assert_eq!(a.digest().len(), 16);
+    }
+
+    #[test]
+    fn the_directory_name_cannot_escape_the_build_tree() {
+        let ident = ImageIdent {
+            bringup: "../../etc".into(),
+            entry: "a/b".into(),
+            board: String::new(),
+            platform: "posix".into(),
+            rmw: String::new(),
+        };
+        let d = ident.dir_name();
+        assert!(!d.contains('/'), "{d}");
+        assert!(!d.contains(".."), "{d}");
+    }
+
+    /// The acceptance in miniature: the two transports of ONE resolve carry
+    /// the same numbers.
+    ///
+    /// This is the property RFC-0094 D2 turns on — `resolved.toml` is "the
+    /// single answer" only if the projection a build actually reads says the
+    /// same thing. Written as an identity over `value_rows()` rather than a
+    /// hand-listed pairing, so a knob added to one transport and not the other
+    /// reds this instead of drifting quietly (the `NROS_DERIVED_NROS_MAX_*`
+    /// class, which cmake resolves to EMPTY rather than to an error).
+    #[test]
+    fn resolved_toml_and_cmake_agree() {
+        let inv = inventory(&[
+            "sub:std_msgs/msg/String",
+            "pub:std_msgs/msg/String",
+            "timer",
+            "service_server:example_interfaces/srv/AddTwoInts",
+            "action_server:example_interfaces/action/Fibonacci",
+        ]);
+        let r = Resolved::compose(ident(), &inv);
+        let cmake = inv.to_cmake();
+        let pairs = [
+            ("max_cbs", "NROS_DERIVED_EXECUTOR_MAX_CBS"),
+            ("action_clients", "NROS_DERIVED_EXECUTOR_ACTION_CLIENTS"),
+            ("max_nodes", "NROS_DERIVED_EXECUTOR_MAX_NODES"),
+            ("max_subscribers", "NROS_DERIVED_MAX_SUBSCRIBERS"),
+            ("rmw_subscriber_slots", "NROS_DERIVED_RMW_SUBSCRIBER_SLOTS"),
+            ("max_publishers", "NROS_DERIVED_MAX_PUBLISHERS"),
+            ("max_queryables", "NROS_DERIVED_MAX_QUERYABLES"),
+        ];
+        let rows: BTreeMap<&str, usize> = r.value_rows().into_iter().collect();
+        for (toml_key, cmake_var) in pairs {
+            let v = rows[toml_key];
+            assert!(
+                cmake.contains(&format!("set({cmake_var} {v})\n")),
+                "resolved.toml says {toml_key} = {v}; the CMake projection does not:\n{cmake}"
+            );
+        }
+        // And every value the TOML publishes is covered by that pairing, so a
+        // new knob cannot be added to `value_rows` and silently skip the check.
+        let covered: Vec<&str> = pairs.iter().map(|(t, _)| *t).collect();
+        for (name, _) in r.value_rows() {
+            assert!(
+                covered.contains(&name) || name == "entity_total",
+                "`{name}` is published with no CMake counterpart under test"
+            );
+        }
+    }
+
+    /// MEASURED, and it is a finding rather than a guarantee: stage 3.5's
+    /// projection and the mid-configure producer's derive the SAME NUMBERS and
+    /// do NOT write the same BYTES.
+    ///
+    /// This matters because `nros_reconfigure_snapshot` hashes CONTENT. The
+    /// CMake seed (`nros_resolved_seed_entity_inventory`) removes a configure
+    /// pass only when the producer that follows it writes what the seed already
+    /// wrote — case B of `tests/cmake-resolved-seed-tests.sh`, which measures
+    /// exactly that. Here the one differing line is
+    /// `NROS_ENTITY_INVENTORY_SOURCE`: the producer composes over
+    /// `nros-metadata.json` AND the model, so its source names both, while this
+    /// phase reads the model alone (the metadata is written DURING a configure,
+    /// which is the lag this phase exists to remove).
+    ///
+    /// So on today's tree the seed makes pass 1 read a real number instead of a
+    /// placeholder, and the producer still arms one re-configure over a comment
+    /// line. Closing that is what the follow-up needs — and asserting the split
+    /// here is what stops someone claiming the pass is saved without measuring
+    /// it, which is the failure mode this acceptance is most likely to have.
+    #[test]
+    fn stage_3_5_and_the_mid_configure_producer_agree_on_every_number() {
+        use crate::entity_inventory::Declaration;
+
+        let entities = [
+            "sub:std_msgs/msg/String",
+            "pub:std_msgs/msg/String",
+            "timer",
+        ];
+        // What stage 3.5 composes: the model alone.
+        let model_only = inventory_from("model.yaml", &entities);
+
+        // What the configure composes: the metadata component set (whose
+        // `entities` key is ABSENT since phase-412 retired `ENTITIES`) merged
+        // with the model. `merged_per_kind_max` is the production function.
+        let mut from_metadata = EntityInventory::new("nros-metadata.json");
+        from_metadata.insert(ComponentEntities {
+            pkg: "talker_pkg".into(),
+            component: "talker".into(),
+            class: "TalkerNode".into(),
+            declaration: Declaration::Absent,
+        });
+        let merged = from_metadata.merged_per_kind_max(&model_only);
+
+        let a = Resolved::compose(ident(), &model_only);
+        let b = Resolved::compose(ident(), &merged);
+        assert_eq!(
+            a.value_rows(),
+            b.value_rows(),
+            "the two composers must derive the same numbers; if they do not, the seed \
+             can under-size an image and `nros_resolved_seed_entity_inventory` is unsafe"
+        );
+
+        // And the bytes: equal EXCEPT for the source line. Asserting the shape
+        // of the difference, not merely that one exists — "they differ" would
+        // stay green if a whole knob went missing.
+        let strip_source = |s: &str| -> String {
+            s.lines()
+                .filter(|l| !l.contains("NROS_ENTITY_INVENTORY_SOURCE"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        let ca = model_only.to_cmake();
+        let cb = merged.to_cmake();
+        assert_ne!(
+            ca, cb,
+            "if these now agree byte-for-byte, the seed saves the \
+                            configure pass in production and this test should say so"
+        );
+        assert_eq!(
+            strip_source(&ca),
+            strip_source(&cb),
+            "the ONLY difference must be the provenance source line"
+        );
+    }
+
+    #[test]
+    fn every_value_row_reaches_the_toml() {
+        let r = Resolved::compose(ident(), &inventory(&["sub:std_msgs/msg/String", "timer"]));
+        let toml = r.to_toml();
+        for (name, v) in r.value_rows() {
+            assert!(
+                toml.contains(&format!("{name} = {v}")),
+                "`{name} = {v}` is a resolved value the artifact does not carry:\n{toml}"
+            );
+        }
+    }
+}

--- a/tests/cmake-resolved-seed-tests.sh
+++ b/tests/cmake-resolved-seed-tests.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# tests/cmake-resolved-seed-tests.sh -- phase-439 W2 (RFC-0094 D1).
+#
+# WHAT THIS MEASURES
+#
+# `nros build` gained a resolve phase (stage 3.5) that writes an image's derived
+# counts BEFORE any configure, as `<NROS_RESOLVED_DIR>/resolved.cmake`.
+# `nros_resolved_seed_entity_inventory()` is the configure-side reader: it seeds
+# the entity-inventory fragment from that file where the build would otherwise
+# have written a placeholder.
+#
+# The claim under test is about the PASS COUNT, not about a number. The
+# producer-after-reader chain (`NanoRosReconfigure.cmake`) costs one extra
+# configure per link, because the earliest reader of pass 1 sees a placeholder
+# and issue 0991's future-mtime arm buys the pass in which it does not. A seed
+# written before the configure removes exactly that pass -- IF the producer then
+# agrees with it.
+#
+# So three cases, and the third is the one that makes this a test rather than a
+# demonstration:
+#
+#   A  no resolve phase         1 re-configure, built with the real answer
+#                               (today's behaviour, and it must not change)
+#   B  resolve AGREES           0 re-configures, built with the real answer
+#                               (the pass this phase removes)
+#   C  resolve DISAGREES        the producer still overwrites and still arms,
+#                               and the build uses the PRODUCER's answer
+#
+# C is the safety property. The seed and the mid-configure producer do not read
+# the same inputs -- the producer also reads `nros-metadata.json`, whose
+# component set is what makes `derive()` refuse when a registered component is
+# absent from the launch declaration -- so a seed that is wrong must lose. A
+# green A and B with a red C would mean this phase can silently ship a number
+# nothing stood behind, which is the exact defect RFC-0094 exists to remove.
+#
+# PRECONDITIONS ARE HARD FAILURES. This script never prints-and-returns: a green
+# here is read as "the resolve seed works and cannot override a producer".
+# Skipping belongs in the `just` recipe's check ledger, which is a different
+# claim from "it passed".
+#
+# Usage: ./tests/cmake-resolved-seed-tests.sh
+# Exit:  0 all assertions held; 1 otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# `nros_grep_q` -- 0 match / 1 no-match / exit 2 when grep could not run, so a
+# tool failure never becomes a finding (issue 0726). HERE-STRING, never a pipe
+# (issue 1077).
+# shellcheck source=../scripts/lib/grep-q.sh
+source "$PROJECT_ROOT/scripts/lib/grep-q.sh"
+
+RECONFIGURE_MODULE="$PROJECT_ROOT/cmake/NanoRosReconfigure.cmake"
+RESOLVED_MODULE="$PROJECT_ROOT/cmake/NanoRosResolved.cmake"
+
+FAILURES=0
+CHECKS=0
+
+fail() {
+    log_error "$*"
+    FAILURES=$((FAILURES + 1))
+}
+
+check() {
+    CHECKS=$((CHECKS + 1))
+}
+
+for _m in "$RECONFIGURE_MODULE" "$RESOLVED_MODULE"; do
+    if [ ! -f "$_m" ]; then
+        fail "module not found: $_m"
+        exit 1
+    fi
+done
+for _t in cmake ninja touch; do
+    if ! command -v "$_t" >/dev/null 2>&1; then
+        fail "$_t is not on PATH -- this test cannot report a verdict without it"
+        exit 1
+    fi
+done
+
+init_test_tmpdir "nros-resolved-seed"
+trap 'cleanup_test_tmpdir' EXIT
+
+# ---------------------------------------------------------------------------
+# The project under test: the reader/producer chain in miniature.
+#
+# The READER seeds (resolve first, placeholder second -- the production order in
+# `_nros_load_derived_entity_inventory`), registers the fragment as a configure
+# dependency, settles, and reads. The PRODUCER, later in the SAME configure,
+# writes `real` and arms on change.
+#
+# The `go` target echoes the answer the configure that generated it read, so
+# what the BUILD used is observable in ninja's output rather than inferred from
+# the fragment on disk. That distinction is the whole subject: the fragment is
+# always eventually correct, and what was wrong is the answer the build was
+# sized from.
+# ---------------------------------------------------------------------------
+write_project() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "$dir/CMakeLists.txt" <<EOF
+cmake_minimum_required(VERSION 3.20)
+project(nros_resolved_seed_probe NONE)
+
+include("$RECONFIGURE_MODULE")
+include("$RESOLVED_MODULE")
+
+set(_frag "\${CMAKE_BINARY_DIR}/frag.cmake")
+
+# ---- the READER, early in the configure -------------------------------------
+if(NOT EXISTS "\${_frag}")
+    nros_resolved_seed_entity_inventory("\${_frag}")
+endif()
+if(NOT EXISTS "\${_frag}")
+    file(WRITE "\${_frag}" "set(ANSWER placeholder)\n")
+endif()
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "\${_frag}")
+nros_reconfigure_settle("\${_frag}")
+include("\${_frag}")
+message(STATUS "PROBE_READ=\${ANSWER}")
+
+# ---- the PRODUCER, later in the same configure -------------------------------
+nros_reconfigure_snapshot("\${_frag}" _before)
+file(WRITE "\${_frag}" "set(ANSWER real)\n")
+nros_reconfigure_on_change("\${_frag}" "\${_before}" LABEL "the probe answer")
+
+add_custom_target(go ALL
+    COMMAND \${CMAKE_COMMAND} -E echo "PROBE_BUILT=\${ANSWER}")
+EOF
+}
+
+# Run `ninja` once and report what the build actually used plus how many times
+# cmake re-ran. `timeout` is a guard, not a convenience: the failure mode this
+# mechanism can have IS an unbounded re-configure loop, and a test that hangs
+# reports nothing.
+run_build() {
+    local build="$1" out
+    out="$(timeout 120 ninja -C "$build" 2>&1)"
+    BUILD_RC=$?
+    BUILD_OUT="$out"
+    BUILD_USED="$(printf '%s\n' "$out" | sed -n 's/.*PROBE_BUILT=\([A-Za-z0-9_]*\).*/\1/p' | tail -1)"
+    BUILD_RERUNS="$(printf '%s\n' "$out" | grep -c 'Re-running CMake')"
+}
+
+SRC="$TEST_TMPDIR/src"
+write_project "$SRC"
+
+# ---------------------------------------------------------------------------
+log_header "A. no resolve phase: today's behaviour, one extra configure"
+# ---------------------------------------------------------------------------
+
+CONFIGURE_OUT="$(cmake -G Ninja -S "$SRC" -B "$TEST_TMPDIR/none-build" 2>&1)"
+check
+if nros_grep_q 'PROBE_READ=placeholder' <<<"$CONFIGURE_OUT"; then
+    log_success "with no NROS_RESOLVED_DIR the first pass reads the placeholder"
+else
+    fail "expected the placeholder on pass 1 with no resolve phase:
+$CONFIGURE_OUT"
+fi
+
+run_build "$TEST_TMPDIR/none-build"
+check
+if [ "$BUILD_USED" = "real" ] && [ "$BUILD_RERUNS" -eq 1 ]; then
+    log_success "no resolve phase: 1 re-configure, built with the real answer (baseline)"
+else
+    fail "the baseline moved: used='$BUILD_USED' re-runs=$BUILD_RERUNS (want real / 1).
+  This case asserts that a lane which ran NO resolve phase is unchanged. If it
+  fails, the seed is reaching a lane that never asked for it.
+$BUILD_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+log_header "B. the resolve phase AGREES: the extra configure is gone"
+# ---------------------------------------------------------------------------
+
+RESOLVED_OK="$TEST_TMPDIR/resolved-ok"
+mkdir -p "$RESOLVED_OK"
+# Byte-for-byte what the producer writes. That is the real condition: the seed
+# saves a pass only when the two composers agree, which is why case C exists.
+printf 'set(ANSWER real)\n' > "$RESOLVED_OK/resolved.cmake"
+
+CONFIGURE_OUT="$(cmake -G Ninja -S "$SRC" -B "$TEST_TMPDIR/ok-build" \
+    "-DNROS_RESOLVED_DIR=$RESOLVED_OK" 2>&1)"
+check
+if nros_grep_q 'PROBE_READ=real' <<<"$CONFIGURE_OUT"; then
+    log_success "the first pass reads the resolve phase's answer, not a placeholder"
+else
+    fail "the seed did not reach the first reader:
+$CONFIGURE_OUT"
+fi
+
+check
+if nros_grep_q 'seeded from the resolve phase' <<<"$CONFIGURE_OUT"; then
+    log_success "and it SAYS so -- a silent seed is not auditable"
+else
+    fail "the seed left no status line; a build must be able to say where its
+  numbers came from (RFC-0094 D2, [provenance]):
+$CONFIGURE_OUT"
+fi
+
+run_build "$TEST_TMPDIR/ok-build"
+check
+if [ "$BUILD_USED" = "real" ] && [ "$BUILD_RERUNS" -eq 0 ]; then
+    log_success "resolve agrees: 0 re-configures, built with the real answer (one pass saved)"
+else
+    fail "the seed did not remove the pass: used='$BUILD_USED' re-runs=$BUILD_RERUNS (want real / 0).
+$BUILD_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+log_header "C. the resolve phase DISAGREES: the producer still wins, and still arms"
+# ---------------------------------------------------------------------------
+#
+# The safety property. The two composers read different inputs, so a seed that
+# is wrong must lose to the producer -- otherwise stage 3.5 could ship a number
+# nothing stood behind, which is the defect this whole RFC exists to remove.
+
+RESOLVED_BAD="$TEST_TMPDIR/resolved-bad"
+mkdir -p "$RESOLVED_BAD"
+printf 'set(ANSWER stale_seed)\n' > "$RESOLVED_BAD/resolved.cmake"
+
+CONFIGURE_OUT="$(cmake -G Ninja -S "$SRC" -B "$TEST_TMPDIR/bad-build" \
+    "-DNROS_RESOLVED_DIR=$RESOLVED_BAD" 2>&1)"
+check
+if nros_grep_q 'PROBE_READ=stale_seed' <<<"$CONFIGURE_OUT"; then
+    log_success "pass 1 read the (wrong) seed, so the disagreement is real"
+else
+    fail "case C did not set up: the seed never reached the reader:
+$CONFIGURE_OUT"
+fi
+
+run_build "$TEST_TMPDIR/bad-build"
+check
+if [ "$BUILD_USED" = "real" ] && [ "$BUILD_RERUNS" -eq 1 ]; then
+    log_success "resolve disagrees: the producer overwrote it, armed, and the build used the PRODUCER's answer"
+else
+    fail "A WRONG SEED REACHED THE BUILD: used='$BUILD_USED' re-runs=$BUILD_RERUNS (want real / 1).
+  The seed must never be able to override the mid-configure producer -- they do
+  not read the same inputs, and the producer is the one that sees the component
+  set that makes a derivation REFUSE.
+$BUILD_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+log_header "D. a refused resolve writes no projection, so nothing is seeded"
+# ---------------------------------------------------------------------------
+#
+# `nros build` writes `resolved.toml` for every image and `resolved.cmake` only
+# for one that DERIVED. A directory holding just the toml must therefore behave
+# exactly like case A -- an empty projection would publish "every count is
+# zero", a substituted default wearing an answer's clothes.
+
+RESOLVED_REFUSED="$TEST_TMPDIR/resolved-refused"
+mkdir -p "$RESOLVED_REFUSED"
+printf 'status = "refused"\n' > "$RESOLVED_REFUSED/resolved.toml"
+
+CONFIGURE_OUT="$(cmake -G Ninja -S "$SRC" -B "$TEST_TMPDIR/refused-build" \
+    "-DNROS_RESOLVED_DIR=$RESOLVED_REFUSED" 2>&1)"
+check
+if nros_grep_q 'PROBE_READ=placeholder' <<<"$CONFIGURE_OUT"; then
+    log_success "a refused resolve seeds nothing; the placeholder stands"
+else
+    fail "a refusal must not seed anything:
+$CONFIGURE_OUT"
+fi
+
+run_build "$TEST_TMPDIR/refused-build"
+check
+if [ "$BUILD_USED" = "real" ] && [ "$BUILD_RERUNS" -eq 1 ]; then
+    log_success "and the build is byte-for-byte case A's outcome"
+else
+    fail "a refused resolve changed the baseline: used='$BUILD_USED' re-runs=$BUILD_RERUNS.
+$BUILD_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+log_header "Summary"
+# ---------------------------------------------------------------------------
+
+if [ "$FAILURES" -eq 0 ]; then
+    log_success "$CHECKS checks passed"
+    exit 0
+fi
+log_error "$FAILURES of $CHECKS checks failed"
+exit 1

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -23,6 +23,11 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosMessageBounds.cmake")
 # ladder: a bound inventory prices a TYPE and this one counts the ENTITIES, and
 # `NROS_EXECUTOR_MAX_CBS` is a question only the second can answer.
 include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosEntityInventory.cmake")
+# phase-439 W2 (RFC-0094 D1) -- `nros_resolved_seed_entity_inventory`, the
+# configure-side reader for `nros build`'s resolve phase. FILE scope for the
+# same reason as its neighbours: an include() inside a function frame drops the
+# file's vars when the frame pops.
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosResolved.cmake")
 # Issue 0991 -- `nros_reconfigure_settle`, for both loaders below. They are the
 # EARLIEST readers of either fragment in a Zephyr configure, which is what makes
 # them the right place to clear a date a previous pass armed. FILE scope, same
@@ -328,6 +333,12 @@ endfunction()
 function(_nros_load_derived_entity_inventory)
     nros_entity_inventory_knobs_file(_knobs)
     if(NOT EXISTS "${_knobs}")
+        # phase-439 W2 (RFC-0094 D1) -- the resolve phase's answer, written
+        # BEFORE this configure, if `nros build` ran one for this image. This is
+        # the EARLIEST reader in a Zephyr configure, so it is the one the
+        # placeholder costs a whole extra pass. A lane that ran no resolve phase
+        # falls through to the placeholder below, unchanged.
+        nros_resolved_seed_entity_inventory("${_knobs}")
         nros_entity_inventory_seed_knobs_file("${_knobs}")
     endif()
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_knobs}")


### PR DESCRIPTION
Implements **phase-439 W2** / **RFC-0094 D1+D2** — stage 3.5, the resolve phase.

**Partial landing, deliberately, using the escape hatch the work item allows.** The
phase and its artifact are here and READ; the three-pass fixed point is not
deleted and **RFC-0094 A3 is not met**. Issue **1228** carries the remainder,
cross-linked to the phase, with the measurement that decides it.

## What landed

* `packages/cli/nros-cli-core/src/resolve.rs` — `Resolved`, `resolved.toml` in
  D2's shape (`[image]` with a digest, `[executor]`, `[pools]`, `[entities]`,
  `[provenance]`), and `write()`, which renders the TOML and the `include()`able
  `resolved.cmake` from ONE composition. `[provenance]` is normative: one line
  per value, plus `HAND_SET_KNOBS` — `ZPICO_MAX_QUERYABLES` and
  `ZPICO_MAX_LARGE_SUBSCRIBERS` now SAY they are hand-set, by name, with the
  reason. That was W2's stated known-gap deliverable.
* **Stage 3.5** in `cmd/build.rs`'s `plan_builds`, between the preflight bail and
  the driver match. Reads the image block, the resolved board, and the launch
  tree's wiring through the SystemModel; runs `EntityInventory::derive` once. No
  compile, no configure, no cargo. **It cannot fail a build** — an image it
  cannot answer for gets a `resolved.toml` recording the refusal and no
  projection.
* `cmake/NanoRosResolved.cmake` — the reader, wired at the two sites that READ
  the entity-inventory fragment, and deliberately **not** at the three inside
  `nros_derive_entity_inventory_knobs()`, which are a PRODUCER recording its own
  refusal.
* `-DNROS_RESOLVED_DIR=<dir>` on the cmake and west handoffs. Passed, never
  guessed. A lane that ran no resolve phase is unchanged.

**DEMAND, not size.** `[executor]` and `[pools]` publish raw counts including
zero; the floor stays at the consumer that names the knob (issues 1015/1033 are
one derived number answered two ways).

## Measured

`just check resolved-seed` (`tests/cmake-resolved-seed-tests.sh`, 9/9). Its
subject is the **pass count** — the thing `NanoRosReconfigure.cmake` spends:

| case | re-configures | built with |
| --- | --- | --- |
| A no resolve phase | 1 | the real answer — today's baseline, unchanged |
| B resolve AGREES | **0** | the real answer — the pass this removes |
| C resolve DISAGREES | 1 | the **producer's** answer — the safety property |
| D resolve REFUSED | 1 | byte-for-byte case A |

Case B **corrected the implementation**: the seed first copied the fragment under
a "seeded from …" banner and measured `re-runs=1`, because
`nros_reconfigure_snapshot` hashes CONTENT and a seed differing by one comment
line arms exactly the re-configure it exists to remove. The seed is verbatim now.

`resolve::tests::stage_3_5_and_the_mid_configure_producer_agree_on_every_number`
runs the production `merged_per_kind_max` / `to_cmake`: the two composers derive
**identical numbers** and differ in **exactly one line**,
`NROS_ENTITY_INVENTORY_SOURCE`. So the seed makes pass 1 read a real number
instead of a placeholder, and the producer still arms one re-configure over
provenance prose. That line is issue 1228's headline.

## Not landed, and not claimed

* `nros_reconfigure_settle` and the future-mtime arm are **still present and
  still authoritative**. A3 is not met.
* The message-bound half of the chain is untouched — a pure-CMake composer over
  codegen fragments with no Rust twin, so a pass survives even once the entity
  link closes.
* **No claim about a real Zephyr image.** This host has no `zephyr-workspace` and
  no Zephyr SDK, so "converges in one pass" and "byte-identical knobs" were **not
  run**. phase-392 W5 had to withdraw a causal claim from a before/after that
  accidentally built the same configuration twice; the deletion's acceptance must
  be a real `west build` with `check-knob-delivery <build-dir>` green on both
  sides and the unrelated values asserted UNCHANGED as the control.

## Tier

`just check fast` green (279 ran, 3 ledgered skips) · `just check api-parity`
green · `just test-unit` green (1222 passed, 1 ledgered skip).

`check::build` has 7 reds, **all environmental in a linked agent worktree** —
`nros_build_root` resolves to the main checkout (`rmw-uorb`, `rmw-xrce`,
`borrowed-e2e`, `staticlib-symbols`) and uninitialised submodules (`cli-tests`
wants `nros-launch-resolve`; `test-targets` / `workspace-features` want
`cyclonedds`). None touches this diff. No Zephyr tier run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5
