### PR TITLE
fix(#1223, phase-438 W0): `#elif` and `#else` are not covered by the `#if` above them

### DIFF
--- a/.config/cpp-freestanding-includes-baseline.txt
+++ b/.config/cpp-freestanding-includes-baseline.txt
@@ -1,0 +1,51 @@
+# Hosted STL includes reached with `NROS_CPP_STD` undefined, in the `#elif
+# defined(__has_include)` arm of nros-cpp's capability blocks.
+#
+# A RATCHET, not an allowlist. It may only SHRINK: a line here that no longer
+# matches a violation is a FAILURE, so the debt cannot go stale, and a new
+# violation not listed here is a failure too, so it cannot grow.
+#
+# WHY THESE ARE HERE RATHER THAN FIXED IN THE SAME CHANGE
+#
+# `check-cpp-freestanding-includes` could not see any of them until issue 1223.
+# Its walker pushed a guard frame on `#if defined(NROS_CPP_STD)` and popped only
+# on `#endif`; `#elif` and `#else` matched neither rule, so the frame from the
+# opening `#if` survived into the alternative arm — the arm whose condition is
+# false by construction. All fourteen scored as guarded.
+#
+# They are REAL, not a false positive of the new walker. Measured per-header on
+# the FreeRTOS lane's own pinned compiler (arm-none-eabi 13.2, `-std=c++14
+# -ffreestanding -fno-exceptions -fno-rtti`): 19 of 45 nros-cpp headers fail to
+# compile, and `log.hpp`'s `<string>` — the first line below — is the entry
+# point for 17 of the 19. That is issue 1187, and no embedded C++ FreeRTOS
+# image builds today because of it.
+#
+# The fix is phase-438 W2: delete the `#elif` arm, so the std surface is
+# reachable only through `NROS_CPP_STD`. It is deliberately NOT in this change.
+# Landing the walker fix alone would put a red fast-line gate on `main`, which
+# blocks every push in the repository — the exact failure this session already
+# cleaned up once for `check-doc-commit-citations`. So the walker lands first
+# with the debt it can finally see recorded here, and W2 empties this file.
+#
+# Keyed on FILE and HEADER, not on a line number, so the entries survive edits
+# above them and so a second `<memory>` appearing in a listed file is still
+# caught.
+#
+# Ordering note for W2: delete a line here in the same commit that deletes the
+# arm it names. A stale entry FAILS, which is what makes this file W2's
+# acceptance rather than its paperwork.
+
+client.hpp <memory>
+fixed_string.hpp <string>
+heap_string.hpp <string>
+log.hpp <string>
+log.hpp <sstream>
+options.hpp <string>
+options.hpp <vector>
+polling_subscription.hpp <memory>
+publisher.hpp <memory>
+service.hpp <memory>
+subscription.hpp <memory>
+subscription.hpp <functional>
+timer.hpp <memory>
+timer.hpp <functional>

--- a/.config/gate-selftest-baseline.txt
+++ b/.config/gate-selftest-baseline.txt
@@ -26,7 +26,6 @@ scripts/check-cc-build-policy.sh
 scripts/check-cli-fresh.sh
 scripts/check-cmake-find-program-shadowed.py
 scripts/check-cpp-ffi-error-mapping.py
-scripts/check-cpp-freestanding-includes.sh
 scripts/check-decoupling.sh
 scripts/check-deploy-board-resolves.py
 scripts/check-doc-refs.sh

--- a/docs/issues/archived/1223-cpp-freestanding-includes-blind-to-elif.md
+++ b/docs/issues/archived/1223-cpp-freestanding-includes-blind-to-elif.md
@@ -3,7 +3,7 @@ id: 1223
 title: "`check-cpp-freestanding-includes` scores every `#elif` and `#else` arm as
   guarded, so the 14 arms that actually break the FreeRTOS build are invisible
   to the gate written to catch them"
-status: open
+status: resolved
 type: bug
 area: [cpp, ci]
 related: [1187, 1023, 0112, 0332, 1204]
@@ -100,6 +100,37 @@ above must FAIL. A gate whose selftest cannot distinguish the arms is the same
 silence with extra steps — and this one currently reports OK on both.
 
 Ordering: this is a prerequisite for phase-438, whose W2 deletes the `#elif`
-arms. Fixed first, the gate turns red on the 14 arms and phase-438 W2 turns it
-green — the gate becomes the acceptance. Fixed after, the arms are gone and the
-blindness ships uncaught for whatever writes the 15th.
+arms. Fixed after them, the arms are gone and the blindness ships uncaught for
+whatever writes the 15th.
+
+Fixed first, the gate sees 14 real violations — and it must NOT simply go red
+on them. It is on the fast line and therefore on the `pre-push` hook, so a red
+one on `main` blocks every push in the repository by every contributor. The fix
+lands with `.config/cpp-freestanding-includes-baseline.txt`, a shrink-only
+ratchet holding the 14 known sites; phase-438 W2 empties it. A baseline line
+that no longer offends FAILS, so the file is still W2's acceptance rather than
+its paperwork.
+
+## Resolution
+
+Landed. `walk_file()` replaces the top frame on `#elif`/`#else` rather than
+leaving it — replaces rather than pops, because at `strict=0` the Cyclone
+backend legitimately takes `<chrono>`/`<thread>` in the `#else` of an
+`NROS_PLATFORM_*` chain, and a pop would make depth 0 there.
+
+Measured: **14 violations across 10 headers**, with `nros.hpp` correctly absent
+— its `STD_CHRONO` block has no `#elif` arm.
+
+The gate had no selftest at all, which is how the first version of this defect
+(issue 1023's `\b`) and this one both survived. It has six cases now, and three
+of them flip when the `#elif` rule is reverted:
+
+```
+SELFTEST FAIL: 'elif __has_include arm' should have been flagged and was not
+SELFTEST FAIL: 'else fallback arm' should have been flagged and was not
+SELFTEST FAIL: 'elif naming NROS_CPP_STD' should be clean, got: 4: #include <string>
+```
+
+Case 5 is the `strict=0` platform-`#else` shape the fix must not break; case 6
+is depth 0. Both ratchet directions are mutation-tested — removing a baseline
+line surfaces the violation it was hiding, adding a paid-off one fails as stale.

--- a/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
+++ b/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
@@ -163,14 +163,31 @@ program — native included — is on the freestanding side already.
 ## Work items
 
 * **W0 — teach `check-cpp-freestanding-includes` about `#elif` and `#else`
-  (issue 1223).** On either, the current frame's condition no longer holds, so
-  the frame is REPLACED rather than kept: pop and push `"other"`; an `#elif` that
-  itself names `NROS_CPP_STD` pushes `"std"`.
-  *Acceptance:* two negative controls the selftest does not have today — the
-  `#elif __has_include` block and an `#else` fallback include — must both FAIL,
-  and the gate must go RED on the 14 arms in the tracked tree. **W2 then turns it
-  green, so the gate becomes W2's acceptance.** Done in the other order, the arms
-  are gone and the blindness ships uncaught for whatever writes the 15th.
+  (issue 1223). LANDED.** On either, the current frame's condition no longer
+  holds, so the frame is REPLACED rather than kept: `stack[sp]` becomes
+  `"other"`, and an `#elif` that itself names `NROS_CPP_STD` becomes `"std"`.
+  Replaced rather than popped, because at `strict=0` the Cyclone backend
+  legitimately takes `<chrono>`/`<thread>` in the `#else` of an
+  `NROS_PLATFORM_*` chain — a pop would make depth 0 there and break it.
+
+  **Correction to this phase's first draft, which said the gate should go RED
+  and W2 should turn it green.** That is not affordable: this gate is on the
+  fast line, so it is on the `pre-push` hook, and a red one on `main` blocks
+  every push in the repository by every contributor. This session had already
+  spent a turn clearing exactly that state for `check-doc-commit-citations`.
+  The intent survives in the affordable form — W0 lands with
+  `.config/cpp-freestanding-includes-baseline.txt`, a shrink-only ratchet
+  carrying the 14 sites the walker can finally see, and **W2 empties it**. A
+  stale entry FAILS, so the file is still W2's acceptance rather than its
+  paperwork; it just does not hold the tree hostage while W2 is written.
+
+  Measured: exactly **14 violations across 10 headers** — the 14 `#elif` arms,
+  with `nros.hpp` correctly absent, since its `STD_CHRONO` block has no `#elif`
+  arm to be blind to.
+  *Acceptance (met):* six selftest cases, of which three flip when the `#elif`
+  rule is reverted — the negative control this gate had none of. Both ratchet
+  directions mutation-tested: removing a baseline line reports the violation,
+  and adding a paid-off one fails as stale.
 
 * **W1 — one detection site.** Replace the 15 blocks with a single
   `nros/std_detect.hpp` the others include. Measured feasible: **14 of the 15
@@ -321,7 +338,9 @@ program — native included — is on the freestanding side already.
 
 ## Ordering
 
-**W0 before W2**, so the gate is the acceptance rather than a casualty.
+**W0 before W2**, so the gate is the acceptance rather than a casualty — and
+W0 lands with a ratchet rather than a red, because a red fast-line gate on
+`main` blocks every push (see W0).
 
 **The phase before phase-426 and phase-427.** W2 changes what "delete both C++
 parameter stores" is deleting from, and W4 is phase-427 W1 relocated. Doing it

--- a/scripts/check-cpp-freestanding-includes.sh
+++ b/scripts/check-cpp-freestanding-includes.sh
@@ -23,6 +23,10 @@
 # NROS_CPP_STD` / `#if defined(NROS_CPP_STD)` region is a violation.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+# `nros_grep_q` — a `grep -q` that cannot report a tool ERROR as a non-match
+# (issue 0726). Fed a here-string, never a pipe (issue 1077).
+# shellcheck source=lib/grep-q.sh
+. scripts/lib/grep-q.sh
 
 # The two trees this toolchain compiles with the shim on the include path. Not
 # a universal claim: it is these two because these are what a board build
@@ -37,6 +41,13 @@ cd "$(dirname "$0")/.."
 # `packages/` and `cmake/`; the only other hits are prose.
 SCAN_DIRS="packages/api/nros-cpp/include/nros packages/rmw/cyclonedds/nros-rmw-cyclonedds/src"
 
+# Known debt this walker could not see before issue 1223, as `<file> <header>`
+# pairs. A RATCHET: an unlisted violation fails, and a listed pair that no
+# longer offends ALSO fails, so the file can only shrink and only on purpose.
+# phase-438 W2 empties it. Keyed on file+header rather than line so an edit
+# above a site does not silently move the debt.
+BASELINE=".config/cpp-freestanding-includes-baseline.txt"
+
 
 # Hosted-only STL headers absent from a minimal freestanding libcpp. The
 # freestanding-guaranteed set (`<cstdint>`, `<cstddef>`, `<cstdlib>`,
@@ -45,34 +56,11 @@ SCAN_DIRS="packages/api/nros-cpp/include/nros packages/rmw/cyclonedds/nros-rmw-c
 # allowed ungated.
 HOSTED='string|vector|map|unordered_map|unordered_set|set|functional|memory|chrono|sstream|iostream|fstream|ostream|istream|algorithm|deque|list|thread|mutex|future|regex'
 
-violations=0
-
-# TWO CONTRACTS, and conflating them would either miss violations or reject
-# correct code:
-#
-#   strict=1  nros-cpp's public headers. The 0112 rule is specific — a hosted
-#             include gates on `NROS_CPP_STD` and on nothing else, because a
-#             HOSTED compiler run `-nostdinc++` against Zephyr's minimal libcpp
-#             still has no `<string>`. `__STDC_HOSTED__` is the wrong question.
-#   strict=0  a backend TU. It has no `NROS_CPP_STD` notion; it guards on the
-#             PLATFORM, which is the right question there —
-#             `nros-rmw-cyclonedds/src/internal.hpp` takes `<chrono>`/`<thread>`
-#             only in the `#else` of its `NROS_PLATFORM_*` chain. Any
-#             conditional counts; depth 0 does not.
-for entry in "packages/api/nros-cpp/include/nros:1" \
-             "packages/rmw/cyclonedds/nros-rmw-cyclonedds/src:0"; do
-  dir="${entry%:*}"
-  strict="${entry##*:}"
-  # `.cpp` too, not only headers: the 1014 break was in a TRANSLATION UNIT, and
-  # a TU that cannot compile is exactly as broken as a header that cannot be
-  # included.
-  for hdr in $(ls "$dir"/*.hpp "$dir"/*.cpp 2>/dev/null); do
-    base="$(basename "$hdr")"
-
-    # Walk the file tracking NROS_CPP_STD guard depth. Flag a hosted `#include`
-    # that appears at guard-depth 0.
-    hits="$(awk -v hosted="$HOSTED" -v strict="$strict" '
-        BEGIN { depth = 0 }
+# The walker, as a function, so the selftest below exercises the SAME code the
+# gate runs. A selftest against a re-typed copy proves nothing about the gate.
+walk_file() {
+  awk -v hosted="$HOSTED" -v strict="$2" '
+        BEGIN { sp = 0 }
         # Enter an NROS_CPP_STD region: `#ifdef NROS_CPP_STD` or
         # `#if defined(NROS_CPP_STD)`. Other #if/#ifdef push a neutral level so
         # a nested #endif does not close the NROS_CPP_STD region prematurely.
@@ -85,6 +73,29 @@ for entry in "packages/api/nros-cpp/include/nros:1" \
         # found by issue 1023 when a backend TU with a real `#if/#elif/#else`
         # chain came into scope. `([[:space:]]|$)` is the portable spelling.
         /^[[:space:]]*#[[:space:]]*(ifdef|ifndef|if)([[:space:]]|$)/ { stack[++sp] = "other"; next }
+        # `#elif` / `#else` REPLACE the top frame rather than leaving it alone
+        # (issue 1223). They matched neither rule above, so they were ordinary
+        # text and the frame from the opening `#if` survived into the
+        # alternative arm — where its condition is false by construction. Every
+        # `#elif defined(__has_include)` arm in nros-cpp scored as
+        # NROS_CPP_STD-guarded because of it, and `#else` was worse: that arm is
+        # the one taken when NROS_CPP_STD is undefined.
+        #
+        # An `#elif` naming NROS_CPP_STD really is a std region. Anything else
+        # is guarded by SOMETHING, just not by that — which is why the
+        # replacement is "other" and not a pop: at strict=0 the Cyclone
+        # backend legitimately takes <chrono>/<thread> in the `#else` of an
+        # NROS_PLATFORM_* chain, and depth must not fall to 0 there.
+        /^[[:space:]]*#[[:space:]]*elif([[:space:]]|\()/ {
+            if (sp == 0) sp = 1
+            stack[sp] = ($0 ~ /NROS_CPP_STD/) ? "std" : "other"
+            next
+        }
+        /^[[:space:]]*#[[:space:]]*else([[:space:]]|$)/ {
+            if (sp == 0) sp = 1
+            stack[sp] = "other"
+            next
+        }
         /^[[:space:]]*#[[:space:]]*endif([[:space:]]|$)/ { if (sp > 0) sp-- ; next }
         {
             guarded = 0
@@ -98,24 +109,155 @@ for entry in "packages/api/nros-cpp/include/nros:1" \
                 printf "%d: %s\n", NR, $0
             }
         }
-    ' "$hdr")"
+    ' "$1"
+}
 
-    if [ -n "$hits" ]; then
-        echo "check-cpp-freestanding-includes: $base includes a hosted STL header outside a guard (issues 0332/1023):" >&2
-        while IFS= read -r line; do echo "  $base:$line" >&2; done <<<"$hits"
-        violations=1
+# --- selftest ----------------------------------------------------------------
+# The negative controls issue 1223 says this gate did not have. Cases 1 and 2
+# are the two spellings that were invisible; 5 is the strict=0 shape the fix
+# must NOT break, and it is the reason `#else` replaces the frame instead of
+# popping it.
+selftest() {
+  local d rc=0 cases=0
+  d="$(mktemp -d)"
+  trap 'rm -rf "$d"' RETURN
+
+  _case() { # name strict expect(hit|clean) body
+    local name="$1" strict="$2" expect="$3" body="$4" got
+    printf '%s' "$body" > "$d/probe.hpp"
+    got="$(walk_file "$d/probe.hpp" "$strict")"
+    cases=$((cases + 1))
+    if [ "$expect" = hit ] && [ -z "$got" ]; then
+      echo "check-cpp-freestanding-includes SELFTEST FAIL: '$name' should have been flagged and was not" >&2
+      rc=1
+    elif [ "$expect" = clean ] && [ -n "$got" ]; then
+      echo "check-cpp-freestanding-includes SELFTEST FAIL: '$name' should be clean, got: $got" >&2
+      rc=1
     fi
+  }
+
+  # 1. The issue-1223 shape: the `__has_include` arm is NOT NROS_CPP_STD-guarded.
+  _case 'elif __has_include arm' 1 hit '#if defined(NROS_CPP_STD)
+#include <memory>
+#elif defined(__has_include)
+#if __has_include(<string>)
+#include <string>
+#endif
+#endif
+'
+  # 2. Worse spelling: the `#else` arm is the one taken when the macro is OFF.
+  _case 'else fallback arm' 1 hit '#if defined(NROS_CPP_STD)
+#include <memory>
+#else
+#include <vector>
+#endif
+'
+  # 3. The correct shape stays clean.
+  _case 'flat NROS_CPP_STD guard' 1 clean '#ifdef NROS_CPP_STD
+#include <string>
+#endif
+'
+  # 4. An `#elif` that names NROS_CPP_STD really is a std region.
+  _case 'elif naming NROS_CPP_STD' 1 clean '#if defined(SOMETHING_ELSE)
+#else
+#elif defined(NROS_CPP_STD)
+#include <string>
+#endif
+'
+  # 5. strict=0: the Cyclone backend takes <chrono> in the `#else` of a platform
+  #    chain. Any conditional counts there, so this must remain clean — a `#else`
+  #    that POPPED instead of replacing would break it.
+  _case 'backend platform else arm' 0 clean '#if defined(NROS_PLATFORM_ZEPHYR)
+#include <cstdint>
+#else
+#include <chrono>
+#endif
+'
+  # 6. Depth 0 is still a violation at both strictnesses.
+  _case 'ungated at depth 0' 0 hit '#include <string>
+'
+
+  if [ "$rc" -ne 0 ]; then
+    echo "check-cpp-freestanding-includes: the walker does not behave as documented; not scanning the tree." >&2
+    exit 1
+  fi
+  echo "check-cpp-freestanding-includes self-test: OK ($cases cases)"
+}
+selftest
+
+# --- baseline ----------------------------------------------------------------
+if [ ! -f "$BASELINE" ]; then
+    echo "check-cpp-freestanding-includes: missing $BASELINE" >&2
+    exit 1
+fi
+# `<file> <header>` pairs, comments and blanks dropped.
+baseline_pairs="$(grep -v '^[[:space:]]*#' "$BASELINE" | grep -v '^[[:space:]]*$' || true)"
+
+violations=0
+unlisted=""
+observed=""
+
+for entry in "packages/api/nros-cpp/include/nros:1" \
+             "packages/rmw/cyclonedds/nros-rmw-cyclonedds/src:0"; do
+  dir="${entry%:*}"
+  strict="${entry##*:}"
+  # `.cpp` too, not only headers: the 1014 break was in a TRANSLATION UNIT, and
+  # a TU that cannot compile is exactly as broken as a header that cannot be
+  # included.
+  for hdr in $(ls "$dir"/*.hpp "$dir"/*.cpp 2>/dev/null); do
+    base="$(basename "$hdr")"
+    hits="$(walk_file "$hdr" "$strict")"
+    [ -n "$hits" ] || continue
+
+    while IFS= read -r line; do
+        # `123: #include <string>` -> `<string>`
+        stl="$(printf '%s' "$line" | sed -n 's/.*\(<[a-z_]*>\).*/\1/p')"
+        pair="$base $stl"
+        observed="$observed$pair
+"
+        if nros_grep_q -xF "$pair" <<<"$baseline_pairs"; then
+            continue
+        fi
+        unlisted="$unlisted  $base:$line
+"
+        violations=1
+    done <<<"$hits"
   done
 done
 
 if [ "$violations" -ne 0 ]; then
+    echo "check-cpp-freestanding-includes: hosted STL header(s) included outside a guard (issues 0332/1023/1223):" >&2
+    printf '%s' "$unlisted" >&2
     echo >&2
     echo "Fix: wrap the hosted section in a guard — \`#ifdef NROS_CPP_STD\` for nros-cpp" >&2
     echo "(std_compat.hpp / bridge.hpp), or a platform \`#if\` for a backend TU" >&2
     echo "(nros-rmw-cyclonedds/src/internal.hpp does the latter for <chrono>/<thread>)." >&2
     echo "If neither fits, the header is not available on that board: do without it." >&2
+    echo >&2
+    echo "An \`#elif\` or \`#else\` arm is NOT covered by the \`#if\` above it: that arm runs" >&2
+    echo "precisely when the \`#if\` condition is false (issue 1223)." >&2
     exit 1
 fi
 
+# The ratchet's other direction: a baseline line that no longer offends is
+# debt-paid that nobody removed, and leaving it means the next real violation at
+# that site is silently excused.
+stale=""
+while IFS= read -r pair; do
+    [ -n "$pair" ] || continue
+    nros_grep_q -xF "$pair" <<<"$observed" || stale="$stale  $pair
+"
+done <<<"$baseline_pairs"
+
+if [ -n "$stale" ]; then
+    echo "check-cpp-freestanding-includes: $BASELINE lists site(s) that no longer offend." >&2
+    printf '%s' "$stale" >&2
+    echo >&2
+    echo "Delete them. A baseline entry outlives its violation only by excusing the next one." >&2
+    exit 1
+fi
+
+n_baseline="$(grep -c . <<<"$baseline_pairs" || true)"
 count="$(for d in $SCAN_DIRS; do ls "$d"/*.hpp "$d"/*.cpp 2>/dev/null; done | wc -l)"
-echo "check-cpp-freestanding-includes: OK ($count file(s) across nros-cpp headers and the Cyclone backend; no ungated hosted STL includes)"
+echo "check-cpp-freestanding-includes: OK ($count file(s) across nros-cpp headers and the Cyclone backend;" \
+     "no unlisted ungated hosted STL includes; $n_baseline known site(s) in $BASELINE, all still present)"


### PR DESCRIPTION
Stacked on #746. **Retarget to `main` once that merges.**

`check-cpp-freestanding-includes` reported

```
OK (64 file(s) … no ungated hosted STL includes)
```

over a tree where 19 of 45 nros-cpp headers fail to compile on the pinned embedded toolchain for exactly the reason it exists to prevent. That is **issue 1187, and it landed under this green check.**

## The defect

The walker pushed a guard frame on `#if defined(NROS_CPP_STD)` and popped only on `#endif`. `#elif` and `#else` matched neither rule, so they were ordinary text and the frame from the opening `#if` survived into the alternative arm — the arm whose condition is false by construction. Reproduced with the gate's own awk before touching it:

```
2 sp=1 guarded=1  #include <string>          (the NROS_CPP_STD arm — correct)
3 sp=1 PASSTHRU   #elif defined(__has_include)
5 sp=2 guarded=1  #include <string>          (scored guarded; it is not)
```

`#else` is the worse of the two — that arm is the one taken when `NROS_CPP_STD` is *undefined*.

On `#elif`/`#else` the top frame is now **replaced**: `stack[sp]` becomes `"other"`, or `"std"` for an `#elif` naming `NROS_CPP_STD`. Replaced and not popped, because at `strict=0` the Cyclone backend legitimately takes `<chrono>`/`<thread>` in the `#else` of an `NROS_PLATFORM_*` chain, where a pop would make depth 0.

This is the class issue 1023 already fixed half of. 1023 found `\b` is not a word boundary in POSIX ERE, so the neutral push never fired and a nested `#endif` closed the region early — the `#endif` spelling of "a conditional the tracker does not model". All three spellings are modelled now.

## Why the 14 sites are baselined, not fixed here

The walker sees **14 real violations across 10 headers** (`nros.hpp` correctly absent — its `STD_CHRONO` block has no `#elif` arm). Not false positives: on `arm-none-eabi 13.2 -ffreestanding`, deleting the arms takes the per-header loop from `pass=26 fail=19` to `pass=45 fail=0`.

Fixing them is phase-438 W2 — six places need `NROS_CPP_STD`, and acceptance is a FreeRTOS cross build. Landing the walker fix alone would put a **red fast-line gate on `main`**, which is on the pre-push hook and blocks every push in the repository. This session already spent a turn clearing exactly that state for `check-doc-commit-citations`.

So the walker lands with `.config/cpp-freestanding-includes-baseline.txt`, a shrink-only ratchet keyed on file+header, and W2 empties it. **A listed site that no longer offends FAILS**, so the file is W2's acceptance rather than its paperwork.

This corrects phase-438's own W0, which said the gate should go red and W2 turn it green. The intent survives; the mechanism could not.

## The selftest this gate never had

Both instances of this defect survived because there was no negative control. Six cases now, run inline against the same `walk_file()` the scan uses. Three flip when the `#elif` rule is reverted:

```
SELFTEST FAIL: 'elif __has_include arm' should have been flagged and was not
SELFTEST FAIL: 'else fallback arm' should have been flagged and was not
SELFTEST FAIL: 'elif naming NROS_CPP_STD' should be clean, got: 4: #include <string>
```

Case 5 is the `strict=0` platform-`#else` shape the fix must not break; case 6 is depth 0. Both ratchet directions mutation-tested — removing `log.hpp <sstream>` surfaces the violation it was hiding, adding a paid-off `qos.hpp <string>` fails as stale.

## Three meta-gates caught this change, all correctly

`gate-selftests` (the script now has one, so it comes off that ratchet), `grep-q-error-conflation` (issue 0726 — two conditionals that could report a tool error as a non-match), `pipefail-sigpipe-assertions` (issue 1077 — a `printf | grep -q` whose status is read). Both matchers are `nros_grep_q` fed a here-string now.

## Tier

`just check fast` — 282 gates, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj