### PR TITLE
fix(fixtures): the advertised-state probe asked for a feature its crate has not — 20 of 20

### DIFF
--- a/.config/interop-verdicts.toml
+++ b/.config/interop-verdicts.toml
@@ -48,6 +48,15 @@ where = "ros2 distrobox, Humble, tree with #684 + #692"
 evidence = "1 case(s) produced a result in ros2_action_e2e.xml"
 
 [[verdict]]
+cell = "native-advertised-state-rust-cyclone-bidir"
+date = "2026-09-08"
+verdict = "pass"
+tests = ["actual_qos_read_back_matches_what_a_stock_peer_reads", "matched_counts_rise_when_a_peer_appears_and_fall_when_it_leaves", "publisher_gid_identifies_us_to_the_peer"]
+run = "cargo nextest run -p nros-tests --test advertised_state_interop"
+where = "ros2 distrobox, Humble"
+evidence = "4/4: matched counts on both edges, GID, actual QoS read back from the peer, serialization format. First run of this cell; a fixture SELECTOR bug had made every case resolve to a skip."
+
+[[verdict]]
 cell = "native-graph-rust-cyclone-r2n"
 date = "2026-09-07"
 verdict = "pass"

--- a/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
@@ -3677,12 +3677,29 @@ pub fn build_graph_probe_rmw(rmw: Rmw) -> TestResult<&'static Path> {
 /// No `rmw` parameter, unlike [`build_graph_probe_rmw`]: Cyclone is the only
 /// backend that fills any of those slots, so there is one row and one binary.
 /// A zenoh build would assert against NULL pointers.
+///
+/// `select_sole_row` and NOT `select_row(FixtureVariant::rmw(..))`, and the
+/// difference is why this cell could never run. The variant selector asks for
+///
+///   Selector { rmw: "cyclonedds", features: "rmw-cyclonedds", no_default_features: true }
+///
+/// because that is the shape the graph-probe rows have — but this crate has no
+/// `[features]` table at all. It path-deps `nros-rmw-cyclonedds-sys` directly,
+/// which is what its own manifest comment means by "exactly one coordinate".
+/// So the row is correct and the SELECTOR was wrong, and the two are plausible
+/// in isolation: `select_row` reported `no [[fixture]] row … with Selector`,
+/// which reads as a missing row.
+///
+/// Every case then resolved to `[SKIPPED] fixture not built`, and bare
+/// `cargo nextest` renders a `skip!` panic as FAILED — so the cell read as
+/// three live failures against a peer it never reached. Found on its first run
+/// (phase-433, 2026-09-08); adding the feature to the row instead fails with
+/// `the package 'advertised-state-probe' does not contain this feature`.
 pub fn build_advertised_state_probe() -> TestResult<&'static Path> {
     static BIN: OnceCell<PathBuf> = OnceCell::new();
     BIN.get_or_try_init(|| {
-        let row = crate::fixtures::groups::select_row(
+        let row = crate::fixtures::groups::select_sole_row(
             "packages/testing/nros-tests/bins/advertised-state-probe",
-            &crate::fixtures::groups::FixtureVariant::rmw(Rmw::Cyclonedds),
         )?;
         let profile = cargo_target_profile_dir();
         let rel = PathBuf::from(format!("{profile}/advertised-state-probe"));


### PR DESCRIPTION
**20 of 20 Runtime cells now carry a live verdict, all passing.** The ledger said 2 of 20 this morning and 0 before phase-433.

```
4/4  matched counts on both edges · GID · actual QoS read back from the
     peer's `ros2 topic info --verbose` · serialization format
```

## The defect

`build_advertised_state_probe` used `select_row(FixtureVariant::rmw(Cyclonedds))`, which asks for

```
Selector { rmw: "cyclonedds", features: "rmw-cyclonedds", no_default_features: true }
```

because that's the shape the graph-probe rows have. The row is

```
Selector { rmw: "cyclonedds", features: "",               no_default_features: false }
```

and **the row is correct**: the crate has no `[features]` table at all — it path-deps `nros-rmw-cyclonedds-sys` directly, which is what its own manifest comment means by *"exactly one coordinate"*. So the selector was wrong. `select_sole_row` is the call `build_native_param_talker` already uses.

I fixed the row first, and the build refuted me in one line: `the package 'advertised-state-probe' does not contain this feature: rmw-cyclonedds`.

## Why it read as three live failures

Every case resolved to `[SKIPPED] fixture not built`, and **bare `cargo nextest` renders a `skip!` panic as FAILED**. So the cell looked like three failures against a peer it never reached.

That's the third time in this phase a skip has worn a failure's clothes (`params`, the W2 batch, here), and the second time I began reading a green-path defect into one before checking the message.

## Why it survived review and CI

The two halves are plausible in isolation and nothing compares them — and `select_row`'s own error says *"no `[[fixture]]` row … with Selector"*, which reads as a **missing row**. It could only surface on the cell's first run.

## Verification

`just check fast` — 280 ran, 1 skipped (unprovisioned NVIDIA FSP tree) · cell 4/4 live in the ROS 2 distrobox · verdict recorded from that junit, not typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA