### PR TITLE
fix(#1229): the hook side-effect rule is about repositories, not about bash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,7 +617,12 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   Gate: `check-hook-repo-side-effects` (runs the hook and every `git init`-ing
   script under both environment shapes against a victim repo compared byte for
   byte, mtimes included — a hook that rewrites a tracked file re-stales every
-  fixture).
+  fixture). **The rule is about repository side effects, not about bash**: the
+  gate read `scripts/**/*.sh` only until 2026-09-08, and all 4 Python gates that
+  build a repo measured DIRTY — including the one that cleared BY HAND, 4 of
+  git's 16 names, leaking `GIT_OBJECT_DIRECTORY` into the victim's object store.
+  The Python spelling of the helper is `scripts/lib/git_hook_env.py`, same
+  function name; popping some `GIT_*` variables is never what earns the credit.
 - **A red CI lane answers one of two questions and they look identical** — the
   lane RAN and the code is broken (a verdict), or it never ran (no verdict). A
   uniformly-red lane has NO signal capacity: a regression landing in it looks

--- a/docs/issues/archived/1229-box-sync-gate-blind-to-nested-repos.md
+++ b/docs/issues/archived/1229-box-sync-gate-blind-to-nested-repos.md
@@ -173,3 +173,16 @@ paid only where the trees exist, which is the only host the box sync runs on.
 gate that builds a throwaway repository is outside its reach. This script clears
 `GIT_DIR` & co. itself (issue 0986's hazard) and says so, but the gate's reach
 is narrower than the rule it enforces — the 0196 shape, one series over.
+
+**DONE 2026-09-08.** The gate enumerates `scripts/**/*.py` too, runs each
+hazardous file through its own interpreter, and credits one identifier in both
+languages (`nros_clear_inherited_git_env`, Python spelling in
+`scripts/lib/git_hook_env.py`). Four Python files build a repository and all
+four measured DIRTY against a victim repo under a hook environment — including
+**this one**: the clearing it claims above was a hand-written subset, four of
+git's sixteen repository-local names, so under the `explicit` shape the leaked
+`GIT_OBJECT_DIRECTORY` sent its own fixture's `git add` into the victim's object
+store. That is 0986's own argument (four hand-written copies of a subset)
+reproduced one language over, and it is why "the file pops some `GIT_`
+variables" is not what satisfies the rule. The shell marker alone found 0 of
+the 4, so a naive port would have reported a clean sweep.

--- a/just/check/workflows.just
+++ b/just/check/workflows.just
@@ -508,7 +508,13 @@ workflow-setup-spelling:
 # So this runs them, and the hook, under the environment git actually supplies,
 # against a victim repo compared byte for byte including mtimes — which matters
 # here beyond correctness: anything that rewrites a tracked file re-stales every
-# prebuilt fixture in the tree. ~6 s, no network, no build.
+# prebuilt fixture in the tree. No network, no build.
+#
+# SHELL AND PYTHON since 2026-09-08. The rule is about repository side effects,
+# not about bash, and the enumeration read `scripts/**/*.sh` only — so the four
+# Python gates that build a repository were outside it, and all four measured
+# DIRTY under a hook environment (issue 1229's "Not done here", 0196's shape).
+# Measured cost of the widening: 11.9 s -> 14.6 s warm, on this host.
 [private]
 hook-repo-side-effects:
     @bash scripts/check-hook-repo-side-effects.sh

--- a/scripts/check-board-descriptor-single-source.py
+++ b/scripts/check-board-descriptor-single-source.py
@@ -34,6 +34,16 @@ import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
+from git_hook_env import nros_clear_inherited_git_env  # noqa: E402
+
+# Before the first git call, at module scope so no entry path can skip it. The
+# self-test below builds a throwaway repository, and an inherited `GIT_DIR`
+# overrides both `cwd=` and `git -C` — measured DIRTY against a victim repo in
+# both hook environment shapes before this line existed (issue 0986). This gate
+# is on `check-fast`, which the pre-push hook runs.
+nros_clear_inherited_git_env()
+
 # `[package.metadata.nros.board]`, allowing whitespace the way TOML does. A
 # mention inside a comment or a doc string is NOT a table header, so the match
 # is anchored at line start.

--- a/scripts/check-box-sync-covers-tracked-source.py
+++ b/scripts/check-box-sync-covers-tracked-source.py
@@ -81,6 +81,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SYNC = ROOT / "scripts/dev/ros2-box-sync.sh"
 
+sys.path.insert(0, str(ROOT / "scripts/lib"))
+from git_hook_env import nros_clear_inherited_git_env  # noqa: E402
+
 # A component that cannot occur in a real path, appended to a DIRECTORY so the
 # directory-only rules (which require more path after the match) evaluate as
 # "this directory is an ancestor of something". See `dir_verdict`.
@@ -202,11 +205,16 @@ def git_env():
     Same hazard `scripts/ci/submodule-pins-check.sh` clears for its fixtures
     (issue 0986): this gate runs from `just`, from CI and from the pre-push
     hook, and a hook is invoked with GIT_DIR already set.
+
+    The list is git's own (`rev-parse --local-env-vars`), through the one
+    shared helper, because the four names this function used to pop by hand
+    were four of sixteen. Measured 2026-09-08: under the `explicit` hook shape
+    the leaked `GIT_OBJECT_DIRECTORY` sent this gate's own fixture `git add`
+    into the victim repository's object store — two loose objects, in the file
+    that cites 0986 for doing the clearing. Popping SOME variables is not what
+    satisfies the rule; asking git is.
     """
-    env = dict(os.environ)
-    for k in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"):
-        env.pop(k, None)
-    return env
+    return nros_clear_inherited_git_env(dict(os.environ))
 
 
 def is_repo(path):

--- a/scripts/check-hook-repo-side-effects.sh
+++ b/scripts/check-hook-repo-side-effects.sh
@@ -8,6 +8,22 @@
 #   not its config, not its index, not its object store, not the mtime of a
 #   tracked file — whatever git puts in the environment.
 #
+# The rule says "a script", not "a shell script". This gate read only
+# `scripts/**/*.sh` and `.githooks/*` until 2026-09-08, so a PYTHON gate that
+# built a throwaway repository was outside its reach entirely — the 0196 shape
+# (a gate narrower than the rule it enforces), noted in issue 1229's "Not done
+# here" and closed here. Measured at the time of widening, over the 251 tracked
+# Python files under `scripts/`: four build a repository, and all four were
+# DIRTY under a hook environment, including the one that cleared by hand. Both
+# languages are enumerated below, run through their own interpreter, and
+# credited by the same identifier — `nros_clear_inherited_git_env`, which now
+# has a Python spelling in `scripts/lib/git_hook_env.py` beside the shell one.
+#
+# The enumeration is still `scripts/**` + `.githooks/*`, and that boundary was
+# measured rather than assumed: no `tests/*.sh` (0 of 17), no `just` recipe body
+# and no workflow `run:` block anywhere in the tree builds a repository. A gate
+# tier reaches those through a script, and the script is what is checked here.
+#
 # WHY IT NEEDS A GATE AND NOT JUST A FIX
 #
 # 0986 was three scripts building throwaway repositories in their selftests. An
@@ -74,7 +90,11 @@ nros_clear_inherited_git_env
 
 REPO="$PWD"
 HOOK=".githooks/pre-push"
+# The two spellings of the clearing helper. Both name the hazard in their own
+# prose, so both match the marker below and both are excluded from it — the
+# helper is what a match is told to CALL.
 LIB="scripts/lib/git-hook-env.sh"
+LIB_PY="scripts/lib/git_hook_env.py"
 CLEAR_FN="nros_clear_inherited_git_env"
 
 fail=0
@@ -90,28 +110,66 @@ ok()  { echo "  ok    $1"; }
 # is only ever about a repository the script is CREATING. Every 0986 offender
 # has one. Text in, verdict out, so the selftest can feed it synthetic input.
 #
+# TWO spellings, because a language that does not write command lines as text
+# does not write `git init` either. Python spells it `["git", "init", …]` or
+# `git(tmp, "init", …)`, and the shell pattern alone found 0 of the 4 real
+# Python offenders — a naive port of this check would have reported a clean
+# sweep over the very files that measured DIRTY. The second alternative is
+# "a line naming git that also carries `init` as a QUOTED ARGUMENT", which is
+# narrow enough to leave prose alone: measured over the 251 tracked Python
+# files it matches exactly those 4, and over the 240 shell files it adds
+# nothing to what the first alternative already found. It also does not fire on
+# `git submodule update --init`, which appears in four gates' user-facing
+# advice — `--init` is not a quoted `init` token.
+#
+# What it deliberately does NOT flag: a script that runs git READ-ONLY against
+# the repository (106 of the 251 Python files invoke git; 4 create one). Reading
+# the wrong repository under an inherited GIT_DIR is a correctness bug and worth
+# clearing for, but it is not a repository side effect, and a marker that fired
+# on all 106 would be a gate nobody could keep green.
+#
 # needs_clear: 0 = builds a throwaway repo, 1 = does not.
-needs_clear() { nros_grep_q -E -- '(^|[^-[:alnum:]])git[[:space:]]+init([[:space:]]|$)'; }
+needs_clear() {
+    nros_grep_q -E -- \
+        '(^|[^-[:alnum:]])git[[:space:]]+init([[:space:]]|$)|git.*['"'"'"]init['"'"'"]'
+}
 # has_clear: 0 = calls the shared clearing helper.
 has_clear() { nros_grep_q -- "$CLEAR_FN"; }
+
+# how_to_clear <file> — the fix, in the language of the file that needs it.
+#
+# ONE identifier in both, deliberately. Crediting "the file pops some GIT_
+# variables" is what let `check-box-sync-covers-tracked-source.py` clear four of
+# git's sixteen names and still leak `GIT_OBJECT_DIRECTORY` into a victim's
+# object store; the helper asks `git rev-parse --local-env-vars`, so the list
+# cannot be a subset and cannot drift.
+how_to_clear() {
+    case "$1" in
+        *.py) printf '%s' "            sys.path.insert(0, os.path.join(ROOT, \"scripts\", \"lib\"))
+            from git_hook_env import $CLEAR_FN
+            $CLEAR_FN()" ;;
+        *) printf '%s' "            . \"\$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")/…/lib\" && pwd)/git-hook-env.sh\"
+            $CLEAR_FN" ;;
+    esac
+}
 
 echo "check-hook-repo-side-effects: every throwaway-repo builder clears first"
 hazardous=()
 while IFS= read -r f; do
     [ -f "$f" ] || continue
     [ "$f" = "$LIB" ] && continue
+    [ "$f" = "$LIB_PY" ] && continue
     needs_clear < "$f" || continue
     hazardous+=("$f")
     if has_clear < "$f"; then
         ok "$f clears the inherited git environment"
     else
-        bad "$f runs \`git init\` and never calls $CLEAR_FN.
+        bad "$f builds a repository with \`git init\` and never calls $CLEAR_FN.
         An inherited GIT_DIR makes that \`git init\` rewrite the CALLER's
         repository instead of building a temp one (issue 0986). Add:
-            . \"\$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")/…/lib\" && pwd)/git-hook-env.sh\"
-            $CLEAR_FN"
+$(how_to_clear "$f")"
     fi
-done < <(git ls-files 'scripts/*.sh' 'scripts/**/*.sh' '.githooks/*')
+done < <(git ls-files 'scripts/*.sh' 'scripts/**/*.sh' 'scripts/*.py' 'scripts/**/*.py' '.githooks/*')
 
 if [ "${#hazardous[@]}" -eq 0 ]; then
     bad "no script matched \`git init\` at all — the enumeration is broken,
@@ -228,6 +286,33 @@ self_test() {
     has_clear   < "$t/dirty.sh" && { echo "  selftest: saw a clear that is not there" >&2; errs=1; }
     has_clear   < "$t/clean.sh" || { echo "  selftest: missed the clearing call" >&2; errs=1; }
 
+    # The same four questions in Python, because the shell spelling answered
+    # `no` to all four for every Python file in the tree. `prose.py` is the
+    # false positive that would make this widening unaffordable: four gates
+    # print `git submodule update --init` as advice, and none of them builds a
+    # repository.
+    printf 'import subprocess\nsubprocess.run(["git", "init", "-q", tmp])\n' > "$t/dirty.py"
+    printf 'from git_hook_env import %s\n%s()\nsubprocess.run(["git", "init", tmp])\n' \
+        "$CLEAR_FN" "$CLEAR_FN" > "$t/clean.py"
+    printf 'print("run: git submodule update --init packages/x")\n' > "$t/prose.py"
+    needs_clear < "$t/dirty.py" || {
+        echo "  selftest: missed a Python \`git init\` — this is the widening" >&2; errs=1; }
+    needs_clear < "$t/prose.py" && {
+        echo "  selftest: flagged \`git submodule update --init\` in prose" >&2; errs=1; }
+    has_clear   < "$t/dirty.py" && { echo "  selftest: saw a clear that is not there" >&2; errs=1; }
+    has_clear   < "$t/clean.py" || { echo "  selftest: missed the Python clearing call" >&2; errs=1; }
+
+    # The Python helper the credit above is granted for. It has its own
+    # negative control (does its fallback list still cover what this git calls
+    # repository-local?), and a helper that clears a SUBSET is the defect this
+    # widening measured, so it is run here rather than trusted.
+    if ! python3 "$REPO/$LIB_PY" >/dev/null 2>&1; then
+        echo "  selftest: $LIB_PY --self-test FAILED — the Python clearing helper" >&2
+        echo "       does not hold, so every Python credit above is unearned:" >&2
+        python3 "$REPO/$LIB_PY" 2>&1 | sed 's/^/         /' >&2
+        errs=1
+    fi
+
     # --- dynamic half, both directions ----------------------------------
     # An offender in miniature: 0986's two damage sites, verbatim in shape.
     cat > "$t/offender.sh" <<'EOF'
@@ -262,9 +347,46 @@ EOF
            printf '%s\n' "$verdict" >&2; errs=1 ;;
     esac
 
+    # --- the same, in Python --------------------------------------------
+    #
+    # Not a formality: `subprocess.run(["git", "init", …])` is a different
+    # spelling of the same syscall, and a gate that runs every hazardous file
+    # through `bash` would report a Python offender as a shell SYNTAX error
+    # with a clean victim — i.e. CLEAN, loudly, for the wrong reason.
+    cat > "$t/offender.py" <<'EOF'
+import subprocess
+import tempfile
+
+tmp = tempfile.mkdtemp()
+subprocess.run(["git", "init", "-q", tmp], capture_output=True)
+open(tmp + "/f", "w").write("x\n")
+subprocess.run(["git", "-C", tmp, "add", "f"], capture_output=True)
+EOF
+    for shape in worktree explicit; do
+        verdict="$(run_probe "$shape" "$t" python3 "$t/offender.py")"
+        case "$verdict" in
+            DIRTY*) ;;
+            *) echo "  selftest: a PYTHON offender was reported CLEAN under" >&2
+               echo "       \`$shape\`. The widening to Python catches nothing." >&2
+               errs=1 ;;
+        esac
+    done
+
+    { printf 'import sys\nsys.path.insert(0, %q)\nfrom git_hook_env import %s\n%s()\n' \
+        "$REPO/$(dirname "$LIB_PY")" "$CLEAR_FN" "$CLEAR_FN"
+      cat "$t/offender.py"; } > "$t/fixed.py"
+    verdict="$(run_probe worktree "$t" python3 "$t/fixed.py")"
+    case "$verdict" in
+        CLEAN) ;;
+        *) echo "  selftest: a CLEARED Python script was reported DIRTY — false" >&2
+           echo "       positive, which would make the widening unaffordable:" >&2
+           printf '%s\n' "$verdict" >&2; errs=1 ;;
+    esac
+
     rm -rf "$t"
     [ "$errs" -eq 0 ] || { echo "check-hook-repo-side-effects: SELFTEST FAILED" >&2; return 1; }
-    echo "  ok    selftest: an offender is caught in both shapes, a fixed one is not"
+    echo "  ok    selftest: a shell AND a Python offender are caught in both shapes,
+        their cleared twins are not, and the Python helper's own control holds"
     return 0
 }
 
@@ -283,11 +405,29 @@ self_test || fail=1
 # cannot afford. Against HEAD nothing has moved, so it takes the
 # skipped-unchanged path — after running its selftest, which is the 0986 site
 # this is here to exercise.
+# `gen-issue-index.py` takes `--self-test` for a second reason: its normal path
+# WRITES `docs/issues/open.md` into the real tree, and a gate has no business
+# regenerating a build artifact as a side effect of asking a question about
+# it. `--self-test` is the arm that builds the throwaway repo, which is the
+# 0986 site, and it is what the `issue-index` recipe runs first anyway.
 probe_args() {
     case "$1" in
         scripts/reserve-claim.sh) echo "--selftest" ;;
         scripts/ci/submodule-commits-reachable.sh) echo "--changed HEAD" ;;
+        scripts/gen-issue-index.py) echo "--self-test" ;;
         *) echo "" ;;
+    esac
+}
+
+# interp <file> — the interpreter that file's callers use.
+#
+# The scripts are run rather than sourced, so the shebang would do; naming it
+# keeps the probe's command line explicit and keeps a non-executable checkout
+# (a fresh clone, a CI tarball) from changing the answer.
+interp() {
+    case "$1" in
+        *.py) echo "python3" ;;
+        *) echo "bash" ;;
     esac
 }
 
@@ -299,10 +439,11 @@ for f in "${hazardous[@]}"; do
         # The real repo is the working directory because that is where these run
         # from; the VICTIM is what the environment names, and it is the thing
         # compared. A script that ignored the environment entirely and wrote to
-        # its cwd is out of this gate's reach and in `check fast`'s: these three
-        # are gates themselves and run there every push.
+        # its cwd is out of this gate's reach and in `check fast`'s: all but
+        # `gen-issue-index.py` are gates themselves and run there every push,
+        # and that one runs from the `issue-index` gate beside them.
         # shellcheck disable=SC2046  # deliberate: an empty arg set must vanish
-        verdict="$(run_probe "$shape" "$REPO" bash "$REPO/$f" $(probe_args "$f"))"
+        verdict="$(run_probe "$shape" "$REPO" "$(interp "$f")" "$REPO/$f" $(probe_args "$f"))"
         case "$verdict" in
             CLEAN) ok "$f [$shape]" ;;
             *) bad "$f [$shape] MODIFIED the repository its environment named:

--- a/scripts/check-test-scripts-have-callers.py
+++ b/scripts/check-test-scripts-have-callers.py
@@ -39,6 +39,16 @@ import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
+from git_hook_env import nros_clear_inherited_git_env  # noqa: E402
+
+# Before the first git call, at module scope so no entry path can skip it. The
+# self-test below builds a throwaway repository, and an inherited `GIT_DIR`
+# overrides both `cwd=` and `git -C` — measured DIRTY against a victim repo in
+# both hook environment shapes before this line existed (issue 0986). This gate
+# is on `check-fast`, which the pre-push hook runs.
+nros_clear_inherited_git_env()
+
 # Where a caller may live. A script named ONLY inside `tests/` does not count:
 # tests calling each other is not a route from CI or from a developer's `just`.
 CALLER_DIRS = ["just", ".github", "scripts"]

--- a/scripts/gen-issue-index.py
+++ b/scripts/gen-issue-index.py
@@ -43,6 +43,15 @@ import subprocess
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
+from git_hook_env import nros_clear_inherited_git_env  # noqa: E402
+
+# Before the first git call, at module scope so no entry path can skip it. The
+# self-test below builds a throwaway repository, and an inherited `GIT_DIR`
+# overrides both `cwd=` and `git -C` — measured DIRTY against a victim repo in
+# both hook environment shapes before this line existed (issue 0986).
+nros_clear_inherited_git_env()
 INDEX = os.path.join(ROOT, "docs", "issues", "open.md")
 
 # The authored preamble, used when the file does not exist yet. It is here

--- a/scripts/lib/git_hook_env.py
+++ b/scripts/lib/git_hook_env.py
@@ -1,0 +1,180 @@
+"""The ONE way to drop a git-repository-local environment, in Python — issue 0986.
+
+This is the Python twin of `scripts/lib/git-hook-env.sh`, and it exists for the
+same reason and shares its NAME: `nros_clear_inherited_git_env`. The rule is
+about repository side effects, not about `bash` — a Python gate that builds a
+throwaway repository is the same hazard in a different language, and
+`check-hook-repo-side-effects` credits the mitigation by grepping for that one
+identifier in either language.
+
+WHAT GOES WRONG (measured here, not reasoned about)
+
+`GIT_DIR` and its family override BOTH a path argument and `git -C`, so under an
+inherited one a fixture-building script does not build a fixture: every command
+lands in the repository the environment names. Measured on 2026-09-08, running
+each Python gate that calls `git init` under the two environment shapes
+`check-hook-repo-side-effects` uses, against a victim repo compared byte for
+byte:
+
+    check-test-scripts-have-callers.py       DIRTY / DIRTY
+    check-board-descriptor-single-source.py  DIRTY / DIRTY
+    gen-issue-index.py --self-test           DIRTY / DIRTY
+    check-box-sync-covers-tracked-source.py  clean / DIRTY
+
+The fourth is the interesting one, and it is why this module clears the list git
+gives rather than a list someone types. That gate ALREADY cleared the
+environment — by hand, `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`,
+`GIT_COMMON_DIR`, four of the sixteen names git 2.34 reports. It therefore
+leaked `GIT_OBJECT_DIRECTORY`, and its fixture's `git add` wrote two loose
+objects into the victim's object store. That is exactly the divergence issue
+0986 records for shell (four hand-written copies of a subset, none of them
+clearing `GIT_CONFIG`), reproduced one language over — so "the file pops some
+GIT_ variables" cannot be what satisfies the rule. Asking git is.
+
+USE
+
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+    from git_hook_env import nros_clear_inherited_git_env
+
+    nros_clear_inherited_git_env()               # clears os.environ, in place
+    env = nros_clear_inherited_git_env(dict(os.environ))   # a cleaned copy
+
+Call it BEFORE the first git invocation. Do NOT call it from a script that is
+SUPPOSED to act on the repository the environment names; nothing in this tree
+is.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SHELL_TWIN = Path(__file__).resolve().with_name("git-hook-env.sh")
+
+# The shell twin's fallback block is the ONE written-down list in the tree. It
+# is parsed rather than retyped here: a second copy is the very thing 0986 is
+# about, and this module would be the fifth.
+_FALLBACK_BLOCK = re.compile(r"\bunset\s+\\\n((?:\s*GIT_[A-Z_]+\s*\\?\n)+)")
+
+
+def _fallback_vars():
+    """The shell twin's fallback list, or `[]` if it cannot be read."""
+    try:
+        text = SHELL_TWIN.read_text(encoding="utf8")
+    except OSError:
+        return []
+    m = _FALLBACK_BLOCK.search(text)
+    if not m:
+        return []
+    return re.findall(r"GIT_[A-Z_]+", m.group(1))
+
+
+def local_env_vars():
+    """Every repository-local git variable name, git's own answer first.
+
+    `git rev-parse --local-env-vars` needs no repository to answer and grows
+    when git grows. The fallback is for a git too old or too absent to answer,
+    and it is LOUD when empty: a helper that silently clears nothing leaves the
+    environment armed, which is worse than the hazard it was called about.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--local-env-vars"],
+            capture_output=True,
+            text=True,
+        )
+        names = out.stdout.split()
+        if out.returncode == 0 and names:
+            return names
+    except OSError:
+        pass
+    names = _fallback_vars()
+    if not names:
+        raise RuntimeError(
+            f"git could not answer `rev-parse --local-env-vars` and the fallback "
+            f"list in {SHELL_TWIN} could not be parsed. Refusing to report a "
+            f"cleared environment that is still armed (issue 0986)."
+        )
+    return names
+
+
+def nros_clear_inherited_git_env(env=None):
+    """Remove every repository-local git variable from `env`.
+
+    `env=None` clears the live process environment, which is the shell twin's
+    semantics and what a script wants when nothing it does is meant to touch
+    the repository the environment names. Pass a mapping (typically
+    `dict(os.environ)`) to get a cleaned copy for a `subprocess` call instead.
+
+    Returns the mapping that was cleaned.
+    """
+    target = os.environ if env is None else env
+    for name in local_env_vars():
+        target.pop(name, None)
+    return target
+
+
+def _self_test():
+    """The fallback list must agree with the git on this host.
+
+    A parse that quietly returns a SHORTER list is the failure mode with no
+    symptom — it clears something, so nothing looks broken, and the variable it
+    misses is the one that does the damage.
+    """
+    parsed = set(_fallback_vars())
+    if not parsed:
+        print(
+            f"git_hook_env self-test FAILED: no fallback list parsed out of "
+            f"{SHELL_TWIN}",
+            file=sys.stderr,
+        )
+        return 1
+    live = set()
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--local-env-vars"], capture_output=True, text=True
+        )
+        if out.returncode == 0:
+            live = set(out.stdout.split())
+    except OSError:
+        pass
+    missing = live - parsed
+    if missing:
+        print(
+            f"git_hook_env self-test FAILED: this git reports "
+            f"{sorted(missing)} as repository-local and the fallback list in "
+            f"{SHELL_TWIN.name} does not name them. The fallback is what runs "
+            f"when git cannot answer, so it must not be a SUBSET (issue 0986).",
+            file=sys.stderr,
+        )
+        return 1
+
+    # The clearing itself, both forms, in both directions.
+    probe = {"GIT_DIR": "/x", "GIT_OBJECT_DIRECTORY": "/y", "PATH": "/bin"}
+    got = nros_clear_inherited_git_env(dict(probe))
+    if "GIT_DIR" in got or "GIT_OBJECT_DIRECTORY" in got:
+        print(
+            f"git_hook_env self-test FAILED: the mapping form left {sorted(got)}",
+            file=sys.stderr,
+        )
+        return 1
+    if got.get("PATH") != "/bin":
+        print("git_hook_env self-test FAILED: a non-git variable was dropped", file=sys.stderr)
+        return 1
+    os.environ["GIT_DIR"] = "/x"
+    nros_clear_inherited_git_env()
+    if "GIT_DIR" in os.environ:
+        print("git_hook_env self-test FAILED: os.environ was not cleared", file=sys.stderr)
+        return 1
+    print(
+        f"git_hook_env self-test: OK ({len(parsed)} name(s) in the shell twin's "
+        f"fallback, {len(live)} reported by this git)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_self_test())


### PR DESCRIPTION
## The rule, in one sentence

**A script reachable from a git hook must not modify the invoking repository — not its config, not its index, not its object store, not the mtime of a tracked file — whatever git puts in the environment** (issue 0986). It says *a script*, not *a shell script*.

`check-hook-repo-side-effects` enumerated `scripts/**/*.sh` + `.githooks/*`, so a **Python** gate that builds a throwaway repository was outside its reach entirely — issue 1229's own "Not done here", the 0196 shape.

## What was measured before changing anything

Each Python file under `scripts/` that runs `git init`, executed under the two hook environment shapes the gate already uses, against a victim repo compared byte for byte including mtimes:

| file | `worktree` | `explicit` |
| --- | --- | --- |
| `check-test-scripts-have-callers.py` | **DIRTY** | **DIRTY** |
| `check-board-descriptor-single-source.py` | **DIRTY** | **DIRTY** |
| `gen-issue-index.py --self-test` | **DIRTY** | **DIRTY** |
| `check-box-sync-covers-tracked-source.py` | clean | **DIRTY** |

Four of the 251 tracked Python files under `scripts/` build a repository; all four were dirty; all four are on `check-fast`, which the pre-push hook runs.

## The finding

The fourth row is the one worth reading. That gate **already cleared the environment** and cites 0986 for doing so — by hand: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, four of the sixteen names git 2.34 reports as repository-local. It therefore leaked `GIT_OBJECT_DIRECTORY`, and its own fixture's `git add` wrote two loose objects into the victim's object store.

That is 0986's own argument — four hand-written copies of a subset, none of them clearing `GIT_CONFIG` — reproduced one language over. So **"the file pops some `GIT_` variables" cannot be what satisfies the rule**; asking git is.

## What satisfies the rule in Python

`scripts/lib/git_hook_env.py`, the twin of the shell helper: the same function name `nros_clear_inherited_git_env`, the same `git rev-parse --local-env-vars` derivation, and a fallback list **parsed out of the shell twin** rather than retyped — a second written-down copy would have been the fifth. One identifier means the gate's static half greps for one string in either language, and the credit is for using the one derivation, not for a per-language list of accepted idioms.

## The gate

One gate, both languages. It enumerates `scripts/**/*.py` too, dispatches `bash` vs `python3` per file, and carries a second marker alternative — *a line naming git that also carries `init` as a quoted argument*. The shell marker alone matched **0 of the 4** Python offenders, so a naive port would have reported a clean sweep over exactly the files that measured DIRTY.

False positives, measured rather than argued: over the 251 Python files the union matches those 4 and nothing else. 106 of them invoke `git` read-only and are deliberately not flagged — reading the wrong repository under an inherited `GIT_DIR` is a correctness bug, not a repository side effect. `git submodule update --init` appears in four gates' user-facing advice and is not a quoted `init` token. Over the 240 shell files the new alternative adds nothing to what was already found.

Enumeration boundary measured, not assumed: no `tests/*.sh` (0 of 17), no `just` recipe body and no workflow `run:` block builds a repository.

## Proof it fails in the new direction

A throwaway Python gate, added and then reverted:

* **inits a repo, no clear** → static half `FAIL` naming the file with a Python-shaped fix, dynamic half `FAIL` in both shapes.
* **mentions the helper, then pops the same four names by hand** → static half `ok`, dynamic half `FAIL` under `explicit`, naming the two loose objects. The gate does not take a file's word for it — which is precisely the real defect measured above.

Both directions are in the selftest permanently (Python offender DIRTY in both shapes, cleared twin CLEAN), plus the helper's own control: its fallback list must not be a subset of what this git reports.

## Cost and verification

Gate 11.9 s → 14.6 s warm on this host (8 more probe runs, 3 more selftest probes). `--self-test`/`--check` equivalents green: `check-gate-selftests`, `check-gate-lists`, `check-gate-visibility`, `check-default-gates-run-somewhere`, `check-lane-contracts`.

`just check fast`: 281 of 283 green; the two failures are provisioning in an agent worktree (`capability-conditionals` and `xrce-vendored-versions`, both "submodule not checked out"), unrelated to this change and present on `main` in the same tree.

Sweep for the next person:

```sh
git ls-files 'scripts/**/*.py' | xargs grep -lE "git.*['\"]init['\"]"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA
