### PR TITLE
feat(phase-412 #5): state the graph cache as a capability, not as bytes

### DIFF
--- a/docs/issues/1234-worktree-agents-share-the-parent-build-dir.md
+++ b/docs/issues/1234-worktree-agents-share-the-parent-build-dir.md
@@ -1,0 +1,94 @@
+---
+id: 1234
+title: "A linked worktree inherits `NROS_REPO_DIR` and writes its build dir and SKIP LEDGER into the parent checkout — one tree's skips appear in another's gate summary"
+status: open
+type: bug
+area: ci, tooling
+severity: medium
+found: 2026-09-08
+related: [1161, 1184, 0584]
+---
+
+# Two checkouts, one skip ledger
+
+Running `just check fast` in the main checkout while an agent ran the same lane
+in a linked worktree, the main run's summary reported skips from the OTHER tree:
+
+```
+check-fast (parallel): 278 gate(s) ran, 5 SKIPPED
+  [SKIPPED] workspace-order: no in-tree nros at
+      /home/aeon/repos/nano-ros/.claude/worktrees/agent-af1ce245.../packages/cli/target/release/nros
+  [SKIPPED] zpico-config-keys: zenoh-pico submodule not checked out
+```
+
+Neither is true of the checkout that printed them. `zpico-config-keys` skipped
+because the WORKTREE has no submodule; the main tree does. An earlier run showed
+`ivc-fsp` twice — once per tree.
+
+## The mechanism, and it is documented in the function that has it
+
+`scripts/build/build-root.sh:56-62`:
+
+```sh
+# worktree, where an inherited `NROS_REPO_DIR` may still name the main checkout.
+nros_build_root() {
+    if [ -n "${NROS_BUILD_ROOT:-}" ]; then
+        printf '%s' "${NROS_BUILD_ROOT%/}"
+        return 0
+    fi
+    printf '%s/build' "${NROS_REPO_ROOT:-${NROS_REPO_DIR:-$_NROS_BUILD_ROOT_REPO}}"
+}
+```
+
+The last-resort `_NROS_BUILD_ROOT_REPO` is derived from `${BASH_SOURCE[0]}`, so
+it WOULD resolve per-worktree and be correct. It never gets the chance:
+`activate.sh` exports `NROS_REPO_DIR`, a child process inherits it, and the
+middle branch wins. Measured: `NROS_REPO_DIR=/home/aeon/repos/nano-ros` in the
+parent shell; the worktree has no `build/check-skips` of its own, and the
+parent's `checks.skipped` carries a line naming the worktree's path.
+
+The comment above the function names this case exactly. It reads as a caveat
+that something downstream handles; nothing does.
+
+## Why it matters beyond noise
+
+The skip ledger is what `check-fast` prints as "N SKIPPED", and issues 0584,
+1161 and 1184 all turn on that number meaning something. A skip that crossed
+from another checkout is worse than an uncounted one: it is a gate reporting a
+condition that is FALSE HERE. A reader chasing "zenoh-pico submodule not checked
+out" in a tree where it plainly is has been sent somewhere that does not exist.
+
+It is not only the ledger. Everything under `nros_build_root()` is shared —
+fixture stamps, `cargo-fixtures/*` target dirs, the reconfigure snapshots. Two
+trees building different branches into one `build/` is the phase-340 cargo-group
+hazard (issue 0616) across checkouts rather than within one.
+
+## What it does NOT appear to be
+
+The verdicts themselves were not wrong in the runs observed: no gate reported a
+false PASS or FAIL, and `rc` matched the tree it ran in. The corruption seen so
+far is confined to the SKIP accounting and to shared build artifacts. That is a
+statement about what was observed, not a proof — two trees writing one fixture
+stamp is exactly the shape that produces a stale-artifact verdict, and the
+`.fixtures-built` stamp lives under the same root.
+
+## Shape of a fix
+
+`NROS_REPO_DIR` should not out-rank the file's own location when the two
+disagree. `_NROS_BUILD_ROOT_REPO` already computes the right answer from
+`BASH_SOURCE`; the ordering is what defeats it. A worktree is detectable
+(`git rev-parse --git-common-dir` differs from `--git-dir`), so the rule could
+be: an inherited repo dir that is not an ancestor of this file's own root is
+stale and ignored.
+
+Whatever the fix, it wants a test — two checkouts is a shape no gate models
+today, which is why a documented hazard survived as a comment.
+
+## Reproduction
+
+```sh
+git worktree add /tmp/wt origin/main
+source ./activate.sh          # exports NROS_REPO_DIR=<main checkout>
+( cd /tmp/wt && just check fast )   # its skips land in the MAIN tree's ledger
+grep agent /home/aeon/repos/nano-ros/build/check-skips/checks.skipped
+```

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -549,7 +549,7 @@ fn shim_config_from_env() -> ShimConfig {
         // Default matches the C `#ifndef` fallback exactly: the two must agree,
         // because a build that goes through cargo now states the number and one
         // that does not still falls through to the literal in `zpico.c`.
-        graph_cache_size: env_usize("ZPICO_GRAPH_CACHE_SIZE", 65536),
+        graph_cache_size: resolve_graph_cache_size(),
         max_pending_gets: env_usize("ZPICO_MAX_PENDING_GETS", 4),
         max_sessions: env_usize("ZPICO_MAX_SESSIONS", 1),
         // phase-400 W6 — BUILTINS, like the tx pair below: these five are
@@ -624,6 +624,7 @@ const KCONFIG_KNOBS: &[(&str, &str)] = &[
     ("ZPICO_MAX_QUERYABLES", "CONFIG_NROS_MAX_QUERYABLES"),
     ("ZPICO_MAX_LIVELINESS", "CONFIG_NROS_MAX_LIVELINESS"),
     ("ZPICO_GRAPH_CACHE_SIZE", "CONFIG_NROS_GRAPH_CACHE_SIZE"),
+    ("NROS_GRAPH_MAX_ENTITIES", "CONFIG_NROS_GRAPH_MAX_ENTITIES"),
     ("ZPICO_MAX_PENDING_GETS", "CONFIG_NROS_MAX_PENDING_GETS"),
     ("ZPICO_GET_REPLY_BUF_SIZE", "CONFIG_NROS_GET_REPLY_BUF_SIZE"),
     (
@@ -686,6 +687,77 @@ fn declared_floored(name: &str) -> Option<usize> {
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
         .map(|v| v.max(1))
+}
+
+/// Bytes one cached liveliness keyexpr costs: the keyexpr plus its separator.
+///
+/// MEASURED, not modelled. `zpico.c` records it: "A ROS 2 liveliness keyexpr
+/// runs ~140 bytes. Measured against a host running one stock `talker` plus the
+/// ROS 2 daemon, the domain carried 222 tokens — ~31 KB". The cache stores them
+/// NUL-separated with no index and no per-entry struct, so the only overhead
+/// beyond the text is the one separator byte (`zpico_graph_set_apply`).
+const GRAPH_KEYEXPR_BYTES: usize = 141;
+
+/// The graph cache, sized from a CAPABILITY the operator states.
+///
+/// phase-412 — this knob is not derivable and never will be: the cache holds a
+/// liveliness keyexpr for every entity of every node ON THE DOMAIN, remote
+/// included, so no inventory of this image can answer it. The W2 table says so
+/// and the census classifies it `sizing` for that reason.
+///
+/// What was still wrong is that the only way to state it was in BYTES, which is
+/// not the thing an operator knows. They know roughly how many nodes and
+/// endpoints share the domain. `NROS_GRAPH_MAX_ENTITIES` takes that count and
+/// does the arithmetic; `ZPICO_GRAPH_CACHE_SIZE` still wins when someone wants
+/// to name the bytes directly, so nothing that set it changes.
+///
+/// Shape follows `resolve_queryable_default` one function up — the tree's
+/// existing precedent for a bound that is stated rather than derived. There is
+/// no derived FLOOR here, and that is the honest difference: a queryable floor
+/// is provable from the image's own declaration, and nothing about the peer
+/// graph is.
+///
+/// UNDER-SIZING IS NOT A SMALLER CACHE. Overflow is counted, never truncated
+/// (`zpico_graph_set_apply`), and a non-zero `dropped` makes `service_is_ready`
+/// answer `Unsupported` — "cannot say" — which every caller reads as "keep
+/// waiting". `for_each_entity` discards the count entirely, so `ros2 node list`
+/// and the count verbs under-report with no signal at all. Being generous here
+/// costs `.bss`; being short costs a hang and a wrong graph answer.
+/// Bytes needed to cache `entities` liveliness keyexprs.
+///
+/// Pure, with the environment lifted out, so the arithmetic is testable without
+/// a build — the shape `facts_from_model` uses one crate over.
+///
+/// Floored at one keyexpr: `zpico.c` refuses a cache under 1 byte with an
+/// `#error` (issue 1015), and a stated 0 is a claim about the DOMAIN ("no other
+/// entities"), never a request for a zero-length buffer. This image's own
+/// entities are in that domain, so 0 is not reachable in practice anyway.
+fn graph_cache_bytes_for(entities: usize) -> usize {
+    entities
+        .saturating_mul(GRAPH_KEYEXPR_BYTES)
+        .max(GRAPH_KEYEXPR_BYTES)
+}
+
+fn resolve_graph_cache_size() -> usize {
+    // Through `env_usize`, not a bare `env::var`: that helper is what consults
+    // `$DOTCONFIG` for the `KCONFIG_KNOBS` row below, so a Zephyr image gets
+    // `CONFIG_NROS_GRAPH_MAX_ENTITIES` for free. Reading the environment
+    // directly would have given the knob a Kconfig entry that reaches the C
+    // lane and not this one — issue 0460's shape, and the exact defect this
+    // phase keeps finding.
+    //
+    // 0 is the "not stated" spelling, matching the Kconfig default: a domain
+    // with zero entities does not exist (this image's own are on it), so the
+    // value is free to mean absence.
+    let from_entities = match env_usize("NROS_GRAPH_MAX_ENTITIES", 0) {
+        0 => None,
+        n => Some(graph_cache_bytes_for(n)),
+    };
+    // The byte knob outranks the capability, and its default matches the C
+    // `#ifndef` fallback exactly: a build that goes through cargo states the
+    // number and one that does not falls through to the literal in `zpico.c`.
+    // The two must agree or the same source compiles to two sizes.
+    env_usize("ZPICO_GRAPH_CACHE_SIZE", from_entities.unwrap_or(65536))
 }
 
 fn env_usize(name: &str, default: usize) -> usize {
@@ -2740,5 +2812,43 @@ mod platform_watch_tests {
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod graph_cache_capability_tests {
+    use super::{GRAPH_KEYEXPR_BYTES, graph_cache_bytes_for};
+
+    /// The number an operator states is a COUNT, and the bytes follow from the
+    /// measurement `zpico.c` records — 222 tokens took ~31 KB on a host domain,
+    /// i.e. ~140 bytes each plus the NUL separator.
+    #[test]
+    fn a_stated_entity_count_becomes_its_measured_byte_cost() {
+        assert_eq!(graph_cache_bytes_for(1), GRAPH_KEYEXPR_BYTES);
+        assert_eq!(graph_cache_bytes_for(60), 60 * GRAPH_KEYEXPR_BYTES);
+        // The host-scale measurement the 65536 default was sized for.
+        assert_eq!(graph_cache_bytes_for(222), 222 * GRAPH_KEYEXPR_BYTES);
+        assert!(
+            graph_cache_bytes_for(222) < 65536,
+            "the measured host domain must fit inside the historical default, \
+             or the default was never sized for what its own comment cites"
+        );
+    }
+
+    /// Zero is a claim about the DOMAIN, not a request for a zero-length
+    /// buffer, and `zpico.c` refuses a cache under one byte with an `#error`
+    /// (issue 1015). The floor belongs here, at the consumer that names the
+    /// knob, exactly as it does for the two C-array pools.
+    #[test]
+    fn zero_entities_is_floored_rather_than_refused() {
+        assert_eq!(graph_cache_bytes_for(0), GRAPH_KEYEXPR_BYTES);
+    }
+
+    /// A count large enough to overflow `usize` must saturate rather than wrap
+    /// — wrapping would hand `zpico.c` a SMALL number for a huge claim, which
+    /// is the one direction that under-sizes silently.
+    #[test]
+    fn an_absurd_count_saturates_instead_of_wrapping() {
+        assert_eq!(graph_cache_bytes_for(usize::MAX), usize::MAX);
     }
 }

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -75,6 +75,15 @@ KNOB_CLASS = {
     # that sizes it: the cache holds a liveliness keyexpr for every entity of
     # every node on the domain, remote included. Not a property of this image,
     # so no inventory can answer it and an operator states it.
+    # phase-412 — the CAPABILITY spelling of the knob below: an operator states
+    # how many entities share the domain, and the bytes follow from the measured
+    # ~141 per keyexpr. Same category — nothing derives it, because the peer
+    # graph is not a property of this image.
+    "NROS_GRAPH_MAX_ENTITIES": (
+        "sizing",
+        "domain entity budget; sizes ZPICO_GRAPH_CACHE_SIZE, which still "
+        "outranks it when someone names the bytes directly",
+    ),
     "ZPICO_GRAPH_CACHE_SIZE": (
         "sizing",
         "per-session graph cache bytes; sized by the PEER graph, so it is "

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -759,6 +759,32 @@ config NROS_GET_REPLY_BUF_SIZE
       Size of the buffer for get (service call) reply payloads (bytes).
       Maps to ZPICO_GET_REPLY_BUF_SIZE.
 
+config NROS_GRAPH_MAX_ENTITIES
+    int "Entities you expect on this ROS 2 domain (0 = state the bytes instead)"
+    default 0
+    help
+      A DECLARED CAPABILITY, not a derivation. The graph cache holds one
+      liveliness keyexpr for every entity of every node on the domain —
+      remote nodes included — so nothing about this image can answer it.
+      What an operator does know is roughly how many nodes and endpoints
+      share the domain, and this takes that count.
+
+      The bytes follow from a measurement, not a model: a ROS 2 liveliness
+      keyexpr runs ~140 bytes and the cache stores them NUL-separated with
+      no index, so one entity costs 141 bytes. Upstream measured a host
+      running one stock talker plus the ROS 2 daemon carrying 222 tokens.
+
+      0 means "I am stating the bytes instead" — NROS_GRAPH_CACHE_SIZE
+      outranks this and keeps its own default, so nothing that already sets
+      it changes.
+
+      UNDER-STATING IS NOT A SMALLER CACHE. Overflow is counted, never
+      truncated, and a non-zero dropped count makes service_is_ready answer
+      "cannot say", which every caller reads as keep waiting; the node and
+      topic list verbs discard the count entirely and simply under-report.
+      Being generous costs .bss; being short costs a hang and a wrong graph
+      answer.
+
 config NROS_GRAPH_CACHE_SIZE
     int "Graph liveliness cache size"
     default 65536


### PR DESCRIPTION
`ZPICO_GRAPH_CACHE_SIZE` is not derivable and never will be — the cache holds a liveliness keyexpr
for every entity of every node **on the domain**, remote included, so no inventory of this image
can answer it. That part of W2's table stands.

What was still wrong is that the only way to state it was in **bytes**, which is not what an
operator knows. They know roughly how many nodes and endpoints share the domain.
`NROS_GRAPH_MAX_ENTITIES` takes that count and does the arithmetic.

## The bytes come from a measurement, not a model

`zpico.c` records it: a ROS 2 liveliness keyexpr runs ~140 bytes, and a host domain running one
stock talker plus the ROS 2 daemon carried 222 tokens (~31 KB). The cache stores them
NUL-separated with **no index and no per-entry struct**, so one entity costs exactly 141 bytes —
the text plus its separator. `graph_cache_bytes_for` is that arithmetic, pure and unit-tested with
the environment lifted out, the shape `facts_from_model` uses.

`ZPICO_GRAPH_CACHE_SIZE` still outranks the count, so nothing that already sets it changes, and
its default still mirrors the C `#ifndef` exactly — the two must agree or one source compiles to
two sizes.

## Read through the ladder, not around it

`env_usize`, not a bare `env::var`: that helper consults `$DOTCONFIG` for the new `KCONFIG_KNOBS`
row, so a Zephyr image gets `CONFIG_NROS_GRAPH_MAX_ENTITIES` for free. Reading the environment
directly would have given the knob a Kconfig entry reaching the C lane and not this one — issue
0460's shape, and the defect this phase keeps finding. `0` is the "not stated" spelling; a domain
with zero entities does not exist, since this image's own are on it.

**No derived floor**, and that is the honest difference from `QueryableSizing`, whose shape this
otherwise follows: a queryable floor is provable from the image's own declaration, and nothing
about the peer graph is.

## Tests

Three, covering: a stated count becomes its measured byte cost; the 222-token measurement fits
inside the historical 65536 default (or that default was never sized for what its own comment
cites); zero is floored rather than refused, because `zpico.c` `#error`s under one byte; and an
absurd count **saturates rather than wrapping** — wrapping would hand `zpico.c` a small number for
a huge claim, the one direction that under-sizes silently.

Kconfig help states what under-stating costs: overflow is counted, never truncated, and a non-zero
dropped count makes `service_is_ready` answer "cannot say" — which every caller reads as keep
waiting — while the node and topic list verbs discard the count and simply under-report.

```
just check fast                                                278 ran, 0 failed
just check zenoh-lane-ownership / kconfig-knob-forwarding / config-knob-census   PASS
cargo test -p nros-zpico-build                                 35 passed
```

## Also files issue 1234, found while measuring this

A linked worktree inherits `NROS_REPO_DIR` and writes its build dir **and skip ledger** into the
parent checkout, so one tree's skips appear in another's `check-fast` summary — I saw
`zpico-config-keys: zenoh-pico submodule not checked out` in a tree where it plainly is. The
hazard is named in a comment directly above the function that has it, and nothing downstream
handles it. It also means everything under `nros_build_root()` is shared between concurrent
checkouts, fixture stamps included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119aFbZ4oJ6u4agj4PjknPd