### PR TITLE
feat(phase-438 W1+W2, #1187): one detection site, then the std surface is REQUESTED — every embedded C++ FreeRTOS image compiles again

### DIFF
--- a/.config/cpp-freestanding-includes-baseline.txt
+++ b/.config/cpp-freestanding-includes-baseline.txt
@@ -1,32 +1,22 @@
-# Hosted STL includes reached with `NROS_CPP_STD` undefined, in the `#elif
-# defined(__has_include)` arm of nros-cpp's capability blocks.
+# Hosted STL includes reached with `NROS_CPP_STD` undefined, in nros-cpp's
+# capability blocks.
 #
 # A RATCHET, not an allowlist. It may only SHRINK: a line here that no longer
 # matches a violation is a FAILURE, so the debt cannot go stale, and a new
 # violation not listed here is a failure too, so it cannot grow.
 #
-# EMPTY as of issue 1240 (2026-09-09). All fourteen entries are paid.
+# EMPTY as of issue 1240 (2026-09-09). All fourteen entries are paid, and
+# phase-438 W1+W2 then removed the shape that produced them.
 #
-# WHAT PAID THEM, AND WHY IT IS NOT WHAT WAS PLANNED
+# WHAT PAID THEM, IN TWO STEPS THAT DISAGREED ABOUT THE INSTRUMENT
 #
-# The plan recorded here was phase-438 W2: "delete the `#elif` arm, so the std
-# surface is reachable only through `NROS_CPP_STD`." That would have been the
-# wrong fix, and `nros.hpp` already says why in its `<chrono>` note — NOTHING
-# THAT SHIPS DEFINES `NROS_CPP_STD`. It appears in no cmake module, no
-# toolchain file, no build.rs and no Kconfig, only in docs and in `check.just`'s
-# own probe TUs. Deleting the arm would not have tightened the gate on
-# freestanding targets; it would have removed `std::string`-taking `get_logger`,
-# `std::shared_ptr` aliases and the `<vector>` options surface from EVERY
-# configuration, hosted ones included. `nros.hpp` made exactly that mistake for
-# `<chrono>` on 2026-09-05 and corrected it two days later.
-#
-# What paid them instead is the corrected predicate from that same note, applied
-# to all fourteen sites at once (issue 1240):
+# Issue 1240 paid all fourteen by CORRECTING the probe in place, at all fourteen
+# sites at once:
 #
 #   #if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ \
 #       && __has_include(<string>))
 #
-# Neither probe alone is sufficient and both are necessary:
+# Neither probe alone is sufficient and both were necessary:
 #
 #   * `__has_include` alone answers "does the header FILE exist", which is TRUE
 #     under `-ffreestanding` for a libstdc++ whose `<string>` begins
@@ -37,15 +27,38 @@
 #     hosted compiler run `-nostdinc++` against Zephyr's minimal libcpp reads
 #     HOSTED and still has no `<string>`.
 #
-# The conjunction covers both lanes; `NROS_CPP_STD` stays as the explicit
-# override for a consumer who knows better than the probes.
+# phase-438 W1 then moved that one predicate to its single definition site,
+# `packages/api/nros-cpp/include/nros/std_detect.hpp`, and W2 DELETED the
+# discovery disjunct there. 1240's objection to deleting it — "nothing that
+# ships defines `NROS_CPP_STD`, so the arm is what gives the hosted build
+# `std::string`-taking `get_logger`, the `SharedPtr` aliases and the `<vector>`
+# options surface" — was correct about the tree as it stood, and W2 is what
+# makes it stop being true: five consumers now make the request out loud (the
+# rclcpp compat shim, the phase-417 ported-surface probes, the four refusal
+# probes, the `cpp_compat_snippets` compile-check arm, and
+# `check-cpp-capability-layout`'s hosted arm). A better probe was still a probe;
+# the macro answers which SURFACE a consumer asked for, which no probe can see.
 #
-# The walker was tightened in the same change so it cannot be satisfied by the
-# TOKEN alone: an `#if`/`#elif` naming NROS_CPP_STD that also reaches
-# `__has_include` without `__STDC_HOSTED__` is NOT a std region. Without that,
-# the broken shape and the corrected one score identically, which is the 0196
-# rule — a gate whose reach is narrower than the rule it enforces.
+# Measured on the toolchain that could not build at all before (arm-none-eabi
+# 13.2, `-std=c++14 -ffreestanding -fno-exceptions -fno-rtti`), per-header
+# standalone parse:
+#
+#     before W2   pass=26 fail=20
+#     after W2    pass=47 fail=0
+#
+# The walker was tightened by 1240 so it cannot be satisfied by the TOKEN alone:
+# an `#if`/`#elif` naming NROS_CPP_STD that also reaches `__has_include` without
+# `__STDC_HOSTED__` is NOT a std region. Without that, the broken shape and the
+# corrected one score identically, which is the 0196 rule — a gate whose reach
+# is narrower than the rule it enforces. After W2 no capability block reaches
+# `__has_include` at all, so the tightened walker has nothing left to reject
+# here; it stays because the rule outlives this file's emptiness.
 #
 # Keyed on FILE and HEADER, not on a line number, so an entry survives edits
 # above it and so a second `<memory>` appearing in a listed file is still
 # caught. Add a line here only with a written reason and a tracked issue id.
+#
+# The file stays rather than being deleted: the gate requires it, and the next
+# genuine hosted-include debt needs somewhere to be recorded with its reason
+# instead of being argued about in a review. An entry that stops offending
+# FAILS, so an empty file cannot quietly refill.

--- a/cmake/compat/NrosRclcppCompat.cmake
+++ b/cmake/compat/NrosRclcppCompat.cmake
@@ -114,6 +114,24 @@ function(_nros_compat_apply_force_includes target)
     # header) resolve to the nano-ros compat shims.
     target_include_directories(${target} PRIVATE
         "${_nros_compat_dir}/include")
+    # phase-438 W2 — ASK for the std surface. A file reaching
+    # `<rclcpp/rclcpp.hpp>` subclasses `rclcpp::Node`, whose signatures are
+    # spelled in `std::shared_ptr` / `std::string` / `std::vector`; that surface
+    # is now reachable only through `NROS_CPP_STD`, never discovered from the
+    # include path (issue 1187 — `__has_include(<string>)` is TRUE on
+    # arm-none-eabi `-ffreestanding`, where including it is a hard `#error`).
+    #
+    # This target is exactly the right place and nowhere else is: the shim is
+    # applied per-target and is deliberately NOT auto-applied on Zephyr (see
+    # below), so the opt-in follows the porting surface instead of leaking to
+    # images that use `nros::Node` directly.
+    #
+    # Until now this function set NO compile definition at all, and the whole
+    # ported-code path worked only because a hosted compiler happened to find
+    # libstdc++. `scripts/api-parity.py` even documented the opposite —
+    # "that is the flavour the compat CMake path builds under" — of a path that
+    # defined nothing. It is true from here.
+    target_compile_definitions(${target} PRIVATE NROS_CPP_STD=1)
 endfunction()
 
 # Phase 210.E.3.c — Zephyr context: do NOT auto-apply force-include of

--- a/docs/issues/archived/1187-freertos-embedded-cpp-freestanding-string.md
+++ b/docs/issues/archived/1187-freertos-embedded-cpp-freestanding-string.md
@@ -3,7 +3,7 @@ id: 1187
 title: "Every embedded C++ FreeRTOS image fails to compile: `<string>` reaches
   `requires_hosted.h` under `-ffreestanding` on the PINNED arm-none-eabi-gcc,
   and the `__has_include` gate cannot see it"
-status: open
+status: resolved
 type: bug
 area: cpp
 related: [0112, 0332, 1146]
@@ -131,3 +131,59 @@ consolidate.
 Blocked on issue 1223 only in ordering: `check-cpp-freestanding-includes` cannot
 see any of these arms, so it must be taught to before they are deleted, or the
 blindness ships uncaught.
+
+## Resolution — phase-438 W1 + W2
+
+The `#elif defined(__has_include)` arms are gone. The std surface is reachable
+only through `NROS_CPP_STD`, which is a consumer REQUEST and not a probe, so no
+toolchain can answer the question wrongly any more.
+
+Two commits, in the order that made the second one small:
+
+* **W1** consolidated the fourteen hand-copied detection blocks into one
+  `nros/std_detect.hpp`. Behaviour-neutral, measured — the per-header failing
+  set was byte-identical before and after.
+* **W2** deleted the discovery arms. Five lines in one file, plus `<chrono>`'s
+  `||` disjunct.
+
+### Acceptance — this issue's own, as written
+
+```
+$ NROS_CMAKE_EXTRA_DEFS=-DCMAKE_TOOLCHAIN_FILE=$PWD/cmake/toolchain/arm-freertos-armcm3.cmake \
+  bash scripts/build/fixtures-build.sh freertos cpp zenoh
+EXIT=0
+requires_hosted hits: 0
+```
+
+Six ARM ELF binaries where none built before: `cpp_talker`, `cpp_listener`,
+`cpp_service_server`, `cpp_service_client`, `cpp_action_server`,
+`cpp_action_client`.
+
+Per-header standalone parse on this issue's toolchain (`arm-none-eabi 13.2`,
+`-std=c++14 -ffreestanding -fno-exceptions -fno-rtti`):
+
+```
+before   pass=26 fail=20
+after    pass=47 fail=0
+```
+
+### Corrections to the analysis above
+
+* **The second fix option in "Fix direction" would not have worked either.**
+  Pairing `__has_include` with `__STDC_HOSTED__` fails on the OTHER embedded
+  lane: `__STDC_HOSTED__` is 0 here and 1 on Zephyr's `-nostdinc++` lane, where
+  `<string>` is genuinely absent. Each probe is correct on exactly one embedded
+  lane; only the opt-in is correct on both.
+* **"with the rationale, from issue 0112" is not what 0112 says.** 0112's
+  Resolution chose `NROS_CPP_STD` over `__STDC_HOSTED__`; it never chose
+  `__has_include`, which arrived later in `acf213871`. Eleven header comments
+  cited 0112 as authority for the construct; W1 rewrote them.
+* **The count was 15 blocks across 11 headers**, not 19 sites across 13.
+  Nineteen is the `__has_include(<...>)` occurrence count, 29 is the
+  `#define NROS_CPP_HAS_*` line count.
+
+### What this unblocks
+
+Issue 1146 can now measure the FreeRTOS app-task stack on the C++ path, so
+`cmake/templates/freertos_app_config.c.in`'s 512 KiB — one number serving C and
+C++, measured only on the C half — can be reduced to the measured figure.

--- a/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
+++ b/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
@@ -1,6 +1,6 @@
 # phase-438 — the C++ std surface is an opt-in PORTING surface, not a discovered capability
 
-**Status (2026-09-08). Opened; feasibility MEASURED.** The C++ half of phase-359's
+**Status (2026-09-09). W0, W1, W2 LANDED — issue 1187 is closed. W3-W5 open.** The C++ half of phase-359's
 argument. Implements RFC-0089's compile-or-conform rule by making the surface that
 rule needs an explicit request rather than a property of the toolchain. Re-cuts
 phase-427 W1, which currently works around this rather than fixing it.
@@ -341,6 +341,11 @@ program — native included — is on the freestanding side already.
 **W0 before W2**, so the gate is the acceptance rather than a casualty — and
 W0 lands with a ratchet rather than a red, because a red fast-line gate on
 `main` blocks every push (see W0).
+
+**W1 before W2**, and it earned its place: W2 landed as a five-line deletion in
+one file instead of a fourteen-site sweep, and the baseline is the count —
+14 entries after W0, 5 after W1, 0 after W2, with no debt paid to get from 14
+to 5.
 
 **The phase before phase-426 and phase-427.** W2 changes what "delete both C++
 parameter stores" is deleting from, and W4 is phase-427 W1 relocated. Doing it

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -860,8 +860,15 @@ cpp: cpp-fmt
     # other use in this recipe, and issue 0726.
     # shellcheck source=scripts/lib/grep-q.sh
     source scripts/lib/grep-q.sh
-    echo "  - one node type: hosted shape + both create families (c++14)"
-    c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti \
+    # `-DNROS_CPP_STD=1` since phase-438 W2: this probe is ABOUT the hosted
+    # shape (the `shared_ptr` and `std::string` families, and the parameter
+    # facade behind `NROS_CPP_NODE_HOSTED`), and W2 made that shape a REQUEST
+    # rather than something a hosted compiler is handed. Without the flag the TU
+    # stops compiling at `declare_parameter`, which is W2 working, not a
+    # regression. The freestanding half has its own probe below and correctly
+    # takes no flag.
+    echo "  - one node type: hosted shape + both create families (c++14, -DNROS_CPP_STD)"
+    c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti -DNROS_CPP_STD=1 \
         -Itarget/nros-cpp-generated \
         -Itarget/nros-c-generated \
         -Ipackages/api/nros-cpp/include \
@@ -971,8 +978,13 @@ cpp: cpp-fmt
     # is empty for any ported node holding a timer. Deleting it outright is what
     # turned that gate red; this probe is what stops the name regrowing a base
     # underneath it instead.
-    echo "  - rclcpp::TimerBase is a NAME for the flat rclcpp::Timer, not a hierarchy (c++17)"
-    c++ -fsyntax-only -std=c++17 -fno-exceptions -fno-rtti \
+    # `-DNROS_CPP_STD=1` since phase-438 W2, same reason as the ported-surface
+    # probes below: `rclcpp::TimerBase` is a name on the PORTING surface (the
+    # `shared_ptr`-returning `create_wall_timer(period, cb)` hands it out), and
+    # W2 made that surface a request. Without the flag this TU fails on the
+    # chrono overload, which says nothing about the hierarchy it probes.
+    echo "  - rclcpp::TimerBase is a NAME for the flat rclcpp::Timer, not a hierarchy (c++17, -DNROS_CPP_STD)"
+    c++ -fsyntax-only -std=c++17 -DNROS_CPP_STD=1 -fno-exceptions -fno-rtti \
         -Itarget/nros-cpp-generated \
         -Itarget/nros-c-generated \
         -Ipackages/api/nros-cpp/include \

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -1055,9 +1055,16 @@ cpp: cpp-fmt
         }; \
     done
     echo "  - phase-417: ported-file surface COMPILES (aliases, string interop, graph, actions, executor)"
+    # `-DNROS_CPP_STD` since phase-438 W2. These probes exist to prove that a
+    # PORTED rclcpp file compiles, and that is the surface the flag names — so
+    # asking for it here is not a workaround, it is the probes stating what they
+    # are. Before W2 they got the same surface without asking, because
+    # `__has_include` found libstdc++ on the host; the flag makes the request
+    # explicit and is what a real ported consumer now writes too
+    # (`cmake/compat/NrosRclcppCompat.cmake` sets it for exactly these files).
     for probe in ros2_api_adoption node_graph_forwarders ros2_api_adoption_stage2 ros2_one_dispatch_path \
                  ros2_init_argv_refusal action_goal_uuid executor_cancel; do \
-        c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti \
+        c++ -fsyntax-only -std=c++14 -DNROS_CPP_STD=1 -fno-exceptions -fno-rtti \
             -Itarget/nros-cpp-generated \
             -Itarget/nros-c-generated \
             -Ipackages/api/nros-cpp/include \
@@ -1067,7 +1074,7 @@ cpp: cpp-fmt
     done
     # c++17 alone: it enables NROS_SYSTEM_PARAM_SERVICES in-file, which reaches
     # `ComponentNode::adopt_launch_seed_`'s `if constexpr`.
-    c++ -fsyntax-only -std=c++17 -fno-exceptions -fno-rtti \
+    c++ -fsyntax-only -std=c++17 -DNROS_CPP_STD=1 -fno-exceptions -fno-rtti \
         -Itarget/nros-cpp-generated \
         -Itarget/nros-c-generated \
         -Ipackages/api/nros-cpp/include \
@@ -1086,11 +1093,18 @@ cpp: cpp-fmt
     # non-zero and would read as "the refusal fired". So each is grepped for the
     # marker its message carries, and `test -f` runs first because a missing
     # file compiles to nothing and passes.
+    #
+    # `-DNROS_CPP_STD` since phase-438 W2, and the lane's own guard is why it is
+    # here: without it `ros2_refuse_node_options_probe.cpp` still FAILED, but on
+    # `'NodeOptions' is not a member of 'rclcpp'` rather than on the refusal —
+    # the exact "broke for another reason, so this check proves nothing" case
+    # the grep below exists to catch. A refusal probe must reach the refusal,
+    # which means compiling in the flavour the refusal lives in.
     echo "  - phase-417: the refusals FAIL, each naming its own constraint"
     for probe in node_options system_defaults_qos log_throttle service_callback; do \
         f="packages/api/nros-cpp/tests/compile/ros2_refuse_${probe}_probe.cpp"; \
         test -f "$f" || { echo "ERROR: $f is MISSING -- this check passes on absence." >&2; exit 1; }; \
-        if c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti \
+        if c++ -fsyntax-only -std=c++14 -DNROS_CPP_STD=1 -fno-exceptions -fno-rtti \
                -Itarget/nros-cpp-generated -Itarget/nros-c-generated \
                -Ipackages/api/nros-cpp/include -Ipackages/api/nros-c/include \
                -Ipackages/platform/nros-platform-api/include "$f" 2>"tmp/refuse-$probe.log"; then \

--- a/packages/api/nros-cpp/include/nros/client.hpp
+++ b/packages/api/nros-cpp/include/nros/client.hpp
@@ -18,14 +18,11 @@
 #include "nros/size_bound.hpp" // nros::rx_buffer_capacity<M> — the receive-buffer size
 #include "nros/future.hpp"
 
-// phase-417 W1.a — `<memory>` for the nested pointer aliases. Rationale (and
-// why the test needs BOTH `__has_include` and `__STDC_HOSTED__` — issues
-// 0112 and 1240)
-// lives in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
-#include <memory>
-#define NROS_CPP_HAS_SHARED_PTR 1
-#endif
+// phase-417 W1.a — `<memory>` for the nested pointer aliases below.
+// `NROS_CPP_HAS_SHARED_PTR` and the other capability macros have ONE definition
+// site, and the measured reason they are a REQUEST rather than a probe is
+// stated there (phase-438 W1).
+#include "nros/std_detect.hpp"
 
 #include "nros_cpp_ffi.h"
 

--- a/packages/api/nros-cpp/include/nros/fixed_string.hpp
+++ b/packages/api/nros-cpp/include/nros/fixed_string.hpp
@@ -17,17 +17,11 @@
 #include <string.h>
 
 // phase-417 W1.c — `std::string` interop. `<string>` is absent from a minimal
-// freestanding libcpp, so gate on the declared std flavour, else ASK THE
-// COMPILER, with BOTH probes. `__STDC_HOSTED__` alone is the wrong question
-// (issue 0112): the Zephyr XRCE C++ leaves compile `-fno-freestanding
-// -nostdinc++`, i.e. hosted with no `<string>`. `__has_include` alone is wrong
-// too (issue 1240): under `-ffreestanding` a full libstdc++ HAS `<string>` and
-// `#error`s on it. Same two-probe idiom as every other capability block; the longer
-// rationale is in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<string>))
-#include <string>
-#define NROS_CPP_HAS_STD_STRING 1
-#endif
+// freestanding libcpp, so the interop below exists only where
+// `NROS_CPP_HAS_STD_STRING` does. That macro has ONE definition site
+// (phase-438 W1), which also carries the measurement for why it is a REQUEST
+// and not a probe of the include path.
+#include "nros/std_detect.hpp"
 
 namespace nros {
 

--- a/packages/api/nros-cpp/include/nros/heap_string.hpp
+++ b/packages/api/nros-cpp/include/nros/heap_string.hpp
@@ -28,12 +28,8 @@
 #include <nros/platform.h>
 
 // phase-417 W1.c — `std::string` interop, gated exactly as `fixed_string.hpp`
-// gates it (`__has_include` AND `__STDC_HOSTED__` — issues 0112 and 1240;
-// rationale in `publisher.hpp`).
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<string>))
-#include <string>
-#define NROS_CPP_HAS_STD_STRING 1
-#endif
+// gates it, on `NROS_CPP_HAS_STD_STRING` from the one detection site.
+#include "nros/std_detect.hpp"
 
 namespace nros {
 

--- a/packages/api/nros-cpp/include/nros/log.hpp
+++ b/packages/api/nros-cpp/include/nros/log.hpp
@@ -102,22 +102,15 @@
 
 // `<string>` for `rclcpp::get_logger(const std::string&)` and `<sstream>` for
 // the `_STREAM` family. Gated: this header is reachable from a `no_std` C++
-// build with a minimal libcpp, where neither exists — and from a
-// `-ffreestanding` build against a FULL libstdc++, which has both files and
-// refuses to be included from either. `__has_include` AND `__STDC_HOSTED__`:
-// issues 0112 and 1240, rationale in `publisher.hpp`. When they are
-// absent the names below simply do not exist, which is what a freestanding
-// target should see; the un-gated half (the refusal vocabulary, `Logger`, the
-// printf-style macros) still reaches it.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<string>))
-#include <string>
-#define NROS_CPP_HAS_STD_STRING 1
-#endif
-
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<sstream>))
-#include <sstream>
-#define NROS_CPP_HAS_STD_SSTREAM 1
-#endif
+// build with a minimal libcpp, where neither exists. When they are absent the
+// names below simply do not exist, which is what a freestanding target should
+// see; the un-gated half (the refusal vocabulary, `Logger`, the printf-style
+// macros) still reaches it.
+//
+// Worth knowing where this sits: `qos.hpp` includes this header and every
+// entity header includes `qos.hpp`, so the `_STREAM` family's `<sstream>` is on
+// the transitive include path of every freestanding TU in the API.
+#include "nros/std_detect.hpp"
 
 namespace rclcpp {
 

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -241,6 +241,16 @@ inline Result spin(uint32_t duration_ms, int32_t poll_ms = 10) {
 #include <cstdlib>     // std::abort -- the runtime half of RFC-0089 W3.b
 #include <type_traits> // the SFINAE guards on create_service / create_client
 
+// The `NROS_CPP_HAS_*` capability macros, including `<chrono>` and the
+// measured reason its condition is not the same as the other five.
+//
+// This header USED four of these macros and DEFINED none, so which of them
+// held depended on `publisher.hpp` / `options.hpp` / `subscription.hpp`
+// having been included first — the only header in the tree in that state,
+// and a latent issue 0135 (two TUs of one image disagreeing about a
+// capability, hence about a layout). phase-438 W1.
+#include "nros/std_detect.hpp"
+
 namespace rclcpp {
 
 // --- Process-level lifecycle -------------------------------------------------

--- a/packages/api/nros-cpp/include/nros/options.hpp
+++ b/packages/api/nros-cpp/include/nros/options.hpp
@@ -189,21 +189,11 @@ struct ClientOptions {
 // claim about a switch that does not exist — the same silent difference one
 // step further from the call site.
 //
-// `<string>` / `<vector>` are GATED (issues 0112 + 1240 — `__has_include` AND
-// `__STDC_HOSTED__`, rationale in `publisher.hpp`), because this header is on
-// the freestanding path. Upstream's
-// `arguments()` signature is spelled in terms of `std::vector<std::string>`, so
-// where those types are absent the class is too; a freestanding build has no
-// `rclcpp::Node` to hand it to either.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<string>))
-#include <string>
-#define NROS_CPP_HAS_STD_STRING 1
-#endif
-
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<vector>))
-#include <vector>
-#define NROS_CPP_HAS_STD_VECTOR 1
-#endif
+// `<string>` / `<vector>` are GATED, because this header is on the freestanding
+// path. Upstream's `arguments()` signature is spelled in terms of
+// `std::vector<std::string>`, so where those types are absent the class is too;
+// a freestanding build has no `rclcpp::Node` to hand it to either.
+#include "nros/std_detect.hpp"
 
 #if defined(NROS_CPP_HAS_STD_STRING) && defined(NROS_CPP_HAS_STD_VECTOR)
 

--- a/packages/api/nros-cpp/include/nros/polling_subscription.hpp
+++ b/packages/api/nros-cpp/include/nros/polling_subscription.hpp
@@ -28,14 +28,11 @@
 #include "nros/result.hpp"
 #include "nros/subscription.hpp"
 
-// phase-417 W1.a — `<memory>` for the nested pointer aliases. Rationale (and
-// why the test needs BOTH `__has_include` and `__STDC_HOSTED__` — issues
-// 0112 and 1240)
-// lives in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
-#include <memory>
-#define NROS_CPP_HAS_SHARED_PTR 1
-#endif
+// phase-417 W1.a — `<memory>` for the nested pointer aliases below.
+// `NROS_CPP_HAS_SHARED_PTR` and the other capability macros have ONE definition
+// site, and the measured reason they are a REQUEST rather than a probe is
+// stated there (phase-438 W1).
+#include "nros/std_detect.hpp"
 
 namespace nros {
 

--- a/packages/api/nros-cpp/include/nros/publisher.hpp
+++ b/packages/api/nros-cpp/include/nros/publisher.hpp
@@ -28,44 +28,12 @@
 // `<cstdint>`, `<new>`, plus this repo's `zephyr/cxx-compat/`; neither has
 // `<memory>`).
 //
-// Gate on the declared std flavour, else ASK THE COMPILER — with BOTH probes,
-// because each one alone gives a wrong answer on a lane the other gets right.
-//
-// `__STDC_HOSTED__` alone is the WRONG question (issue 0112), and measurably
-// so: the Zephyr XRCE C++ leaves compile with `-fno-freestanding -nostdinc++`,
-// i.e. they read HOSTED while having no `<memory>` at all, and the aarch64
-// workspace leaf has `-nostdinc++` with no `-ffreestanding` either. Only
-// `__has_include` sees that.
-//
-// `__has_include` alone is ALSO wrong, and this half was missing until issue
-// 1240. It answers "does the header FILE exist" — which is TRUE under
-// `-ffreestanding` against a FULL libstdc++, whose `<memory>` / `<string>` /
-// `<vector>` / `<sstream>` open with
-//
-//     #error "This header is not available in freestanding mode."
-//
-// GCC 16 made that unmissable: `just check cpp`'s own `-ffreestanding` probe
-// stopped compiling, ~200 errors deep inside `/usr/include/c++/16` and none in
-// our code, and the `shared_ptr does not name a template type` reports it ended
-// with were a CASCADE — `timer.hpp` includes `<memory>` and always did. The
-// same shape had been failing quietly on the FreeRTOS lane's arm-none-eabi 13.2
-// for longer (issue 1187: 19 of 45 headers, 17 of them entered through
-// `log.hpp`'s `<string>`). `__STDC_HOSTED__` is the only probe that separates
-// "present" from "present and usable"; `nros.hpp` measured the same thing for
-// `<chrono>` two days earlier and this is its class.
-//
-// So: `NROS_CPP_STD` (the explicit consumer opt-in, which nothing that ships
-// defines — do not gate on it ALONE, that removes the surface from the hosted
-// build too) OR the conjunction. Gated by
-// `scripts/check-cpp-freestanding-includes.sh`, which since 1240 rejects an
-// `#if` that names `NROS_CPP_STD` while its live arm asks only
-// `__has_include`.
-//
-// The other entity headers repeat this block; the rationale lives here.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
-#include <memory>
-#define NROS_CPP_HAS_SHARED_PTR 1
-#endif
+// This header used to CARRY the detection block and the rationale for it, and
+// the other entity headers copied both. Neither is here any more: phase-438 W1
+// gives the capability macros one definition site, and `std_detect.hpp` states
+// — with the measurement — why they are a consumer REQUEST rather than a probe
+// of what the include path happens to hold.
+#include "nros/std_detect.hpp"
 
 namespace nros {
 

--- a/packages/api/nros-cpp/include/nros/service.hpp
+++ b/packages/api/nros-cpp/include/nros/service.hpp
@@ -17,14 +17,11 @@
 #include "nros/result.hpp"
 #include "nros/size_bound.hpp" // nros::rx_buffer_capacity<M> — the receive-buffer size
 
-// phase-417 W1.a — `<memory>` for the nested pointer aliases. Rationale (and
-// why the test needs BOTH `__has_include` and `__STDC_HOSTED__` — issues
-// 0112 and 1240)
-// lives in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
-#include <memory>
-#define NROS_CPP_HAS_SHARED_PTR 1
-#endif
+// phase-417 W1.a — `<memory>` for the nested pointer aliases below.
+// `NROS_CPP_HAS_SHARED_PTR` and the other capability macros have ONE definition
+// site, and the measured reason they are a REQUEST rather than a probe is
+// stated there (phase-438 W1).
+#include "nros/std_detect.hpp"
 
 #include "nros_cpp_ffi.h"
 

--- a/packages/api/nros-cpp/include/nros/std_detect.hpp
+++ b/packages/api/nros-cpp/include/nros/std_detect.hpp
@@ -81,46 +81,46 @@
 // three positions in every instance. `<chrono>` below is the one that does not,
 // and it is kept separate rather than normalised into these.
 //
-// The predicate is the one issue 1240 landed at all fourteen sites, moved here
-// unchanged, and its two probes are each necessary:
+// DISCOVERY IS GONE (phase-438 W2). The predicate is the request and nothing
+// else. Issue 1240 had just corrected discovery at all fourteen sites to the
+// two-probe conjunction
 //
-//   * `__STDC_HOSTED__` alone is the WRONG question (issue 0112): the Zephyr
-//     XRCE C++ leaves compile `-fno-freestanding -nostdinc++`, so they read
-//     HOSTED while having no `<memory>` at all. Only `__has_include` sees that.
-//   * `__has_include` alone is ALSO wrong (issue 1240): it answers "does the
-//     header FILE exist", which is TRUE under `-ffreestanding` against a FULL
-//     libstdc++ whose `<memory>` / `<string>` / `<vector>` / `<sstream>` open
-//     with `#error "This header is not available in freestanding mode."` GCC 16
-//     made that unmissable — `just check cpp`'s own `-ffreestanding` probe
-//     produced ~200 errors inside `/usr/include/c++/16` and none in our code —
-//     and the same shape had been failing quietly on the FreeRTOS lane's
-//     arm-none-eabi 13.2 for longer (issue 1187: 19 of 45 headers, 17 of them
-//     entered through `log.hpp`'s `<string>`).
+//     defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__
+//                               && __has_include(<string>))
 //
-// Do not gate on `NROS_CPP_STD` ALONE while the disjunct is the only thing
-// defining these macros in a shipped build — that removes the surface from the
-// hosted build too, which is the over-tightening `<chrono>` below records twice.
-// (phase-438 W2 removes the disjunct, and pairs the removal with the five sites
-// that then have to make the request.) Gated by
-// `scripts/check-cpp-freestanding-includes.sh`, which since 1240 rejects an
-// `#if` naming `NROS_CPP_STD` whose live arm asks only `__has_include`.
+// because each probe alone is wrong on a lane the other gets right:
+// `__STDC_HOSTED__` alone misreads Zephyr's `-fno-freestanding -nostdinc++`
+// leaves as having `<memory>` (issue 0112), and `__has_include` alone answers
+// "does the FILE exist", which is TRUE under `-ffreestanding` against a full
+// libstdc++ whose `<string>` opens `#error "This header is not available in
+// freestanding mode."` (issue 1240, made unmissable by GCC 16; issue 1187 is
+// the same shape failing quietly on arm-none-eabi 13.2).
+//
+// That conjunction is a better PROBE. W2's claim is that no probe is the right
+// instrument: the question a capability macro answers is which SURFACE the
+// consumer asked to be compiled, not what the include path happens to hold.
+// So the conjunction is removed rather than kept as a fallback, and the five
+// consumers that need the porting surface make the request out loud -- the
+// rclcpp compat shim, the phase-417 ported-surface probes, the four refusal
+// probes, the `cpp_compat_snippets` compile-check arm, and this gate's own
+// hosted arm.
 
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
+#if defined(NROS_CPP_STD)
 #include <memory>
 #define NROS_CPP_HAS_SHARED_PTR 1
 #endif
 
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<string>))
+#if defined(NROS_CPP_STD)
 #include <string>
 #define NROS_CPP_HAS_STD_STRING 1
 #endif
 
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<vector>))
+#if defined(NROS_CPP_STD)
 #include <vector>
 #define NROS_CPP_HAS_STD_VECTOR 1
 #endif
 
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<functional>))
+#if defined(NROS_CPP_STD)
 #include <functional>
 #define NROS_CPP_HAS_STD_FUNCTION 1
 #endif
@@ -130,18 +130,22 @@
 // includes `qos.hpp` — so a stream-formatting convenience sits on the
 // transitive include path of every freestanding TU. That is a separate leak
 // from how it is gated (phase-438, "which failures are real", cause (c)).
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<sstream>))
+#if defined(NROS_CPP_STD)
 #include <sstream>
 #define NROS_CPP_HAS_STD_SSTREAM 1
 #endif
 
-// --- `<chrono>`: the one condition that is NOT the uniform block --------------
+// --- `<chrono>`: the block that got here first --------------------------------
 //
-// Moved here verbatim from `nros.hpp`, comment included, because the comment IS
-// the evidence: three successive corrections, each measured against a recorded
-// compile command. Do not normalise this into the five above — it differs in
-// three ways that are each load-bearing, and the differences are why it needs
-// its own paragraph rather than its own file.
+// `<chrono>` reached the opt-in-only form one phase ahead of the other five,
+// the hard way, and its comment is kept because it is the EVIDENCE for what
+// phase-438 W2 then did to all of them. Three successive corrections, each
+// measured against a build's own recorded compile command, each narrowing a
+// probe that was answering the wrong question. Read as history now — the
+// `__STDC_HOSTED__ && __has_include(<chrono>) && __has_include(<ratio>)`
+// disjunct it describes is gone, because W2 removed discovery from every
+// capability here. What survives is the finding: a header can be PRESENT,
+// pass every probe, and still not provide the thing you need.
 
 // `<chrono>` requires the EXPLICIT opt-in, not `__has_include`, and that is
 // measured rather than stylistic.
@@ -222,7 +226,7 @@
 // build, which is the same over-tightening the note above records.
 // `_GLIBCXX_CHRONO` also separates the two but is libstdc++'s private spelling;
 // `__has_include` is the portable question.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<chrono>) && __has_include(<ratio>))
+#if defined(NROS_CPP_STD)
 #include <chrono>
 #define NROS_CPP_HAS_STD_CHRONO 1
 #endif

--- a/packages/api/nros-cpp/include/nros/std_detect.hpp
+++ b/packages/api/nros-cpp/include/nros/std_detect.hpp
@@ -1,0 +1,230 @@
+// nros-cpp: standard-library capability detection — THE one site
+// Freestanding C++ — this header includes nothing a minimal libcpp lacks
+// unless it first establishes that the capability is there.
+
+/**
+ * @file std_detect.hpp
+ * @brief The single definition of the `NROS_CPP_HAS_*` capability macros.
+ *
+ * Every other nros-cpp header includes this one and tests the macros. None of
+ * them defines one. Before phase-438 W1 this block was hand-copied 15 times
+ * across 11 headers, which is the "second spelling rather than one shared
+ * helper" antipattern CLAUDE.md records for the Zephyr unset-variable guard
+ * (#282 → #326), and it cost three separate things:
+ *
+ *   1. `nros.hpp` USED four of these macros and DEFINED none, so its behaviour
+ *      depended on `publisher.hpp` / `options.hpp` / `subscription.hpp` having
+ *      been included first. It was the only header in that state, and the
+ *      failure mode is issue 0135's: two TUs of one image disagreeing about a
+ *      capability, hence about a layout.
+ *   2. The rationale drifted. Eleven of the copies carried a comment saying the
+ *      test is `__has_include` "rather than `__STDC_HOSTED__`, issue 0112" —
+ *      and issue 0112 says no such thing (see below).
+ *   3. Fixing the gate meant fixing 15 sites. It now means fixing one.
+ *
+ * ## What decides a capability: the CONSUMER, not the toolchain
+ *
+ * `NROS_CPP_STD` is a request. A consumer defines it to say "compile me the
+ * surface that lets an upstream rclcpp file build unmodified" — a PORTING
+ * surface, which is a different question from "can this toolchain reach
+ * `<memory>`". Two questions, and they used to share one name.
+ *
+ * Probing the include path for them was tried, and measured to be wrong on the
+ * lane it mattered most (issue 1187): every embedded C++ FreeRTOS image failed
+ * to compile, because
+ *
+ *                          __STDC_HOSTED__  __has_include(<string>)  #include
+ *   arm-none-eabi 13.2                  0            TRUE          hard #error
+ *     `-ffreestanding` (FreeRTOS lane)
+ *   Zephyr `-nostdinc++`,               1            FALSE          absent
+ *     minimal libcpp (issue 0112)
+ *   hosted g++ 12.3                     1            TRUE          works
+ *
+ * Each probe is right on exactly one embedded lane and wrong on the other.
+ * libstdc++ 13 added `bits/requires_hosted.h`, so on the FreeRTOS lane
+ * `<string>` is PRESENT and including it is a hard `#error` — presence stopped
+ * implying usability. Only the request is right on both, because it is not a
+ * probe.
+ *
+ * ## Issue 0112 did not say what eleven comments said it said
+ *
+ * 0112's Resolution reads: "moved the `<string>` include into its own `#ifdef
+ * NROS_CPP_STD` block, so it follows its actual consumer." It chose the opt-in
+ * over `__STDC_HOSTED__`. It never chose `__has_include`, which arrived later
+ * in `acf213871` and re-broadened the gate 0112 had narrowed. 0112's FINDING —
+ * hostedness does not imply header availability — still holds; what changed is
+ * that `__has_include` stopped being a fix for it.
+ *
+ * ## Widening, stated
+ *
+ * A consumer that needs only `<memory>` now also gets the other five when it
+ * asks for the std surface. That is deliberate and it is what makes one site
+ * possible. It is safe because `NROS_CPP_STD` means "this toolchain has the C++
+ * standard library", not "this toolchain has some of it": the one in-tree
+ * consumer that sets it says so in its own CMakeLists ("PX4 SITL is real posix
+ * with full libstdc++, so opt in explicitly"). A toolchain with `<memory>` and
+ * no `<sstream>` is not one that should be declaring `NROS_CPP_STD`.
+ *
+ * It also FIXES a latent version of issue 0135: with detection scattered, a TU
+ * including only `client.hpp` and one including `nros.hpp` disagreed about
+ * `NROS_CPP_HAS_STD_CHRONO`. Now every TU that includes any nros-cpp header
+ * agrees about all six.
+ */
+
+#ifndef NROS_CPP_STD_DETECT_HPP
+#define NROS_CPP_STD_DETECT_HPP
+
+// --- The five uniform capabilities -------------------------------------------
+//
+// Uniform in the literal sense: before W1 these fourteen blocks normalised to
+// one block text, with the header name and the macro name consistent at all
+// three positions in every instance. `<chrono>` below is the one that does not,
+// and it is kept separate rather than normalised into these.
+//
+// The predicate is the one issue 1240 landed at all fourteen sites, moved here
+// unchanged, and its two probes are each necessary:
+//
+//   * `__STDC_HOSTED__` alone is the WRONG question (issue 0112): the Zephyr
+//     XRCE C++ leaves compile `-fno-freestanding -nostdinc++`, so they read
+//     HOSTED while having no `<memory>` at all. Only `__has_include` sees that.
+//   * `__has_include` alone is ALSO wrong (issue 1240): it answers "does the
+//     header FILE exist", which is TRUE under `-ffreestanding` against a FULL
+//     libstdc++ whose `<memory>` / `<string>` / `<vector>` / `<sstream>` open
+//     with `#error "This header is not available in freestanding mode."` GCC 16
+//     made that unmissable — `just check cpp`'s own `-ffreestanding` probe
+//     produced ~200 errors inside `/usr/include/c++/16` and none in our code —
+//     and the same shape had been failing quietly on the FreeRTOS lane's
+//     arm-none-eabi 13.2 for longer (issue 1187: 19 of 45 headers, 17 of them
+//     entered through `log.hpp`'s `<string>`).
+//
+// Do not gate on `NROS_CPP_STD` ALONE while the disjunct is the only thing
+// defining these macros in a shipped build — that removes the surface from the
+// hosted build too, which is the over-tightening `<chrono>` below records twice.
+// (phase-438 W2 removes the disjunct, and pairs the removal with the five sites
+// that then have to make the request.) Gated by
+// `scripts/check-cpp-freestanding-includes.sh`, which since 1240 rejects an
+// `#if` naming `NROS_CPP_STD` whose live arm asks only `__has_include`.
+
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
+#include <memory>
+#define NROS_CPP_HAS_SHARED_PTR 1
+#endif
+
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<string>))
+#include <string>
+#define NROS_CPP_HAS_STD_STRING 1
+#endif
+
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<vector>))
+#include <vector>
+#define NROS_CPP_HAS_STD_VECTOR 1
+#endif
+
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<functional>))
+#include <functional>
+#define NROS_CPP_HAS_STD_FUNCTION 1
+#endif
+
+// `<sstream>` is the `RCLCPP_*_STREAM` family only. It is worth noting that
+// `log.hpp` pulls it, `qos.hpp` includes `log.hpp`, and every entity header
+// includes `qos.hpp` — so a stream-formatting convenience sits on the
+// transitive include path of every freestanding TU. That is a separate leak
+// from how it is gated (phase-438, "which failures are real", cause (c)).
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<sstream>))
+#include <sstream>
+#define NROS_CPP_HAS_STD_SSTREAM 1
+#endif
+
+// --- `<chrono>`: the one condition that is NOT the uniform block --------------
+//
+// Moved here verbatim from `nros.hpp`, comment included, because the comment IS
+// the evidence: three successive corrections, each measured against a recorded
+// compile command. Do not normalise this into the five above — it differs in
+// three ways that are each load-bearing, and the differences are why it needs
+// its own paragraph rather than its own file.
+
+// `<chrono>` requires the EXPLICIT opt-in, not `__has_include`, and that is
+// measured rather than stylistic.
+//
+// `__has_include(<chrono>)` is TRUE on the Zephyr arm-none-eabi toolchain --
+// the file exists -- but under `-ffreestanding` libstdc++ ships it INCOMPLETE:
+// `std::chrono::duration_cast` is absent, so `create_wall_timer` and `Rate`
+// failed to compile on every Zephyr C++ image with
+// `'duration_cast' is not a member of 'std::chrono'`. Replayed from that build
+// dir's own recorded compile command, not inferred.
+//
+// So the idiom has a boundary worth stating: `__has_include` answers "does the
+// header exist", which is the right question for `<memory>` (present or absent
+// as a unit) and the WRONG one for `<chrono>` (present but hollowed out). Where
+// a freestanding toolchain ships a partial header, only the consumer's own
+// `NROS_CPP_STD` opt-in is a reliable signal. Issue 0112's class, one layer past
+// where step A caught it.
+// CORRECTED 2026-09-05. The `NROS_CPP_STD`-only gate above was measured on the
+// Zephyr lane and never on a plain hosted one, and NOTHING THAT SHIPS DEFINES
+// `NROS_CPP_STD`: it appears in no cmake module, no toolchain file, no build.rs
+// and no Kconfig -- only in docs and in `check.just`'s own probe TUs. So the
+// narrow gate did not merely tighten `<chrono>`; it removed `create_wall_timer`
+// and `Rate` from EVERY shipped configuration, including the hosted one, where
+// `examples/templates/cpp-port-minimal-publisher` calls `create_wall_timer` and
+// is phase-417's own acceptance criterion.
+//
+// The right predicate needs BOTH halves, because the two lanes fail
+// differently and neither test alone sees both:
+//
+//   * Zephyr / ThreadX-RV64 build `-nostdinc++` against a minimal libcpp that
+//     has no `<chrono>` at all, so `__has_include` answers FALSE and is exactly
+//     right there.
+//   * FreeRTOS armcm3 builds `-ffreestanding` WITHOUT `-nostdinc++`, so
+//     `__has_include(<chrono>)` answers TRUE against the host's own libstdc++
+//     -- which then refuses to be used, because GCC 13 gates
+//     `bits/requires_hosted.h` on `__STDC_HOSTED__` and `-ffreestanding` clears
+//     it. That is the "present but hollow" case, and `__STDC_HOSTED__` is
+//     precisely the flag that distinguishes it.
+//
+// `__STDC_HOSTED__` alone is still not enough -- CLAUDE.md's pitfall entry says
+// so, and it is right: a hosted compiler can run `-nostdinc++` against Zephyr's
+// minimal libcpp, where the macro is 1 and the header is absent. Neither test
+// covers both lanes; the conjunction does.
+//
+// `NROS_CPP_STD` stays as an explicit override for a consumer who knows better
+// than the probes, which is what the parity extractor and the docs use it for.
+// CORRECTED AGAIN 2026-09-07, and this time the discriminator is the library's
+// own feature-test macro rather than a guess about which RTOS ships what.
+//
+// The conjunction above is still not enough. Measured under the safety island's
+// OWN recorded compile command (`-nostdinc++`, arm-zephyr-eabi, picolibc), not
+// inferred:
+//
+//     __STDC_HOSTED__          1
+//     __has_include(<chrono>)  TRUE
+//     __cpp_lib_chrono         ABSENT
+//
+// So Zephyr does NOT merely "have no <chrono> at all" -- this toolchain ships
+// one that is present and hollow, which is the case the note above attributes
+// to FreeRTOS alone. Both halves of the conjunction answer yes and
+// `duration_cast` is still missing, so `Rate`'s duration constructor failed to
+// compile on the island exactly as it did before that note was written.
+//
+// `<ratio>` is the third test, and it is a PREREQUISITE rather than a proxy.
+// `duration_cast<To>(duration<Rep, Period>)` is defined in terms of
+// `std::ratio_divide` -- a duration's `Period` IS a `std::ratio` -- so a
+// `<chrono>` shipped without `<ratio>` cannot provide `duration_cast`, and that
+// is exactly the shape this toolchain ships. Measured on both sides:
+//
+//                        island (Zephyr)   hosted g++ -std=c++14
+//   __has_include(<chrono>)   TRUE              TRUE
+//   __has_include(<ratio>)    FALSE             TRUE
+//
+// `__cpp_lib_chrono` was tried first and is WRONG here: it is a C++17
+// feature-test macro, so it is absent under `-std=c++14` even where the library
+// is complete. `check-cpp` compiles the phase-417 probes at C++14 and caught
+// that immediately -- gating on it removed `create_wall_timer` from the hosted
+// build, which is the same over-tightening the note above records.
+// `_GLIBCXX_CHRONO` also separates the two but is libstdc++'s private spelling;
+// `__has_include` is the portable question.
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<chrono>) && __has_include(<ratio>))
+#include <chrono>
+#define NROS_CPP_HAS_STD_CHRONO 1
+#endif
+
+#endif // NROS_CPP_STD_DETECT_HPP

--- a/packages/api/nros-cpp/include/nros/subscription.hpp
+++ b/packages/api/nros-cpp/include/nros/subscription.hpp
@@ -21,14 +21,11 @@
 #include "nros/serialization_format.hpp"
 #include "nros/stream.hpp"
 
-// phase-417 W1.a — `<memory>` for the nested pointer aliases. Rationale (and
-// why the test needs BOTH `__has_include` and `__STDC_HOSTED__` — issues
-// 0112 and 1240)
-// lives in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
-#include <memory>
-#define NROS_CPP_HAS_SHARED_PTR 1
-#endif
+// phase-417 W1.a — `<memory>` for the nested pointer aliases below.
+// `NROS_CPP_HAS_SHARED_PTR` and the other capability macros have ONE definition
+// site, and the measured reason they are a REQUEST rather than a probe is
+// stated there (phase-438 W1).
+#include "nros/std_detect.hpp"
 
 #include "nros_cpp_ffi.h"
 
@@ -859,12 +856,8 @@ Result Node::create_subscription_with_safety(Subscription<M>& out, const char* t
 // aliases live on `nros::Subscription<M>` itself (phase-417 W1.a), so the
 // alias template carries them through with no wrapper type in between.
 
-// `<functional>` for the type-erased callback cell below. Gated — issue 0112,
-// rationale in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<functional>))
-#include <functional>
-#define NROS_CPP_HAS_STD_FUNCTION 1
-#endif
+// The type-erased callback cell below needs `<functional>`, which arrives with
+// `NROS_CPP_HAS_STD_FUNCTION` from the detection site included at the top.
 
 namespace rclcpp {
 

--- a/packages/api/nros-cpp/include/nros/timer.hpp
+++ b/packages/api/nros-cpp/include/nros/timer.hpp
@@ -20,14 +20,11 @@
 #include <memory>
 #endif
 
-// phase-417 W1.a — `<memory>` for the nested pointer aliases. Rationale (and
-// why the test needs BOTH `__has_include` and `__STDC_HOSTED__` — issues
-// 0112 and 1240)
-// lives in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<memory>))
-#include <memory>
-#define NROS_CPP_HAS_SHARED_PTR 1
-#endif
+// phase-417 W1.a — `<memory>` for the nested pointer aliases below.
+// `NROS_CPP_HAS_SHARED_PTR` and the other capability macros have ONE definition
+// site, and the measured reason they are a REQUEST rather than a probe is
+// stated there (phase-438 W1).
+#include "nros/std_detect.hpp"
 
 #include "nros_cpp_ffi.h"
 
@@ -243,12 +240,8 @@ class Timer {
 // RFC-0019/RFC-0020 violation class 2. Do not reintroduce a second dispatch
 // loop.
 
-// `<functional>` for the type-erased callback cell. Gated for the same reason
-// `<memory>` is above — issue 0112, rationale in `publisher.hpp`.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<functional>))
-#include <functional>
-#define NROS_CPP_HAS_STD_FUNCTION 1
-#endif
+// The type-erased callback cell needs `<functional>`, which arrives with
+// `NROS_CPP_HAS_STD_FUNCTION` from the detection site included at the top.
 
 namespace rclcpp {
 

--- a/packages/api/nros-cpp/tests/compile/one_node_type.cpp
+++ b/packages/api/nros-cpp/tests/compile/one_node_type.cpp
@@ -8,6 +8,15 @@
 // (`ported_create_publisher_freestanding_probe.cpp`) proves that a ported
 // `create_publisher<M>("chatter", 10)` FAILS THERE rather than differing.
 //
+// The lane compiles this one with `-DNROS_CPP_STD=1`, and it has to since
+// phase-438 W2: the hosted shape is a REQUEST now, not a property of the
+// toolchain. Everything below `NROS_CPP_NODE_HOSTED` — the `shared_ptr` and
+// `std::string` families AND the whole parameter facade, `const char*`-keyed
+// forms included — is absent without it. A `rclcpp::Node` still EXISTS with no
+// flag, which is phase-427's point and what
+// `rclcpp_node_freestanding_surface.cpp` instantiates; it is a smaller surface,
+// which is phase-438's.
+//
 // WHAT THIS PROVES
 //   1. `rclcpp::Node` and `nros::Node` are the SAME TYPE, not two types with a
 //      converting constructor between them. This is the whole item: before the

--- a/scripts/api-parity.py
+++ b/scripts/api-parity.py
@@ -270,13 +270,25 @@ CPP_TRANSLATION_UNITS = (
     # it was never macro-gated — extracting with and without the flag yielded
     # identical records. What made it std-only was unconditional `<memory>`,
     # `<string>`, `<functional>`, `<vector>`, `<chrono>` and `std::shared_ptr`
-    # in public signatures. After the move those includes are `__has_include`-
-    # gated, so the `rclcpp::` names that need them are genuinely absent from a
-    # freestanding build — which makes the marking TRUE now in the way the issue
-    # only claimed it was.
+    # in public signatures. After the move those includes were `__has_include`-
+    # gated, so the `rclcpp::` names that need them were absent from a
+    # freestanding build — which made the marking TRUE in the way the issue only
+    # claimed it was. phase-438 W2 then removed the discovery arm, so they are
+    # gated on `NROS_CPP_STD` alone and the marking is true on EVERY target, not
+    # only the ones whose include path happened to lack the headers.
     #
     # Extracted WITH the flag, because that is the flavour the compat CMake path
-    # builds under, and a surface should be measured as it ships.
+    # builds under, and a surface should be measured as it ships. That sentence
+    # was false when it was written — `cmake/compat/NrosRclcppCompat.cmake` set
+    # no compile definition at all — and phase-438 W2 made it true by having the
+    # shim's own `_nros_compat_apply_force_includes` set `NROS_CPP_STD`.
+    #
+    # The `base` and `component` TUs above deliberately do NOT get the flag, and
+    # after W2 that is a stronger statement than it used to be: they measure the
+    # NATIVE surface as a consumer who never asked for the porting flavour sees
+    # it. Verified after W2 — `just check api-parity` green with no ledger
+    # movement, so the native records were never coming from the discovered
+    # macros.
     ("compat", '#include "nros/nros.hpp"\n', ("-DNROS_CPP_STD=1",),
      {"rclcpp", "rclcpp_action", "rclcpp_lifecycle"},
      {"std_only": True, "surface": PORTED}),

--- a/scripts/build/compile-check-fixtures.sh
+++ b/scripts/build/compile-check-fixtures.sh
@@ -670,8 +670,27 @@ cxx_syntax_check() {
     # a third path (nros-platform-api, the cmake compat shim, or a generated
     # config header under `target/`) was invisible. `-MD` composes with
     # `-fsyntax-only` — no object is produced, the dep list still is.
+    # phase-438 W2 — the std surface is REQUESTED now, never discovered from the
+    # include path, so a snippet that ports rclcpp code has to ask.
+    #
+    # A RULE, not a list, because a list drifts: `platform_hdr_*` snippets exist
+    # to prove `<nros/platform.h>` type-checks on a FREESTANDING target, and
+    # handing them the std surface would weaken exactly what they measure. Every
+    # other snippet here reaches `<rclcpp/rclcpp.hpp>` through
+    # `cmake/compat/include` — the ported flavour — and gets the flag, matching
+    # what `cmake/compat/NrosRclcppCompat.cmake` now sets for a real consumer.
+    #
+    # Measured need: `rclcpp_node_options` (rclcpp::NodeOptions) and
+    # `spin_until_future_complete` (rclcpp::Node) fail without it;
+    # `subscription_with_info` does not. All three are on the same side of the
+    # rule, which is the point of having one.
+    local std_opt=()
+    case "$id" in
+        platform_hdr_*) ;;
+        *) std_opt=(-DNROS_CPP_STD=1) ;;
+    esac
     rm -f "$staged/deps.d"
-    if "$cxx" -std=c++14 -fsyntax-only -MD -MF "$staged/deps.d" "${inc[@]}" "$src"; then
+    if "$cxx" -std=c++14 -fsyntax-only "${std_opt[@]+"${std_opt[@]}"}" -MD -MF "$staged/deps.d" "${inc[@]}" "$src"; then
         date -u +%Y-%m-%dT%H:%M:%SZ > "$staged/.compile-ok"
         echo "   stamped $staged/.compile-ok"
     else

--- a/scripts/check-cpp-capability-layout.py
+++ b/scripts/check-cpp-capability-layout.py
@@ -160,7 +160,23 @@ CAPS = (
 # Hosted is c++17 because the umbrella's `if constexpr` needs it; the
 # freestanding flags are copied verbatim from the `cpp` lane's `-nostdinc++`
 # header-parse arm so the two agree by construction.
-HOSTED_FLAGS = ["-std=c++17"]
+#
+# `-DNROS_CPP_STD` is on the hosted arm since phase-438 W2, and it is not a new
+# configuration — it is the SAME one, asked for out loud. Before W2 a hosted
+# compiler got the std surface because `__has_include` found the headers, so
+# this arm measured the std-flavoured types without naming them. W2 deleted
+# discovery; without the flag the probe TU no longer compiles and the gate
+# reports "could not measure sizeof(rclcpp::Node)" instead of a size.
+#
+# Note what this arm is and is not. Forcing an individual `NROS_CPP_HAS_*` ON
+# here is close to a no-op, because the baseline already has them all — that is
+# issue 1204's finding, and the answer to it is the FREESTANDING arm below,
+# which is where the macros are genuinely off. A THIRD arm is now measurable
+# and was not before W2: hosted WITHOUT the opt-in, i.e. the shape a hosted
+# consumer gets by default from here on. It belongs with phase-438 W4, whose
+# acceptance is that `sizeof(rclcpp::Node)` does not move between it and this
+# one.
+HOSTED_FLAGS = ["-std=c++17", "-DNROS_CPP_STD=1"]
 THREADX_SHIM = "packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat"
 FREESTANDING_FLAGS = [
     "-std=c++14",


### PR DESCRIPTION
Stacked on #763 (which is stacked on #746). **Retarget as those land.**

Two commits. W1 is behaviour-neutral and makes W2 small; W2 closes **issue 1187**.

## Acceptance — issue 1187's own, as it wrote it

```
$ NROS_CMAKE_EXTRA_DEFS=-DCMAKE_TOOLCHAIN_FILE=$PWD/cmake/toolchain/arm-freertos-armcm3.cmake \
  bash scripts/build/fixtures-build.sh freertos cpp zenoh
EXIT=0
requires_hosted hits: 0
```

Six ARM ELF binaries where none built before: `cpp_talker`, `cpp_listener`, `cpp_service_server`, `cpp_service_client`, `cpp_action_server`, `cpp_action_client`.

Per-header standalone parse on that toolchain (`arm-none-eabi 13.2`, `-std=c++14 -ffreestanding -fno-exceptions -fno-rtti`):

| | pass | fail |
|---|---|---|
| before | 26 | 20 |
| after | **47** | **0** |

## W1 — one detection site

Fourteen hand-copied instances of one preprocessor block, across ten headers, become `nros/std_detect.hpp`. Plus `<chrono>`'s block, which is **not** the same block and is moved rather than merged.

It cost three things, and only one was the obvious one:

1. **`nros.hpp` USED four capability macros and DEFINED none.** It depended on `publisher.hpp` / `options.hpp` / `subscription.hpp` being included first — the only header in the tree in that state, and a latent issue 0135 (two TUs of one image disagreeing about a capability, hence a layout). Consolidation fixes it as a side effect.
2. **The rationale drifted.** Eleven copies said the test is `__has_include` "rather than `__STDC_HOSTED__`, issue 0112" — and 0112 says no such thing. Rewritten, not moved.
3. **W2 was a fourteen-site sweep.** It is five lines in one file. The baseline is the count: 14 → 5 → 0, with no debt paid to get from 14 to 5.

**Behaviour-neutral, measured.** Hosted `pass=46 fail=0` → `47/0`; arm `26/20` → `26/21`. Both deltas are the new file appearing in the loop as its own header; the pre-existing failing set is byte-identical.

**`<chrono>` is not normalised.** No `#elif` arm, an `__STDC_HOSTED__` conjunct, and `<ratio>` as a *prerequisite* rather than a proxy — `duration_cast` is defined via `std::ratio_divide` and the safety island ships `<chrono>` with `<ratio>` absent. Its 79-line comment moves verbatim: the comment is the evidence, not decoration.

## W2 — delete discovery

| | `__STDC_HOSTED__` | `__has_include(<string>)` | `#include` |
|---|---|---|---|
| arm-none-eabi 13.2 `-ffreestanding` | 0 | **TRUE** | hard `#error` |
| Zephyr `-nostdinc++` minimal libcpp | 1 | FALSE | absent |
| hosted g++ 12.3 | 1 | TRUE | works |

libstdc++ 13 added `bits/requires_hosted.h`, so presence stopped implying usability. Each probe is right on exactly one embedded lane — **including issue 1187's own second fix option**, ANDing the two, which fails on whichever lane it is not measured on. Only the request is right on both.

### Where the flag went — five sites

- **`cmake/compat/NrosRclcppCompat.cmake`** — the shim's own apply function, which until now set **no compile definition at all**. This is the one that reaches real ported code: five `compile_check_fixture` rows plus the `diagnostic_updater` shim. Per-target, so it does not leak to Zephyr images using `nros::Node` directly.
- **The phase-417 ported-surface probes** — they exist to prove a ported rclcpp file compiles, which *is* the surface the flag names.
- **The four REFUSAL probes**, and the lane's own guard is why: without the flag `ros2_refuse_node_options_probe.cpp` still failed, but on `'NodeOptions' is not a member of 'rclcpp'` rather than on the refusal — the exact "broke for another reason, so this check proves nothing" case the grep exists to catch. It caught it.
- **`compile-check-fixtures.sh`'s snippets arm**, as a **rule not a list**: `platform_hdr_*` prove `<nros/platform.h>` type-checks *freestanding* and must not get the flag; everything else reaches `<rclcpp/rclcpp.hpp>` and does.
- **`check-cpp-capability-layout.sh`'s `HOSTED_FLAGS`** — not a new configuration, the same one asked for out loud.

### One predicted cost did not materialise

phase-438 listed `api-parity.py`'s `base` and `component` TUs as needing the flag. **They do not** — green with no ledger movement, so the native records were never coming from the discovered macros. Their flaglessness is now a stronger statement: they measure the native surface as a consumer who never asked for the porting flavour sees it.

## Unblocks

Issue 1146 can now measure the FreeRTOS app-task stack on the C++ path, so `freertos_app_config.c.in`'s 512 KiB — one number serving C and C++, measured only on the C half — can come down to the measured figure.

## Tier

`just check fast` (282 gates), `just check cpp`, `just check api-parity` — all green, plus the cross build above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj