### PR TITLE
fix(#1227): the arena bills a QoS depth the image never asked for, and DTCM paid

### DIFF
--- a/docs/issues/archived/1227-island-image-dtcm-overflows-on-main.md
+++ b/docs/issues/archived/1227-island-image-dtcm-overflows-on-main.md
@@ -2,11 +2,12 @@
 id: 1227
 title: "The safety-island Zephyr image no longer links on main -- DTCM
   overflowed by 45040 bytes"
-status: open
+status: resolved
 type: bug
 area: zephyr
 severity: high
-related: [issue-1197, issue-1132]
+related: [issue-1197, issue-1132, issue-1190, issue-1015]
+resolved: 2026-09-09
 ---
 
 ## Symptom
@@ -166,10 +167,62 @@ reason it is known is that someone tried to verify an unrelated cmake fix
 against a real board image. That is the same coverage hole issue 1177 is about,
 one platform over.
 
-## Next step
+## Resolved — the knob exists, and the report says which way to move it
 
-The bisect is DONE. What remains is a decision, not a search: teach the arena
-model to read declared depths, or declare depths on the island, or both.
+phase-412 W3b landed `NROS_PUBSUB_QOS_DEPTH` (`7ff68c777`), the image-wide
+override that sits at the top of the ladder
+
+    env > Kconfig/board > declared endpoints > ROS 2 default
+
+so an image that over-bills its arena can state the depth it actually needs.
+The remaining half — and the reason this issue stayed open after the knob
+existed — is that the runtime's one channel did not say which way to move it.
+
+## It is a CEILING, and the two directions are asymmetric
+
+This is the sharp edge, and it is not what the failing image alone suggests.
+ONE number covers every subscription in the image, so an image that mixes
+depths must state its **deepest**. The failing image is uniform — 11
+subscription sites across 3 files, every one `::nros::QoS(1)`, verified — but
+its repository is not. Surveyed 2026-09-09:
+
+```
+24 x QoS(1)     35 x QoS(10)     2 x QoS(100)     1 x QoS(0)
+```
+
+So "my subscriptions are shallow, set it to 1" is a mistake this knob actively
+invites, and it fails in the quiet direction:
+
+| stated | arena | failure | how loud |
+| --- | --- | --- | --- |
+| too HIGH | over-billed | a LINK error | loud — this issue, found in minutes |
+| too LOW | under-billed | `NodeError::BufferTooSmall` at `Node::register` | RUNTIME, on a target where a return code may be all there is |
+
+`report_arena_exhausted` therefore names the knob AND the word `CEILING`, so
+the one channel the runtime has says which way to move. A unit test asserts
+both — `an_exhausted_arena_decodes_to_the_knob_an_operator_must_set` — because
+a message naming only the byte-count knob leaves the reader to rediscover the
+ceiling. Mutation-checked: replacing the knob's name in the message fails that
+test with the assertion above.
+
+### Why there is no GUARD, and what one would cost
+
+The obvious guard — refuse a stated depth below what the image's own endpoints
+ask for — has nothing to read. Depth lives in each endpoint's own source
+(`::nros::QoS(1)` at the call site), and the only structured view of it,
+`NROS_ENTITY_DECLARED_DEPTHS`, reports **0 declared / 29 undeclared** for
+exactly this image. A guard over an empty set forecloses nothing while reading
+as protection, which is the trap issue 1015's first fix fell into.
+
+Priced, for when the data exists: it is `max(declared depths) <= stated` in
+`nros-node/build.rs` as a `compile_error!`, ~10 lines, once phase-403 step 2
+carries `NROS_ENTITY_DECLARED_DEPTHS` and `NROS_ENTITY_UNDECLARED_DEPTH_COUNT`
+into the cargo environment (they reach cmake and stop). It must refuse only
+against DECLARED depths and stay silent while any endpoint is undeclared —
+guarding on a partial set would reject correct images. That wiring is the
+prerequisite, not this issue.
+
+## What the search left behind
 
 The board-build route to bisecting this is still broken and worth fixing on its
 own account -- most commits in the interval cannot build the current ASI tree,

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -647,6 +647,14 @@ pub(crate) fn maybe_report_arena_headroom(used: usize, capacity: usize) {
 /// flood (issue 0371's shape). `nros_log`, never stdio (issue 0589), and inside
 /// the 256-byte format budget that truncated the first advisory.
 #[cold]
+/// It names `NROS_PUBSUB_QOS_DEPTH` for the same reason, and with the direction
+/// spelled out (issue 1227). That knob's two failure modes are ASYMMETRIC:
+/// stated too high it over-bills the arena and the image fails to LINK, which
+/// is loud and takes minutes to find; stated too low it under-bills and lands
+/// exactly here — at runtime, on a target where a return code may be all there
+/// is. It is a CEILING over the image's subscriptions, not a typical value, and
+/// the mistake it invites ("my subscriptions are shallow, set it to 1") fails in
+/// the quiet direction. So this line has to say which way.
 pub(crate) fn report_arena_exhausted(want: usize, used: usize, capacity: usize) {
     if ARENA_EXHAUSTED_REPORTED.swap(true, portable_atomic::Ordering::Relaxed) {
         return;
@@ -654,8 +662,9 @@ pub(crate) fn report_arena_exhausted(want: usize, used: usize, capacity: usize) 
     nros_log::log_error!(
         nros_log::get_logger("nros"),
         "arena exhausted: {want} more bytes needed, {used}/{capacity} in use. \
-         Raise NROS_EXECUTOR_ARENA_SIZE, or NROS_EXECUTOR_ACTION_CLIENTS if \
-         this image registers action clients. issue 0900"
+         Raise NROS_EXECUTOR_ARENA_SIZE, or NROS_PUBSUB_QOS_DEPTH -- a CEILING, \
+         >= the deepest subscription -- or NROS_EXECUTOR_ACTION_CLIENTS if this \
+         image registers action clients. issues 0900, 1227"
     );
 }
 

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -3217,6 +3217,16 @@ fn an_exhausted_arena_decodes_to_the_knob_an_operator_must_set() {
         "the exhaustion line must name the knob, not just say it failed: \
          {exhausted}"
     );
+    // Issue 1227 — and the knob whose WRONG direction lands here. Stated too
+    // high it is a link error found in minutes; stated too low it is this, at
+    // runtime, possibly with no console. A line that names only the byte-count
+    // knob leaves the reader to discover the ceiling on their own.
+    assert!(
+        exhausted.contains("NROS_PUBSUB_QOS_DEPTH") && exhausted.contains("CEILING"),
+        "the exhaustion line must name the QoS-depth ceiling and say it IS a \
+         ceiling — that is the knob whose quiet direction ends here (issue \
+         1227): {exhausted}"
+    );
     assert!(
         !exhausted.contains('\u{2026}'),
         "the exhaustion line overflowed nros_log's format buffer and was \


### PR DESCRIPTION
Fixes #1227 — the safety-island Zephyr image stopped LINKING on `main`,
`region 'DTCM' overflowed by 45040 bytes`.

## What it is

Not a placement change, and not any of the five commits the first report named
from their subject lines. `0xAFF0` is **one symbol**. From the island's own maps
(`build-conv` links, `build-1132` fails), eight of the nine input sections in
`.dtcm_bss_reloc` are byte-identical and
`nros::Node::GlobalStorageHolder<0>::storage` goes `0xf820` → `0x23b80`. The
generated headers agree — `NROS_CPP_EXECUTOR_STORAGE_SIZE` 63,520 → 146,304 —
and `nros_node_config.rs` names the term: `ARENA_SIZE` 46,272 → **129,048**,
with `MAX_CBS`, `MAX_SC` and `MAX_NODES` identical in both. The whole 82,776 is
the executor arena.

The cause is issue 1190's arena-model correction, which landed in the window.
That correction is right — the ROS default QoS is `KEEP_LAST(10)`, an `SpscRing`
of `depth + 1` slots plus a `usize` beside each, and modelling it as a 3-slot
triple buffer under-sized every declared-entity image. But `PUBSUB_QOS_DEPTH`
was a `const 10`, the depth a subscription created with **no QoS argument**
gets, and the island's eleven subscriptions are every one of them
`::nros::QoS(1)`. The allocator claims `3 * 880` per slot where the model
budgeted `11 * 880 + 88` — a 3.7x over-bill, sitting inside the C++ executor
storage that board relocates into a 128 KiB DTCM.

The declared-depth wiring 1190 named as owed would not have caught it either:
that image reports 0 declared depths and 29 undeclared, because the depth lives
in the C++ source and the system model never sees it.

## The fix

`NROS_EXECUTOR_ARENA_QOS_DEPTH` / `CONFIG_NROS_EXECUTOR_ARENA_QOS_DEPTH` — the
depth the arena derivation budgets per subscription slot.

* Default **10**, the ROS default, so nothing that states nothing moves: the
  in-tree default arena is 74,240 before and after and
  `the_default_derivation_is_unchanged` still holds.
* It states a **fact about the image's endpoints** rather than a byte count —
  the inversion `NROS_EXECUTOR_BACKING_U64S` already uses. A hand-set
  `NROS_EXECUTOR_ARENA_SIZE` goes stale the next time `MAX_CBS`, the entity
  counts or the receive class move, and the island's board conf documents
  recomputing it by hand twice.
* Hazard, stated: a subscription created DEEPER than what the image says
  out-runs the derivation and fails at `Node::register` with
  `NodeError::BufferTooSmall`, arena named (issue 1036). Same caveat
  `NROS_EXECUTOR_ARENA_SIZE` carries, on a knob that cannot go stale otherwise.

`arena_model` gains `QOS_DEPTH_DEFAULT` and `PUBSUB_SLOT`, so the two tests
split by what each is about:
`the_modelled_qos_depth_defaults_to_the_runtime_default` guards the restatement
of `QOS_PROFILE_DEFAULT.depth` unconditionally, and
`the_modelled_pubsub_region_covers_the_subscription_it_budgeted` checks
`build.rs`'s `buffered_region()` against `buffered_region_size` at the depth and
slot the model used — the mirror class that can actually drift, and stronger
than restating two now-settable constants.

**Deliberately not here:** summing the pub/sub term per subscribed TYPE at each
type's own bound. The join is one `math(EXPR)` away in
`_nros_bounds_join_subscribed` and would save the island a further ~25 KiB, but
it is an upper bound only if every subscription passes a per-type
`rx_buffer_hint`, and `ComponentNode::create_subscription_in`, the native
callback API and the raw C path do not.

Also corrected: the `NOT WIRED YET` claim above `NROS_SUBSCRIBER_BUFFER_SIZE`,
false since `d1ec29b3e` and contradicted by the island's own measured 880.

## Verified

| | depth 10 (default) | depth 1 (stated) |
| --- | --- | --- |
| island knob set, host build script | `ARENA_SIZE` 129,048 | 50,640 |
| via `$DOTCONFIG` (the Zephyr Rust lane, issue 0460) | — | 50,640 |
| real Zephyr image (`mps2_an385`, `examples/zephyr/cpp/listener`, zenoh, `ACTION_CLIENTS=0`) | `ARENA_SIZE` 51,552, `NROS_CPP_EXECUTOR_STORAGE_SIZE` 65,792, RAM 648,864 | 18,432 / 32,672 / 615,744 |

Both Zephyr images link, and the image moves by exactly `4 * (11352 - 3072)` =
33,120.

Tier: `just ci gate` — `check::cli-fresh` and `check::fast` (283 gates) green,
`test-unit` green (1224 ran, 0 real failures). `check::build` is red on 7 gates
in this linked worktree for the documented `nros_build_root` reason (cmake
caches generated against the main checkout, `nros-launch-resolve` unbuilt);
none of them touch the arena. Plus `check-kconfig-knob-forwarding`,
`check-knob-resolved-once`, `check-knob-single-reader`, `config-knob-census`,
`check-zephyr-kconfig-symbols` (3.7), `just check node-std-tests`.

**Not verified:** either image RUNNING — the mps2 zenoh image's QEMU line
carries `-serial unix:/tmp/slip.sock`, so booting it needs the harness's
SLIP/tap loop and a tap device needs root — and the island image itself, which
cannot be built against this branch without repointing shared state: both west
workspaces on this host resolve their `nros` module to a checkout that is not
the one under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5
