### PR TITLE
fix(#1238): the xrce host lane could only pass against a cache primed by hand

### DIFF
--- a/docs/issues/archived/1238-xrce-lane-never-primes-its-out-dir.md
+++ b/docs/issues/archived/1238-xrce-lane-never-primes-its-out-dir.md
@@ -1,0 +1,73 @@
+---
+id: 1238
+title: "`just check rmw-xrce` could only pass against a cache somebody primed by hand — fresh tree says `NROS_XRCE_CFFI_OUT_DIR is not set`, stale tree names a directory cargo replaced"
+status: resolved
+type: bug
+area: build, rmw
+severity: medium
+found: 2026-09-09
+resolved: 2026-09-09
+related: [0787, 0952, 1018]
+---
+
+# The lane that says it "does both halves" does neither
+
+phase-420 W9 step 4 stopped `packages/rmw/xrce/nros-rmw-xrce` from compiling
+the vendored micro-XRCE-DDS-Client / micro-CDR sources a second time: it now
+LINKS the archive the cargo lane builds, so the CTest harness exercises the
+objects images actually ship. That is the right shape. Its configure therefore
+needs `NROS_XRCE_CFFI_OUT_DIR`, and the CMakeLists says so twice — once as a
+`FATAL_ERROR` when the variable is unset, and once when the directory it names
+holds no `nros-xrce-vendor-build.txt`. The second message ends:
+
+> Run `cargo build -p nros-rmw-xrce-cffi` — or just `just check rmw-xrce`,
+> which does both halves.
+
+**`just check rmw-xrce` did not do either half.** The recipe was:
+
+    BD="$(nros_build_dir "$NROS_KIND_XRCE_CHECK")"
+    cmake -S packages/rmw/xrce/nros-rmw-xrce -B "$BD" -DCMAKE_BUILD_TYPE=Release
+
+No cargo build, no `-DNROS_XRCE_CFFI_OUT_DIR`. So the lane had exactly two
+outcomes and both are red:
+
+* **fresh build dir** — `CMakeLists.txt:90`, "NROS_XRCE_CFFI_OUT_DIR is not
+  set", every time. Measured against `/tmp` with the submodule present.
+* **existing build dir** — the value comes from `CMakeCache.txt`, written by
+  whatever hand-run last primed it. The OUT_DIR is FINGERPRINT-named, so it
+  moves whenever anything in the crate's dependency closure changes; the cached
+  path then names a directory cargo has replaced and the configure dies at
+  `CMakeLists.txt:106` instead.
+
+The second is what was actually observed: a `nros-node/build.rs` edit
+(unrelated, issue 1233) re-fingerprinted the closure, six
+`nros-rmw-xrce-cffi-*` hash directories existed, and the cache pointed at a
+seventh that no longer did. Rebuilding the crate by hand did not help — that
+writes a NEW hash directory and leaves the cache pointing at the old one.
+
+## Why it stayed invisible
+
+The lane lives in `check-build`, which is `schedule` / `workflow_dispatch`
+only, so no merge-gating event runs it (this is deliberate — it needs generated
+bindings and prebuilt stamps no CI job builds). A uniformly-red lane has no
+signal capacity: a regression landing in it looks exactly like yesterday's
+failure. Issue 0952's rule, one lane over.
+
+Issue 0787 added this lane precisely because the xrce C ABI seam had no
+compiler looking at it on the host. It has had none since W9 changed how the
+project links.
+
+## Fixed
+
+`scripts/build/xrce-cffi-out-dir.py` builds the crate and prints the OUT_DIR
+its build script ran in, read out of `--message-format=json`'s
+`build-script-executed` record (emitted for a FRESH unit too — cargo replays
+it, so the lookup does not depend on a rebuild). The lane calls it and passes
+the result as `-DNROS_XRCE_CFFI_OUT_DIR`, on EVERY run, so a cache can never
+outlive the path it holds.
+
+One spelling, because there were two and neither ran: the by-hand pipeline the
+CMakeLists prints in its error, and a lane that passed nothing at all.
+
+Acceptance: `just check rmw-xrce` from a tree whose xrce build dir is stale —
+now `2/2 tests passed`, where before it was `Configuring incomplete`.

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -1595,7 +1595,16 @@ rmw-xrce:
         exit 0
     fi
     BD="$(nros_build_dir "$NROS_KIND_XRCE_CHECK")"
-    cmake -S packages/rmw/xrce/nros-rmw-xrce -B "$BD" -DCMAKE_BUILD_TYPE=Release
+    # Issue 1238 — the project links the archive the CARGO lane builds instead
+    # of compiling the vendored sources twice, so the configure needs an OUT_DIR
+    # only cargo can name, and it is fingerprint-named: it MOVES whenever the
+    # crate's dependency closure changes. This lane passed no `-D` at all, so it
+    # could only ever pass against a cache primed by hand, and a stale cache
+    # names a directory cargo has replaced. Re-resolved on every run, and passed
+    # explicitly so the cache cannot outlive the path.
+    OUT="$(python3 scripts/build/xrce-cffi-out-dir.py)"
+    cmake -S packages/rmw/xrce/nros-rmw-xrce -B "$BD" -DCMAKE_BUILD_TYPE=Release \
+        -DNROS_XRCE_CFFI_OUT_DIR="$OUT"
     cmake --build "$BD" --parallel
     ctest --test-dir "$BD" --output-on-failure
 

--- a/scripts/build/xrce-cffi-out-dir.py
+++ b/scripts/build/xrce-cffi-out-dir.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Build `nros-rmw-xrce-cffi` and print the OUT_DIR its build script ran in.
+
+Issue 1238 — `packages/rmw/xrce/nros-rmw-xrce/CMakeLists.txt` links the
+vendored archive that cargo lane builds instead of compiling the sources a
+second time (phase-420 W9 step 4), so a configure needs a path that only cargo
+knows: the OUT_DIR is fingerprint-named, and the fingerprint moves whenever
+anything in the crate's dependency closure changes.
+
+ONE spelling of that lookup, because there were two and neither ran: the
+CMakeLists prints a by-hand pipeline in its FATAL_ERROR and `just check
+rmw-xrce` passed no `-D` at all, so the lane could only pass against a CMake
+cache some earlier hand-run had primed -- and a stale cache names a directory
+cargo has since replaced, which is the same error one line down.
+
+Prints the directory on stdout. Everything else goes to stderr so the caller
+can use `$(...)` directly.
+"""
+
+import json
+import subprocess
+import sys
+
+PACKAGE = "nros-rmw-xrce-cffi"
+
+
+def main() -> int:
+    cmd = [
+        "cargo",
+        "build",
+        "-p",
+        PACKAGE,
+        "--message-format=json-render-diagnostics",
+    ] + sys.argv[1:]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    sys.stderr.write(proc.stderr)
+    if proc.returncode != 0:
+        return proc.returncode
+
+    # `build-script-executed` is emitted for a FRESH unit too -- cargo replays
+    # the recorded output rather than re-running the script -- so this does not
+    # depend on the crate having been rebuilt by this invocation.
+    out_dir = None
+    for line in proc.stdout.splitlines():
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("reason") != "build-script-executed":
+            continue
+        if PACKAGE + "#" not in msg.get("package_id", ""):
+            continue
+        out_dir = msg.get("out_dir")
+    if not out_dir:
+        sys.stderr.write(
+            "xrce-cffi-out-dir: cargo built %s and emitted no `build-script-executed`\n"
+            "  message for it. Nothing can be linked without the OUT_DIR, so this is a\n"
+            "  hard failure rather than a guessed path (issue 1238).\n" % PACKAGE
+        )
+        return 1
+    print(out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`just check rmw-xrce` never built `nros-rmw-xrce-cffi` and never passed
`-DNROS_XRCE_CFFI_OUT_DIR`, though the CMakeLists' own error text says it
"does both halves". Since phase-420 W9 step 4 the project LINKS the archive
the cargo lane builds, so that variable is mandatory.

Both outcomes were red:

* fresh build dir — `CMakeLists.txt:90`, "NROS_XRCE_CFFI_OUT_DIR is not set";
* existing build dir — the cached value from some earlier hand-run, and the
  OUT_DIR is fingerprint-named, so it moves whenever the crate's dependency
  closure changes and the configure dies one line down on a directory cargo
  has replaced. Rebuilding by hand does not fix it: that writes a new hash
  dir and leaves the cache on the old one.

Invisible because the lane runs only in `check-build`
(`schedule`/`workflow_dispatch`), and a uniformly-red lane has no signal
capacity (issue 0952). Issue 0787 added this lane so the xrce C ABI seam had
a host compiler on it — it has had none since W9.

`scripts/build/xrce-cffi-out-dir.py` is the one lookup now (reads
`build-script-executed` out of cargo's JSON, which cargo replays for fresh
units too), and the lane passes it on every run so no cache can outlive the
path.

Before: `Configuring incomplete, errors occurred!`
After: `100% tests passed, 0 tests failed out of 2`

Issue: docs/issues/archived/1238-xrce-lane-never-primes-its-out-dir.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)