### PR TITLE
docs(phase-438 W5, #1187): NROS_CPP_STD is a PORTING surface — say which one a consumer is on

### DIFF
--- a/book/src/getting-started/porting-a-cpp-node.md
+++ b/book/src/getting-started/porting-a-cpp-node.md
@@ -15,6 +15,38 @@ The canonical proof lives at
 the ROS 2 tutorial's `minimal_publisher.cpp` vendored unmodified, building
 against nano-ros via the three glue lines below.
 
+## The one compile definition, and why you do not type it
+
+A ported file names `rclcpp::Node`, `std::make_shared<MyNode>()` and
+`create_publisher<M>(...)` returning a `SharedPtr`. Those signatures are spelled
+in `std::shared_ptr` and `std::string`, and nano-ros compiles that surface only
+when a build **asks** for it by defining `NROS_CPP_STD`. It is never inferred
+from what your compiler happens to have on its include path.
+
+**`cmake/compat/NrosRclcppCompat.cmake` sets it for you**, on every target it
+applies the compat shim to, so a project following the two layers of glue below
+needs nothing extra. You type it yourself only when you build a ported
+translation unit *outside* the compat path:
+
+```cmake
+target_compile_definitions(my_ported_node PRIVATE NROS_CPP_STD=1)
+```
+
+Two things worth knowing before you reach for it:
+
+* **This is not a host-versus-embedded switch.** Code written against
+  `nros::Node` does not want the flag on a native Linux build either; ported
+  rclcpp code wants it on a Cortex-M3 build just as much. The split is *whose
+  code it is*, not *what it runs on*. See
+  [C++ API — two surfaces](../reference/cpp-api.md#two-surfaces-freestanding-and-nros_cpp_std).
+* **Define it per target, not per file.** It changes the layout of
+  `rclcpp::Node`, so two translation units of one image disagreeing about it is
+  an ODR break rather than a missing function.
+
+If you forget it the failure is loud and at compile time — an unknown
+`rclcpp::Node`, or a `create_publisher` overload that does not match — never a
+silent behaviour change.
+
 ## Two layers of glue
 
 ### Per-package CMakeLists.txt — **zero nano-ros lines**

--- a/book/src/reference/cpp-api.md
+++ b/book/src/reference/cpp-api.md
@@ -24,9 +24,10 @@ public surface a user application needs.
 - [`nros::Executor`](../api/cpp/classnros_1_1Executor.html), [`Timer`](../api/cpp/classnros_1_1Timer.html), [`GuardCondition`](../api/cpp/classnros_1_1GuardCondition.html)
 - [`nros::ParameterServer<Cap>`](../api/cpp/classnros_1_1ParameterServer.html) — node-local typed parameter store (`bool` / `int64_t` / `double` / `const char*`); compose alongside a `Node`. See [Differences from ROS 2 §9](../concepts/ros2-comparison.md#9-parameters-node-local-server-no-descriptors-no-callbacks-yet) for what is intentionally smaller than `rclcpp`.
 
-The library is freestanding C++14 — no STL, no exceptions. Define
-`NROS_CPP_STD` if you want the optional `std::string` / `std::function` /
-`std::chrono` overloads.
+The library is freestanding C++14 — no STL, no exceptions. A second,
+std-flavoured surface exists for porting upstream rclcpp code and is reached by
+defining `NROS_CPP_STD`; see [Two surfaces](#two-surfaces-freestanding-and-nros_cpp_std)
+below for whether you need it.
 
 > **Two-layer API.** The `nros::ActionServer<A>` / `ActionClient<A>`
 > templates are L2 callback handles (set callbacks via
@@ -45,6 +46,81 @@ The library is freestanding C++14 — no STL, no exceptions. Define
 > cancel_response,result,feedback}_wake_callback(state, cb, ctx)`
 > methods. Pair an `nros_cpp_wake_state_t`
 > with each entity / channel to wake on rx instead of polling.
+
+## Two surfaces: freestanding, and `NROS_CPP_STD`
+
+One set of headers ships two API shapes, and a build picks one.
+
+**The freestanding surface is the default and it is not a fallback.** It is
+plain C++14 with no standard library, no exceptions and no RTTI: `nros::Node`,
+`create_*` writing through an out-reference and returning an `nros::Result`,
+`const char*` for names, `uint64_t period_ms` for durations. Every nano-ros
+program in this repository is on it — the native/host examples included.
+
+**The std surface is an opt-in and it is reached only by defining
+`NROS_CPP_STD`.** Defining it turns on the six `NROS_CPP_HAS_*` capability
+macros in `nros/std_detect.hpp`, and with them: the `std::string` /
+`std::function` / `std::chrono` / `std::vector` convenience overloads in
+`nros/std_compat.hpp`, the `RCLCPP_*_STREAM` logging macros, and — the piece
+that actually motivates the flag — `rclcpp::Node`, whose factories return
+`std::shared_ptr` and whose name parameters are `const std::string&`.
+
+### Do I need this flag?
+
+**The split is *ported rclcpp code* versus *code written for nano-ros*. It is
+not host versus embedded.** A native Linux build does not want the flag any more
+than a Cortex-M3 build does; a ported node wants it on both.
+
+| You are… | Flag | Why |
+| --- | --- | --- |
+| writing a new node against `nros::Node` / `nros::Publisher<M>` / `nros::Executor` | **no** | The freestanding surface is the whole API you are using. This is the common case on every platform, native included. |
+| compiling an upstream ROS 2 `.cpp` unmodified — it says `class MyNode : public rclcpp::Node`, `std::make_shared<MyNode>()`, `create_publisher<M>(...)` returning a `SharedPtr` | **yes** | Those signatures are *spelled in* `std::shared_ptr` and `std::string`. Without the flag they do not exist and you get a compile error naming a missing overload or an unknown `rclcpp::Node`. |
+| passing a `std::string` topic name or a `std::chrono` period into an otherwise nano-ros-native file | **yes** | Those are the `std_compat.hpp` overloads. |
+| building for Zephyr, FreeRTOS, NuttX, ThreadX, or any `-ffreestanding` toolchain | **no** | And here it is not merely unnecessary: asking for the std surface asks the headers to `#include <string>`, which on those toolchains is either absent or a hard `#error`. |
+
+If you are unsure, build without it. The failure direction is loud: a missing
+overload at compile time, never a silent behaviour change.
+
+### Turning it on
+
+Define it on the **target**, not per file:
+
+```cmake
+target_compile_definitions(my_ported_node PRIVATE NROS_CPP_STD=1)
+```
+
+Per-target rather than per-`#define`-before-include, because the macro changes
+the *layout* of `rclcpp::Node` (it carries hosted-only members and an
+`enable_shared_from_this` base), so two translation units of one image
+disagreeing about it is an ODR/layout break rather than a missing function. That
+disagreement is reachable in practice — `examples/px4/cpp/bridge/` sets the flag
+on one module of a larger image deliberately — so keep the definition at
+target granularity and give every TU of a target the same answer.
+
+**A ported project usually needs none of this.**
+`cmake/compat/NrosRclcppCompat.cmake` sets `NROS_CPP_STD=1` on every target it
+touches. Anything reaching `<rclcpp/rclcpp.hpp>` through the compat shim already
+has the surface it needs; see
+[Porting a ROS 2 C++ node](../getting-started/porting-a-cpp-node.md).
+
+### Why it is not detected for you
+
+It used to be. Until phase-438 the capability macros were *discovered* from the
+include path with `__has_include`, so a hosted compiler handed you the
+std-flavoured API whether you asked for it or not. That was removed because no
+probe answers the question correctly on both embedded lanes:
+
+| | `__STDC_HOSTED__` | `__has_include(<string>)` | `#include <string>` |
+| --- | --- | --- | --- |
+| arm-none-eabi 13.2, `-ffreestanding` (FreeRTOS lane) | 0 | TRUE | hard `#error` |
+| Zephyr `-nostdinc++`, minimal libcpp | 1 | FALSE | absent |
+| hosted g++ 12.3 | 1 | TRUE | works |
+
+Each probe is right on exactly one embedded lane and wrong on the other:
+libstdc++ 13 added `bits/requires_hosted.h`, so header *presence* stopped
+implying *usability*. Only the request is right on both, because it is not a
+probe — it is you saying which surface you want. The full measurement lives in
+`packages/api/nros-cpp/include/nros/std_detect.hpp`.
 
 ## Generating locally
 

--- a/changelog.d/1187.breaking.md
+++ b/changelog.d/1187.breaking.md
@@ -1,0 +1,39 @@
+The std-flavoured C++ surface — `rclcpp::Node`, the `std::shared_ptr`-returning
+`create_*` factories, the `std::string` / `std::function` / `std::chrono`
+overloads in `nros/std_compat.hpp` and the `RCLCPP_*_STREAM` macros — is now
+reachable **only** by defining `NROS_CPP_STD`. Until now the six
+`NROS_CPP_HAS_*` capability macros were also discovered from the include path
+with `__has_include`, so any hosted compiler handed you that surface whether you
+asked for it or not.
+
+**This breaks out-of-tree consumers that relied on the discovery.** If your
+build compiled ported rclcpp code without defining `NROS_CPP_STD`, it will now
+get the freestanding API where it used to get the std one, and the failure is a
+compile error naming an unknown `rclcpp::Node` or a `create_publisher` overload
+that does not match. The fix is one line —
+`target_compile_definitions(<target> PRIVATE NROS_CPP_STD=1)` — and if you reach
+nano-ros through `cmake/compat/NrosRclcppCompat.cmake` you need nothing at all,
+because that path now sets the definition itself (it previously set none, and
+worked only because a hosted compiler happened to find libstdc++).
+
+There is **no deprecation cycle, and there cannot be one**: the change is a
+macro that stops being defined, and nothing can warn on that. This note is the
+whole migration path.
+
+The reason for the removal is that discovery was not merely over-broad, it was
+wrong on the lane it mattered on. `__has_include(<string>)` answers TRUE on the
+pinned arm-none-eabi 13.2 under `-ffreestanding`, where libstdc++ 13's
+`bits/requires_hosted.h` makes the include a hard `#error` — so **no embedded
+C++ FreeRTOS image compiled at all** (issue 1187). Per-header parsing on that
+toolchain moves from 26 pass / 20 fail to 47 pass / 0 fail, and
+`scripts/build/fixtures-build.sh freertos cpp zenoh` now produces six ARM ELF
+binaries where none built before. `__STDC_HOSTED__` is not a repair: it is 0 on
+that lane but 1 on Zephyr's `-nostdinc++` minimal libcpp, where `<string>` is
+absent. Each probe is right on exactly one embedded lane; only the request is
+right on both, because it is not a probe.
+
+Which surface a consumer is on is documented in the book
+(`C++ API — two surfaces`, and `Porting a ROS 2 C++ node`) and in
+`docs/reference/c-api-cmake.md`. The short version: the split is ported rclcpp
+code versus code written for nano-ros, and it is **not** host versus embedded —
+a native host build of a nano-ros-native node does not want this flag.

--- a/docs/design/0018-cpp-api-design.md
+++ b/docs/design/0018-cpp-api-design.md
@@ -105,11 +105,31 @@ The C++ API must work without the C++ standard library. This means:
 This is the C++ equivalent of Rust's `no_std`. The same binary runs on
 bare-metal Cortex-M, Zephyr, FreeRTOS, NuttX, ThreadX, and Linux.
 
-### Optional `std` mode
+### Opt-in `std` surface
 
-When `NROS_CPP_STD` is defined (or detected via `__STDC_HOSTED__`), the
-API can optionally expose convenience overloads that accept `std::string`,
-`std::function`, etc. These are `#ifdef`-guarded and never required.
+When `NROS_CPP_STD` is defined, the API exposes convenience overloads that
+accept `std::string`, `std::function`, etc., plus the `rclcpp::Node` shape whose
+factories return `std::shared_ptr`. These are `#ifdef`-guarded and never
+required.
+
+**It is REQUESTED by the build, never detected.** This paragraph read "or
+detected via `__STDC_HOSTED__`" until phase-438, and the headers did carry such
+a probe — latterly `__has_include`, which had re-broadened the gate issue 0112
+narrowed. Both were deleted, for a measured reason: no compile-time probe
+answers correctly on both embedded lanes. `__STDC_HOSTED__` is 1 for a hosted
+compiler run `-nostdinc++` against Zephyr's minimal libcpp (0112's own finding),
+and `__has_include(<string>)` is TRUE on arm-none-eabi 13.2 under
+`-ffreestanding`, where libstdc++ 13's `bits/requires_hosted.h` makes the
+include a hard `#error` — which broke every embedded C++ FreeRTOS build
+(issue 1187). Only the request is right on both, because it is not a probe.
+
+The consequence for the design is that the split is **ported rclcpp code versus
+code written for nano-ros**, not hosted versus embedded: the std surface exists
+to let an upstream ROS 2 source file compile unmodified (RFC-0089's
+compile-or-conform rule), so a native host build of a nano-ros-native node stays
+on the freestanding surface. Detection sits in one place,
+`packages/api/nros-cpp/include/nros/std_detect.hpp`, which carries the
+measurement.
 
 ## Error Handling
 

--- a/docs/guides/cpp-api.md
+++ b/docs/guides/cpp-api.md
@@ -9,7 +9,7 @@ The nros C++ API (`nros-cpp`) provides a freestanding C++14 interface for embedd
 - **rclcpp naming** — `Node`, `Publisher<M>`, `Subscription<M>`, `Service<S>`, `Client<S>`, `ActionServer<A>`, `ActionClient<A>`, `Timer`, `GuardCondition`, `Executor`
 - **Result-based error handling** — `nros::Result` + `NROS_TRY` macro (no exceptions)
 - **Generated message types** — `std_msgs::msg::Int32`, `example_interfaces::srv::AddTwoInts`, etc.
-- **Optional std mode** — `NROS_CPP_STD` enables `std::string`, `std::function`, `std::chrono` conveniences
+- **Opt-in std surface** — `NROS_CPP_STD` enables `std::string`, `std::function`, `std::chrono` conveniences and `rclcpp::Node`. It is a PORTING surface, requested by the build; it is never detected from the toolchain
 
 ## Building with CMake
 
@@ -364,14 +364,34 @@ Error codes (`nros::ErrorCode`):
 - `Full` (-5) — buffer full
 - `TransportError` (-100) — middleware transport failure
 
-## Optional `std` Mode (`NROS_CPP_STD`)
+## Opt-in `std` Surface (`NROS_CPP_STD`)
 
-For any toolchain with a C++ standard library, define `NROS_CPP_STD` to enable STL convenience overloads. This is automatically available when including `<nros/nros.hpp>` with the macro defined.
+`NROS_CPP_STD` selects the std-flavoured API: the STL convenience overloads
+below, plus `rclcpp::Node` and its `std::shared_ptr`-returning factories.
 
-```cpp
-#define NROS_CPP_STD
-#include <nros/nros.hpp>
+**Ask for it when you are compiling ported rclcpp code; do not ask for it
+otherwise.** The split is *whose code it is*, not *what it runs on* — a native
+Linux build of a node written against `nros::Node` stays on the freestanding
+surface, and a ported upstream node wants this flag on a Cortex-M3 build just
+as much as on a host. Nothing detects it for you: the headers do not probe the
+include path, because no probe answers correctly on both embedded lanes (the
+measurement is in `packages/api/nros-cpp/include/nros/std_detect.hpp`, and
+before phase-438 the probe that was there broke every embedded C++ FreeRTOS
+build — issue 1187).
+
+Set it on the target, so every translation unit of an image agrees:
+
+```cmake
+target_compile_definitions(my_ported_node PRIVATE NROS_CPP_STD=1)
 ```
+
+A per-file `#define NROS_CPP_STD` ahead of `<nros/nros.hpp>` compiles, but it
+changes the layout of `rclcpp::Node`, so mixing it within one image is an ODR
+break rather than a missing function.
+
+If you are using `cmake/compat/NrosRclcppCompat.cmake` — the drop-in
+source-compat path for ported packages — the flag is already set on every
+target the shim touches and you need nothing here.
 
 ### `std::string` overloads
 

--- a/docs/reference/c-api-cmake.md
+++ b/docs/reference/c-api-cmake.md
@@ -180,6 +180,89 @@ The example's own `CMakeLists.txt` add_subdirectory's nano-ros; the
 Corrosion target tree under `build/talker/cargo/` holds the
 per-build staticlib (`libnros_c.a`, `libnros_rmw_zenoh_staticlib.a`, …).
 
+## C++ surface selection: `NROS_CPP_STD`
+
+`nros-cpp` ships two API surfaces out of one header set, and a build selects
+one with a compile definition. Nothing in CMake, and nothing in the headers,
+probes for it.
+
+- **Freestanding (default).** C++14, no standard library, no exceptions, no
+  RTTI. `nros::Node`, `create_*` writing through an out-reference and returning
+  `nros::Result`, `const char *` names, `uint64_t` millisecond durations. This
+  is the surface every nano-ros application in this repository is built
+  against, `posix` host builds included.
+- **std (`NROS_CPP_STD`).** Defining it turns on the six `NROS_CPP_HAS_*`
+  capability macros in `nros/std_detect.hpp`, and with them the `std::string` /
+  `std::function` / `std::chrono` / `std::vector` overloads in
+  `nros/std_compat.hpp`, the `RCLCPP_*_STREAM` macros, and `rclcpp::Node`,
+  whose factories return `std::shared_ptr` and whose name parameters are
+  `const std::string &`.
+
+**The split is ported-rclcpp-code versus code-written-for-nano-ros, not host
+versus embedded.** A native `posix` build wants the flag no more than a
+`freertos` build does; a vendored upstream `.cpp` wants it on both. Concretely:
+`NROS_CPP_STD` is what makes an upstream ROS 2 source file compile *unmodified*,
+so it is a **porting** surface, and it is the only reason to ask for it.
+
+### Where it is set
+
+```cmake
+target_compile_definitions(my_ported_node PRIVATE NROS_CPP_STD=1)
+```
+
+Two build paths already set it, and between them they cover every in-tree
+consumer:
+
+- **`cmake/compat/NrosRclcppCompat.cmake`** sets `NROS_CPP_STD=1` on every
+  target it applies the compat shim to. Anything reaching
+  `<rclcpp/rclcpp.hpp>` through `find_package(rclcpp)` and the Find-stub is
+  therefore already on the std surface with no line of its own — which is why
+  the ported-package `CMakeLists.txt` in
+  [book/src/getting-started/porting-a-cpp-node.md](../../book/src/getting-started/porting-a-cpp-node.md)
+  still carries zero nano-ros lines.
+- **`examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/CMakeLists.txt`** sets
+  it directly, on one module of a larger PX4 image — PX4 SITL is real POSIX with
+  a full libstdc++, so that module opts in explicitly.
+
+Set it **per target**, not with a `#define` ahead of the include. The macro
+changes the layout of `rclcpp::Node` (hosted-only members plus an
+`enable_shared_from_this` base), so two translation units of one image
+disagreeing about it is an ODR/layout break rather than a missing function —
+the issue 0135 class. The px4 case above shows the disagreement is reachable in
+a real image, not a theoretical one.
+
+### Why CMake does not detect it
+
+It used to, in the headers rather than in CMake, and it was removed in
+phase-438 because no compile-time probe answers the question correctly on both
+embedded lanes. Measured on each lane's own pinned compiler:
+
+| | `__STDC_HOSTED__` | `__has_include(<string>)` | `#include <string>` |
+| --- | --- | --- | --- |
+| arm-none-eabi 13.2, `-ffreestanding` (FreeRTOS lane) | 0 | TRUE | hard `#error` |
+| Zephyr `-nostdinc++`, minimal libcpp | 1 | FALSE | absent |
+| hosted g++ 12.3 | 1 | TRUE | works |
+
+Each probe is right on exactly one embedded lane and wrong on the other, and
+the reason presence stopped being a usable proxy is upstream: libstdc++ 13
+added `bits/requires_hosted.h`, so on the FreeRTOS lane `<string>` is present
+*and* including it is a hard `#error`. Only the request is right on both,
+because it is not a probe.
+
+The cost of getting this wrong was not hypothetical. While the headers
+discovered the macros with `__has_include`, **no embedded C++ FreeRTOS image
+compiled at all** (issue 1187): per-header parsing on the pinned arm-none-eabi
+toolchain stood at 26 pass / 20 fail. After the discovery arm was deleted it is
+47 pass / 0 fail, and
+`bash scripts/build/fixtures-build.sh freertos cpp zenoh` (with
+`NROS_CMAKE_EXTRA_DEFS=-DCMAKE_TOOLCHAIN_FILE=$PWD/cmake/toolchain/arm-freertos-armcm3.cmake`)
+exits 0 with six ARM ELF binaries where none built before.
+
+Rationale and the full measurement:
+`packages/api/nros-cpp/include/nros/std_detect.hpp`,
+[RFC-0089](../design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md),
+and `docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md`.
+
 ## Board capabilities & deterministic build (RFC-0042)
 
 The C/C++ build contract is **structural**, not convention-enforced — see

--- a/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
+++ b/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
@@ -1,6 +1,6 @@
 # phase-438 — the C++ std surface is an opt-in PORTING surface, not a discovered capability
 
-**Status (2026-09-09). W0, W1, W2, W3, W4 LANDED — issue 1187 is closed; W5 open.** The C++ half of phase-359's
+**Status (2026-09-09). W0-W5 LANDED — issue 1187 is closed; the phase is complete.** The C++ half of phase-359's
 argument. Implements RFC-0089's compile-or-conform rule by making the surface that
 rule needs an explicit request rather than a property of the toolchain. W4 was
 written as a re-cut of phase-427 W1; the node merge landed that implementation
@@ -432,13 +432,46 @@ program — native included — is on the freestanding side already.
   `nros::spin()` / `nros::spin_once()`, which are unconditional.
 
 
-* **W5 — say which surface a consumer is on.** The book and
-  `docs/reference/c-api-cmake.md` document `NROS_CPP_STD` as the porting surface,
-  and the CMake verb that turns it on. A consumer porting an rclcpp file asks for
-  it; a consumer writing for nano-ros never does. The eleven header comments
-  miscitng 0112 are corrected here, with the three-lane probe table as the reason.
-  *Acceptance:* a reader can answer "do I need this flag" from the book without
-  reading a header.
+* **W5 — say which surface a consumer is on. LANDED.** `NROS_CPP_STD` is
+  documented as the PORTING surface, in four voices: the book's C++ API
+  reference gains a `Two surfaces` section with a "do I need this flag?" table;
+  `book/src/getting-started/porting-a-cpp-node.md` gains the one compile
+  definition and the fact that `NrosRclcppCompat.cmake` already sets it;
+  `docs/reference/c-api-cmake.md` carries the same at reference depth beside the
+  other CMake knobs; and `docs/guides/cpp-api.md`'s "Optional std Mode" is
+  re-cut, since "for any toolchain with a C++ standard library" was exactly the
+  host-versus-embedded framing this phase disproves. Each states the split as
+  ported-rclcpp-code versus code-written-for-nano-ros — measured, not asserted:
+  1 in-tree user of the hosted `shared_ptr`-returning `create_*` against 27 call
+  sites of the freestanding out-ref form in `examples/` alone — and each carries
+  the three-lane probe table as the reason nothing detects it.
+
+  Two things the item did not anticipate. **The changelog entry is `breaking`,
+  not `docs`** (`changelog.d/1187.breaking.md`): an out-of-tree consumer that
+  relied on the discovered macros now gets the freestanding API where it used to
+  get the std one, and there is no deprecation path, because nothing can warn on
+  a macro that stops being defined. And **RFC-0018 itself asserted the removed
+  behaviour** — "When `NROS_CPP_STD` is defined (or detected via
+  `__STDC_HOSTED__`)" — which is the same claim one layer above the header
+  comments; corrected in place, with no status flip.
+
+  The eleven header comments miscitng 0112 were already corrected by W1, which
+  moved them to `std_detect.hpp`. The tree-wide sweep for the same claim
+  elsewhere found **one live residue**, `nros.hpp:237` — *"gated on the
+  standard-library pieces their signatures are spelled in (`__has_include`,
+  never `__STDC_HOSTED__` — issue 0112, rationale in `publisher.hpp`)"* — stale
+  twice over now, since the gate is `NROS_CPP_STD` and the rationale moved. It
+  was left to W4, which owns that file; **W4 has since landed without taking
+  it** — verified 2026-09-10, the two lines still read that way at
+  `nros.hpp:242` and `git log -- packages/api/nros-cpp/include/nros/nros.hpp`
+  shows no phase-438 commit touching the file. One stale comment is what the
+  phase leaves behind, and it is a comment, not a gate. Every other
+  `__STDC_HOSTED__` citation in
+  the tree is about a **C-library** facility (`printf`/`getenv`/`fopen`), which
+  is the different question this phase's "Not in scope" already enumerates, and
+  each reads correctly.
+  *Acceptance (met):* a reader can answer "do I need this flag" from the book
+  without reading a header — the table does it in one row per consumer shape.
 
 ## Not in scope
 


### PR DESCRIPTION
## What

phase-438 W5 — documents `NROS_CPP_STD` as what W2 made it: an opt-in **porting**
surface, not a capability the toolchain hands you.

Before this phase, the six `NROS_CPP_HAS_*` capability macros were DISCOVERED
from the include path with `#elif defined(__has_include)`, so any hosted
compiler gave a consumer the std-flavoured C++ API whether they asked for it or
not. W2 deleted that arm. Nothing in the book or the reference docs told a
consumer which surface they were on, and after W2 that question has an answer
they need to be able to reach without opening a header.

## The framing, since it is not the obvious one

**The split is *ported rclcpp code* versus *code written for nano-ros*. It is
NOT host versus embedded.** `NROS_CPP_STD` exists so an upstream ROS 2 source
file compiles unmodified — that is the whole reason to ask for it — and every
real nano-ros program in this tree, native/host builds included, is on the
freestanding surface already. Measured: **1** in-tree user of the hosted
`shared_ptr`-returning `create_*` (a compile test) against **27** call sites of
the freestanding out-ref form in `examples/` alone.

The one shipping build path that sets the flag is the px4 uORB bridge module,
plus `cmake/compat/NrosRclcppCompat.cmake`, which W2 made set it for every
target using the rclcpp compat shim — so a ported project usually needs nothing.

## Files

| File | What it gains |
| --- | --- |
| `book/src/reference/cpp-api.md` | A `Two surfaces` section: what each surface is, a **"do I need this flag?" table** with one row per consumer shape, how to turn it on, that the compat CMake already does, and the three-lane probe table as the reason nothing detects it. |
| `book/src/getting-started/porting-a-cpp-node.md` | The same at the point a porter meets it — the one compile definition, and that they will not type it. |
| `docs/reference/c-api-cmake.md` | Reference depth, in that document's voice, beside the other CMake knobs; names both in-tree paths that set the definition and the measured cost of the discovery it replaced. |
| `docs/guides/cpp-api.md` | "Optional std Mode" re-cut. Its opening — *"for any toolchain with a C++ standard library"* — was exactly the host-versus-embedded framing this phase disproves. |
| `changelog.d/1187.breaking.md` | New. See below. |
| `docs/design/0018-cpp-api-design.md` | See below. |
| `docs/roadmap/phase-438-...md` | W5 marked landed, with what the item did not anticipate. |

## Two things W5's work item did not anticipate

**The changelog entry is `breaking`, not `docs`.** W2 is a breaking change for
any out-of-tree consumer that relied on the discovered macros: they now get the
freestanding API where they used to get the std one. The failure is the loud
direction — a compile error naming an unknown `rclcpp::Node` or a
`create_publisher` overload that does not match — and the fix is one
`target_compile_definitions` line. But **there is no deprecation cycle and there
cannot be one**, since nothing can warn on a macro that stops being defined. The
fragment says that plainly rather than implying a migration window exists.

**RFC-0018 asserted the removed behaviour itself** — *"When `NROS_CPP_STD` is
defined (or detected via `__STDC_HOSTED__`)"*. That is the same claim the header
comments carried, one layer up, and left alone it would keep regenerating the
misunderstanding from the design source of truth. Corrected in place, with **no
status flip**, so no ARCHITECTURE.md drift-rule obligation is triggered.

## Tree-wide sweep for the issue-0112 miscitation

`grep -rn` for `__STDC_HOSTED__` and `__has_include` across `packages/ cmake/
docs/ book/ scripts/ just/ examples/ config/ zephyr/ integrations/`,
third-party and generated trees excluded.

W1 had already corrected the eleven header comments by folding them into
`std_detect.hpp`. **One live residue remains, and it is deliberately not fixed
here:** `packages/api/nros-cpp/include/nros/nros.hpp:237` —

> gated on the standard-library pieces their signatures are spelled in
> (`__has_include`, never `__STDC_HOSTED__` — issue 0112, rationale in
> `publisher.hpp`)

Stale twice over now: the gate is `NROS_CPP_STD`, and the rationale moved out of
`publisher.hpp` into `std_detect.hpp`. `nros.hpp` is owned by the concurrent W4
change, and two branches editing one header is the conflict this split exists to
avoid, so it is left to that change.

Every other `__STDC_HOSTED__` citation in the tree reads correctly. All of them
guard a **C-library** facility (`printf`, `getenv`, `fopen`), which is the
different question — "is there a libc to print with" — that this phase's "Not in
scope" section already enumerates, and `__STDC_HOSTED__` is precisely what
answers it.

## Base branch

**This PR bases on `feat/phase-438-w1-w2-std-detect` (PR #770) and must be
retargeted to `main` once #770 lands.** #770 is itself stacked on #763.

## Verification

Docs only — no code, no gate, no build input changed.

`just check fast` green in a dedicated worktree: **281 gates ran, 1 skipped with
attribution** (`ivc-fsp`: `NV_SPE_FSP_DIR` unset, an unprovisioned gated SDK).
That lane carries all five formatting gates (`c-fmt`, `cli-fmt`, `cpp-fmt`,
`example-fmt`, `workspace-fmt`) and both link gates (`book-links`,
`markdown-links`), so the new cross-document links and section anchors are
checked rather than eyeballed. The same lane ran green again on the `pre-push`
hook.

`just format` could not be run to completion in the fresh worktree: it walks
example leaves, and `examples/workspaces/features/` needs its gitignored nested
`Cargo.toml`, which is generated by `nros build` rather than `nros sync`. That
is a worktree-provisioning gap, orthogonal to a markdown-only diff — and the
formatting question it would answer is covered by the five `*-fmt` gates above,
which are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
