### PR TITLE
fix(phase-433 W5): the stack-floor hook never ran, and the SIGPIPE fix was for a cause that did not exist

### DIFF
--- a/scripts/build/workspace-fixtures-build.sh
+++ b/scripts/build/workspace-fixtures-build.sh
@@ -463,19 +463,35 @@ build_workspace() {
             # the gate's path sniff looks for the BOARD; an unmapped platform
             # RAISES rather than passing, so a new one is a decision.
             #
-            # `-print -quit`, NOT `| head -1`. Under this script's
-            # `set -euo pipefail`, a `find` that still has output to write when
-            # `head` exits takes SIGPIPE, the pipeline reports 141, and the
-            # command substitution kills the script. It survived review and a
-            # local run because this tree had exactly ONE match, so `find`
-            # finished before `head` left; CI had more, and the build died
-            # immediately after `built: … native_entry` with no message of its
-            # own — `error: recipe build-workspace-fixtures failed on line 234`
-            # and nothing else. `-quit` stops find itself at the first hit, so
-            # there is no second writer and no pipeline to fail.
+            # `-print -quit`, NOT `| head -1`, and ROOTED AT THE REPO ROOT.
+            # `$dir` is repo-root-relative (`examples/workspaces/rust`) while
+            # this function runs with the WORKSPACE as CWD, so the original
+            # line handed `find` a DOUBLED path
+            # (`examples/workspaces/rust/examples/workspaces/rust/...`) that has
+            # never existed on any host. `find` exits 1, `2>/dev/null` discards
+            # the reason, and `set -euo pipefail` takes the script down with no
+            # message of its own -- `error: recipe build-workspace-fixtures
+            # failed on line 234` and nothing else.
+            #
+            # The earlier fix here read that fingerprint as SIGPIPE (a `find`
+            # still writing when `head` exits) and swapped in `-print -quit`.
+            # MEASURED 2026-09-09, that cause never existed: with the doubled
+            # path `find` exits 1 before writing a byte, so `head` never leaves
+            # early and there is no SIGPIPE to take -- and `pipefail` fails the
+            # pipeline on find's own 1 regardless. Running the pre-`-quit` form
+            # under `set -euo pipefail` against the doubled path dies
+            # identically. `-quit` stays because it is the better shape, not
+            # because it fixed anything.
+            #
+            # So this gate had NEVER RUN, and this build had never got past
+            # here, from the day the block landed (2026-09-07) -- which is why
+            # the live-peer lane could not reach a single cell.
+            #
+            # `|| true` because an ABSENT elf is a legitimate state that the
+            # `[ -n ... ]` below already handles; it must not be a silent abort.
             local _sf_elf
-            _sf_elf="$(find "$dir/$out_root" -type f -name "$entry" \
-                -path "*/$row_profile_dir/*" -print -quit 2>/dev/null)"
+            _sf_elf="$(find "$NROS_REPO_ROOT/$dir/$out_root" -type f -name "$entry" \
+                -path "*/$row_profile_dir/*" -print -quit 2>/dev/null || true)"
             if [ -n "$_sf_elf" ]; then
                 python3 "$NROS_REPO_ROOT/scripts/check-stack-floor.py" \
                     --board-for-row "$platform" "$_sf_elf"


### PR DESCRIPTION
The RMW live-verification ledger reached 20 of 20 Runtime cells passing. The lane
meant to keep it honest — `live-peer.yml`, scheduled 04:00 UTC — has fired once,
run `34186427723`, and **failed at "Build the fixtures those cells resolve"**,
reaching zero cells. So the 20/20 was measured but unguarded.

This is why.

## The bug

`workspace-fixtures-build.sh` looks for the ELF it just built:

```sh
find "$dir/$out_root" -type f -name "$entry" -path "*/$row_profile_dir/*" -print -quit 2>/dev/null
```

`$dir` is repo-root-relative (`examples/workspaces/rust`); the function runs with
the **workspace** as CWD. So `find` is handed
`examples/workspaces/rust/examples/workspaces/rust/target-fixtures` — a path that
has never existed on any host. `find` exits 1, `2>/dev/null` discards the reason,
and `set -euo pipefail` takes the script down with no message of its own:
`error: recipe build-workspace-fixtures failed on line 234` and nothing else.

## The fix that was aimed at it, and missed

That fingerprint was read once already, in 6e7779b05, as SIGPIPE from a `find`
still writing when `head -1` exits — fixed with `-print -quit`. Measured today,
**that cause never existed**: with the doubled path `find` exits 1 before writing a
byte, so `head` never leaves early and there is nothing to take a SIGPIPE; and
`pipefail` fails the pipeline on find's own 1 either way. The pre-`-quit` form
dies identically:

```
cd examples/workspaces/rust
bash -c 'set -euo pipefail
  x="$(find examples/workspaces/rust/target-fixtures -type f -name native_entry \
       -path "*/nros-relwithdebinfo/*" 2>/dev/null | head -1)"; echo reached'
# rc=1, "reached" never prints
```

`-quit` stays — it is the better shape — but it fixed nothing, and the real bug
rode straight through the fix aimed at it. The comment in the file now says so.

## What that cost, since 8f8a239b0 landed on 2026-09-07

* **`check-stack-floor.py --board-for-row` has never run on a workspace row.**
  The gate 8f8a239b0 added — for an esp32 entry that crashed on a stack the gate
  was never given — was itself never given one. Before `-quit` the pipeline's
  `head` also masked the empty result; after, the same failure became a hard abort.
* **`build-workspace-fixtures` has never got past the first workspace entry**,
  which is the whole of the live-peer lane's failure.

## Verification

* From the workspace CWD, the rooted `find` resolves
  `examples/workspaces/rust/target-fixtures/nros-relwithdebinfo/native_entry`
  (rc=0) where the old spelling returned empty (rc=1) — so the stack-floor gate
  runs for the first time, and passes.
* A full `workspace-fixtures-build.sh linux` in the ros2 distrobox — which has the
  ROS this host lacks — completes **rc=0**, past the rust entry that used to be the
  last line before the abort, on through
  `examples/workspaces/c/build/posix-xrce-native/cmake/native_xrce_entry`.
* On this host the run still stops at `std_msgs` unresolvable. That is the
  documented no-ROS limitation, not this defect.

## One thing this does not fix

`live-peer.yml` discriminates "the run did not happen" from "a cell regressed"
only inside `test-live-peer-regression`'s cell loop, by exit code. The three steps
upstream of it — CLI build, ledger report, fixture build — report as a plain lane
`failure`, which is exactly the ambiguity the lane was written to eliminate, one
step upstream of where the guard was put. Issue 1158's `matrix-triage` shape
(name the stage in the check-run) is the precedent. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzPvAy8k8yiuoGmKMzKyiJ
