### PR TITLE
fix(phase-433 W5, #1158): the live-peer lane could not say whether it had reached a cell

### DIFF
--- a/.github/workflows/live-peer.yml
+++ b/.github/workflows/live-peer.yml
@@ -46,10 +46,27 @@ jobs:
     defaults:
       run:
         shell: bash
+    # WHICH STAGE DID THIS RUN REACH? — issue 1158's third axis, applied here.
+    #
+    # This lane already discriminated "the run did not happen" from "a cell
+    # regressed", but ONLY inside `test-live-peer-regression`'s cell loop, by
+    # exit code (100 = nextest ran and failed; anything else = the run did not
+    # happen). Every step UPSTREAM of that loop reported as a flat lane
+    # `failure` — which is the exact ambiguity the loop was written to remove,
+    # one step above where the guard was put.
+    #
+    # Measured: run 34186427723 (2026-09-08) died in the fixture build and
+    # reached zero cells. `gh run list` said `failure`, indistinguishable from a
+    # recorded-passing cell having regressed — which is the one thing this lane
+    # exists to report.
+    outputs:
+      stage_label: ${{ steps.stage.outputs.label }}
+      reached_cells: ${{ steps.stage.outputs.reached_cells }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Build the nros CLI
+        id: cli
         run: |
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
@@ -59,11 +76,20 @@ jobs:
           "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
 
       - name: Report what the ledger claims, before running anything
+        id: ledger
         run: |
           source ./activate.sh
           just interop-verdicts
 
-      - name: Build the fixtures those cells resolve
+      # NOT "the fixtures those CELLS resolve", which is what this said until
+      # 2026-09-09. `lane-stage.py` classifies a step by keyword, `cells` is the
+      # marker for the runtime stage, and the classifier takes the most specific
+      # stage first — so the old name made a FIXTURE BUILD failure report as
+      # "the cells ran and failed", i.e. as a live-peer regression. Run
+      # 34186427723 is exactly that failure. The self-test pins the old spelling
+      # as a misclassification so the rename cannot be undone by accident.
+      - name: Build the fixtures those rows resolve
+        id: fixtures
         run: |
           source ./activate.sh
           # Order is load-bearing: the CLI first (above), then anything that runs
@@ -75,6 +101,7 @@ jobs:
           bash scripts/build/fixtures-build.sh linux rust cyclonedds
 
       - name: Run the cells with a recorded PASS
+        id: cells
         run: |
           source ./activate.sh
           just native test-live-peer-regression
@@ -84,3 +111,53 @@ jobs:
         run: |
           source ./activate.sh
           just interop-verdicts || true
+
+      # `steps.<id>.outcome`, not `.conclusion`: the outcome is the step's own
+      # result before any `continue-on-error` rewrite, and it speaks the same
+      # vocabulary `gh run view --json jobs` returns — which is what lets
+      # `--history` classify this lane's past runs with the identical function
+      # this step calls.
+      - name: Which stage did this lane reach?
+        id: stage
+        if: always()
+        env:
+          NROS_LANE_STEPS: >-
+            [{"name": "Build the nros CLI", "conclusion": "${{ steps.cli.outcome }}"},
+             {"name": "Report what the ledger claims, before running anything", "conclusion": "${{ steps.ledger.outcome }}"},
+             {"name": "Build the fixtures those rows resolve", "conclusion": "${{ steps.fixtures.outcome }}"},
+             {"name": "Run the cells with a recorded PASS", "conclusion": "${{ steps.cells.outcome }}"}]
+        run: python3 scripts/ci/lane-stage.py --report --lane "live-peer regression"
+
+  # The job NAME carries the stage, for the same reason `run-matrix.yml`'s
+  # `coverage` job does: a check-run name is the last piece of a run that is
+  # legible without opening a log — `gh run view`, the commit's checks list, the
+  # run list. Everything else this lane knows about how far it got dies in a log
+  # nobody reads until something is already wrong.
+  #
+  # `if: always()` and `needs`, so it reports on a failure and a skip alike;
+  # `|| 'DID NOT START'` covers the run where `regression` produces no outputs
+  # at all, which is neither a verdict nor a lane failure.
+  stage:
+    name: "live-peer — ${{ needs.regression.outputs.stage_label || 'DID NOT START' }}"
+    needs: [regression]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      # Through `env:`, never interpolated into the script body — a `${{ }}`
+      # expansion is substituted as TEXT before the shell parses the line, so a
+      # label carrying a quote would be a shell injection rather than a string.
+      - name: Say in the run list what the log would have to be opened for
+        env:
+          LABEL: ${{ needs.regression.outputs.stage_label || 'DID NOT START' }}
+          REACHED: ${{ needs.regression.outputs.reached_cells }}
+        run: |
+          label="$LABEL"
+          reached="$REACHED"
+          echo "live-peer regression: $label"
+          if [ "$reached" != "true" ]; then
+              echo ""
+              echo "The cells did not run, so this run says NOTHING about whether"
+              echo "a recorded-passing cell still passes. It is a verdict about"
+              echo "the lane, not about the code. Do not read a green ledger as"
+              echo "guarded until a run reaches its cells."
+          fi

--- a/scripts/ci/lane-stage.py
+++ b/scripts/ci/lane-stage.py
@@ -98,9 +98,13 @@ STAGE_MARKERS = (
     # The build: real code failures, but not the runtime verdict.
     (BUILD, ("build",)),
     # Everything that has to be true before the lane can build anything.
+    # `ledger` is live-peer.yml's: that lane reads `.config/interop-verdicts.toml`
+    # before it runs anything, and a lane that cannot read its own membership
+    # has not reached a stage.
     (PROVISIONING, ("setup", "set up", "provision", "install", "checkout",
                     "cache", "fetch", "submodule", "labels", "doctor",
-                    "reclaim disk", "free disk", "apt", "rustup", "register")),
+                    "ledger", "reclaim disk", "free disk", "apt", "rustup",
+                    "register")),
 )
 
 # Steps that belong to no stage: housekeeping that runs `if: always()` after the
@@ -215,8 +219,9 @@ def report(lane, steps_json):
         out.append("")
         out.append("  This run answers NOTHING about the code under test. The lane")
         out.append("  stopped before its cells, so a regression landing today would")
-        out.append("  look exactly like this — which is how issues 1075/1098/1104/1114")
-        out.append("  rode in (issue 1158).")
+        out.append("  look exactly like this. On `run-matrix.yml` that is how issues")
+        out.append("  1075/1098/1104/1114 rode in (issue 1158); this reporter exists")
+        out.append("  so no lane has to learn it a second time.")
     print("\n".join(out))
 
     # An annotation, because it is the one thing visible on the run page and in
@@ -383,44 +388,108 @@ HISTORICAL = (
 )
 
 
-WORKFLOW = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-    ".github", "workflows", "run-matrix.yml")
+# The one run `live-peer.yml` has had, recorded from
+# `gh run view 34186427723 --json jobs` on 2026-09-09. Verbatim, housekeeping
+# included, and under the step names that run actually used — which is why the
+# fixture step here still says `cells`: this is the evidence for the rename, not
+# a copy of the tree after it.
+_LIVE_PEER_34186427723 = _steps(
+    ("Set up job", "success"),
+    ("Initialize containers", "success"),
+    ("Run actions/checkout@v4", "success"),
+    ("Build the nros CLI", "success"),
+    ("Report what the ledger claims, before running anything", "success"),
+    ("Build the fixtures those cells resolve", "failure"),
+    ("Run the cells with a recorded PASS", "skipped"),
+    ("Ledger after the run", "success"),
+    ("Post Run actions/checkout@v4", "success"),
+    ("Stop containers", "success"),
+    ("Complete job", "success"))
 
-# Every step name `run-matrix.yml` hands to `--report`, and the stage it MUST
-# classify as. Asserted against the workflow itself, both directions.
-EXPECTED_MAP = {
-    "just setup tier2": PROVISIONING,
-    "Verify this runner's labels are true": PROVISIONING,
-    "just build tier2": BUILD,
-    "just ci matrix": CELLS,
-}
+# The same run as the workflow now reports it: four steps, current names.
+_LIVE_PEER_FIXTURES_DIED = _steps(
+    ("Build the nros CLI", "success"),
+    ("Report what the ledger claims, before running anything", "success"),
+    ("Build the fixtures those rows resolve", "failure"),
+    ("Run the cells with a recorded PASS", "skipped"))
+
+
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _workflow_path(basename):
+    return os.path.join(REPO_ROOT, ".github", "workflows", basename)
+
+
+# A staged lane, and the step->stage map it MUST produce. Asserted against the
+# workflow itself, both directions — the map is AUTHORED (each workflow hands
+# `--report` a copy of its own `- name:` lines), and an authored map drifts the
+# moment a step is renamed, silently and in the safe-looking direction.
+#
+# `report_job` is the job whose NAME carries the answer, because a check-run
+# name is the last piece of a run that is legible without opening a log.
+LaneSpec = collections.namedtuple(
+    "LaneSpec", "workflow job report_job expected_map")
+
+LANES = (
+    LaneSpec("run-matrix.yml", "matrix", "coverage", {
+        "just setup tier2": PROVISIONING,
+        "Verify this runner's labels are true": PROVISIONING,
+        "just build tier2": BUILD,
+        "just ci matrix": CELLS,
+    }),
+    # phase-433 W5. This lane already told "the run did not happen" from "a cell
+    # regressed" — but only INSIDE the cell loop, by exit code. Everything above
+    # the loop was a flat `failure`, which is the same ambiguity one step
+    # upstream of the guard.
+    LaneSpec("live-peer.yml", "regression", "stage", {
+        "Build the nros CLI": BUILD,
+        "Report what the ledger claims, before running anything": PROVISIONING,
+        "Build the fixtures those rows resolve": BUILD,
+        "Run the cells with a recorded PASS": CELLS,
+    }),
+)
+
+# Kept for `--history`'s default and for anything importing the old name.
+WORKFLOW = _workflow_path("run-matrix.yml")
+EXPECTED_MAP = LANES[0].expected_map
 
 
 def _workflow_consistency(chk):
-    """Cross-check the authored step->stage map against run-matrix.yml.
+    """Cross-check every lane's authored step->stage map against its workflow.
 
-    Returns lines to print when the check could not be made — a REPORTED skip,
+    Returns lines to print when a check could not be made — a REPORTED skip,
     never a silent one (issue 1043's shape: "could not evaluate" is a third
     answer, not a pass).
     """
     try:
         import yaml
     except ModuleNotFoundError:
-        return ["[skip] lane-stage: PyYAML missing — the run-matrix.yml "
-                "consistency arm did NOT run"]
-    if not os.path.exists(WORKFLOW):
-        return [f"[skip] lane-stage: {WORKFLOW} absent — the consistency arm "
-                "did NOT run"]
+        return ["[skip] lane-stage: PyYAML missing — the workflow "
+                "consistency arm did NOT run for ANY lane"]
 
-    with open(WORKFLOW, encoding="utf-8") as fh:
-        doc = yaml.safe_load(fh)
-    steps = doc["jobs"]["matrix"]["steps"]
+    notes = []
+    for lane in LANES:
+        path = _workflow_path(lane.workflow)
+        if not os.path.exists(path):
+            notes.append(f"[skip] lane-stage: {path} absent — the consistency "
+                         f"arm did NOT run for {lane.workflow}")
+            continue
+        with open(path, encoding="utf-8") as fh:
+            doc = yaml.safe_load(fh)
+        notes.extend(_one_lane_consistency(chk, lane, doc))
+    return notes
+
+
+def _one_lane_consistency(chk, lane, doc):
+    w = lane.workflow
+    job = doc["jobs"][lane.job]
+    steps = job["steps"]
     names = [s.get("name", "") for s in steps]
-    reporter = [s for s in steps
-                if "lane-stage.py" in str(s.get("run", ""))]
+    reporter = [s for s in steps if "lane-stage.py" in str(s.get("run", ""))]
 
-    chk("run-matrix.yml has exactly one lane-stage reporter", len(reporter) == 1)
+    chk(f"{w} has exactly one lane-stage reporter", len(reporter) == 1)
     if not reporter:
         return []
 
@@ -429,21 +498,25 @@ def _workflow_consistency(chk):
                reporter[0]["env"]["NROS_LANE_STEPS"]))
     declared_names = [d["name"] for d in declared]
 
-    chk("every step name the workflow reports is a real step in that job",
+    chk(f"{w}: every reported step name is a real step in `{lane.job}`",
         all(n in names for n in declared_names))
-    chk("every staged step of the workflow is reported",
-        set(declared_names) == set(EXPECTED_MAP))
+    chk(f"{w}: every staged step is reported",
+        set(declared_names) == set(lane.expected_map))
     for n in declared_names:
-        chk(f"`{n}` still classifies as {EXPECTED_MAP.get(n)}",
-            stage_of(n) == EXPECTED_MAP.get(n))
-    chk("the reporter runs `if: always()` — a stage report that is skipped when "
-        "the lane dies is no report",
+        chk(f"{w}: `{n}` still classifies as {lane.expected_map.get(n)}",
+            stage_of(n) == lane.expected_map.get(n))
+    chk(f"{w}: the reporter runs `if: always()` — a stage report that is "
+        "skipped when the lane dies is no report",
         "always()" in str(reporter[0].get("if", "")))
-    chk("the matrix job exports the stage label for the coverage job's name",
+    chk(f"{w}: `{lane.job}` exports the stage label for the report job's name",
         "stage.outputs.label" in
-        str(doc["jobs"]["matrix"].get("outputs", {}).get("stage_label", "")))
-    chk("the coverage job's NAME carries the stage",
-        "needs.matrix.outputs.stage_label" in str(doc["jobs"]["coverage"]["name"]))
+        str(job.get("outputs", {}).get("stage_label", "")))
+    chk(f"{w}: the `{lane.report_job}` job's NAME carries the stage",
+        f"needs.{lane.job}.outputs.stage_label" in
+        str(doc["jobs"][lane.report_job]["name"]))
+    chk(f"{w}: the `{lane.report_job}` job runs `if: always()`, so it reports "
+        "on a dead run too",
+        "always()" in str(doc["jobs"][lane.report_job].get("if", "")))
     return []
 
 
@@ -527,6 +600,41 @@ def selftest(verbose=False):
                         ("just build tier2", "success"),
                         ("just ci matrix", "skipped")), "failure").reached_cells
         is False)
+
+    # 8b. live-peer.yml — phase-433 W5. The lane whose ledger says 20 of 20
+    #     cells pass live, and whose single run reached ZERO of them.
+    lp = classify(_LIVE_PEER_FIXTURES_DIED, "failure")
+    chk("34186427723 (2026-09-08) -> no-verdict/build, not a cell regression",
+        lp.kind == "no-verdict" and lp.stage == BUILD)
+    chk("...and it names the step that actually stopped it",
+        lp.failing_step == "Build the fixtures those rows resolve")
+    chk("...and does not claim to have reached the cells",
+        lp.reached_cells is False)
+
+    # The rename is load-bearing, so the old spelling is pinned as the
+    # misclassification it was. `cells` is the CELLS marker and the classifier
+    # takes the most specific stage first, so under the old name a FIXTURE BUILD
+    # failure reported as `VERDICT: cells ran and FAILED` — this lane saying the
+    # one thing it exists to say, about a run that never started a cell.
+    chk("the OLD step name misclassified a fixture build as the cells stage",
+        stage_of("Build the fixtures those cells resolve") == CELLS)
+    chk("...and the current name does not",
+        stage_of("Build the fixtures those rows resolve") == BUILD)
+    chk("the old name turned the real run into a false cell regression",
+        classify(_LIVE_PEER_34186427723, "failure").kind == "verdict-fail")
+
+    chk("`Run the cells with a recorded PASS` is the cells stage",
+        stage_of("Run the cells with a recorded PASS") == CELLS)
+    chk("`Report what the ledger claims, before running anything` is provisioning",
+        stage_of("Report what the ledger claims, before running anything")
+        == PROVISIONING)
+    chk("live-peer cells that RAN and failed are a verdict",
+        classify(_steps(
+            ("Build the nros CLI", "success"),
+            ("Report what the ledger claims, before running anything", "success"),
+            ("Build the fixtures those rows resolve", "success"),
+            ("Run the cells with a recorded PASS", "failure")),
+            "failure").kind == "verdict-fail")
 
     # 9. THE MAP IS AUTHORED, SO IT DRIFTS. `--report` is handed step names by
     #    the workflow, and those names are a copy of the workflow's own `- name:`


### PR DESCRIPTION
`test-live-peer-regression` already discriminates carefully: nextest's `100`
means the cells ran and some failed (a regression); any other non-zero means the
run did not happen, and the recipe says so in as many words — *"that is a harness
fault, NOT a regression verdict"*.

All of that lives **inside the cell loop**. Every step upstream of it — the CLI
build, the ledger report, the fixture build — reported as a flat lane `failure`.
That is the exact ambiguity the loop was written to remove, one step above where
the guard was put.

## Measured, on the only run this lane has had

Run `34186427723`, 2026-09-08. It died in `Build the fixtures those cells
resolve` and reached **zero cells**. `gh run list` said `failure` —
indistinguishable from a cell with a recorded live PASS having stopped passing,
which is the one thing this lane exists to report. Meanwhile the ledger read 20
of 20 and nothing said the guard had never run.

CLAUDE.md states the rule; issue 1158 built the mechanism for `run-matrix.yml`.
This applies that mechanism rather than inventing a second one.

## What changed

* **`live-peer.yml`** — step ids, a `Which stage did this lane reach?` reporter
  (`if: always()`, reading `steps.<id>.outcome`), job outputs, and a `stage` job
  whose **NAME** carries the answer. `live-peer — NO VERDICT: stopped in the
  build` is then legible from `gh run view` and the checks list without opening
  a log.
* **`lane-stage.py`** — the consistency arm becomes a table (`LANES`) instead of
  one hardcoded workflow, so both lanes' authored step→stage maps are checked
  against their workflows in both directions. Two properties the first version
  only had for run-matrix now hold for both: the reporter runs `if: always()`,
  and so does the job carrying the name.
* **`ledger`** joins the provisioning markers — this lane reads
  `.config/interop-verdicts.toml` for its own membership, and a lane that cannot
  read that has not reached a stage.

## One rename is load-bearing

`Build the fixtures those cells resolve` → `… those rows resolve`.

The classifier keys on words and takes the most specific stage first, so `cells`
in a **fixture build's** name made that step the runtime stage. Replaying run
`34186427723` verbatim under its real step names yields `verdict-fail` — the
lane confidently reporting a live-peer regression for a run that never started a
cell. The self-test pins **both** spellings: the old one as the misclassification
it was, the new one as `build`, so the rename cannot be undone by accident.

## Verification

* Self-test: **57 checks, 0 failures** (was 29). The recorded run is stored
  verbatim, housekeeping steps included, the way the eight `run-matrix` runs
  already were.
* `just check lane-stage-reporting`, `workflow-repo-env`,
  `workflow-runner-isolation`, `workflow-setup-spelling`, `lane-contracts` — all
  OK.
* `just check fast` — 281 gates, 0 failures, 2 reported skips.
* `--report` dry-run against the real failure's shape:

```
live-peer regression: NO VERDICT: stopped in the build
  first failing step: Build the fixtures those rows resolve
  [ok  ] build        Build the nros CLI
  [ok  ] provisioning Report what the ledger claims, before running anything
  [FAIL] build        Build the fixtures those rows resolve
  [----] cells        Run the cells with a recorded PASS
```

Pairs with #780, which fixes the build failure this run actually hit. That PR
makes the lane able to reach its cells; this one makes it say so when it cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzPvAy8k8yiuoGmKMzKyiJ
