### PR TITLE
docs(#1240): `just check cpp` cannot run on a GCC 16 host, and its first error is not the one to read

### DIFF
--- a/docs/issues/1240-gcc16-libstdcxx-breaks-check-cpp.md
+++ b/docs/issues/1240-gcc16-libstdcxx-breaks-check-cpp.md
@@ -1,0 +1,96 @@
+---
+id: 1240
+title: "`just check cpp` cannot run on a GCC 16 host — libstdc++'s own headers fail under `-Werror` + the new `-Wtemplate-body`"
+status: open
+type: limitation
+area: cpp, build, ci
+severity: medium
+found: 2026-09-09
+related: [0872, 1187]
+---
+
+# The compile tier is unrunnable on this host, and the instruction assumes it is not
+
+CLAUDE.md is unambiguous: **green CI locally BEFORE pushing** — run `just format`
+and the tier your change earns, fix every failure, so the push passes remote CI
+on the first try. On a host with GCC 16 that instruction cannot be followed for
+anything that reaches `check-cpp`: the lane fails before it has compiled a line
+of nano-ros code.
+
+Measured 2026-09-09 on Arch, `gcc (GCC) 16.1.1 20260728`, running `just ci gate`
+on a branch whose entire diff is one shell script.
+
+## What fails
+
+Two distinct failures inside `/usr/include/c++/16`, both raised while compiling
+our headers but neither in our code:
+
+```
+/usr/include/c++/16/bits/stl_vector.h:2195:11: error: there are no arguments to
+  '__throw_length_error' that depend on a template parameter, so a declaration
+  of '__throw_length_error' must be available [-Wtemplate-body]
+
+/usr/include/c++/16/sstream:1150:57: error: no type named 'pos_type' in
+  'std::__cxx11::basic_stringstream<wchar_t>::traits_type'
+  {aka 'struct std::char_traits<wchar_t>'}
+```
+
+`-Wtemplate-body` is new in GCC 16: it diagnoses two-phase-lookup problems in
+template bodies that earlier releases only reported at instantiation. The lane
+compiles with `-Werror`, so a warning in a SYSTEM header becomes an error — and
+these are libstdc++'s own template bodies, not ours.
+
+## The cascade, which is what makes the log misleading
+
+Once `<vector>` and `<sstream>` have failed, `<memory>` is not usable either, so
+`NROS_CPP_HAS_SHARED_PTR` never gets defined and the compiler reports:
+
+```
+packages/api/nros-cpp/include/nros/timer.hpp:68:28: error: 'shared_ptr' in
+  namespace 'std' does not name a template type
+  note: 'std::shared_ptr' is defined in header '<memory>'; this is probably
+  fixable by adding '#include <memory>'
+```
+
+That note is wrong here, and it is the trap. `timer.hpp` DOES include `<memory>`
+— twice, once under `NROS_CPP_STD` and once behind the `__has_include` probe
+phase-417 W1.a added for issue 0112. Taking GCC's suggestion would add a third
+copy of an include that is already there and fix nothing. **The `shared_ptr`
+errors are downstream of the libstdc++ failure above them; read the FIRST error
+in this lane, never the most specific-looking one.**
+
+## Why nothing caught it
+
+CI runs `ubuntu-22.04` (GCC 11), where neither diagnostic exists, so the lane is
+green there and will stay green. `check-cpp` is in the compile tier, which the
+`pre-push` hook deliberately excludes, so a contributor on a rolling distro
+meets this only when they follow the instruction to run the tier locally — which
+is the population most likely to be doing the right thing.
+
+Same shape as issue 0872 one axis over: an arm that has never run to completion
+in one environment, where each fix exposes the next gap. Distinct from issue
+1187, which is `<string>` reaching an embedded FreeRTOS C++ image — that is our
+own porting surface, this is a host toolchain we do not build against anywhere.
+
+## What would resolve it
+
+Not yet decided; the options differ in what they give up.
+
+* Stop `-Werror` from applying to system headers in this lane
+  (`-isystem` for the toolchain's own include dirs is the usual mechanism, and
+  is arguably correct regardless — we do not own those warnings).
+* Pin a supported host compiler for `check-cpp` the way issue 1117 pins a cross
+  toolchain, and say so when the host's default is not one.
+* Suppress `-Wtemplate-body` specifically, which is the narrowest fix and the
+  one that goes stale the fastest.
+
+The first is most likely right: a `-Werror` build has an opinion about ITS OWN
+code, and letting it have one about libstdc++ is what broke here.
+
+## Reproduce
+
+```bash
+just check cpp     # on a GCC >= 16 host
+```
+
+First error is in `/usr/include/c++/16/...`, not under `packages/`.


### PR DESCRIPTION
Filed from a real cli-fresh: OK — source-stamp: fresh (8830f5a56cb8810a)

check-fast: slowest gates (ms)
     63236   18.7%  api-parity
     32820    9.7%  hook-repo-side-effects
     20237    6.0%  rmw-ret-sign
     18694    5.5%  issue-ids
      8363    2.5%  leaf-lockfiles
      8103    2.4%  msg-dep-is-path
      7016    2.1%  rmw-slot-producers
      7001    2.1%  rmw-api-parity
      6728    2.0%  rmw-api-comparison
      6074    1.8%  fixture-staleness-probes
  busy 338s over wall 87s at -P4 => 3.9x effective parallelism
check-fast (parallel): 280 gate(s) ran at -P4 (1 test-thread(s)/gate), 3 SKIPPED; slowest api-parity 63236ms
  [SKIPPED] box-sync-covers-tracked-source: 5 tree(s) NOT VERIFIED — absent here (zephyr-workspace and/or uninitialised submodules), so their tracked source was not swept
  [SKIPPED] ivc-fsp: NV_SPE_FSP_DIR unset — the NVIDIA Orin SPE FSP tree is not provisioned here (phase-418 418.4)
  [SKIPPED] repr-memory-agreement: missing: arm-none-eabi-gcc arm-none-eabi-nm

===== FAIL (cpp, rc=1, 24814ms) =====
Checking C++ formatting... (/home/aeon/.nros/sdk/clang-format/17.0.6-nros1/bin/clang-format)
  - clang-format (nros-cpp headers)
  - clang-format (C++ examples, ALL platforms)
C++ formatting OK.
Checking C++ headers (build + syntax + clippy)...
  - freestanding syntax (c++14)
  - embedded cyclone coordinate (issue 0730): rmw-cffi,alloc,platform-zephyr,ros-humble,panic-platform @ aarch64-unknown-none
warning: dropping unsupported crate type `cdylib` for target `aarch64-unknown-none`

In file included from /usr/include/c++/16/string:40,
                 from packages/api/nros-cpp/include/nros/log.hpp:115,
                 from packages/api/nros-cpp/include/nros/qos.hpp:24,
                 from packages/api/nros-cpp/include/nros/node.hpp:30,
                 from packages/api/nros-cpp/include/nros/action_server.hpp:605,
                 from ./packages/api/nros-cpp/include/nros/action_client.hpp:26,
                 from <command-line>:
/usr/include/c++/16/bits/requires_hosted.h:34:4: error: #error "This header is not available in freestanding mode."
   34 | #  error "This header is not available in freestanding mode."
      |    ^~~~~
In file included from /usr/include/c++/16/x86_64-pc-linux-gnu/bits/c++allocator.h:33,
                 from /usr/include/c++/16/bits/allocator.h:46,
                 from /usr/include/c++/16/string:46:
/usr/include/c++/16/bits/new_allocator.h: In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*)’:
/usr/include/c++/16/bits/new_allocator.h:150:20: error: ‘__throw_bad_array_new_length’ is not a member of ‘std’; did you mean ‘bad_array_new_length’? [-Wtemplate-body]
  150 |               std::__throw_bad_array_new_length();
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    bad_array_new_length
/usr/include/c++/16/bits/new_allocator.h:151:18: error: ‘__throw_bad_alloc’ is not a member of ‘std’ [-Wtemplate-body]
  151 |             std::__throw_bad_alloc();
      |                  ^~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/16/string:58:
/usr/include/c++/16/bits/basic_string.h: In member function ‘void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_check_length(size_type, size_type, const char*) const’:
/usr/include/c++/16/bits/basic_string.h:427:11: error: there are no arguments to ‘__throw_length_error’ that depend on a template parameter, so a declaration of ‘__throw_length_error’ must be available [-Wtemplate-body]
  427 |           __throw_length_error(__N(__s));
      |           ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/basic_string.h:427:11: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/usr/include/c++/16/bits/basic_string.h: In constructor ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, size_type, const _Alloc&)’:
/usr/include/c++/16/bits/basic_string.h:714:16: error: ‘__throw_logic_error’ is not a member of ‘std’; did you mean ‘__throw_runtime_error’? [-Wtemplate-body]
  714 |           std::__throw_logic_error(__N("basic_string: "
      |                ^~~~~~~~~~~~~~~~~~~
      |                __throw_runtime_error
/usr/include/c++/16/bits/basic_string.h: In constructor ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, const _Alloc&)’:
/usr/include/c++/16/bits/basic_string.h:735:16: error: ‘__throw_logic_error’ is not a member of ‘std’; did you mean ‘__throw_runtime_error’? [-Wtemplate-body]
  735 |           std::__throw_logic_error(__N("basic_string: "
      |                ^~~~~~~~~~~~~~~~~~~
      |                __throw_runtime_error
/usr/include/c++/16/bits/basic_string.h: In function ‘int std::__cxx11::stoi(const std::string&, std::size_t*, int)’:
/usr/include/c++/16/bits/basic_string.h:4510:47: error: ‘strtol’ is not a member of ‘std’
 4510 |   { return __gnu_cxx::__stoa<long, int>(&std::strtol, "stoi", __str.c_str(),
      |                                               ^~~~~~
/usr/include/c++/16/bits/basic_string.h: In function ‘long int std::__cxx11::stol(const std::string&, std::size_t*, int)’:
/usr/include/c++/16/bits/basic_string.h:4515:36: error: ‘strtol’ is not a member of ‘std’
 4515 |   { return __gnu_cxx::__stoa(&std::strtol, "stol", __str.c_str(),
      |                                    ^~~~~~
/usr/include/c++/16/bits/basic_string.h: In function ‘long unsigned int std::__cxx11::stoul(const std::string&, std::size_t*, int)’:
/usr/include/c++/16/bits/basic_string.h:4520:36: error: ‘strtoul’ is not a member of ‘std’
 4520 |   { return __gnu_cxx::__stoa(&std::strtoul, "stoul", __str.c_str(),
      |                                    ^~~~~~~
/usr/include/c++/16/bits/basic_string.h: In function ‘long long int std::__cxx11::stoll(const std::string&, std::size_t*, int)’:
/usr/include/c++/16/bits/basic_string.h:4526:36: error: ‘strtoll’ is not a member of ‘std’
 4526 |   { return __gnu_cxx::__stoa(&std::strtoll, "stoll", __str.c_str(),
      |                                    ^~~~~~~
/usr/include/c++/16/bits/basic_string.h: In function ‘long long unsigned int std::__cxx11::stoull(const std::string&, std::size_t*, int)’:
/usr/include/c++/16/bits/basic_string.h:4531:36: error: ‘strtoull’ is not a member of ‘std’
 4531 |   { return __gnu_cxx::__stoa(&std::strtoull, "stoull", __str.c_str(),
      |                                    ^~~~~~~~
/usr/include/c++/16/bits/basic_string.h: In function ‘double std::__cxx11::stod(const std::string&, std::size_t*)’:
/usr/include/c++/16/bits/basic_string.h:4545:36: error: ‘strtod’ is not a member of ‘std’
 4545 |   { return __gnu_cxx::__stoa(&std::strtod, "stod", __str.c_str(), __idx); }
      |                                    ^~~~~~
/usr/include/c++/16/bits/basic_string.h: In function ‘float std::__cxx11::stof(const std::string&, std::size_t*)’:
/usr/include/c++/16/bits/basic_string.h:4551:36: error: ‘strtof’ is not a member of ‘std’
 4551 |   { return __gnu_cxx::__stoa(&std::strtof, "stof", __str.c_str(), __idx); }
      |                                    ^~~~~~
/usr/include/c++/16/bits/basic_string.h: In function ‘long double std::__cxx11::stold(const std::string&, std::size_t*)’:
/usr/include/c++/16/bits/basic_string.h:4573:36: error: ‘strtold’ is not a member of ‘std’
 4573 |   { return __gnu_cxx::__stoa(&std::strtold, "stold", __str.c_str(), __idx); }
      |                                    ^~~~~~~
In file included from /usr/include/c++/16/string:59:
/usr/include/c++/16/bits/basic_string.tcc: In member function ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::pointer std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_create(size_type&, size_type)’:
/usr/include/c++/16/bits/basic_string.tcc:149:14: error: ‘__throw_length_error’ is not a member of ‘std’; did you mean ‘__throw_runtime_error’? [-Wtemplate-body]
  149 |         std::__throw_length_error(__N("basic_string::_M_create"));
      |              ^~~~~~~~~~~~~~~~~~~~
      |              __throw_runtime_error
In file included from /usr/include/c++/16/bits/locale_classes.h:897,
                 from /usr/include/c++/16/bits/ios_base.h:43,
                 from /usr/include/c++/16/ios:46,
                 from /usr/include/c++/16/istream:42,
                 from /usr/include/c++/16/sstream:42,
                 from packages/api/nros-cpp/include/nros/log.hpp:125:
/usr/include/c++/16/bits/locale_classes.tcc: In function ‘const _Facet& std::use_facet(const locale&)’:
/usr/include/c++/16/bits/locale_classes.tcc:230:7: error: there are no arguments to ‘__throw_bad_cast’ that depend on a template parameter, so a declaration of ‘__throw_bad_cast’ must be available [-Wtemplate-body]
  230 |       __throw_bad_cast();
      |       ^~~~~~~~~~~~~~~~
In file included from /usr/include/c++/16/ios:47:
/usr/include/c++/16/streambuf: In instantiation of ‘class std::basic_streambuf<char>’:
/usr/include/c++/16/bits/streambuf.tcc:154:25:   required from here
  154 |   extern template class basic_streambuf<char>;
      |                         ^~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/streambuf:138:57: error: no type named ‘pos_type’ in ‘std::basic_streambuf<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  138 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/streambuf:139:57: error: no type named ‘off_type’ in ‘std::basic_streambuf<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  139 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/streambuf: In instantiation of ‘class std::basic_streambuf<wchar_t>’:
/usr/include/c++/16/bits/streambuf.tcc:162:25:   required from here
  162 |   extern template class basic_streambuf<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/streambuf:138:57: error: no type named ‘pos_type’ in ‘std::basic_streambuf<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  138 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/streambuf:139:57: error: no type named ‘off_type’ in ‘std::basic_streambuf<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  139 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
In file included from /usr/include/c++/16/ios:48:
/usr/include/c++/16/bits/basic_ios.h: In function ‘const _Facet& std::__check_facet(const _Facet*)’:
/usr/include/c++/16/bits/basic_ios.h:53:9: error: there are no arguments to ‘__throw_bad_cast’ that depend on a template parameter, so a declaration of ‘__throw_bad_cast’ must be available [-Wtemplate-body]
   53 |         __throw_bad_cast();
      |         ^~~~~~~~~~~~~~~~
In file included from /usr/include/c++/16/bits/basic_ios.h:532:
/usr/include/c++/16/bits/basic_ios.tcc: In member function ‘void std::basic_ios<_CharT, _Traits>::clear(std::ios_base::iostate)’:
/usr/include/c++/16/bits/basic_ios.tcc:53:9: error: there are no arguments to ‘__throw_ios_failure’ that depend on a template parameter, so a declaration of ‘__throw_ios_failure’ must be available [-Wtemplate-body]
   53 |         __throw_ios_failure(__N("basic_ios::clear"));
      |         ^~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/basic_ios.h: In instantiation of ‘class std::basic_ios<char>’:
/usr/include/c++/16/bits/basic_ios.tcc:179:25:   required from here
  179 |   extern template class basic_ios<char>;
      |                         ^~~~~~~~~~~~~~~
/usr/include/c++/16/bits/basic_ios.h:85:54: error: no type named ‘pos_type’ in ‘struct std::char_traits<char>’
   85 |       typedef typename _Traits::pos_type             pos_type;
      |                                                      ^~~~~~~~
/usr/include/c++/16/bits/basic_ios.h:86:54: error: no type named ‘off_type’ in ‘struct std::char_traits<char>’
   86 |       typedef typename _Traits::off_type             off_type;
      |                                                      ^~~~~~~~
/usr/include/c++/16/bits/basic_ios.h: In instantiation of ‘class std::basic_ios<wchar_t>’:
/usr/include/c++/16/bits/basic_ios.tcc:182:25:   required from here
  182 |   extern template class basic_ios<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/basic_ios.h:85:54: error: no type named ‘pos_type’ in ‘struct std::char_traits<wchar_t>’
   85 |       typedef typename _Traits::pos_type             pos_type;
      |                                                      ^~~~~~~~
/usr/include/c++/16/bits/basic_ios.h:86:54: error: no type named ‘off_type’ in ‘struct std::char_traits<wchar_t>’
   86 |       typedef typename _Traits::off_type             off_type;
      |                                                      ^~~~~~~~
In file included from /usr/include/c++/16/ostream:42,
                 from /usr/include/c++/16/istream:43:
/usr/include/c++/16/bits/ostream.h: In instantiation of ‘class std::basic_ostream<char>’:
/usr/include/c++/16/bits/ostream.tcc:349:25:   required from here
  349 |   extern template class basic_ostream<char>;
      |                         ^~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/ostream.h:72:57: error: no type named ‘pos_type’ in ‘struct std::char_traits<char>’
   72 |       typedef typename _Traits::pos_type                pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/bits/ostream.h:73:57: error: no type named ‘off_type’ in ‘struct std::char_traits<char>’
   73 |       typedef typename _Traits::off_type                off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/bits/ostream.h: In instantiation of ‘class std::basic_ostream<wchar_t>’:
/usr/include/c++/16/bits/ostream.tcc:375:25:   required from here
  375 |   extern template class basic_ostream<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/ostream.h:72:57: error: no type named ‘pos_type’ in ‘struct std::char_traits<wchar_t>’
   72 |       typedef typename _Traits::pos_type                pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/bits/ostream.h:73:57: error: no type named ‘off_type’ in ‘struct std::char_traits<wchar_t>’
   73 |       typedef typename _Traits::off_type                off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream: In instantiation of ‘class std::basic_istream<char>’:
/usr/include/c++/16/istream:753:24:   required from here
  753 |     basic_istream<char>::
      |                        ^~
/usr/include/c++/16/istream:72:57: error: no type named ‘pos_type’ in ‘struct std::char_traits<char>’
   72 |       typedef typename _Traits::pos_type                pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream:73:57: error: no type named ‘off_type’ in ‘struct std::char_traits<char>’
   73 |       typedef typename _Traits::off_type                off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream: In instantiation of ‘class std::basic_istream<wchar_t>’:
/usr/include/c++/16/istream:769:27:   required from here
  769 |     basic_istream<wchar_t>::
      |                           ^~
/usr/include/c++/16/istream:72:57: error: no type named ‘pos_type’ in ‘struct std::char_traits<wchar_t>’
   72 |       typedef typename _Traits::pos_type                pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream:73:57: error: no type named ‘off_type’ in ‘struct std::char_traits<wchar_t>’
   73 |       typedef typename _Traits::off_type                off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream: In instantiation of ‘class std::basic_iostream<char>’:
/usr/include/c++/16/bits/istream.tcc:1154:25:   required from here
 1154 |   extern template class basic_iostream<char>;
      |                         ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/istream:1006:57: error: no type named ‘pos_type’ in ‘struct std::char_traits<char>’
 1006 |       typedef typename _Traits::pos_type                pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream:1007:57: error: no type named ‘off_type’ in ‘struct std::char_traits<char>’
 1007 |       typedef typename _Traits::off_type                off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream: In instantiation of ‘class std::basic_iostream<wchar_t>’:
/usr/include/c++/16/bits/istream.tcc:1176:25:   required from here
 1176 |   extern template class basic_iostream<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/istream:1006:57: error: no type named ‘pos_type’ in ‘struct std::char_traits<wchar_t>’
 1006 |       typedef typename _Traits::pos_type                pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/istream:1007:57: error: no type named ‘off_type’ in ‘struct std::char_traits<wchar_t>’
 1007 |       typedef typename _Traits::off_type                off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_stringbuf<char>’:
/usr/include/c++/16/bits/sstream.tcc:295:25:   required from here
  295 |   extern template class basic_stringbuf<char>;
      |                         ^~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:106:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_stringbuf<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  106 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:107:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_stringbuf<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  107 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_istringstream<char>’:
/usr/include/c++/16/bits/sstream.tcc:296:25:   required from here
  296 |   extern template class basic_istringstream<char>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:618:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_istringstream<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  618 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:619:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_istringstream<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  619 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_ostringstream<char>’:
/usr/include/c++/16/bits/sstream.tcc:297:25:   required from here
  297 |   extern template class basic_ostringstream<char>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:884:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_ostringstream<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  884 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:885:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_ostringstream<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
  885 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_stringstream<char>’:
/usr/include/c++/16/bits/sstream.tcc:298:25:   required from here
  298 |   extern template class basic_stringstream<char>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:1150:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_stringstream<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
 1150 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:1151:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_stringstream<char>::traits_type’ {aka ‘struct std::char_traits<char>’}
 1151 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_stringbuf<wchar_t>’:
/usr/include/c++/16/bits/sstream.tcc:301:25:   required from here
  301 |   extern template class basic_stringbuf<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:106:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_stringbuf<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  106 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:107:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_stringbuf<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  107 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_istringstream<wchar_t>’:
/usr/include/c++/16/bits/sstream.tcc:302:25:   required from here
  302 |   extern template class basic_istringstream<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:618:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_istringstream<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  618 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:619:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_istringstream<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  619 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_ostringstream<wchar_t>’:
/usr/include/c++/16/bits/sstream.tcc:303:25:   required from here
  303 |   extern template class basic_ostringstream<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:884:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_ostringstream<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  884 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:885:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_ostringstream<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
  885 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream: In instantiation of ‘class std::__cxx11::basic_stringstream<wchar_t>’:
/usr/include/c++/16/bits/sstream.tcc:304:25:   required from here
  304 |   extern template class basic_stringstream<wchar_t>;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/sstream:1150:57: error: no type named ‘pos_type’ in ‘std::__cxx11::basic_stringstream<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
 1150 |       typedef typename traits_type::pos_type            pos_type;
      |                                                         ^~~~~~~~
/usr/include/c++/16/sstream:1151:57: error: no type named ‘off_type’ in ‘std::__cxx11::basic_stringstream<wchar_t>::traits_type’ {aka ‘struct std::char_traits<wchar_t>’}
 1151 |       typedef typename traits_type::off_type            off_type;
      |                                                         ^~~~~~~~
In file included from /usr/include/c++/16/vector:68,
                 from packages/api/nros-cpp/include/nros/options.hpp:212,
                 from packages/api/nros-cpp/include/nros/node.hpp:34:
/usr/include/c++/16/bits/stl_vector.h: In member function ‘std::vector<_Tp, _Alloc>::size_type std::vector<_Tp, _Alloc>::_M_check_len(size_type, const char*) const’:
/usr/include/c++/16/bits/stl_vector.h:2195:11: error: there are no arguments to ‘__throw_length_error’ that depend on a template parameter, so a declaration of ‘__throw_length_error’ must be available [-Wtemplate-body]
 2195 |           __throw_length_error(__N(__s));
      |           ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/stl_vector.h: In static member function ‘static std::vector<_Tp, _Alloc>::size_type std::vector<_Tp, _Alloc>::_S_check_init_len(size_type, const allocator_type&)’:
/usr/include/c++/16/bits/stl_vector.h:2206:11: error: there are no arguments to ‘__throw_length_error’ that depend on a template parameter, so a declaration of ‘__throw_length_error’ must be available [-Wtemplate-body]
 2206 |           __throw_length_error(
      |           ^~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/16/vector:69:
/usr/include/c++/16/bits/stl_bvector.h: In member function ‘void std::vector<bool, _Alloc>::reserve(size_type)’:
/usr/include/c++/16/bits/stl_bvector.h:1208:11: error: there are no arguments to ‘__throw_length_error’ that depend on a template parameter, so a declaration of ‘__throw_length_error’ must be available [-Wtemplate-body]
 1208 |           __throw_length_error(__N("vector::reserve"));
      |           ^~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/stl_bvector.h: In member function ‘std::vector<bool, _Alloc>::size_type std::vector<bool, _Alloc>::_M_check_len(size_type, const char*) const’:
/usr/include/c++/16/bits/stl_bvector.h:1738:11: error: there are no arguments to ‘__throw_length_error’ that depend on a template parameter, so a declaration of ‘__throw_length_error’ must be available [-Wtemplate-body]
 1738 |           __throw_length_error(__N(__s));
      |           ^~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/16/vector:74:
/usr/include/c++/16/bits/vector.tcc: In member function ‘void std::vector<_Tp, _Alloc>::reserve(size_type)’:
/usr/include/c++/16/bits/vector.tcc:74:9: error: there are no arguments to ‘__throw_length_error’ that depend on a template parameter, so a declaration of ‘__throw_length_error’ must be available [-Wtemplate-body]
   74 |         __throw_length_error(__N("vector::reserve"));
      |         ^~~~~~~~~~~~~~~~~~~~
In file included from packages/api/nros-cpp/include/nros/node.hpp:44:
packages/api/nros-cpp/include/nros/timer.hpp: At global scope:
packages/api/nros-cpp/include/nros/timer.hpp:68:28: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
   68 |     using SharedPtr = std::shared_ptr<Timer>;
      |                            ^~~~~~~~~~
packages/api/nros-cpp/include/nros/timer.hpp:37:1: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; this is probably fixable by adding ‘#include <memory>’
   36 | #include "nros_cpp_ffi.h"
  +++ |+#include <memory>
   37 | 
packages/api/nros-cpp/include/nros/timer.hpp:70:33: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
   70 |     using ConstSharedPtr = std::shared_ptr<const Timer>;
      |                                 ^~~~~~~~~~
packages/api/nros-cpp/include/nros/timer.hpp:70:28: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; this is probably fixable by adding ‘#include <memory>’
   70 |     using ConstSharedPtr = std::shared_ptr<const Timer>;
      |                            ^~~
packages/api/nros-cpp/include/nros/timer.hpp:236:28: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
  236 |     using SharedPtr = std::shared_ptr<TimerBase>;
      |                            ^~~~~~~~~~
packages/api/nros-cpp/include/nros/timer.hpp:236:23: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; this is probably fixable by adding ‘#include <memory>’
  236 |     using SharedPtr = std::shared_ptr<TimerBase>;
      |                       ^~~
packages/api/nros-cpp/include/nros/timer.hpp:237:33: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
  237 |     using ConstSharedPtr = std::shared_ptr<const TimerBase>;
      |                                 ^~~~~~~~~~
packages/api/nros-cpp/include/nros/timer.hpp:237:28: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; this is probably fixable by adding ‘#include <memory>’
  237 |     using ConstSharedPtr = std::shared_ptr<const TimerBase>;
      |                            ^~~
packages/api/nros-cpp/include/nros/timer.hpp:272:10: error: ‘function’ in namespace ‘std’ does not name a template type
  272 |     std::function<void()> callback; // destroyed LAST
      |          ^~~~~~~~
packages/api/nros-cpp/include/nros/timer.hpp:220:1: note: ‘std::function’ is defined in header ‘<functional>’; this is probably fixable by adding ‘#include <functional>’
  219 | #include <functional>
  +++ |+#include <functional>
  220 | #define NROS_CPP_HAS_STD_FUNCTION 1
packages/api/nros-cpp/include/nros/timer.hpp: In static member function ‘static void rclcpp::detail::WallTimer::trampoline(void*)’:
packages/api/nros-cpp/include/nros/timer.hpp:267:38: error: ‘class rclcpp::detail::WallTimer’ has no member named ‘callback’
  267 |         if (self != nullptr && self->callback) {
      |                                      ^~~~~~~~
packages/api/nros-cpp/include/nros/timer.hpp:268:19: error: ‘class rclcpp::detail::WallTimer’ has no member named ‘callback’
  268 |             self->callback();
      |                   ^~~~~~~~
/usr/include/c++/16/bits/basic_string.h: In instantiation of ‘void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_check_length(size_type, size_type, const char*) const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’:
/usr/include/c++/16/bits/basic_string.tcc:578:7:   required from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
  578 |       _M_check_length(__len1, __len2, "basic_string::_M_replace");
      |       ^~~~~~~~~~~~~~~
/usr/include/c++/16/bits/basic_string.h:2486:9:   required from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
 2486 |         return _M_replace(_M_check(__pos, "basic_string::replace"),
      |                ^~~~~~~~~~
/usr/include/c++/16/bits/basic_string.h:2243:22:   required from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::insert(size_type, const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
 2243 |         return this->replace(__pos, size_type(0), __s,
      |                ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
 2244 |                              traits_type::length(__s));
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/bits/basic_string.h:4018:36:   required from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc> std::operator+(const _CharT*, __cxx11::basic_string<_CharT, _Traits, _Alloc>&&) [with _CharT = char; _Traits = char_traits<char>; _Alloc = allocator<char>]’
 4018 |     { return std::move(__rhs.insert(0, __lhs)); }
      |                        ~~~~~~~~~~~~^~~~~~~~~~
/usr/include/c++/16/system_error:568:51:   required from here
  568 |     : runtime_error(__what + (": " + __ec.message())), _M_code(__ec) { }
      |                                                   ^
/usr/include/c++/16/bits/basic_string.h:427:31: error: ‘__throw_length_error’ was not declared in this scope
  427 |           __throw_length_error(__N(__s));
      |           ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
error: recipe `cpp` failed with exit code 1

===== FAIL (rmw-xrce, rc=1, 543ms) =====
CMake Error at CMakeLists.txt:90 (message):
  nros-rmw-xrce: NROS_XRCE_CFFI_OUT_DIR is not set.

  This project no longer compiles the vendored micro-XRCE-DDS-Client /
  micro-CDR sources — it links the archive the cargo lane builds, so that
  the CTest harness exercises the objects images actually ship (phase-420 W9
  step 4).

  Build it and configure with it:

    just check rmw-xrce

  or, by hand:

    OUT=$(cargo build -p nros-rmw-xrce-cffi --message-format=json \
          | python3 -c 'import sys,json;print([json.loads(l)["out_dir"] for l in sys.stdin if "build-script-executed" in l and "nros-rmw-xrce-cffi#" in l][0])')
    cmake -S packages/rmw/xrce/nros-rmw-xrce -B <build> -DNROS_XRCE_CFFI_OUT_DIR="$OUT"


-- Configuring incomplete, errors occurred!
error: recipe `rmw-xrce` failed with exit code 1

check-build: slowest gates (ms)
    232840   30.8%  cli-tests
    155442   20.6%  source-gates
     99507   13.2%  borrowed-e2e
     78742   10.4%  workspace-features
     72039    9.5%  test-targets
     26208    3.5%  rmw-cyclonedds
     24814    3.3%  cpp
     18884    2.5%  required-features-tests
     14875    2.0%  node-std-tests
     14696    1.9%  c
  busy 755s over wall 232s at -P4 => 3.2x effective parallelism

check-build (parallel): 2 of 21 gate(s) FAILED

CI GATE FAILED at step 3 of 6.

  ok       check::cli-fresh
  ok       check::fast
  FAILED   check::build
  NOT RUN  check::api-parity
  NOT RUN  test-unit
  NOT RUN  test-lane-contracts

  3 step(s) did NOT run. This lane stops at the first failure, so a
  red step WITHDRAWS every step after it — `check::build` among them,
  which is the only place the C/C++ backends compile. A red count is
  not a coverage report: fix the failure and re-run before reading
  this lane as a verdict on anything below it (issue 0952). run on Arch with `gcc (GCC) 16.1.1`, on a branch whose entire diff was one shell script.

GCC 16's new `-Wtemplate-body` fires inside libstdc++'s own template bodies, and the lane compiles `-Werror`, so a system-header warning becomes an error. `<vector>`, `<sstream>`, `<string>` all fail before any nano-ros code compiles.

**The cascade is the trap.** With `<memory>` unusable, `NROS_CPP_HAS_SHARED_PTR` never gets defined, so GCC reports `'shared_ptr' in namespace 'std' does not name a template type` in `timer.hpp` and suggests adding `#include <memory>`. That header already includes it twice — under `NROS_CPP_STD` and behind the `__has_include` probe phase-417 W1.a added for issue 0112. Following the suggestion would add a third copy and fix nothing.

CI runs ubuntu-22.04 (GCC 11), where neither diagnostic exists, and `check-cpp` sits in the compile tier the `pre-push` hook excludes — so this is met only by someone on a rolling distro doing what CLAUDE.md asks and running the tier locally.

Filed rather than fixed: the three candidate fixes give up different things, and picking one is a decision. Document only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzPvAy8k8yiuoGmKMzKyiJ