### PR TITLE
fix(#1241): a `sort` destroyed the ratchet's header and every lane stayed green

### DIFF
--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -1,20 +1,37 @@
+# Prose references to an issue id with no file on disk.
 #
+# A RATCHET, not an allowlist: this file may only shrink. Each row is
+# `<path>:<id>`. The legitimate reason to be here is an IN-FLIGHT issue —
+# the citing doc is on main, its issue file is in another open PR — where
+# deleting the correct citation would be the wrong fix.
 #
+# Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline
 #
+# CLASSIFIED 2026-09-08, because "in flight" is only true of some of these:
 #
+#   1099  IN FLIGHT — `docs/issues/1099-cpp-trigger-transition-crosses-
+#         lifecycle-ids.md` exists on `origin/design/context-init-shape`.
+#         The citation is correct and the file is coming.
 #
+#   9999  NEGATION — the citation is deliberately unresolvable. Issue 1092
+#         describes a mutation test whose control is "a gap reason naming
+#         issue 9999, which DOES NOT EXIST". Filing 9999 would destroy the
+#         control; deleting the sentence would delete the test's description.
+#         The same class `check-doc-recipe-refs` calls NEGATION.
 #
+#         TWO documents cite it now: issue 1092, which describes the test, and
+#         issue 1241 (archived — it landed resolved), which quotes 1092's
+#         control while explaining why this header is worth a gate. `archived/`
+#         is not scanned, so only 1092's citation needs a row.
 #
 #   0417  RESERVED, NEVER WRITTEN. `refs/issue-ids/0417` exists on origin, so
 #   1080  the id was claimed with `just issue-new` and no file was ever
-#   1099  IN FLIGHT — `docs/issues/1099-cpp-trigger-transition-crosses-
-#   9999  NEGATION — the citation is deliberately unresolvable. Issue 1092
-# A RATCHET, not an allowlist: this file may only shrink. Each row is
-# CLASSIFIED 2026-09-08, because "in flight" is only true of some of these:
 #         committed — issue 0999's shape ("the id was reserved, the fix
-#         control; deleting the sentence would delete the test's description.
-# deleting the correct citation would be the wrong fix.
-#         describes a mutation test whose control is "a gap reason naming
+#         landed, the file never got written"). The citations are honest and
+#         point at nothing, and the fix is to write the file, which needs
+#         whoever claimed the id. Not deleted: a reference removed is a
+#         record lost, and the id is not free either.
+#
 docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
 docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
 docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md:1080
@@ -22,18 +39,6 @@ docs/issues/1186-executor-backing-latch-test-races-siblings.md:0417
 docs/issues/1231-cyclone-assert-publisher-liveliness-null.md:1164
 docs/roadmap/phase-428-api-porting-principle-sweep.md:1099
 docs/roadmap/phase-432-codegen-one-producer-many-packs.md:1080
-#         issue 9999, which DOES NOT EXIST". Filing 9999 would destroy the
 just/check/docs.just:1110
 just/check/lanes.just:1099
-#         landed, the file never got written"). The citations are honest and
-#         lifecycle-ids.md` exists on `origin/design/context-init-shape`.
-# `<path>:<id>`. The legitimate reason to be here is an IN-FLIGHT issue —
-#         point at nothing, and the fix is to write the file, which needs
-# Prose references to an issue id with no file on disk.
-#         record lost, and the id is not free either.
-# Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline
 scripts/build/rustdoc-set.sh:1110
-#         The citation is correct and the file is coming.
-# the citing doc is on main, its issue file is in another open PR — where
-#         The same class `check-doc-recipe-refs` calls NEGATION.
-#         whoever claimed the id. Not deleted: a reference removed is a

--- a/docs/issues/archived/1241-prose-issue-ref-baseline-scrambled-by-sort.md
+++ b/docs/issues/archived/1241-prose-issue-ref-baseline-scrambled-by-sort.md
@@ -1,0 +1,91 @@
+---
+id: 1241
+title: "A ratchet's classification header is content no gate reads, so a `sort`
+  during a conflict resolution destroyed it on `main` and every lane stayed
+  green"
+status: resolved
+type: bug
+area: [ci, docs]
+found: 2026-09-09
+resolved: 2026-09-09
+related: [0989, 0206, 1161]
+---
+
+## What
+
+`.config/prose-issue-ref-baseline.txt` on `main` had its header comments
+interleaved among its data rows. Its first seven lines were seven bare `#`, and
+the `CLASSIFIED 2026-09-08` block that says WHY each row is there was scattered
+between the rows it classifies:
+
+```
+#
+#
+#   0417  RESERVED, NEVER WRITTEN. `refs/issue-ids/0417` exists on origin, so
+#   1080  the id was claimed with `just issue-new` and no file was ever
+# A RATCHET, not an allowlist: this file may only shrink. Each row is
+docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
+...
+#         issue 9999, which DOES NOT EXIST". Filing 9999 would destroy the
+just/check/docs.just:1110
+```
+
+Every line is present; the file is sorted alphabetically as a whole. It arrived
+in `0a02601b5`, a commit about something else, and is the signature of a
+conflict resolved by running `sort` over the file.
+
+## Why nothing caught it
+
+`check-prose-issue-refs` reads the baseline as a SET of rows and discards
+comments. So the gate's verdict is identical before and after — and the thing
+that was destroyed is precisely the content no gate reads.
+
+That is what makes it worth a gate rather than care. The rows are
+`<path>:<id>` and say nothing about why. The header is the only place that
+distinguishes:
+
+* **IN FLIGHT** — the issue file is coming on another branch;
+* **NEGATION** — issue 9999 is deliberately unresolvable, because issue 1092
+  describes a mutation test whose control is "a gap reason naming issue 9999,
+  which DOES NOT EXIST"; filing it would destroy the control;
+* **RESERVED, NEVER WRITTEN** — 0417 and 1080, ids claimed with `just issue-new`
+  whose files were never committed.
+
+Without it, a reader cannot tell which lines are debt, and the ratchet degrades
+into an allowlist — the exact failure its own header warns about.
+
+Sorting has this effect only because comments and rows share a file. It is
+harmless to the rows: they are a set.
+
+## The second way the same content is lost
+
+`--write-baseline` REPLACED the header with a hard-coded default, so
+regenerating the file after adding one row deleted every classification a
+person had written. Two mechanisms, one casualty.
+
+## Fix
+
+`check_baseline_shape` refuses a baseline in which any comment line follows the
+first data row — the weakest rule that catches a whole-file sort, permitting
+any header a person writes and refusing the shape no person writes. It carries
+five self-test cases on the normal path, including the sorted-file case, so its
+failure path is exercised on every run.
+
+`--write-baseline` now keeps an existing header and rewrites only the rows,
+falling back to the default only when there is no header to keep. Verified
+idempotent: regenerating an already-correct file leaves it byte-identical.
+
+`main`'s file is restored from `ace79ba9d` (the last commit before the scramble)
+plus the one row `0a02601b5` legitimately added,
+`docs/issues/1231-…:1164` — measured row-wise, nothing else changed and nothing
+was lost.
+
+## What this does not cover
+
+The sibling ratchets — `.config/doc-commit-citations-baseline.txt`,
+`.config/capability-skip-baseline.txt`, `.config/prose-issue-ref-baseline.txt`'s
+own relatives — carry the same authored-header-plus-derived-rows shape and have
+no such check. `check_baseline_shape` takes a list of lines and nothing else, so
+adopting it in those gates is a call each one can make; none of them has been
+scrambled yet, and a gate added for a defect that has not occurred is a
+different decision from one added for a defect that has.

--- a/scripts/check-prose-issue-refs.py
+++ b/scripts/check-prose-issue-refs.py
@@ -192,6 +192,49 @@ def scan():
     return bad
 
 
+def check_baseline_shape(lines):
+    """A comment may not follow a data row. Returns an error string, or None.
+
+    The baseline's rows are a set and the checker ignores comments entirely, so
+    NOTHING about the gate's verdict depends on their order — which is exactly
+    why the file can be destroyed without any lane noticing. It happened: a
+    conflict resolution ran the whole file through `sort`, and `main` carried a
+    baseline whose first seven lines were seven bare `#` and whose CLASSIFIED
+    block was interleaved among the rows it classifies. Every gate stayed green,
+    because the content that was lost is the content no gate reads.
+
+    That content is the file's entire value. Its rows are `<path>:<id>` and say
+    nothing about WHY; the header is where an IN-FLIGHT citation is told apart
+    from a deliberate NEGATION (issue 9999, whose control issue 1092 would be
+    destroyed by filing it) and from an id reserved but never written (0417,
+    1080). Without it the next reader cannot tell which lines are debt.
+
+    The rule is the weakest one that catches a sort: comments come first. It
+    permits any header a person writes and refuses the shape no person writes.
+    """
+    first_row = next((i for i, l in enumerate(lines)
+                      if l.strip() and not l.startswith("#")), None)
+    if first_row is None:
+        return None
+    late = [i for i, l in enumerate(lines[first_row:], first_row)
+            if l.startswith("#")]
+    if not late:
+        return None
+    return (
+        "check-prose-issue-refs: the baseline's comments are INTERLEAVED with its "
+        "rows.\n"
+        "  %d comment line(s) appear after the first row (line %d), which is the\n"
+        "  shape a `sort` of the whole file leaves behind — see line %d.\n"
+        "  Nothing about this gate's verdict depends on comment order, so this\n"
+        "  cannot be caught by the rows being wrong: the header is the part that\n"
+        "  says which rows are debt and which are deliberate, and it is gone.\n"
+        "  Restore the header from git history, and do not `sort` the whole\n"
+        "  file again. `--write-baseline` is safe: it keeps the header and\n"
+        "  rewrites only the rows.\n"
+        % (len(late), first_row + 1, late[0] + 1)
+    )
+
+
 def load_baseline():
     if not os.path.exists(BASELINE):
         raise SystemExit(
@@ -200,25 +243,61 @@ def load_baseline():
             "  Regenerate deliberately with --write-baseline."
         )
     with open(BASELINE, encoding="utf8") as fh:
-        return {l.strip() for l in fh if l.strip() and not l.startswith("#")}
+        lines = fh.read().split("\n")
+    bad_shape = check_baseline_shape(lines)
+    if bad_shape:
+        raise SystemExit(bad_shape)
+    return {l.strip() for l in lines if l.strip() and not l.startswith("#")}
+
+
+DEFAULT_HEADER = (
+    "# Prose references to an issue id with no file on disk.\n"
+    "#\n"
+    "# A RATCHET, not an allowlist: this file may only shrink. Each row is\n"
+    "# `<path>:<id>`. The legitimate reason to be here is an IN-FLIGHT issue —\n"
+    "# the citing doc is on main, its issue file is in another open PR — where\n"
+    "# deleting the correct citation would be the wrong fix.\n"
+    "#\n"
+    "# Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline\n"
+    "# — which KEEPS this header and rewrites only the rows below it. Never\n"
+    "# `sort` the file: the rows are a set and sorting them is harmless, but it\n"
+    "# takes the header apart line by line and no gate reads comments.\n"
+)
+
+
+def existing_header():
+    """The comment block at the top of the current file, if there is one.
+
+    Regenerating used to REPLACE the header with the default, which silently
+    deleted whatever classification a person had written — the same content a
+    stray `sort` scrambles, lost the other way. The rows are derived and the
+    header is authored, so only the rows are rewritten.
+    """
+    try:
+        with open(BASELINE, encoding="utf8") as fh:
+            lines = fh.read().split("\n")
+    except OSError:
+        return None
+    head = []
+    for line in lines:
+        if line.startswith("#") or not line.strip():
+            head.append(line)
+        else:
+            break
+    while head and not head[-1].strip():
+        head.pop()
+    return "\n".join(head) + "\n" if head else None
 
 
 def write_baseline(bad):
     os.makedirs(os.path.dirname(BASELINE), exist_ok=True)
+    header = existing_header() or DEFAULT_HEADER
     with open(BASELINE, "w", encoding="utf8") as fh:
-        fh.write(
-            "# Prose references to an issue id with no file on disk.\n"
-            "#\n"
-            "# A RATCHET, not an allowlist: this file may only shrink. Each row is\n"
-            "# `<path>:<id>`. The legitimate reason to be here is an IN-FLIGHT issue —\n"
-            "# the citing doc is on main, its issue file is in another open PR — where\n"
-            "# deleting the correct citation would be the wrong fix.\n"
-            "#\n"
-            "# Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline\n"
-        )
+        fh.write(header)
         for row in sorted(bad):
             fh.write(row + "\n")
-    print(f"wrote {BASELINE} — {len(bad)} known dangling reference(s)")
+    kept = "kept the existing header" if existing_header() else "wrote the default header"
+    print(f"wrote {BASELINE} — {len(bad)} known dangling reference(s), {kept}")
 
 
 def self_test():
@@ -240,6 +319,28 @@ def self_test():
     # A bare number is NOT a reference — this is what keeps the gate quiet.
     case("bare number ignored", "port 7447 and 0640 bytes", set())
     case("word boundary", "issue 09755 is not an id", set())
+
+    # The shape rule's own negative control. A check whose failure path is never
+    # exercised is the class this gate's own baseline was destroyed by: green
+    # either way, so nobody notices it stopped answering.
+    shape_cases = [
+        ("a header then rows passes",
+         ["# why", "#   0417  reserved", "a.md:0417", "b.md:1080"], False),
+        ("a sorted file fails",
+         ["#", "#   0417  reserved", "a.md:0417", "# why", "b.md:1080"], True),
+        ("rows with no header at all passes",
+         ["a.md:0417"], False),
+        ("comments only passes",
+         ["# just a header"], False),
+        ("a trailing blank line is not a row",
+         ["# why", "a.md:0417", ""], False),
+    ]
+    for name, lines, want_fail in shape_cases:
+        got_fail = check_baseline_shape(lines) is not None
+        if got_fail != want_fail:
+            print(f"  [FAIL] shape: {name}: fails={got_fail}, want {want_fail}",
+                  file=sys.stderr)
+            fails += 1
 
     if fails:
         print(f"check-prose-issue-refs: self-test FAILED ({fails} case(s))", file=sys.stderr)


### PR DESCRIPTION
A defect on `main`, found while rebasing two unrelated PRs that both hit it as a conflict.

## What is wrong

`.config/prose-issue-ref-baseline.txt` has its comments interleaved among its rows. Its first seven lines are seven bare `#`, and the `CLASSIFIED 2026-09-08` block sits between the rows it classifies:

```
#
#   0417  RESERVED, NEVER WRITTEN. `refs/issue-ids/0417` exists on origin, so
#   1080  the id was claimed with `just issue-new` and no file was ever
# A RATCHET, not an allowlist: this file may only shrink. Each row is
docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
...
#         issue 9999, which DOES NOT EXIST". Filing 9999 would destroy the
just/check/docs.just:1110
```

Every line is present and the file is sorted alphabetically as a whole — the signature of a conflict resolved by running `sort` over it. It arrived in `0a02601b5`, a commit about something else entirely.

## Why no lane noticed

`check-prose-issue-refs` reads the baseline as a **set of rows** and discards comments. Its verdict is byte-identical before and after. What was destroyed is precisely the content no gate reads.

That is what makes it worth a gate rather than care. The rows are `<path>:<id>` and say nothing about why. The header is the only place separating:

- **IN FLIGHT** — the issue file is coming on another branch
- **NEGATION** — issue 9999 is deliberately unresolvable; issue 1092 describes a mutation test whose control is *"a gap reason naming issue 9999, which DOES NOT EXIST"*, so filing it would destroy the control
- **RESERVED, NEVER WRITTEN** — 0417 and 1080, ids claimed with `just issue-new` whose files were never committed

Without it a reader cannot tell which lines are debt, and the ratchet degrades into an allowlist — what its own header warns against.

## The fix, and the second mechanism it closes

`check_baseline_shape` refuses a baseline where any comment follows the first data row. That is the **weakest** rule that catches a whole-file sort: it permits any header a person writes and refuses the shape no person writes. Five self-test cases run on the normal path, including the sorted-file case, so its failure path is exercised on every run — the same oversight class as the defect itself.

`--write-baseline` was the *other* way to lose the same content: it REPLACED the header with a hard-coded default, so regenerating after adding one row deleted every classification a person had written. It now keeps an existing header and rewrites only the rows, falling back to the default only when there is none.

## Restoration is measured, not eyeballed

From `ace79ba9d` (last commit before the scramble) plus the one row `0a02601b5` legitimately added. Row-wise: **9 there, 10 on main, one added, none lost.**

## Verified

- Gate exits **1** on a file put back through `sort`, and prints what to do
- Gate exits **0** on the restored file
- `--write-baseline` on an already-correct file is **byte-for-byte idempotent**, reporting `kept the existing header`
- `just check fast` **281/283** — `capability-conditionals` and `xrce-vendored-versions` refuse because a fresh worktree has no submodules and no `nros setup` sources; neither is reachable from this diff

## Note for reviewers

#629 and #753 each repair this file as a side effect of their own rebase, so expect a ratchet conflict with whichever lands second. All three agree on the target content; only this PR adds the check that stops it recurring.

Issue 1241 lands **archived** — the fix is in the same commit, and an open issue against a fixed defect is a false claim in the series whose job is to say what is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N