### PR TITLE
docs(#1227): four measured verdicts, one retraction, and why the bisect stopped

### DIFF
--- a/docs/issues/1227-island-image-dtcm-overflows-on-main.md
+++ b/docs/issues/1227-island-image-dtcm-overflows-on-main.md
@@ -103,6 +103,62 @@ Issue 1235: the `sync` step refuses a CORRECTLY paired resolver on these commits
 `setup-cli` / `setup-launch-resolve` cannot repair what their own errors name.
 Every bisect step needs this working around before it can even reach a compiler.
 
+## ROOT CAUSE FOUND -- `0368d4040`, and it is a correct fix exposing a real gap
+
+Bisected on the HOST, seconds per step instead of twelve minutes. `nros-node`'s
+`build.rs` derives the arena from the knobs and prints `cargo:arena_size`, so
+the island's number is reproducible with a plain `cargo build -p nros-node` and
+the island's knobs in the environment -- no Zephyr, no board, and every commit
+in the interval builds, which is what made it searchable at all after the board
+route stalled.
+
+| commit | derived arena |
+| --- | --- |
+| `316915dc3` (parent) | 61,936 |
+| **`0368d4040`** | **207,096** |
+| `6e7779b05` (main today) | 207,096 |
+
+`git bisect run` over `d7e7bb477..fb94d1896` names `0368d4040` --
+`fix(#1190): the arena priced a subscription's QoS history at three slots`. The
+arena grows by 145,160 B in one commit and has stayed there since.
+
+### It is not a mistake to revert
+
+That commit CORRECTED an under-count. The old model charged `3 * rx_buf + 512`
+per subscription -- a `TripleBuffer`, the `depth <= 1` case -- while the runtime
+registers `KEEP_LAST(10)`: eleven slots plus a length array. Issue 1190 is the
+symptom of the old number, a zenoh listener taking `BufferTooSmall` on register.
+
+So the island was never really fitting. The model was under-counting what the
+image already allocates, and DTCM at 71.22% measured the wrong quantity.
+
+### The gap it exposes
+
+`PUBSUB_QOS_DEPTH` is a hardcoded `const ... = 10`
+(`packages/core/nros-node/build.rs:27`). It is read neither from the environment
+nor from the image's DECLARED QoS, so every subscription is priced at the ROS
+default whatever the image says.
+
+The island declares no depths at all -- `safety_island.contract.yaml` contains
+zero `depth:` keys -- so today it correctly inherits KEEP_LAST(10) and correctly
+pays for it. But the machinery to know better already exists: the declared-QoS
+producer (issue 1084) emits `nros_declared_qos_generated.h` and
+`check-declared-qos-header` gates it. The arena model is the one consumer that
+does not read it.
+
+Two separable pieces of work:
+
+1. **`nros-node`** -- price each subscription at its DECLARED depth, falling
+   back to the ROS default only where nothing is declared. A per-image constant
+   of 10 makes every shallow subscription pay for a deep one.
+2. **the island** -- declare the depths it actually needs. At depth 1 a
+   subscription is a `TripleBuffer` again, and eleven of those cost a fraction
+   of eleven-slot rings. That is a queueing decision, and it should be made
+   deliberately rather than inherited.
+
+Until one of those lands the image does not fit, and the honest reading is that
+it has not fitted since `0368d4040` started telling the truth about it.
+
 ## Why this matters more than the byte count
 
 Nothing merge-gating builds this image. The regression reached main and the only
@@ -112,7 +168,12 @@ one platform over.
 
 ## Next step
 
-Bisect the five commits above with the island's board-build recipe on a wiped
-directory, and
-if it is `dc2416f6e`, compare the generated linker script and the DTCM section
-list against `fb94d1896`.
+The bisect is DONE. What remains is a decision, not a search: teach the arena
+model to read declared depths, or declare depths on the island, or both.
+
+The board-build route to bisecting this is still broken and worth fixing on its
+own account -- most commits in the interval cannot build the current ASI tree,
+and issue 1235 blocks the rest -- but it is no longer on the path to an answer
+here. The host oracle (`cargo:arena_size`) should be the first tool reached for
+any future memory-derivation bisect: three orders of magnitude cheaper, and it
+does not depend on the consumer building at all.

--- a/docs/issues/1227-island-image-dtcm-overflows-on-main.md
+++ b/docs/issues/1227-island-image-dtcm-overflows-on-main.md
@@ -43,27 +43,65 @@ Overflowing by 45040 puts it near 176 KB, so roughly 83 KB has appeared. That is
 not drift; something is placed in DTCM that was not there before, or is placed
 twice.
 
-## Bisect boundary, established
+## Bisect: four verdicts, and why it could not be finished
 
-Not caused by the change that found it. A control build of clean `origin/main`
-with that change stashed produces the IDENTICAL overflow, to the byte.
+Measured on `mr_canhubk3/s32k344`, wiped build directory each time. BAD is
+always the SAME byte count, which is itself evidence it is one cause:
 
-The last commit known to produce a linking image is `fb94d1896`
-(`fix(zephyr): the C-for-C++ nros-c string must read the C++ one`), measured on
-its own branch at 71.22% DTCM before it merged. The commits merged after it:
+| commit | verdict |
+| --- | --- |
+| `1976727d8` | GOOD -- DTCM 93344 B, 71.22% |
+| `e3786749a` | GOOD -- DTCM 93344 B, 71.22% |
+| `d7e7bb477` | GOOD -- DTCM 93336 B, 71.21% |
+| `fb94d1896` | BAD -- overflowed by 45040 bytes |
+
+`d7e7bb477` (2026-09-06 21:14) is the newest commit known to build, and is the
+floor to search from. The regression is in what `main` gained between it and
+`fb94d1896`.
+
+NOT environmental: `e3786749a` reproduces 71.22% a day after the same tree first
+produced it, and the three GOOD commits agree to within 8 bytes.
+
+### Two wrong readings, recorded so they are not repeated
+
+* **"the first suspect is `dc2416f6e`"** -- from reading subject lines
+  (`the placement arithmetic moves to a crate a build script can call`). It IS
+  bad, but so is every commit below it in that range, including `3e5dc6e4f`,
+  a CI cache fix that cannot move RAM. Reading a subject line is not a bisect.
+* **`01cb87d8f` reported BAD -- RETRACTED.** It built only because it ran before
+  the probe directory was touched, so `sync` skipped metadata regeneration and
+  it consumed metadata emitted by ANOTHER commit's codegen. Its number is not
+  attributable to that commit. Any narrowing that rested on it (an 11-commit
+  range was claimed) is withdrawn.
+
+### What blocks finishing it
+
+Most commits in the range cannot build the CURRENT safety-island tree at all.
+The CLI's `sync` step regenerates the message metadata whenever the CLI
+changes, and at those commits regeneration fails:
 
 ```
-055b84387 fix(check): doc-commit-citations is red on main, in both directions
-56fc7b03c build(#1197): six more leaf locks the gate surfaced once the first 13 were fixed
-a0992e5d8 build(#1197): the 13 leaf locks that carry nros-node gain the new path dep
-dc2416f6e feat(#1197): the placement arithmetic moves to a crate a build script can call
-3e5dc6e4f fix(ci): the CLI cache stored the whole job, not the CLI build
+build/nros-metadata/metadata-probe-cmake/build/nros-ws-nav_msgs/.../nav_msgs_msg_odometry.hpp:99:93:
+error: static assertion failed: NROS_UNBOUNDED__nav_msgs_msg_odometry__field_header_frame_id:
+nav_msgs/Odometry states no serialized-size bound
 ```
 
-`dc2416f6e` is the one to look at first -- it moves the PLACEMENT arithmetic,
-which is what decides what lands in DTCM. The other four are a lockfile sweep, a
-CI cache fix and a docs gate, none of which should reach a linker script. This
-is a reading of the subject lines, NOT a bisect: the bisect was not run.
+Reproduced at `0368d4040`, `5a3cbc008`, `3da478ffb`, `4d6e0da9c`, `09ed8e069`,
+`c89431210`, `29ea7d181`, `e957bc634` -- with and without clearing
+`build/nros-metadata`. ASI's caps are not being applied by those commits'
+codegen, so the consumer's own messages come out unbounded.
+
+Bisecting a library against a fixed consumer assumes the consumer builds at
+every commit. Here it does not, and the commits that do not build are most of
+the interval. Finishing this needs the ASI side moved in lockstep with the
+library, or that codegen incompatibility understood first -- not more builds of
+the same shape.
+
+### Also in the way
+
+Issue 1235: the `sync` step refuses a CORRECTLY paired resolver on these commits, and
+`setup-cli` / `setup-launch-resolve` cannot repair what their own errors name.
+Every bisect step needs this working around before it can even reach a compiler.
 
 ## Why this matters more than the byte count
 


### PR DESCRIPTION
Updates #1227 with what four board builds established, and stops the bisect
rather than continue with a method that had begun producing wrong answers.

## Measured

`mr_canhubk3/s32k344`, wiped build directory each time:

| commit | verdict |
| --- | --- |
| `1976727d8` | GOOD -- DTCM 93344 B, 71.22% |
| `e3786749a` | GOOD -- DTCM 93344 B, 71.22% |
| `d7e7bb477` | GOOD -- DTCM 93336 B, 71.21% |
| `fb94d1896` | BAD -- overflowed by 45040 bytes |

`d7e7bb477` is the newest commit known to build. Not environmental --
`e3786749a` reproduces 71.22% a day after the same tree first produced it, and
the three GOOD commits agree to within 8 bytes. Every BAD is the identical byte
count, which is itself evidence of one cause.

## Retraction

`01cb87d8f` was reported BAD earlier in this investigation. **Withdrawn.** It
built only because it ran before the probe directory was touched, so `sync`
skipped metadata regeneration and it consumed metadata emitted by another
commit's codegen. Its number is not attributable to that commit, and the
11-commit range that rested on it is withdrawn with it.

The first suspect, `dc2416f6e`, was also picked by reading subject lines. It is
bad -- but so is `3e5dc6e4f` below it, a CI cache fix that cannot move RAM.

## Why it stopped

Most commits in the interval cannot build the current ASI tree at all. The
CLI's `sync` step regenerates message metadata whenever the CLI changes, and at
eight measured commits that regeneration fails:

```
error: static assertion failed:
NROS_UNBOUNDED__nav_msgs_msg_odometry__field_header_frame_id
```

ASI's caps are not applied by those commits' codegen. Bisecting a library
against a fixed consumer assumes the consumer builds at every commit; here it
does not, for most of the interval. Finishing this wants the ASI side moved in
lockstep, or that codegen incompatibility understood -- not more builds of the
same shape.

Issue #1235 (PR #774) is the other thing in the way: `sync` refuses a correctly
paired resolver on these commits, and the sanctioned rebuild commands cannot
repair what their own errors name.

## Note on the baseline

`.config/prose-issue-ref-baseline.txt` gains ONE row, because 1227 now cites
1235 and 1235's file is in #774. Added by hand rather than with
`--write-baseline`, which rewrites the file and would have dropped 22 existing
rows -- the ratchet-shrink that put `main` red three times this week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)