### PR TITLE
docs(AGENTS.md): the stacked-branch paragraph stranded its own citation, and it is red on main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,8 +532,17 @@ so does every rebase of A onto a newer `main`. B's base then stops being an
 ancestor and B cannot be restacked mechanically, because its copies of A's
 commits conflict with their own rebased twins. Measured on #704 after #629 was
 rebased twice: common ancestor an old `main` tip, base **110 commits** past it,
-and the restack conflicted on `bd4b087c1` — one of A's own commits. The remedy
-is to wait for A to land, retarget B to `main`, and rebase there.
+and the restack conflicted on one of A's own commits — #629's QoS-SSoT commit
+("one QoS SSoT, and the field four transcriptions disagreed about"), which #704
+carried a stale copy of. The remedy is
+to wait for A to land, retarget B to `main`, and rebase there.
+
+That sentence used to name that commit by short hash, and the hash is gone,
+because #629 was rebased again — which is the very failure this paragraph
+describes, committed inside the paragraph describing it. `check-doc-commit-citations`
+caught it, on `main`, where a red fast-line gate blocks every push in the
+repository. A citation to a commit on an UNMERGED branch is a citation with an
+expiry date; describe the commit instead.
 
 **The `main`-based alternative self-cleans, because the queue rebase-merges.**
 `merge_method=REBASE` replays A's commits onto `main` with new hashes and


### PR DESCRIPTION
`check-doc-commit-citations` fails on `main`:

```
AGENTS.md:535   `bd4b087c1`
```

That gate is on the fast line and therefore on the `pre-push` hook, so a red one blocks **every push in the repository by every contributor**, whatever they are working on. Second time this session a dangling short hash has had that effect.

## The irony is the useful part

The sentence sits inside **"Rebasing A strands B"** — the passage explaining that every rebase of a stacked branch invalidates references into it — and it cited one of #629's own commits by short hash. #629 was then rebased again, and the hash died exactly as the surrounding prose predicts.

So the case is now recorded in the paragraph rather than only in a commit message, with the rule it teaches, one line, where the next person will be writing the citation: *a citation to a commit on an unmerged branch is a citation with an expiry date.*

## The fix

A description a rebase cannot invalidate — #629's QoS-SSoT commit, quoted by subject.

Verified against `gh pr view 629` rather than recalled: my first draft called it "the Zephyr QoS SSoT commit", and "Zephyr" was not in it.

**Not baselined.** `.config/doc-commit-citations-baseline.txt` is for citations this repository can never resolve (FOREIGN) or whose claim is unrecoverable. Neither holds here, and the claim survives fine without the hash.

## Sweep

The gate is its own sweep — it reports every offending citation in one run. After this change: **197 citations across 897 live files resolve**, 12 declared foreign/known-dead.

## Tier

`just check fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj