### PR TITLE
feat(phase-436 W7 + #1242): a C-ABI for the wake-source seam, and Zephyr parks through it

### DIFF
--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -1488,6 +1488,62 @@ nros_cpp_ret_t nros_cpp_executor_set_active_groups(void *executor,
  * `tiers` must be a valid pointer to `n_tiers` [`NativeTierSpecC`] entries,
  * valid for the duration of the call. `session_name` is NULL or a valid
  * null-terminated string.
+ * phase-436 W7.a — register a platform deadline source on this executor.
+ *
+ * The seam existed only as a Rust method, so the board entries that go through
+ * this ABI — FreeRTOS, NuttX and the C arm of Zephyr, which is the arm the
+ * Zephyr FVP lane takes — could not reach it at all. They hold an opaque
+ * handle, not a typed `Executor`.
+ *
+ * `next` returns microseconds FROM NOW until this source next needs the
+ * executor; `u64::MAX` means nothing pending, which is how an asynchronous
+ * source spells itself while breaking the park by signalling instead.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL. `next` and
+ * `ctx` must outlive the executor.
+ */
+nros_cpp_ret_t nros_cpp_executor_register_wake_source(void *handle,
+                                                      uint64_t (*next)(void*),
+                                                      void *ctx);
+
+/**
+ * phase-436 W7.a — the wake object a port's park primitive must wait on.
+ *
+ * Returns NULL when this build has no wake primitive linked.
+ *
+ * A `ParkUntilFn` that waits on its own fresh object cannot be broken by the
+ * backend's listener, because the listener signals THIS one — and installing
+ * such a park makes latency WORSE, since `spin_once` drops the transport
+ * drain to non-blocking once a port has parked. Pass this as the park's
+ * `ctx`.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL.
+ */
+void *nros_cpp_executor_wake_handle(void *handle);
+
+/**
+ * phase-436 W7.a — install THE primitive this executor blocks on.
+ *
+ * Singular by nature: only one thing can actually wait. `granularity_us` is
+ * the finest park the primitive can express, and the port states it because
+ * only the port knows — an RTOS tick is a coarser limit than the ABI
+ * signature, a timespec primitive a finer one (issue 1242).
+ *
+ * `park` returns 0 when woken by an event, 1 when the deadline expired, and a
+ * negative value when it cannot park.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL. `park` and
+ * `ctx` must outlive the executor.
+ */
+nros_cpp_ret_t nros_cpp_executor_set_park_primitive(void *handle,
+                                                    int8_t (*park)(void*, uint64_t),
+                                                    void *ctx,
+                                                    uint64_t granularity_us);
+
+/**
  * Declare how often this executor's loop intends to come round, in
  * microseconds. `0` (the default) falls back to the `spin_once` timeout.
  *

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3484,6 +3484,95 @@ pub struct NativeTierSpecC {
 /// valid for the duration of the call. `session_name` is NULL or a valid
 /// null-terminated string.
 #[cfg(all(feature = "rmw-cffi", feature = "env"))]
+
+/// phase-436 W7.a — register a platform deadline source on this executor.
+///
+/// The seam existed only as a Rust method, so the board entries that go through
+/// this ABI — FreeRTOS, NuttX and the C arm of Zephyr, which is the arm the
+/// Zephyr FVP lane takes — could not reach it at all. They hold an opaque
+/// handle, not a typed `Executor`.
+///
+/// `next` returns microseconds FROM NOW until this source next needs the
+/// executor; `u64::MAX` means nothing pending, which is how an asynchronous
+/// source spells itself while breaking the park by signalling instead.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL. `next` and
+/// `ctx` must outlive the executor.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_register_wake_source(
+    handle: *mut c_void,
+    next: Option<unsafe extern "C" fn(*mut c_void) -> u64>,
+    ctx: *mut c_void,
+) -> nros_cpp_ret_t {
+    let Some(next) = next else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    let Some(cpp) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    match cpp.executor.register_wake_source(next, ctx) {
+        Ok(_) => NROS_CPP_RET_OK,
+        // The table is fixed-capacity and refuses rather than dropping: a
+        // source silently discarded would leave the executor sleeping past a
+        // deadline it had been told about.
+        Err(_) => NROS_CPP_RET_ERROR,
+    }
+}
+
+/// phase-436 W7.a — the wake object a port's park primitive must wait on.
+///
+/// Returns NULL when this build has no wake primitive linked.
+///
+/// A `ParkUntilFn` that waits on its own fresh object cannot be broken by the
+/// backend's listener, because the listener signals THIS one — and installing
+/// such a park makes latency WORSE, since `spin_once` drops the transport
+/// drain to non-blocking once a port has parked. Pass this as the park's
+/// `ctx`.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_wake_handle(handle: *mut c_void) -> *mut c_void {
+    match unsafe { cpp_ctx_checked(handle) } {
+        Some(cpp) => cpp.executor.wake_raw_ptr(),
+        None => core::ptr::null_mut(),
+    }
+}
+
+/// phase-436 W7.a — install THE primitive this executor blocks on.
+///
+/// Singular by nature: only one thing can actually wait. `granularity_us` is
+/// the finest park the primitive can express, and the port states it because
+/// only the port knows — an RTOS tick is a coarser limit than the ABI
+/// signature, a timespec primitive a finer one (issue 1242).
+///
+/// `park` returns 0 when woken by an event, 1 when the deadline expired, and a
+/// negative value when it cannot park.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL. `park` and
+/// `ctx` must outlive the executor.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_set_park_primitive(
+    handle: *mut c_void,
+    park: Option<unsafe extern "C" fn(*mut c_void, u64) -> i8>,
+    ctx: *mut c_void,
+    granularity_us: u64,
+) -> nros_cpp_ret_t {
+    let Some(park) = park else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    let Some(cpp) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    cpp.executor.set_park_primitive(park, ctx, granularity_us);
+    NROS_CPP_RET_OK
+}
+
 #[cfg(feature = "rmw-cffi")]
 /// Declare how often this executor's loop intends to come round, in
 /// microseconds. `0` (the default) falls back to the `spin_once` timeout.
@@ -3495,6 +3584,7 @@ pub struct NativeTierSpecC {
 ///
 /// # Safety
 /// `handle` must be a live executor handle from this ABI, or NULL.
+#[cfg(feature = "rmw-cffi")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_executor_set_spin_nominal_us(
     handle: *mut c_void,
@@ -3507,6 +3597,7 @@ pub unsafe extern "C" fn nros_cpp_executor_set_spin_nominal_us(
     NROS_CPP_RET_OK
 }
 
+#[cfg(all(feature = "rmw-cffi", feature = "env"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_board_native_run_tiers(
     session_name: *const c_char,

--- a/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
+++ b/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
@@ -162,6 +162,40 @@ extern int nros_cpp_executor_open_over_session(void* session_handle, const char*
                                                uint32_t domain_id, void* out_storage);
 
 extern int nros_cpp_executor_set_active_groups(void* executor, const char* const* groups, size_t n);
+/* phase-436 W7 — the wake-source seam's C-ABI surface. Without these the
+ * executor here is an opaque handle and the seam is unreachable from this
+ * arm, which is the arm the Zephyr FVP lane takes. */
+extern void* nros_cpp_executor_wake_handle(void* executor);
+extern int nros_cpp_executor_set_park_primitive(void* executor,
+                                                int8_t (*park)(void*, uint64_t), void* ctx,
+                                                uint64_t granularity_us);
+extern int8_t nros_platform_wake_park_until_us(void* w, uint64_t deadline_us);
+extern uint64_t nros_platform_wake_park_granularity_us(void);
+
+/* Install the microsecond park on `executor`, if this build has a wake object
+ * to park on.
+ *
+ * The ctx is the executor's OWN wake object, deliberately: the backend's
+ * listener signals that one, so parking on it keeps the async break. A park on
+ * a fresh semaphore would sleep its whole deadline with data already waiting,
+ * because `spin_once` drops the transport drain to non-blocking once a port
+ * has parked — worse than not parking at all.
+ *
+ * Silent no-op when no wake object exists; that build keeps the millisecond
+ * `wake_wait_ms` path it already had. */
+static void zephyr_install_park(void* executor, const char* tier_name) {
+    void* wake = nros_cpp_executor_wake_handle(executor);
+    if (wake == NULL) {
+        return;
+    }
+    int rc = nros_cpp_executor_set_park_primitive(executor, nros_platform_wake_park_until_us,
+                                                  wake, nros_platform_wake_park_granularity_us());
+    if (rc != 0) {
+        printk("nros: park primitive NOT installed tier=`%s` rc=%d — falling back to the "
+               "millisecond wake path\n",
+               (tier_name != NULL) ? tier_name : "?", rc);
+    }
+}
 
 extern int nros_cpp_spin_once(void* handle, int32_t timeout_ms);
 
@@ -342,6 +376,8 @@ static void* zephyr_tier_task(void* arg) {
     if (ctx->n_groups > 0 && ctx->groups != NULL) {
         nros_cpp_executor_set_active_groups(ctx->executor_storage, ctx->groups, ctx->n_groups);
     }
+
+    zephyr_install_park(ctx->executor_storage, ctx->name);
 
     /* Run the tier's node-setup function. */
     if (ctx->setup != NULL) {
@@ -552,6 +588,8 @@ int32_t nros_board_zephyr_run_tiers(const char* locator, uint8_t domain_id,
     if (boot->n_groups > 0 && boot->groups != NULL) {
         nros_cpp_executor_set_active_groups(boot_storage, boot->groups, boot->n_groups);
     }
+
+    zephyr_install_park(boot_storage, boot->name);
 
     /* Boot tier node setup. */
     if (boot->setup != NULL) {

--- a/packages/core/nros-node/src/executor/node_wake.rs
+++ b/packages/core/nros-node/src/executor/node_wake.rs
@@ -119,6 +119,20 @@ impl NodeWake {
 
     /// Block until signaled or `timeout_ms` elapses. Returns
     /// `true` on signal, `false` on timeout or error.
+    /// The raw primitive a PORT must wait on if it installs its own park.
+    ///
+    /// phase-436 W7 — a park primitive that waits on its own fresh object
+    /// cannot be broken by the backend's listener, because the listener
+    /// signals THIS one. Installing such a park makes latency worse, not
+    /// better: `spin_once` drops the transport drain to non-blocking once a
+    /// port has parked, so an unbreakable park sleeps out its whole deadline
+    /// with data already waiting.
+    ///
+    /// A port's `ParkUntilFn` therefore takes this pointer as its `ctx`.
+    pub(crate) fn raw_ptr(&self) -> *mut c_void {
+        self.storage.as_ptr() as *mut c_void
+    }
+
     pub(crate) fn wait_ms(&self, timeout_ms: u32) -> bool {
         let ptr = self.storage.as_ptr() as *mut c_void;
         // SAFETY: ptr was init'd in `new`; the underlying

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -2533,6 +2533,22 @@ impl<'s> Executor<'s> {
         self.park_granularity_declared_us = granularity_us;
     }
 
+    /// The wake primitive a port must hand its `ParkUntilFn` as `ctx`, or NULL
+    /// when this build has none.
+    ///
+    /// phase-436 W7 — a park that waits on its own fresh object is NOT
+    /// breakable by the backend's listener, and installing one makes latency
+    /// worse: once a port has parked, the transport drain drops to
+    /// non-blocking, so an unbreakable park sleeps out its full deadline with
+    /// data already waiting. Waiting on THIS object keeps the async break.
+    #[cfg(all(feature = "alloc", feature = "rmw-cffi"))]
+    pub fn wake_raw_ptr(&self) -> *mut core::ffi::c_void {
+        match self.node_wake.as_ref() {
+            Some(w) => w.raw_ptr(),
+            None => core::ptr::null_mut(),
+        }
+    }
+
     /// Whether a platform park primitive is installed.
     pub fn has_park_primitive(&self) -> bool {
         self.park_primitive.is_some()

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1551,6 +1551,10 @@ pub struct Executor<'s> {
     /// The single thing that actually blocks. Many sources say WHEN; one
     /// primitive does the waiting.
     pub(crate) park_primitive: Option<(ParkUntilFn, *mut core::ffi::c_void)>,
+    /// phase-436 W7.b (issue 1242) — the finest park the INSTALLED primitive
+    /// can actually express, in microseconds. `0` = none installed, fall back
+    /// to the `wake_wait_ms` ABI floor.
+    pub(crate) park_granularity_declared_us: u64,
     /// Wakes that were already past their nominal deadline, and wakes total.
     ///
     /// The maximum alone cannot distinguish one bad wake from a loop that is
@@ -1751,6 +1755,7 @@ impl<'s> Executor<'s> {
             wake_sources: [None; MAX_WAKE_SOURCES],
             wake_source_count: 0,
             park_primitive: None,
+            park_granularity_declared_us: 0,
             late_wakes: 0,
             total_wakes: 0,
             report_violations: true,
@@ -2514,8 +2519,18 @@ impl<'s> Executor<'s> {
 
     /// Install THE thing that blocks. Singular by nature — only one primitive
     /// can actually wait — so this replaces whatever was there.
-    pub fn set_park_primitive(&mut self, park: ParkUntilFn, ctx: *mut core::ffi::c_void) {
+    /// `granularity_us` is the finest park this primitive can actually
+    /// express. The port states it because only the port knows: the ABI
+    /// signature is not the limit — an RTOS tick is a second, coarser one, and
+    /// a timespec primitive is a finer one.
+    pub fn set_park_primitive(
+        &mut self,
+        park: ParkUntilFn,
+        ctx: *mut core::ffi::c_void,
+        granularity_us: u64,
+    ) {
         self.park_primitive = Some((park, ctx));
+        self.park_granularity_declared_us = granularity_us;
     }
 
     /// Whether a platform park primitive is installed.
@@ -2610,27 +2625,35 @@ impl<'s> Executor<'s> {
         }
     }
 
-    /// The finest park this build can actually express, in microseconds.    /// The finest park this build can actually express, in microseconds.
+    /// The finest park this build can actually express, in microseconds.
     ///
-    /// Every `nros_platform_wake_*` port today takes `uint32_t timeout_ms`, so
-    /// the floor is one millisecond on every target — microseconds cannot
-    /// reach the primitive at all. A port that grows a finer slot lowers this,
-    /// and nothing above needs to change: callers ask in microseconds and are
-    /// told what was achieved.
+    /// Comes from the INSTALLED primitive, because only the port knows. The
+    /// exported ABI signature is not the limit in either direction (issue
+    /// 1242):
+    ///
+    /// * an RTOS tick is a COARSER limit — ThreadX pins
+    ///   `TX_TIMER_TICKS_PER_SECOND = 100`, a 10 ms tick, so a 1 ms park is not
+    ///   achievable there however the ABI is spelled;
+    /// * a timespec primitive is a FINER one — POSIX's `sem_timedwait` and
+    ///   `pthread_cond_timedwait` are nanosecond-native, and only the
+    ///   `uint32_t timeout_ms` signature floors them at a millisecond.
+    ///
+    /// This was a hardcoded `1_000` justified by "every `nros_platform_wake_*`
+    /// port takes `uint32_t timeout_ms`". That was right for FreeRTOS by
+    /// coincidence and wrong for the other two, and it made the W3 jitter
+    /// report over-claim on ThreadX — the failure W3 exists to prevent,
+    /// reproduced one layer below W3 in its own dependency.
+    ///
+    /// With nothing installed the fallback is 1 ms, which IS the honest floor
+    /// of the `wake_wait_ms` ABI every port exports today.
     pub fn park_granularity_us(&self) -> u64 {
-        // 1 ms — the granularity of `nros_platform_wake_wait_ms`.
-        1_000
+        if self.park_granularity_declared_us != 0 {
+            self.park_granularity_declared_us
+        } else {
+            1_000
+        }
     }
 
-    /// Round a requested park UP to the platform's grid.
-    ///
-    /// Up, not nearest and not down. `as_millis()` truncated, which is how a
-    /// 500 us request became a 0 ms park — the non-blocking path, i.e. a
-    /// 100 % CPU spin with no warning (issue 1193) — and how 1500 us became a
-    /// 1 ms wait that is 33 % short of what was asked.
-    ///
-    /// Zero is preserved exactly: a zero timeout claims no cadence, and
-    /// promoting it to a granule would throttle every deliberate poll.
     pub(crate) fn round_park_up_us(&self, requested_us: u64) -> u64 {
         if requested_us == 0 {
             return 0;

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -2073,6 +2073,72 @@ fn test_arena_alignment() {
 // ====================================================================
 
 // ===========================================================================
+// phase-436 W7.b (issue 1242) — the park granularity comes from the installed
+// primitive, not from a constant.
+// ===========================================================================
+
+/// With no primitive installed, 1 ms stands: that is the honest floor of the
+/// `nros_platform_wake_wait_ms` ABI every port exports today.
+#[test]
+fn granularity_falls_back_to_the_abi_floor_with_no_primitive() {
+    let executor: Executor = executor_with_clock(MockSession::new());
+    assert_eq!(executor.park_granularity_us(), 1_000);
+}
+
+/// ThreadX pins `TX_TIMER_TICKS_PER_SECOND = 100` — a 10 ms tick. A port that
+/// says so must be believed, or the executor reports a 1 ms park as achievable
+/// on a platform that cannot deliver one.
+#[test]
+fn a_coarser_port_granularity_is_honoured() {
+    unsafe extern "C" fn park(_c: *mut core::ffi::c_void, _d: u64) -> i8 {
+        1
+    }
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.set_park_primitive(park, core::ptr::null_mut(), 10_000);
+
+    assert_eq!(executor.park_granularity_us(), 10_000);
+    assert_eq!(
+        executor.round_park_up_us(1_000),
+        10_000,
+        "a 1 ms request on a 10 ms tick must round up to what the tick can do"
+    );
+}
+
+/// POSIX's `sem_timedwait` is timespec-native, so a port may declare finer
+/// than a millisecond. The old constant floored it at 1 ms and threw the
+/// precision away before the primitive was ever called.
+#[test]
+fn a_finer_port_granularity_is_honoured() {
+    unsafe extern "C" fn park(_c: *mut core::ffi::c_void, _d: u64) -> i8 {
+        1
+    }
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.set_park_primitive(park, core::ptr::null_mut(), 1);
+
+    assert_eq!(executor.park_granularity_us(), 1);
+    assert_eq!(
+        executor.round_park_up_us(1_500),
+        1_500,
+        "a microsecond-capable port must not be rounded to the ABI floor"
+    );
+}
+
+/// The jitter report follows the same source. W3 reads the granularity to say
+/// what its number is worth, so a wrong granularity makes W3 over-claim — the
+/// failure W3 exists to prevent, in W3's own dependency.
+#[test]
+fn the_jitter_granularity_follows_the_port_not_the_constant() {
+    unsafe extern "C" fn park(_c: *mut core::ffi::c_void, _d: u64) -> i8 {
+        1
+    }
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.set_park_primitive(park, core::ptr::null_mut(), 10_000);
+    // No declared cadence, so the wait paces the loop and its granularity is
+    // the floor on the measurement.
+    assert_eq!(executor.release_jitter_granularity_us(), 10_000);
+}
+
+// ===========================================================================
 // phase-436 W6 — the wake-source seam. Many sources say WHEN; one primitive
 // does the waiting.
 // ===========================================================================
@@ -2092,7 +2158,7 @@ fn spin_once_parks_through_the_registered_primitive() {
 
     SEEN.store(u64::MAX, Ordering::SeqCst);
     let mut executor: Executor = executor_with_clock(MockSession::new());
-    executor.set_park_primitive(recording_park, core::ptr::null_mut());
+    executor.set_park_primitive(recording_park, core::ptr::null_mut(), 1_000);
     executor
         .register_timer(TimerDuration::from_millis(10), || {})
         .unwrap();
@@ -2257,7 +2323,7 @@ fn the_park_primitive_is_singular_and_replaceable() {
     }
     let mut executor: Executor = executor_with_clock(MockSession::new());
     assert!(!executor.has_park_primitive(), "none installed by default");
-    executor.set_park_primitive(park_a, core::ptr::null_mut());
+    executor.set_park_primitive(park_a, core::ptr::null_mut(), 1_000);
     assert!(executor.has_park_primitive());
 }
 

--- a/packages/platform/nros-platform-api/include/nros/platform.h
+++ b/packages/platform/nros-platform-api/include/nros/platform.h
@@ -702,6 +702,26 @@ int8_t  nros_platform_wake_wait_ms(void *w, uint32_t timeout_ms);
 int8_t  nros_platform_wake_signal(void *w);
 int8_t  nros_platform_wake_signal_from_isr(void *w);
 
+/** phase-436 W7 — OPTIONAL microsecond park, the `ParkUntilFn` a port may
+ *  install through `nros_cpp_executor_set_park_primitive`.
+ *
+ *  `nros_platform_wake_wait_ms` above is the required primitive and floors
+ *  every wait at a millisecond through its own signature; this is the same
+ *  wait without that floor, for kernels whose timeout type is finer (issue
+ *  1242). Ports that cannot do better than a millisecond need not define it.
+ *
+ *  `w` MUST be the executor's own wake object — the backend's listener signals
+ *  that one, and a park on anything else cannot be broken by data arriving.
+ *
+ *  Returns 0 when signalled, 1 when the deadline expired, negative when it
+ *  cannot park. */
+int8_t   nros_platform_wake_park_until_us(void *w, uint64_t deadline_us);
+
+/** The finest park `nros_platform_wake_park_until_us` can express, in
+ *  microseconds. An RTOS tick is a coarser limit than the ABI signature and a
+ *  timespec primitive a finer one, so only the port can answer (issue 1242). */
+uint64_t nros_platform_wake_park_granularity_us(void);
+
 /** Opaque-storage sizing. Both helpers are pure functions (no global
  *  state) and may be called before `nros_platform_wake_init`. */
 size_t  nros_platform_wake_storage_size(void);

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -1060,6 +1060,44 @@ size_t nros_platform_wake_storage_align(void) {
     return __alignof__(struct k_sem);
 }
 
+/* phase-436 W7 — a `ParkUntilFn` for Zephyr, at MICROSECOND resolution.
+ *
+ * `nros_platform_wake_wait_ms` above already does this job, but its exported
+ * signature is `uint32_t timeout_ms`, so the ABI — not the kernel — is what
+ * floors every wait at a millisecond. `k_sem_take` takes a generic
+ * `k_timeout_t` and `K_USEC` is as available as `K_MSEC`; this exists to stop
+ * throwing that resolution away (issue 1242).
+ *
+ * `w` MUST be the executor's own wake object (`nros_cpp_executor_wake_handle`),
+ * not a fresh semaphore. The backend's listener signals THAT one, so a park on
+ * anything else cannot be broken by data arriving — and `spin_once` drops its
+ * transport drain to non-blocking once a port has parked, which would turn an
+ * unbreakable park into a full deadline slept with data already waiting.
+ * That is worse than not parking at all.
+ *
+ * Contract, matching `ParkUntilFn`: 0 = signalled, 1 = deadline expired,
+ * -1 = cannot park. */
+int8_t nros_platform_wake_park_until_us(void *w, uint64_t deadline_us) {
+    if (w == NULL) return -1;
+    k_timeout_t to = (deadline_us == 0u) ? K_NO_WAIT : K_USEC((int64_t) deadline_us);
+    int rc = k_sem_take((struct k_sem *) w, to);
+    if (rc == 0)       return 0;
+    if (rc == -EAGAIN) return 1;
+    return -1;
+}
+
+/* The finest park the function above can actually express, in microseconds.
+ *
+ * The kernel rounds a `K_USEC` request up to whole ticks, so the tick period
+ * is the real floor — NOT the millisecond the ABI signature suggests, and not
+ * a constant the executor can assume (issue 1242: a hardcoded 1 ms was wrong
+ * high on ThreadX and wrong low on POSIX). Rounded up, so a tick rate that
+ * does not divide a second is never reported finer than it is. */
+uint64_t nros_platform_wake_park_granularity_us(void) {
+    return (uint64_t) ((1000000 + CONFIG_SYS_CLOCK_TICKS_PER_SEC - 1)
+                       / CONFIG_SYS_CLOCK_TICKS_PER_SEC);
+}
+
 /* phase-359 W10 — opaque-storage sizing for `task`, the sibling of the wake
  * probes above. `task_init`'s contract says the implementor decides the size;
  * these let a caller ASK instead of hard-coding it (issue 0570's trap). */


### PR DESCRIPTION
> **Stacked on #648.** Rebase to `main` once it lands.

## #1242 — the park granularity comes from the primitive

`park_granularity_us()` was a hardcoded `1_000`, justified by "every `nros_platform_wake_*` port takes `uint32_t timeout_ms`". The ABI signature is not the limit in either direction:

| | constant claimed | reality |
|---|---|---|
| **ThreadX** | 1 ms | **10 ms** tick (`TX_TIMER_TICKS_PER_SECOND=100`, both board configs) |
| FreeRTOS | 1 ms | 1 ms — correct by coincidence |
| **POSIX/NuttX** | 1 ms | **timespec-native**, could do µs |

And it never consulted the installed primitive, so a port supplying a microsecond `ParkUntilFn` still couldn't produce a sub-ms park. W3's jitter report reads this to say what its number is worth — so on ThreadX it claimed precision against a 10 ms tick. **That is the failure W3 exists to prevent, one layer below W3, in its own dependency.** Both are mine.

`set_park_primitive` now takes the granularity the port declares.

## W7.a — the C-ABI surface

The seam existed only as a Rust method. `nros_cpp_executor_register_wake_source`, `..._set_park_primitive`, `..._wake_handle`.

## The trap that made `wake_handle` necessary

Wiring Zephyr, I checked what happens to the async wake once a park is installed:

```rust
let timeout_ms = if parked { 0 } else { ... };   // → wake.wait_ms(0)
```

**A park primitive silently demotes the async wake to a poll.** A park waiting on its own fresh semaphore can't be broken by the backend's listener — the listener signals the *executor's* object — so it sleeps its whole deadline with data already waiting. Worse than not parking. It passes every test and is invisible in a quiet run.

`wake_handle` hands the port the right object; the constraint is written into the platform header, the shim and the board entry, because the next port gets it wrong by default.

## Zephyr

`nros_platform_wake_park_until_us` — `k_sem_take` with **`K_USEC`**, the same wait without the millisecond floor its own signature imposes. `..._park_granularity_us` derives the real floor from `CONFIG_SYS_CLOCK_TICKS_PER_SEC`, since the kernel rounds `K_USEC` up to whole ticks. Both **optional** in `platform.h`.

## Verification

Instrumented at both ends, because installing and being called are different failures a quiet run can't separate:

```
park install tier=`control` wake=0xaad9d0 gran=1000us rc=0
park CALLED first deadline=5000us
```

Non-null wake = the trap avoided. 5000 µs = ASI's declared `spin_period_us`, not the 10 ms the tier loops pass `spin_once` — W1's min and #648's nominal in one number.

**Limit stated plainly:** this board's tick is 1 kHz, so the derived granularity is 1000 µs — the same number the old constant produced. The run proves the value *flows from the port*; the unit tests carry the behavioural difference (10 ms coarser, 1 µs finer).

Also fixes a latent gate of mine: `nros_cpp_executor_set_spin_nominal_us` called `cpp_ctx_checked` without the `rmw-cffi` gate that function carries.

**Scope:** Zephyr's C arm only. ThreadX, bare metal and Zephyr's Rust arm remain unwired, and **bare metal has no one-shot timer to wire** — no board in the tree can arm a deadline compare today.

378 passed, 0 failed. Image builds, boots, installs on every tier, no violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPKwuBESsmHcbgkCN3odw4