### PR TITLE
docs(RFC-0089): four decisions — the spin family, the `_in` rule, the layout rule, and vacuous gates

### DIFF
--- a/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -768,6 +768,70 @@ sweep does not need a flag day. What it does need is the ORDER this RFC already
 states: the compatibility is the work, the rename is cheap, and a type is only
 worth moving once its contract is the one the name promises.
 
+## Settled: state hides behind a pointer only when it EXCEEDS a pointer (2026-09-09)
+
+The node's `void* hosted_` (phase-438 W4) is right, and the two sections above
+give the reason in terms of the node alone. Applied as a habit it is wrong for
+most types, and the C++ sweep was about to apply it as a habit — so the rule is
+stated with both halves.
+
+> **Configuration-dependent state goes out of line behind one unconditional
+> pointer when it is LARGER than a pointer. When it is the SIZE of a pointer,
+> the member stays, unconditionally, in every configuration.**
+
+Both halves are the same arithmetic, and neither is a style preference.
+
+**The large half.** `rclcpp::Node`'s hosted-only state is a `weak_ptr`, the
+owned-entity list and the rest of the shape a ported file reaches, against a
+192-byte freestanding node. Hiding it buys the whole 0135/0460 property: one
+layout in every TU of one image, so a freestanding TU holding a node by value
+and a hosted TU taking `Node&` agree about every member offset. The indirection
+is paid on hosted-shape calls only, and never on a freestanding target, where
+the pointer is null and the block is never allocated. `check-cpp-capability-layout`
+is what measures it.
+
+**The small half, and this is the one that had to be decided.** `nros::Timer`
+and `nros::GuardCondition` each carry exactly one configuration-dependent
+member: a `std::unique_ptr<std::function<void()>>` under `NROS_CPP_STD`
+(`timer.hpp:159-169`, `guard_condition.hpp:119-123`), which owns the closure the
+`NROS_CPP_STD` convenience wrappers heap-allocate. Measured, on the member
+layout the two classes actually declare:
+
+| type | freestanding | `-DNROS_CPP_STD` | delta |
+| --- | ---: | ---: | ---: |
+| `nros::Timer` | 24 | 32 | **8** |
+| `nros::GuardCondition` | 32 | 40 | **8** |
+| `void*` | | | 8 |
+
+The delta IS a pointer. So hiding it behind a pointer costs the same eight
+bytes it was going to cost, adds a dereference on the dispatch path, and adds an
+allocation and its failure mode — in exchange for nothing, because the eight
+bytes were the whole disagreement.
+
+**Decision: both take the member unconditionally, in both configurations.** A
+freestanding image pays eight bytes per timer and per guard condition for a
+layout that is the same everywhere, with no one-definition hazard to reason
+about and no indirection where the executor dispatches. The member is unused
+freestanding — the wrappers that populate it do not exist there — which is
+exactly what "pay eight bytes for one stable layout" means.
+
+The rule, restated as the test to apply to the next type the sweep reaches:
+*measure the delta first.* If it exceeds a pointer, indirection is a saving. If
+it is a pointer, indirection is the same cost plus a dereference plus an
+allocator, and the honest answer is to stop hiding it. If it is SMALLER than a
+pointer — a `bool`, a `uint8_t` — indirection is a net loss and the question does
+not arise.
+
+Two things this deliberately does not do. It does not gate the member on
+`NROS_CPP_STD`, which is the shape that MAKES the hazard (a base or a member
+present in one TU and absent in another is issues 0135 and 0460, and px4 sets
+`-DNROS_CPP_STD` on one module of a larger image on purpose). And it does not
+hand-mirror a standard-library type's size to "equalise" the two
+configurations — this repo has a gate against that shape for FFI structs
+(`check-ffi-struct-mirrors`) and a standard-library internal is a worse thing to
+mirror than our own header, not a better one. Declaring the real member is the
+only way to be sure the two configurations agree about it.
+
 ## Settled: C takes rcl's spellings (2026-09-04)
 
 The question the disposition pass could not answer, because it is a decision and

--- a/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -2110,6 +2110,157 @@ flat.** The hierarchy would only become right if the executor needed a
 type-erased base, and it will not, because dispatch stays a raw function
 pointer in the arena.
 
+## The `spin` family: upstream's names get upstream's contracts (2026-09-09)
+
+Settled. The Rust executor ships five spin verbs and the two upstream names
+among them are attached to the wrong things: `spin` is ours (`Duration -> !`,
+the body of an RTOS task) while upstream's `spin(SpinOptions)` has nowhere to
+go, and the form that CAN end is called `spin_blocking`, a name upstream has
+never had. That is what makes a ported rclrs `main` rename a call — the seventh
+porting difference phase-427 W10 measured and left open.
+
+> **Upstream's names get upstream's contracts. The RTOS-specific forms get
+> honest ours-only names.**
+
+Applied, the family is four verbs:
+
+| verb | signature | disposition |
+| --- | --- | --- |
+| `spin` | `(&mut self, opts: SpinOptions) -> Result<(), NodeError>` | **adopt-bounded** — rclrs returns `Vec<RclrsError>`; there is no allocator here, so the FIRST error |
+| `spin_once` | `(&mut self, timeout: Duration) -> SpinOnceResult` | rclcpp's name and meaning; the tick primitive |
+| `spin_some` | `(&mut self, max: Duration) -> Result<(), NodeError>` | **adopt-bounded** — upstream's drain verb |
+| `spin_forever` | `(&mut self, opts: SpinOptions) -> !` | **extension** — a bare-metal entry has no shutdown source and nothing to return to |
+
+Implementation is phase-427's; this section is the decision and the constraints
+behind it.
+
+### The four constraints, which are the reusable part
+
+The verb table is one library's answer. The constraints are what produce that
+answer, and they will produce the same shape for the next family this campaign
+reaches, so they are recorded rather than the table alone.
+
+1. **No allocator, so no collection can be RETURNED.** rclrs's
+   `Executor::spin(&mut self, SpinOptions) -> Vec<RclrsError>` hands back every
+   error its callbacks produced. Building that needs `alloc`, and `core` /
+   `core+alloc` is the terminal state (ARCHITECTURE §2), so the name is adopted
+   with the return type narrowed to the FIRST error. That is weaker and it does
+   not invert: a caller who checks gets *an* error, at the same point upstream
+   would have given them a batch. `SpinOnceResult`'s per-spin counters remain
+   the surface for the ones not returned, which is what makes this
+   `adopt-bounded` rather than `adopt`.
+2. **No shutdown source, so a DIVERGING form must exist and must be
+   nameable.** A hosted `main` returns to an OS; a Zephyr entry, a ThreadX
+   thread and a bare-metal `app_main` do not. `-> !` is the honest type for
+   that shape, and upstream has no verb with it — so it needs a name of its
+   own, and `spin` cannot be that name without spending it on the case upstream
+   already spells. `spin_forever` says what it does at the call site, which is
+   the property the old `spin(Duration) -> !` did not have.
+3. **Every wait carries an EXPLICIT budget.** RFC-0002 puts one executor on one
+   RTOS task, so an unbounded block in that task starves everything below its
+   priority. Both bounded verbs take their budget as an argument —
+   `spin_once(timeout)` and `spin_some(max)` — rather than reading it from a
+   config, so a reader of the call site can see what the task will hold for.
+   This is also why `SpinOptions::timeout` matching rclrs's spelling is worth
+   something: the budget is upstream's concept too, and only its default is
+   ours.
+4. **The tick primitive must fit inside a loop the APPLICATION already owns.**
+   Firmware usually has a superloop, a control cadence or an RTOS periodic task
+   that is not ours to write. `spin_once` therefore returns a VALUE and does not
+   loop; the fixed-period forms (`spin_period`, `spin_one_period`) are built on
+   it rather than under it, and any of them can be dropped into a loop the
+   application wrote.
+
+Constraints 1 and 2 are clause 1 outranking clause 2 — the same reasoning the
+ledger row `rust:Executor::spin` already carries. Constraints 3 and 4 are why
+the family has four members where rclrs has two.
+
+### `spin_once` is where "each language follows its own upstream" needed a choice
+
+Measured against the recorded surface (`docs/reference/api-surface/rclrs.json`):
+**rclrs's `spin_once` is a `SpinOptions` CONSTRUCTOR**, `SpinOptions::spin_once()
+-> Self`, not a method on the executor at all. rclrs's executor has exactly
+`spin(SpinOptions)` and `spin_async(SpinOptions)`, and no `spin_some`.
+
+So the settled rule "each language follows ITS OWN upstream" does not decide
+this one, it only names the tension: followed strictly on the Rust surface,
+`spin_once` would be a builder that constructs an option, and the tick primitive
+would have no name. **We take rclcpp's spelling instead** — `spin_once` is a
+method that performs one cycle, `spin_some` is the drain verb — because the
+concept is one every ROS user has and the language whose upstream lacks it does
+not get to leave it unnamed. `SpinOptions::spin_once()` remains available as the
+option constructor, so the two do not collide.
+
+This is a deliberate exception, recorded as one. The rule stands where the
+upstreams merely SPELL a shared concept differently (logging is its worked
+case); it does not stretch to a concept one upstream does not have at the level
+the other puts it.
+
+**One thing this does not settle.** The ledger row `cpp:Executor::spin_some`
+records that our `spin_once` dispatches EVERY ready arena entry (RFC-0002 §3)
+where rclcpp's `spin_once` executes the next ONE — the names line up and the
+semantics do not, and that row carries an open `rename` blocker for it. The
+decision above is about which METHOD wears the name; the drain-all/execute-one
+question is that row's and is unchanged by it. Do not read this section as
+closing it.
+
+### `SpinOptions` is where the divergence is put, on purpose
+
+Every RTOS-specific field lives in the one type, so a ported file touches one
+name it already had to touch:
+
+* `timeout: Option<Duration>` — rclrs's own, same spelling, same meaning;
+* `max_callbacks: Option<usize>` — **extension**. A bounded-WCET task needs a
+  bound on WORK, not only on time: a time bound says when to give up, never how
+  much has already been done;
+* `only_next: bool` — **extension**, the single-iteration form;
+* rclrs's `until_promise_resolved(Promise<()>)` is declined
+  (`rust:SpinOptions::until_promise_resolved`), and so is `SpinConditions`.
+
+Putting the divergence in the options rather than in a fifth verb is what keeps
+the verb table readable: three of the four rows are upstream names doing
+upstream's job, and the fourth is the only invention.
+
+### The migration, measured
+
+Recorded because a rename's cost is the argument for doing it now rather than
+later, and because `spin_default()`'s zero is the reason one verb can simply go
+rather than being deprecated:
+
+| call site | sites |
+| --- | ---: |
+| `.spin(` | 12 |
+| `spin_blocking(` | 25 |
+| `spin_period(` | 8 |
+| `spin_one_period` | 26 |
+| `spin_default()` | **0** |
+
+Tens of sites in one workspace, all of them ours, none out of tree — which is
+what makes this a rename rather than a compatibility problem. Re-run the count
+before the wave lands: a grep of `packages/` and `examples/` for the same
+patterns on this branch returns 11 / 25 / 5 / 10 / 0, because the numbers move
+with the branch and with whether docs and the C/C++ mirrors are counted. The
+SHAPE is what the decision rests on and the shape is stable: bounded, in-tree,
+and one of the five verbs has no caller at all.
+
+### What this closes, and what it does not
+
+It closes the **seventh porting difference**: a ported rclrs `main` writes
+`spin`, not `spin_blocking`. RFC-0089's "the port is SIX edits" section and
+phase-427 W10 both record it as an open item and both say W10 does not own it;
+this decision names the owner, and phase-427's spin work item is where it lands.
+
+It does not move the ledger. `rust:Executor::spin` and `rust:Executor::spin*`
+describe the SHIPPED shape and a row reads as the shipped state, so they are
+rewritten when the rename lands and not before. `rust:Executor::spin` is
+`adopt-bounded` today and stays `adopt-bounded` after — but for a different
+reason, and the row has to say which: today it is bounded because ours never
+returns and takes a `Duration`, after the rename it is bounded because the
+error channel is one error rather than a `Vec`. A disposition that survives a
+change of subject is exactly the row a reader would take for unchanged.
+`spin_forever` needs a row of its own, `extension`, and `rust:Executor::spin*`
+loses the two members that stop being ours.
+
 ## Parameters: feature-complete, Rust-side SSoT, and `ros2 param list` must work
 
 Decision 3 says the store lives in Rust. Stating what "feature complete" costs,
@@ -2926,6 +3077,13 @@ task, RFC-0002's one-executor-per-task shape — so upstream's
 `spin(SpinOptions)` onto `spin` (and renaming ours) is a later wave; until it
 lands, a ported rclrs `main` renames the call. It is not W10's, and it is not
 closed by W10 being green.
+
+**DECIDED 2026-09-09 — the later wave has a shape and an owner.** §"The `spin`
+family: upstream's names get upstream's contracts" settles it: `spin` takes
+upstream's `SpinOptions` and returns `Result<(), NodeError>`, the diverging
+`-> !` form becomes `spin_forever`, and phase-427's spin work item is where it
+lands. The item stays OPEN here until that work does — a decision is not a
+rename — but it is no longer unowned, and the port then writes `spin`.
 
 ### The C++ shape, and why `init` has two overloads
 

--- a/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -275,6 +275,109 @@ not build upstream; that is clause 1 outranking clause 2 and it is fine. The
 builds here teaches upstream's users nothing. `colcon-parity` exists to hold
 exactly that line, and this rule is what keeps a name available to it.
 
+## The `_in` rule: an ours-only family may not sit under an upstream NAME (2026-09-09)
+
+The sibling of the alias rule, and it points the other way. The alias rule is
+about a name upstream HAS and we lack; this is about a family upstream lacks
+that we were about to hang off a name upstream has.
+
+> **A family with no upstream counterpart takes a different NAME, not merely a
+> different signature.** C++ resolves a signature-only difference silently, so a
+> ported line binds ours, compiles, and gets a different type, a different
+> lifetime and a different failure channel with nothing said.
+
+### The case that produced it, measured
+
+On the merged node type (phase-427 W4) the two `create_publisher` forms become
+overloads on ONE class:
+
+```cpp
+template <class M> ResultOf<Publisher<M>>       create_publisher(const char*,        const QoS&);  // ours
+template <class M> std::shared_ptr<Publisher<M>> create_publisher(const std::string&, const QoS&);  // upstream's
+```
+
+A ported file writes `node->create_publisher<M>("chatter", 10)` and **binds
+ours**. The reason is ordinary overload resolution and it is not close:
+`const char[8]` → `const char*` is array-to-pointer decay, a standard conversion
+(an lvalue transformation), while `const char[8]` → `std::string` needs
+`std::string`'s converting constructor, a user-defined conversion. A standard
+conversion sequence is a better conversion sequence than a user-defined one,
+always, so ours wins with no ambiguity to report.
+
+Measured rather than reasoned — a two-overload probe printing which one it
+reached, on both compilers this tree gates with and both standards it builds at:
+
+| | `-std=c++14` | `-std=c++17` |
+| --- | --- | --- |
+| gcc 11.4.0 | `OURS` | `OURS` |
+| clang 14.0.0 | `OURS` | `OURS` |
+
+Four for four, no diagnostic in any of them.
+
+### Why this is the non-mechanical row, not a rename
+
+Three things change under one spelling, and the governing principle's table
+says the compiler points at none of them:
+
+* **type** — a value, not a `std::shared_ptr`. A ported line usually writes
+  `auto`, which absorbs it;
+* **lifetime** — ours is a caller-owned cell whose address the arena records;
+  upstream's is co-owned by the node through `owned_entities_` (see "The out-ref
+  `create_*` family — forced by the arena");
+* **failure channel** — ours is a `ResultOf<T>` the caller must inspect;
+  upstream's path goes through `detail::require_created`, which aborts naming
+  the verb.
+
+That is "behaviour behind an identical signature" reached by a different route:
+the signature is not identical, it is merely *convertible*, which for the caller
+is the same thing.
+
+**The out-ref family is NOT this hazard, and the difference is the point.**
+`create_publisher(Publisher<M>&, const char*, const QoS&)` differs in ARITY, so
+a ported two-argument call has no matching overload and the compiler names the
+line. This RFC already calls that family "not an invention" for exactly that
+reason. The hazard appears only where the two forms share an arity and differ in
+a parameter type one implicitly converts to — which is what a value-returning
+convenience form would have introduced.
+
+### The spelling
+
+**`_in`**, which is already in the tree rather than invented here:
+`Node::create_timer_in`, `create_subscription_in` and `create_publisher_in`
+(`packages/api/nros-cpp/include/nros/node.hpp:878`, `:909`, `:926`), where the
+suffix marks the form that writes into caller-owned storage in a named callback
+group. Under this rule the suffix generalises to the ours-only family as a
+whole: caller-supplied storage, `Result` channel, no allocation — and the
+callback group stays an argument of the overload that takes one, not part of
+what the suffix means.
+
+The cost is that a nano-ros program's creation verbs read differently from a
+ported one's. That is the one-directional consequence again, paid where it is
+visible instead of at a call site that compiled.
+
+### Third application of one rule; the first two are recorded
+
+This is not a new principle, it is the third place the campaign has reached it,
+and stating that is what makes it a rule rather than three coincidences:
+
+1. **The reordered C node initialiser** — Part IV, "The hazard, CORRECTED".
+   C diagnoses an incompatible pointer argument as a WARNING by default, so a
+   reorder is silent for exactly the out-of-tree callers who do not build with
+   our flags. The conclusion there was already this one: *a C reorder must be
+   accompanied by a RENAME, so a stale call fails on the identifier.*
+2. **The clock-taking C timer verb** — phase-430 W1, shipped as
+   `nros_timer_init_on_clock` rather than as a widened `nros_timer_init`
+   (`packages/api/nros-c/include/nros/rcl_compat.h:389-398`). Its recorded
+   reason is arity and the absence of C overloading, which is the same
+   observation from the language that cannot hide it.
+3. **This one**, which is the first time the mechanism is C++ overload
+   resolution rather than C's permissiveness — and the first time the language
+   actively picks ours.
+
+The generalisation the three share: **a difference the language RESOLVES is a
+difference the user never sees.** Whether it resolves by warning-not-error, by
+arity, or by conversion rank does not change what the porting reader gets.
+
 ## Where the refusal fires: the earliest point the defect is KNOWABLE
 
 `rclcpp::init(argc, argv)` forced this and it generalises.

--- a/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -378,6 +378,48 @@ The generalisation the three share: **a difference the language RESOLVES is a
 difference the user never sees.** Whether it resolves by warning-not-error, by
 arity, or by conversion rank does not change what the porting reader gets.
 
+## A gate whose subject disappears passes vacuously (2026-09-09)
+
+The campaign deletes things — `rclcpp_compat.hpp`, `pump()`, `ComponentNode`,
+`nros::` as a home — and a deletion is the one edit that can turn a gate green
+without anyone touching the gate.
+
+> **When a deletion removes the file or symbol a gate keys on, the gate is
+> retargeted IN THE SAME COMMIT, with a negative control proving it still fails
+> on the condition it was written for.** A gate that no longer has a subject is
+> not a gate that passes; it is a gate that has stopped answering, and it looks
+> identical from the outside.
+
+The negative control is the non-negotiable half. "I moved the pattern" is a
+claim about the gate's text; "it fails on the mutation it exists to catch" is a
+claim about the gate. This repo has the same rule for tests
+(`check-no-vacuous-tests`) and for the merge-gating lanes
+(`check-lane-contracts`); this states it for the deletion case, where the gate
+was correct until the moment the subject went away.
+
+**This is the campaign's most repeated defect class, and every instance was
+found by measurement rather than by review:**
+
+| where | what had stopped answering |
+| --- | --- |
+| `check-cpp-capability-layout`, W1's acceptance (issue 1204) | the gate forced each capability macro ON against a hosted baseline that self-defines all of them, so it compared the baseline against itself seven times — `3752` and `3752`. A broken implementation satisfied it. Rebuilt with a freestanding arm; the honest mutation is on `::nros::Node`, which sits under no capability guard. |
+| `declared_qos_depth.cpp` / `_probe.cpp` (phase-427 W4) | a pair whose whole value is that the lane requires the SECOND to FAIL and greps its diagnostic. "Zero `ComponentNode` in the tree" is satisfied by a migration that leaves both compiling and proving nothing — which is why W4 now accepts on the probe still failing, with the lane's grep moving in the same commit. |
+| `check-cxx-standard-floor`'s docstring | it names `component_node.hpp`'s `if constexpr` as the reason the floor is 17. Delete the header and the gate explains itself with a file that does not exist — the reason goes vacuous even where the check does not. |
+| W4's RFC-0047 acceptance | *"the several-named-nodes capability survives"* — satisfiable only vacuously, because the capability was never there ("The several-named-nodes capability, corrected"). The subject-less variant: no deletion required, the subject never existed. |
+| the `compat` translation unit in the C++ parity lane | reduced by the shim's deletion to a TU that emits only records the `std` TU already emits — measured, 0 of 162 records marked `ported`. A TU that can never contribute reads live and answers nothing; deleted. |
+| `detail::argv_has_ros_args` | the `--ros-args` refusal, if inlined into `init`, would be observable only by a process that then dies. It is `constexpr` and `static_assert`ed in the ordinary compile lane precisely so it cannot quietly stop refusing — both silencing mutations were tried and both fail their own named assertion. |
+
+Two of those (`declared_qos_depth` and `check-cxx-standard-floor`) are owed by
+phase-427 W4's own deletion, which is what makes this a rule the merge has to
+carry rather than a retrospective.
+
+The rule extends past gates to PROSE that cites a subject, which is how this
+class connects to the two staleness rules the campaign already runs:
+`check-ledger-orphan-refs` (a ledger row may not cite a file that does not
+exist) and issue 1022's class (prose citing a source that does not support it).
+A reason nobody can check and a check nobody can fail are the same failure,
+recorded in two places.
+
 ## Where the refusal fires: the earliest point the defect is KNOWABLE
 
 `rclcpp::init(argc, argv)` forced this and it generalises.

--- a/docs/roadmap/phase-427-one-node-type.md
+++ b/docs/roadmap/phase-427-one-node-type.md
@@ -43,10 +43,12 @@ optional to migrate rather than a flag day.
 * **W4 [cpp] — `ComponentNode` deleted.** Its 5 directories move to the one
   type. RFC-0044 is amended, not deleted — its Q2 boot-failure reasoning becomes
   `ok()`'s.
-  *Acceptance (amended 2026-09-09):* zero `ComponentNode` in the tree; the
-  RFC-0047 subnode packages build and run — **as callback-group packages, which
-  is what they are**; **one of them builds for a freestanding target**, which is
-  the test of whether the merged type still fits.
+  *Acceptance (amended 2026-09-09, then SPLIT the same day):* zero
+  `ComponentNode` in the tree; the RFC-0047 subnode packages build and run —
+  **as callback-group packages, which is what they are**; and **the freestanding
+  compile probe stays green**. The clause "one of them builds for a freestanding
+  target" was a NEW PORT rather than a check and moves to **W11**; see (c)
+  below.
 
   The first version of this item also required that "RFC-0047's
   several-named-nodes survives as a documented ours-only capability on it".
@@ -58,6 +60,80 @@ optional to migrate rather than a flag day.
   `node_builder`), one node per component. Preserving a capability that is not
   there would have added a constructor and a ledger row for nothing — RFC-0089
   "The several-named-nodes capability, corrected" carries the measurement.
+
+  **Amended 2026-09-09 — three resolutions the migration was missing.**
+
+  **(a) The ours-only creation family takes the `_in` NAME, not just its
+  signature.** On the merged type a value-returning `create_publisher(const
+  char*, const QoS&)` and upstream's `shared_ptr`-returning
+  `create_publisher(const std::string&, const QoS&)` are overloads, and a string
+  literal binds OURS — array-to-pointer decay is a standard conversion, reaching
+  `std::string` needs a user-defined one, and the standard conversion wins.
+  Measured on gcc 11.4 and clang 14 at `-std=c++14` and `-std=c++17`: four for
+  four, no diagnostic. So a ported line compiles and gets a different type,
+  lifetime and failure channel. RFC-0089 §"The `_in` rule" is the general form;
+  for W4 it means the migration renames rather than overloads, onto the suffix
+  the tree already spells (`node.hpp:878`, `:909`, `:926`). The out-ref
+  `create_*` family is NOT affected — it differs in ARITY, so the compiler names
+  the line.
+
+  **(b) The two inline members split, and they split for different reasons.**
+  Measured on the layout `component_node.hpp` declares:
+
+  | member | bytes | after |
+  | --- | ---: | --- |
+  | the sticky error latch (`has_error_` / `error_what_` / `error_code_`, `:747-749`) | **24** | stays, UNCONDITIONAL |
+  | the inline timer pool (`Timer timers_[NROS_COMPONENT_MAX_TIMERS]`, `:735`) | **192** at the default 8 | a template parameter, defaulting to **0** |
+
+  The latch stays because on a `-fno-exceptions` target it IS the error channel,
+  not a diagnostic convenience: it is the only route by which a `create_*`
+  failure inside a constructor reaches the generated entry, which reads `ok()`,
+  `error_what()` AND `error_code()` and returns the code
+  (`packs/entry/cpp/node_body.jinja`). RFC-0089 correction 5 also makes it
+  STICKY — false if the node failed to create *or* if any later `create_*` /
+  `declare_parameter` failed — so making it conditional would make the error
+  channel a build configuration, which is the shape RFC-0089 refuses everywhere
+  else.
+
+  The pool goes because RFC-0089 correction 6 already removed its reason: it
+  exists only for the storage-LESS `create_wall_timer` overload, and with the
+  out-ref form the caller owns the cell. Nodes that never use the storage-less
+  overload should pay nothing.
+
+  **A default of zero is a real constraint on the implementation, not a knob
+  value.** `Timer timers_[0]` is not ISO C++ (issue 1131, and the `#error` floor
+  at `component_node.hpp:144` from issues 1015/1167), so the parameter must
+  select a base or member that HOLDS NOTHING at `N == 0` rather than a
+  zero-length array — an empty specialisation, not a smaller array. The
+  `NROS_COMPONENT_MAX_TIMERS` macro and its `#error` floor (`:144`, issues
+  1015/1167 — the guard sits BELOW its own default or it fires on every build)
+  move or die with the header, in this commit. The ledger row
+  `cpp:ComponentNode::create_wall_timer` names the pool in its reason and is
+  re-read at the same time.
+
+  **(c) The freestanding acceptance was two claims and only one of them is a
+  check.** Splitting them, because a check and a port do not belong in one
+  acceptance:
+
+  * *stays here:* **the merge keeps the freestanding compile probe green** —
+    `check-cpp`'s `-nostdinc++` header-parse lane (ThreadX `cxx-compat`, and
+    Zephyr's minimal libcpp when the west workspace is present) and
+    `check-cpp-capability-layout`'s freestanding arm. This is a regression
+    check on work W4 does, and it can fail on the day W4 lands.
+  * *moves to W11:* **a subnode package BUILDS for a freestanding target.**
+    Measured, **no embedded fixture derives `ComponentNode` today** — the only
+    `SHAPE rclcpp` packages are the two `subnode_pkg`s and every fixture
+    consuming them is `platform = "linux"` (RFC-0089 correction 8). So this is
+    a new port, not a check on an existing one, and holding W4's acceptance
+    open on a fixture nobody has written is how a work item stops being
+    landable.
+
+  **Gates whose subject W4 deletes are retargeted in the same commit**
+  (RFC-0089 §"A gate whose subject disappears passes vacuously"): the
+  `declared_qos_depth.cpp` / `_probe.cpp` pair (already an acceptance below) and
+  `check-cxx-standard-floor`'s docstring, which names `component_node.hpp`'s
+  `if constexpr` as the reason the floor is 17. Each needs its negative control
+  re-run, not merely its pattern moved.
 
 * **W5 [cpp] — `get_logger()` follows ROS 2.** The `"nros.compat"` sentinel is
   replaced by a logger named for the node (RFC-0089 decision 1).
@@ -73,6 +149,58 @@ optional to migrate rather than a flag day.
 
 * **W7 [migration] — `nros::Node` deprecated, then deleted.** Alias for one
   release with `NROS_DEPRECATED_MSG`, then removed.
+
+* **W11 [cpp, fixture] — a subnode package builds for a freestanding target.**
+  Split out of W4's acceptance on 2026-09-09, because it is a NEW PORT and not a
+  check on existing work. Measured: no embedded fixture derives `ComponentNode`
+  today — the only `SHAPE rclcpp` packages are the two `subnode_pkg`s under
+  `examples/workspaces/realtime-cpp{,-subnode-portable}` and every fixture
+  consuming them is `platform = "linux"` (RFC-0089 correction 8). The capability
+  itself is proved — correction 1 compiled a derivation under
+  `-std=c++14 -fno-exceptions -fno-rtti -ffreestanding -nostdinc++` against the
+  ThreadX shim, with `__is_polymorphic` false for base and derived — so what is
+  missing is a consumer, which is exactly why this is a work item and not an
+  assumption.
+  *Acceptance:* one subnode package has a `fixtures.toml` row on a non-`linux`
+  platform and BUILDS there; the fixture's coordinate is in a lane
+  (`row_coord()` / `row_artifact_root()`), so it is neither unattributable nor
+  silently skipped. A fixture that only ever resolves STALE is not this
+  acceptance met — read the `probe:` lines.
+
+* **W12 [rust] — the `spin` family takes upstream's names.** RFC-0089 §"The
+  `spin` family: upstream's names get upstream's contracts". Today `spin` is
+  ours (`Duration -> !`) and upstream's `spin(SpinOptions)` has no free name,
+  while the form that can end is `spin_blocking`, a name upstream never had.
+  After:
+
+  | verb | signature | disposition |
+  | --- | --- | --- |
+  | `spin` | `(&mut self, opts: SpinOptions) -> Result<(), NodeError>` | `adopt-bounded` — rclrs returns `Vec<RclrsError>`; no allocator, so the FIRST error |
+  | `spin_once` | `(&mut self, timeout: Duration) -> SpinOnceResult` | rclcpp's name and meaning; the tick primitive |
+  | `spin_some` | `(&mut self, max: Duration) -> Result<(), NodeError>` | `adopt-bounded` — upstream's drain verb |
+  | `spin_forever` | `(&mut self, opts: SpinOptions) -> !` | `extension` — a bare-metal entry has no shutdown source and nothing to return to |
+
+  The fixed-period forms (`spin_period`, `spin_one_period`,
+  `spin_one_period_timed`) stay ours and keep their names; the RTOS-specific
+  options stay in `SpinOptions`, which is the one type the divergence is put in.
+  This closes the SEVENTH porting difference W10 recorded and did not own.
+
+  Measured migration cost, which is the argument for doing it as one wave:
+  `.spin(` 12 sites, `spin_blocking(` 25, `spin_period(` 8, `spin_one_period`
+  26, `spin_default()` **0**. All in-tree; `spin_default` can be deleted rather
+  than deprecated. Re-run the count before starting — a grep of `packages/` and
+  `examples/` on the phase-428 base returns 11 / 25 / 5 / 10 / 0, because the
+  totals move with the branch and with whether docs and the C/C++ mirrors are
+  counted; the SHAPE is what is stable.
+  *Acceptance:* `packages/testing/nros-tests/tests/rclrs_talker_port.rs` — the
+  build-time diff that MEASURES the port — shows the ported `main` writing
+  `spin`, and the recorded edit count does not grow; the ledger rows
+  `rust:Executor::spin` and `rust:Executor::spin*` are rewritten (the first
+  stays `adopt-bounded` and must say that its REASON changed, or a reader takes
+  an unchanged disposition for an unchanged row) and `spin_forever` gains an
+  `extension` row; `just check api-parity` green. NOT in scope: the
+  drain-all-versus-execute-one question, which is `cpp:Executor::spin_some`'s
+  standing `rename` blocker and is untouched by this.
 
 ## What stays invented — REVISED after review (2026-09-05)
 
@@ -156,6 +284,12 @@ watched by the collision gate.
   here by `spin(Duration) -> !`, the body of an RTOS task. Moving upstream's
   `spin(SpinOptions)` onto that name is a later wave — **open item, W10 does not
   own it.**
+
+  **OWNED 2026-09-09: that later wave is W12.** RFC-0089 §"The `spin` family"
+  settles the shape — `spin(SpinOptions) -> Result<(), NodeError>` and
+  `spin_forever` for the diverging `-> !` form — and W12 lands it, at which
+  point the port writes `spin` and this difference is gone. It stays open until
+  W12 does; a decision is not a rename.
 
 ## Not in scope
 
@@ -451,3 +585,8 @@ cost are unchanged, but it becomes a hosted-only method over a `weak_ptr` behind
 Remaining here after the move: W2 (construction), W3 (one name, two signatures —
 now four, see the conciliation section), W4 (`ComponentNode` deleted), W5
 (`get_logger`), W7 (the `nros::Node` alias). W0 and W8 are landed.
+
+Two items joined after that move and are not affected by it (2026-09-09): W11,
+the freestanding subnode port split out of W4's acceptance, and W12, the `spin`
+family rename. W11 depends on W4; W12 depends on neither — it is a Rust
+executor rename with no C++ surface in it, so it can land in any order.

--- a/docs/roadmap/phase-430-ros-time-and-clock-driven-timers.md
+++ b/docs/roadmap/phase-430-ros-time-and-clock-driven-timers.md
@@ -256,3 +256,31 @@ phase-425 brought it; the conclusion ("still flat, a runtime field and a
 second verb, no hierarchy") held in the code 425 landed and is what W4–W6 must
 preserve. Finding A is the one place the tree and the RFC disagree, and W7
 owns the ruling.
+
+## Adjacent, and NOT this phase's: the seventh porting difference closes (2026-09-09)
+
+Recorded here because this phase's W4–W6 are the surfaces a ported file's timer
+verbs land on, and a reader arriving at "which spin verb does a ported `main`
+write?" from that direction should not have to find the answer by accident.
+
+PR #753 (phase-427 W10) measured the rclrs talker port at SIX edits and recorded
+a **seventh** difference deliberately outside the count: the port writes
+`spin_blocking`, because `Executor::spin` is taken here by `spin(Duration) -> !`
+— the body of an RTOS task, RFC-0002's one-executor-per-task shape — so
+upstream's `spin(SpinOptions)` has no free name. It cost no extra edit (it falls
+on the same line as one of the two `?`s), which is exactly why it was recorded
+rather than absorbed.
+
+**That item is now decided and owned, and neither is here.** RFC-0089 §"The
+`spin` family: upstream's names get upstream's contracts" settles the shape —
+`spin(SpinOptions) -> Result<(), NodeError>`, `spin_once(Duration)` as the tick
+primitive, `spin_some(Duration)` as upstream's drain verb, and `spin_forever`
+for the diverging `-> !` form that a bare-metal entry needs and upstream has no
+name for. **phase-427 W12** lands it; when it does, the port writes `spin` and
+the seventh difference is gone.
+
+Nothing in this phase moves. The clock axis reaches the node-level surfaces
+through `register_timer_on_clock` (W4–W6) whatever the spin verbs are called,
+and no acceptance here names a spin verb. This paragraph exists so that "it
+closes in phase-427 W12" has an answer in both documents rather than only in the
+one that raised it.


### PR DESCRIPTION
Four decisions the maintainer took, written into RFC-0089, with the two phase docs they change. Docs only — no `packages/**` edit.

## 1. The `spin` family — upstream's names get upstream's contracts

RFC-0089 Part III, §"The `spin` family". Five spin verbs ship and the two upstream names among them are on the wrong things: `spin` is ours (`Duration -> !`, an RTOS task body) while upstream's `spin(SpinOptions)` has no free name, and the form that CAN end is `spin_blocking`, a name upstream never had.

| verb | signature | disposition |
| --- | --- | --- |
| `spin` | `(&mut self, opts: SpinOptions) -> Result<(), NodeError>` | `adopt-bounded` — rclrs returns `Vec<RclrsError>`; no allocator, so the FIRST error |
| `spin_once` | `(&mut self, timeout: Duration) -> SpinOnceResult` | rclcpp's name and meaning; the tick primitive |
| `spin_some` | `(&mut self, max: Duration) -> Result<(), NodeError>` | `adopt-bounded` — upstream's drain verb |
| `spin_forever` | `(&mut self, opts: SpinOptions) -> !` | `extension` — a bare-metal entry has no shutdown source and nothing to return to |

The reusable part is recorded as the four RTOS constraints that PRODUCE that table, not the table alone: no allocator so nothing collected can be returned; no shutdown source so a diverging form must exist **and be nameable**; every wait carries an explicit budget because one executor sits on one RTOS task; and the tick primitive must drop into a loop the application already owns.

Two things needed a deliberate choice and are recorded as choices. Measured against `docs/reference/api-surface/rclrs.json`, **rclrs's `spin_once` is a `SpinOptions` CONSTRUCTOR** (`SpinOptions::spin_once() -> Self`), not an executor method, and rclrs has no `spin_some` — so "each language follows its own upstream" does not decide this one, and ours takes rclcpp's spelling instead. And the divergence is put in `SpinOptions` (one type a ported file already touches) rather than in a fifth verb.

Migration cost recorded, including the honest re-run: 12 / 25 / 8 / 26 / **0**, with a re-count on this base giving 11 / 25 / 5 / 10 / 0 — the totals move with the branch and with what is counted; the shape (bounded, in-tree, `spin_default()` unused) is what the decision rests on.

Explicitly NOT closed: `cpp:Executor::spin_some`'s standing `rename` blocker — ours drains every ready arena entry where rclcpp's `spin_once` executes one. That is a different question and the section says so.

## 2. The `_in` rule — an ours-only family may not sit under an upstream NAME

RFC-0089 Part I, beside the alias rule (they are siblings pointing opposite ways).

On the merged node type, our value-returning `create_publisher(const char*, const QoS&)` and upstream's `shared_ptr`-returning `create_publisher(const std::string&, const QoS&)` are overloads, and a string literal **binds ours**: array-to-pointer decay is a standard conversion, reaching `std::string` needs a user-defined one, and a standard conversion sequence always wins. Measured with a two-overload probe on gcc 11.4.0 and clang 14.0.0 at `-std=c++14` and `-std=c++17` — four for four, `OURS`, no diagnostic in any of them.

So the rule: **a family with no upstream counterpart takes a different NAME, not merely a different signature**, because C++ resolves a signature-only difference silently. The out-ref `create_*` family is not this hazard and the section says why — it differs in ARITY, so the compiler names the line; the hazard is exactly the same-arity, implicitly-convertible case. Spelling is the `_in` suffix already in the tree (`node.hpp:878`, `:909`, `:926`).

Recorded as the **third** application of one rule, with the first two cited: the reordered C node initialiser (Part IV, "a C reorder must be accompanied by a RENAME") and the clock-taking C timer verb shipped as `nros_timer_init_on_clock` (phase-430 W1, `rcl_compat.h:389-398`). What the three share: a difference the LANGUAGE resolves is a difference the user never sees.

## 3. State hides behind a pointer only when it EXCEEDS a pointer

RFC-0089 Part II, as a dated settled decision. `void* hosted_` is right for the node and wrong as a habit, and the C++ sweep was about to apply it as a habit.

Measured on the member layout the two classes actually declare:

| type | freestanding | `-DNROS_CPP_STD` | delta |
| --- | ---: | ---: | ---: |
| `nros::Timer` | 24 | 32 | **8** |
| `nros::GuardCondition` | 32 | 40 | **8** |
| `void*` | | | 8 |

Each carries exactly one configuration-dependent member, a `unique_ptr<function<void()>>`. The delta IS a pointer, so hiding it costs the same eight bytes plus a dereference on the dispatch path plus an allocation and its failure mode, in exchange for nothing. Both take the member unconditionally in both configurations: one stable layout, no one-definition hazard. The node's block is far larger than a pointer, so indirection there is a saving — both halves are written with the arithmetic.

Deliberately refused: gating the member on `NROS_CPP_STD` (that shape IS issues 0135/0460, live on the axis px4 exercises) and hand-mirroring a standard-library type's size to equalise the configurations.

## 4. A gate whose subject disappears passes vacuously

RFC-0089 Part I. A deletion is the one edit that turns a gate green without anyone touching the gate — so when a deletion removes the file or symbol a gate keys on, the gate is retargeted **in the same commit, with a negative control** proving it still fails on the condition it was written for. "I moved the pattern" is a claim about the gate's text, not about the gate.

Six instances from the campaign's own history are tabulated, each found by measurement rather than review: `check-cpp-capability-layout` comparing a hosted baseline against itself seven times (issue 1204), the `declared_qos_depth` probe pair whose value is that the second must FAIL, `check-cxx-standard-floor`'s docstring naming a header W4 deletes, W4's RFC-0047 acceptance that was satisfiable only vacuously, the parity lane's `compat` TU at 0 of 162 contributed records, and `argv_has_ros_args` made `constexpr` so its refusal cannot quietly stop refusing. Two are owed by phase-427 W4's own deletion, which is what makes it a rule the merge carries.

## Phase docs

**`phase-427-one-node-type.md`** — W4 amended with (a) the `_in` resolution, (b) the byte split, and (c) a split acceptance:

* the **24-byte** error latch (`has_error_`/`error_what_`/`error_code_`, `:747-749`) stays UNCONDITIONAL because on `-fno-exceptions` it IS the error channel — the only route by which a `create_*` failure inside a constructor reaches the generated entry, which reads all three;
* the **192-byte** timer pool (8 x 24 at the default, `:735`) becomes a template parameter defaulting to zero, because correction 6 already removed its reason. Recorded as a real implementation constraint rather than a knob value: `Timer timers_[0]` is not ISO C++ (issue 1131, `#error` floor at `:144`), so the parameter must select something that HOLDS NOTHING;
* "the merge keeps the freestanding compile probe green" is a check and stays; "a subnode package builds freestanding" is a NEW PORT — no embedded fixture derives `ComponentNode` today, every consumer of the two `subnode_pkg`s is `platform = "linux"` — and becomes **W11**.

Also adds **W12**, the spin work item, and names the gates W4's own deletion makes vacuous. W10's "open item, W10 does not own it" now names W12 as the owner.

**`phase-430-ros-time-and-clock-driven-timers.md`** — records that the `spin` rename closes the seventh porting difference PR #753 left open, and that nothing in phase-430 moves: the clock axis ends at `register_timer_on_clock` whatever the spin verbs are called.

## Gates

`doc-refs`, `api-parity-ledger`, `ledger-orphan-refs`, `api-parity`, `gate-selftests` — all green. `check fast`: 282 of 285 green; the three reds are the environmental ones this worktree cannot satisfy and are NOT touched here — `capability-conditionals` (zenoh-pico submodule absent), `xrce-vendored-versions` and `xrce-source-manifest` (XRCE vendored trees absent). `doc-commit-citations` passed.

No ledger shard was edited. The two Rust spin rows deliberately stay as they are: a row reads as the SHIPPED state, and the RFC says which way each moves when the rename lands — including that `rust:Executor::spin` stays `adopt-bounded` for a *different reason*, which a rewrite has to state or a reader takes an unchanged disposition for an unchanged row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
