### PR TITLE
fix(#1249): a status you mean to INSPECT dies at the assignment under `set -e` — the sweep and the gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,10 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   conflicting path in three of five open branches, so one merge ejected the rest.
   A custom merge driver cannot fix it: GitHub rebases queue entries SERVER-SIDE,
   where `.gitattributes` drivers do not run.
+- **A status you mean to INSPECT dies at the assignment under `set -e`** (issue 1249) —
+  `out="$(cmd)"` then `rc=$?`/`[ -n "$out" ]` never reaches the handler; write
+  `rc=0; out="$(cmd)" || rc=$?` or `if out="$(cmd)"; then`. Two same-day defects (PR #780's
+  fixture build, PR #798's `pre-push`, each silent). Gate: `check-set-e-bare-assignment`.
 - **A script a git hook reaches must clear the inherited git environment first**
   (issues 0986/0988). `GIT_DIR` & co. override BOTH a path argument and
   `git -C`, so `git init "$tmp/x"` in a selftest builds nothing and instead

--- a/ci/nano-ros-sdk/scripts/build-arm-none-eabi-gcc.sh
+++ b/ci/nano-ros-sdk/scripts/build-arm-none-eabi-gcc.sh
@@ -34,7 +34,10 @@ cd "$root/work"
 curl -fL --retry 3 -o tc.tar.xz "$url"
 tar -xf tc.tar.xz # ARM's top-dir name varies by release/arch — glob it, don't assume.
 
-topdir="$(find . -maxdepth 1 -type d -name 'arm-gnu-toolchain-*' | head -1)"
+# `|| true` because the `[ -z ]` below IS the handler for "no such dir", and
+# under `set -e` a bare assignment would abort here instead of reaching it
+# (issue 1249).
+topdir="$(find . -maxdepth 1 -type d -name 'arm-gnu-toolchain-*' | head -1 || true)"
 if [ -z "$topdir" ]; then
     echo "build-arm-none-eabi-gcc: no extracted toolchain dir; got:" >&2
     ls -la >&2

--- a/docs/issues/archived/1249-set-e-bare-assignment-swallows-inspected-status.md
+++ b/docs/issues/archived/1249-set-e-bare-assignment-swallows-inspected-status.md
@@ -1,0 +1,146 @@
+---
+id: 1249
+title: "A command substitution whose status is meant to be INSPECTED, written as a bare assignment under `set -e` — the class behind two same-day defects, swept and gated"
+status: resolved
+type: tech-debt
+area: ci, build, process
+severity: medium
+found: 2026-09-09
+related: [1246, 1077, 0196, 0442]
+---
+
+# The idiom, not the site
+
+Two independent defects landed on 2026-09-09, in different files, by different
+routes, wearing the same three lines:
+
+```sh
+out="$(cmd)"        # under `set -e`, a non-zero `cmd` ENDS THE SCRIPT HERE
+rc=$?               # never runs; and if it did it would read 0
+if [ "$rc" -eq 2 ]; then ...
+```
+
+* **PR #780** — `scripts/build/workspace-fixtures-build.sh`. A `find` was handed
+  a doubled path that has never existed on any host, exited 1 with no output,
+  and `set -euo pipefail` took the script down at the assignment. The
+  `if [ -n "$_sf_elf" ]` written directly beneath it — whose entire purpose was
+  to tolerate an absent elf — had never executed once. The workspace fixture
+  build died on its first entry with `error: recipe … failed on line 234` and
+  nothing else; a stack-floor gate had therefore never run.
+* **PR #798** (issue 1246) — `.githooks/pre-push`. `out="$("$reach" --changed
+  "$sha" 2>&1)"`, `rc=$?`, and a three-outcome `case` whose rc=2 arm existed to
+  say "could not ask the remotes" and LET THE PUSH THROUGH. Under
+  `set -euo pipefail` a `$reach` exiting 2 killed the hook at the assignment
+  instead: pushes refused with ZERO OUTPUT, which teaches `--no-verify` and so
+  bypasses every other guard in the hook at once.
+
+Two instances in guard/build infrastructure on one day is a fact about the
+idiom. CLAUDE.md's standing rule — *fix the CLASS, not the reported site, then
+prove the sweep* — is what this issue records.
+
+## Why it is invisible on review
+
+The handling is right there, three lines down, correct, and reads as coverage.
+Nothing in the diff says the shell will never reach it. And the failure has no
+signature of its own: `set -e` prints nothing, so the symptom is the caller's
+generic "recipe failed" or an exit status with no output at all. Both authors
+above wrote a considered comment about the failure mode they were handling,
+directly above code that could not run.
+
+Same shape as issue 1077 one lane over (a `pipefail` SIGPIPE turning a match
+into a miss): a red that is not a verdict.
+
+## The sweep
+
+`scripts/check-set-e-bare-assignment.py` over every tracked `*.sh`, `*.just`,
+`justfile`, `.githooks/*` and `.github/workflows/*` — 340 files.
+
+**1278 command-substitution assignments examined; 16 changed.** Every one of the
+16 had an explicit empty-or-failed handler, with a diagnostic, that the shell
+could not reach:
+
+| file | what could not run |
+| --- | --- |
+| `tests/c-msg-gen-tests.sh` | `RESULT=$?`, `echo "$OUTPUT"`, "failed with exit code" — a failing test executable produced no output at all |
+| `scripts/check-kconfig-knob-forwarding.sh` | the gate's own `[FAIL] no _nros_resolve_knob() calls found` |
+| `scripts/check-staleness-probe-exemptions.sh` | the gate's own `[FAIL] no entry points found` |
+| `scripts/ci/issue-ids-check.sh` (×2) | `[FAIL] duplicate ids` on an empty series |
+| `scripts/check-decoupling.sh` | `FAIL: no packages/*/$crate/Cargo.toml found` |
+| `scripts/check-leaf-lockfiles.sh` | the `[ -z "$gv" ] && continue` skip |
+| `scripts/build/host-only-members.sh` | the `[ -n "$name" ] \|\| continue` skip |
+| `scripts/bump-manifest.sh` | `ERROR: could not read the git URL out of the manifests` |
+| `scripts/nuttx/build-nuttx.sh` (×2) | `declares no CONFIG_ARCH`; the no-tarball branch |
+| `scripts/installers/arm-fvp-installer.sh` | the whole multi-line "expected layout" hint |
+| `scripts/stack-analysis-c.sh` | the clang-vs-gcc `-fstack-usage` hint |
+| `scripts/qemu/build-zenoh-pico.sh` | `zenoh_manifest_die "… holds no .c files"` |
+| `packages/…/alloc_free_audit.sh` | `FAIL: no libnros_rmw_cyclonedds*.rlib found` |
+| `ci/nano-ros-sdk/scripts/build-arm-none-eabi-gcc.sh` | `no extracted toolchain dir` + the `ls -la` dump |
+
+Sweep command:
+
+```sh
+python3 scripts/check-set-e-bare-assignment.py
+```
+
+## What was deliberately NOT changed
+
+**Not every bare assignment is a bug**, and the sweep's value is in the sites it
+left alone. Three groups:
+
+1. **`awk` / `sed` / `basename` / `cut` heads.** They report "nothing matched"
+   as exit 0 with empty output, so the author's `[ -n "$x" ]` is live and the
+   code is right (`.github/workflows/docs.yml`'s mdbook-version read is the
+   canonical one). If their INPUT FILE is missing they do exit non-zero — and
+   aborting is then the right answer, because a missing input is a broken
+   precondition, not a result.
+2. **Pipelines without `pipefail`.** `v=$(grep -m1 '^version' "$f" | cut -d'"'
+   -f2)` cannot abort however grep exits: the pipeline's status is `cut`'s.
+   Eight of the tree's candidate sites are exactly that shape
+   (`justfile:4587`, `just/esp_idf.just:104`, `scripts/qemu/setup-qemu-network.sh:80`
+   among them). Flagging those would have been the mass-rewrite the gate exists
+   to avoid — and an early draft of the gate did exactly that, because its
+   `set` parser did not understand `set -euo pipefail` as a bundle.
+3. **Failures that SHOULD abort.** `root="$(git rev-parse --show-toplevel)"`,
+   `dir="$(mktemp -d)"` with nothing inspecting them afterwards. `set -e` is the
+   correct handling, and there is no handler to strand.
+
+Also left: `just workspace doctor`, which runs `set +e` on purpose and reads
+`rustup_rc=$?` legitimately. The gate tracks `set +e` and does not flag it.
+
+## The gate
+
+`just check set-e-bare-assignment` — buildless, source-only, on the fast line
+(so it runs on every push through the `pre-push` hook). Two rules, and each keys
+on the author's OWN evidence of intent rather than on a bare assignment alone:
+
+* **status** — a bare assignment whose next statement is a pure status capture
+  (`rc=$?`), reached across block closers (`fi`, `esac`, `done`) because that is
+  how PR #798 was written. Needs no judgement about the command: after a bare
+  assignment under `set -e`, `$?` is either unreachable or a constant 0.
+* **emptiness** — a bare assignment whose head command spells "nothing found"
+  as a NON-ZERO EXIT (`find`, `grep`, `ls`, `command -v`, `readlink`,
+  `pkg-config` — a closed list), followed by a test of that variable for
+  emptiness. Under `pipefail`, any stage counts; without it, only the last.
+
+A GitHub `run:` block is `bash -e {0}` by GitHub's own default, so errexit is on
+there whether or not anyone wrote `set -e`; the gate treats workflows that way.
+
+### Mutation-tested, and the first version failed
+
+The self-test runs on the normal path, with both real cases in both shapes plus
+five negative controls. Four mutations, all killed:
+
+| mutation | result |
+| --- | --- |
+| `workspace-fixtures-build.sh` loses its `\|\| true` | killed |
+| `pre-push` back to the full pre-fix shape (3 bare arms, `rc=$?` after `esac`) | killed |
+| detector blinded to `find` | killed by the self-test |
+| detector loses closer-skipping | killed |
+
+The second one **survived the first version of the gate**, and that is the
+finding worth keeping. The self-test had used a flattened two-line rendering of
+PR #798 and passed; the real file puts the assignment behind a `case` PATTERN
+and the `rc=$?` behind `esac`, and a detector anchored on "the literally next
+line at statement position" could see neither. A self-test written from the
+commit message rather than from the file is a negative control that agrees with
+your model of the bug instead of with the bug.

--- a/just/check/conventions.just
+++ b/just/check/conventions.just
@@ -96,3 +96,17 @@ pipefail-sigpipe-assertions:
 [group("ci")]
 just-recipe-paths:
     @python3 scripts/check-just-recipe-paths.py
+
+# Issue 1249 — a command substitution whose non-zero exit is meant to be
+# INSPECTED, written as a bare `var="$(cmd)"` under `set -e`, so the inspection
+# never runs and the script dies with no message of its own. Two independent
+# instances landed in guard/build infrastructure on ONE DAY (PR #780's
+# `workspace-fixtures-build.sh` find, PR #798's `pre-push` `rc=$?`), which is a
+# fact about the idiom rather than about either site. Keys on the author's own
+# evidence of intent — a `$?` read, or an emptiness test after a command that
+# spells "nothing found" as a non-zero exit — never on a bare assignment alone,
+# because one whose failure SHOULD abort is correct as written. Buildless,
+# source-only, ~0.3 s; self-tests both real cases in both shapes on every run.
+[private]
+set-e-bare-assignment:
+    @python3 scripts/check-set-e-bare-assignment.py

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/alloc_free_audit.sh
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/alloc_free_audit.sh
@@ -43,8 +43,10 @@ echo "→ Building nros-rmw-cyclonedds for $TARGET (--no-default-features)…"
 cargo build -p nros-rmw-cyclonedds --no-default-features --target "$TARGET" >&2
 
 DEPS_DIR="target/$TARGET/debug/deps"
+# `|| true`: an ABSENT `$DEPS_DIR` is exactly the case the `[[ -z ]]` below
+# reports, and pipefail would otherwise abort here with no message (issue 1249).
 RLIB="$(find "$DEPS_DIR" -maxdepth 1 -name 'libnros_rmw_cyclonedds*.rlib' -printf '%T@ %p\n' \
-        | sort -nr | head -1 | cut -d' ' -f2-)"
+        | sort -nr | head -1 | cut -d' ' -f2- || true)"
 
 if [[ -z "${RLIB:-}" ]]; then
     echo "FAIL: no libnros_rmw_cyclonedds*.rlib found under $DEPS_DIR" >&2

--- a/scripts/build/host-only-members.sh
+++ b/scripts/build/host-only-members.sh
@@ -36,7 +36,9 @@ while IFS= read -r manifest; do
     # of these manifests mention "host-only" in prose, and matching that
     # silently skipped three crates when this was first written.
     grep -qE '^host-only[[:space:]]*=[[:space:]]*true' "$manifest" || continue
-    name="$(grep -m1 -E '^name[[:space:]]*=' "$manifest" | sed -E 's/.*"([^"]+)".*/\1/')"
+    # `|| true` — a manifest with no `name =` is what the `[ -n ]` below skips;
+    # grep's 1 under pipefail would end the whole sweep instead (issue 1249).
+    name="$(grep -m1 -E '^name[[:space:]]*=' "$manifest" | sed -E 's/.*"([^"]+)".*/\1/' || true)"
     [ -n "$name" ] || continue
     names+=("$name")
 done < <(git ls-files 'packages/**/Cargo.toml')

--- a/scripts/bump-manifest.sh
+++ b/scripts/bump-manifest.sh
@@ -49,7 +49,9 @@ if [ "${#MANIFESTS[@]}" -eq 0 ]; then
 fi
 
 # The remote is read from the manifests too, so this script has no URL of its own.
-URL="$(grep -hoE 'https://[^"]*ros-launch-manifest[^"]*\.git' "${MANIFESTS[@]}" | sort -u | head -1)"
+# `|| true` so the diagnostic below is reachable: no match is grep's 1, which
+# under pipefail would abort here with no message at all (issue 1249).
+URL="$(grep -hoE 'https://[^"]*ros-launch-manifest[^"]*\.git' "${MANIFESTS[@]}" | sort -u | head -1 || true)"
 if [ -z "$URL" ]; then
     echo "ERROR: could not read the git URL out of the manifests" >&2
     exit 1

--- a/scripts/check-decoupling.sh
+++ b/scripts/check-decoupling.sh
@@ -51,7 +51,10 @@ check_manifest() {
     # two crates of one name in different layers is itself a defect, and this
     # guard is not the place to discover it.
     local manifest
-    manifest=$(ls -d packages/*/"$crate"/Cargo.toml 2>/dev/null | head -1)
+    # `|| true` — an unmatched glob is `ls` exiting 2, which is the very case
+    # the `[[ -z ]]` below reports; without it the function dies here silently
+    # (issue 1249).
+    manifest=$(ls -d packages/*/"$crate"/Cargo.toml 2>/dev/null | head -1 || true)
 
     if [[ -z "$manifest" || ! -f "$manifest" ]]; then
         echo "FAIL: no packages/*/$crate/Cargo.toml found"

--- a/scripts/check-kconfig-knob-forwarding.sh
+++ b/scripts/check-kconfig-knob-forwarding.sh
@@ -98,8 +98,11 @@ NO_RUST_READER=(
 
 [ -f "$CMAKE" ] || { echo "[FAIL] missing $CMAKE" >&2; exit 1; }
 
+# `|| true`: "no calls found" is this gate's own negative control, and grep
+# reports it as exit 1 — which under pipefail would kill the gate before it
+# could say so, turning a loud [FAIL] into a bare status (issue 1249).
 knobs="$(grep -oE '_nros_resolve_knob\(([A-Z0-9_]+)' "$CMAKE" \
-    | sed 's/^_nros_resolve_knob(//' | sort -u)"
+    | sed 's/^_nros_resolve_knob(//' | sort -u || true)"
 [ -n "$knobs" ] || { echo "[FAIL] no _nros_resolve_knob() calls found in $CMAKE" >&2; exit 1; }
 
 fail=0

--- a/scripts/check-leaf-lockfiles.sh
+++ b/scripts/check-leaf-lockfiles.sh
@@ -165,7 +165,9 @@ msg_version_drift_only() {
     for m in "$dir"/generated/*/; do
         [ -d "$m" ] || continue
         n="$(basename "$m")"
-        gv="$(grep -m1 '^version' "$m/Cargo.toml" 2>/dev/null | cut -d'"' -f2)"
+        # `|| true` — a generated crate with no `version` line is what the
+        # `[ -z ]` below skips (issue 1249).
+        gv="$(grep -m1 '^version' "$m/Cargo.toml" 2>/dev/null | cut -d'"' -f2 || true)"
         [ -z "$gv" ] && continue
         lv="$(awk -v n="$n" '/^\[\[package\]\]/{p=0} $0=="name = \""n"\""{p=1} p&&/^version/{gsub(/"/,"",$3); print $3; exit}' "$lock" 2>/dev/null)"
         [ -z "$lv" ] && continue

--- a/scripts/check-set-e-bare-assignment.py
+++ b/scripts/check-set-e-bare-assignment.py
@@ -1,0 +1,781 @@
+#!/usr/bin/env python3
+"""A status you mean to INSPECT may not be captured by a bare assignment.  Issue 1249.
+
+    out="$(cmd)"        # <- under `set -e`, a non-zero `cmd` ENDS THE SCRIPT HERE
+    rc=$?               # <- never runs; and if it did it would read 0
+    if [ "$rc" -eq 2 ]; then ...
+
+Two independent defects landed on 2026-09-09 wearing exactly this shape, in
+two different files, neither author aware of the other:
+
+  * `scripts/build/workspace-fixtures-build.sh` (PR #780).  A `find` was handed
+    a doubled path that has never existed, exited 1 with no output, and
+    `set -euo pipefail` took the whole script down AT THE ASSIGNMENT -- so the
+    `if [ -n "$_sf_elf" ]` written directly beneath it, whose entire purpose was
+    to tolerate an absent elf, had never executed once.  The workspace fixture
+    build died on its first entry with `error: recipe ... failed on line 234`
+    and no message of its own; a stack-floor gate had therefore never run.
+
+  * `.githooks/pre-push` (PR #798).  `out="$("$reach" --changed "$sha" 2>&1)"`
+    followed by `rc=$?` and a three-outcome `case`.  The rc=2 arm existed to say
+    "could not ask the remotes" and LET THE PUSH THROUGH.  Because the hook runs
+    under `set -euo pipefail`, a `$reach` exiting 2 killed the hook at the
+    assignment instead: every such push was REFUSED WITH ZERO OUTPUT, which
+    teaches `--no-verify` and so bypasses every other guard in the hook.
+
+Same idiom, same day, same silence.  That is a class, not two bugs.
+
+WHY IT IS INVISIBLE ON REVIEW.  The handling code is right there, three lines
+down, correct, and reads as coverage.  Nothing in the diff says the shell will
+never reach it.  And the failure has no signature of its own: `set -e` prints
+nothing, so the symptom is the caller's generic "recipe failed" or, worse, an
+exit status with no output at all.  Both authors above wrote a considered
+comment about the failure mode they were handling, above code that could not
+run.
+
+WHAT IS FLAGGED -- two rules, and each keys on the author's OWN evidence of
+intent, never on the mere presence of a bare assignment:
+
+  RULE 1 (status).  A bare `var="$(cmd)"` whose IMMEDIATELY NEXT statement is a
+  pure status capture (`rc=$?`).  This needs no judgement about `cmd`: after a
+  bare assignment under `set -e`, `$?` is either unreachable or a constant 0, so
+  the line is dead or lying whatever ran.  Zero false positives by construction.
+
+  RULE 2 (emptiness).  A bare assignment whose head command reports "nothing
+  found" as a NON-ZERO EXIT, followed by a test of that same variable for
+  emptiness.  `find` on a missing root, `grep` with no match, `command -v` on an
+  absent tool: the empty case the author is handling is exactly the case the
+  shell will not survive to hand them.  The command list (`EMPTY_IS_NONZERO`) is
+  deliberately closed and small -- see its comment.
+
+WHAT IS NOT FLAGGED, ON PURPOSE.  **Not every bare assignment is a bug.**
+
+  * `ver="$(awk ... f)"` then `[ -n "$ver" ]`.  awk/sed/basename/printf report
+    "nothing matched" as exit 0 WITH EMPTY OUTPUT, so the emptiness test is
+    reachable and the code is correct as written.  If the input file is missing
+    awk does exit non-zero -- and aborting is then the RIGHT answer, because a
+    missing input is a broken precondition, not a result.  This is the negative
+    control the gate must keep passing.
+  * `dir="$(mktemp -d)"`, `root="$(git rev-parse --show-toplevel)"` with no
+    inspection after them.  A failure there SHOULD abort; that is what `set -e`
+    is for, and rewriting these would be the mass-rewrite this gate exists to
+    avoid.
+  * Anything already spelled safely: `x="$(cmd)" || rc=$?`, `x="$(cmd)" || true`,
+    `if x="$(cmd)"; then`.  An assignment inside an `if` condition is exempt from
+    `set -e` by the shell itself, which is why that spelling is a fix.
+  * A recipe or file that has turned errexit OFF (`set +e`).  `just workspace
+    doctor` does exactly this on purpose and reads `rustup_rc=$?` legitimately.
+
+THE FIX, either spelling:
+
+    rc=0
+    out="$(cmd)" || rc=$?
+
+    if out="$(cmd)"; then ...; else ...; fi
+
+A NOTE ON `local`.  `local out="$(cmd)"` does not abort -- `local` is the
+command, and its own status (0) is what `set -e` and a following `$?` both see.
+That is the same lie with a quieter delivery, so RULE 1 flags it too and names
+the distinction.  Declare first, assign on its own line, then capture.
+
+EXEMPTIONS have ONE spelling: the `ALLOWLIST` below, keyed by line text, with a
+reason on every entry.  Per-site subsets are how issue 0442 happened.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Exemptions.  ONE spelling, keyed by the assignment's LINE TEXT (not a line
+# number -- an insertion above a listed site must not re-point every entry).
+# A reason is mandatory.  A stale entry is a FAILURE, not a silent no-op: it
+# silences a line that has moved and reads as though it still guards something.
+# ---------------------------------------------------------------------------
+ALLOWLIST: dict[str, tuple[tuple[str, str], ...]] = {}
+
+# Head commands whose "nothing found" IS a non-zero exit, so an emptiness test
+# written after them can never see the case it handles.  Closed and small on
+# purpose -- every entry is a command where empty-output and failure are the
+# SAME event:
+#
+#   find      a search root that does not exist  -> 1, no output   (PR #780)
+#   grep      no match                           -> 1, no output
+#   ls        a path that does not exist         -> 2, no output
+#   command -v / which / type / hash   absent    -> 1, no output
+#   readlink / realpath   a path that is not there -> 1, no output
+#   pkg-config            module not installed   -> 1, no output
+#
+# NOT in here, and deliberately: awk, sed, basename, dirname, cut, tr, printf.
+# Those answer "nothing" with exit 0, so the author's emptiness test is live and
+# the code is right.  Adding one of them would turn this gate into the
+# mass-rewrite it exists to avoid.
+EMPTY_IS_NONZERO = (
+    "find",
+    "grep", "egrep", "fgrep", "rg",
+    "ls",
+    "command", "which", "type", "hash",
+    "readlink", "realpath",
+    "pkg-config",
+)
+
+# A bare assignment whose right-hand side is a command substitution. `local`
+# and friends are captured so RULE 1 can name the masking variant.
+#
+# `arm` allows a `case` PATTERN in front of it. That is not decoration: the real
+# PR #798 defect was `*[!0]*) out="$("$reach" --changed "$sha" 2>&1)" ;;`, and a
+# detector anchored at column-plus-indent could not see it. Nothing else may
+# precede an assignment here -- a `&&`/`||`/`;` prefix means the status is
+# already being read, which NOT_STATEMENT_START rejects.
+ASSIGN = re.compile(
+    r"^(?P<indent>[ \t]*)"
+    r"(?P<arm>[^ \t()&|;]+\)[ \t]+)?"
+    r"(?P<decl>(?:local|declare|typeset|export|readonly)[ \t]+(?:-[A-Za-z]+[ \t]+)*)?"
+    r"(?P<var>[A-Za-z_][A-Za-z0-9_]*)="
+    r"(?P<rhs>\"?\$\(|\"?`)"
+)
+
+# Block CLOSERS, skipped when looking for the statement whose `$?` reads the
+# assignment. `rc=$?` after `fi` / `esac` / `done` reads the last command the
+# compound ran, which is the assignment -- and that is exactly how PR #798 was
+# written: three arms of a `case`, the `rc=$?` beneath `esac`. Anchoring on
+# "the literally next line" made the gate blind to the file it was written for
+# (measured: the mutation survived).
+#
+# `else` and `elif` are NOT here on purpose: skipping them would pair an
+# assignment in the THEN branch with a `$?` that belongs to the ELSE branch's
+# last command. The else-branch assignment is flagged on its own.
+BLOCK_CLOSER = re.compile(r"^[ \t]*(?:fi|esac|done|\}|;;&?|;&|\))[ \t]*(?:#.*)?$")
+
+# The statement is not at statement position -- it is a condition, a loop head,
+# or the right arm of an operator, all of which the shell already exempts.
+NOT_STATEMENT_START = re.compile(r"^[ \t]*(?:if|elif|while|until|!|then|do|&&|\|\|)\b")
+
+# A pure status capture: the whole statement is `[local ]var=$?`.
+STATUS_CAPTURE = re.compile(
+    r"^[ \t]*(?:local[ \t]+|declare[ \t]+)?[A-Za-z_][A-Za-z0-9_]*=\$\?[ \t]*(?:;.*)?$"
+)
+
+# errexit on / off. Parsed rather than pattern-matched so `set -uo pipefail`
+# (no `e`) and `set -o errexit` both land on the right answer.
+SET_DIRECTIVE = re.compile(r"^[ \t]*set[ \t]+(?P<args>[-+].*)$")
+
+# `#!/usr/bin/env bash` opening a `just` recipe body. Without a shebang a just
+# recipe runs each LINE in its own shell, so a `$?` on the next line reads a
+# different process entirely -- a distinct defect, and not this one.
+BASH_SHEBANG = re.compile(r"^[ \t]*#![ \t]*(?:/usr/bin/env[ \t]+bash|/bin/bash|/usr/bin/bash)\b")
+
+# A `just` recipe header at column 0 (`name:`, `name arg:`, `name: dep`).
+JUST_RECIPE_HEADER = re.compile(r"^@?[a-zA-Z_][a-zA-Z0-9_-]*(?:[ \t]+[^:]*)?:(?:[ \t].*)?$")
+
+
+def set_options(args: str) -> dict[str, bool]:
+    """Parse one `set` line into {option-name: on}.
+
+    Bash bundles short flags and lets `-o` take its argument from the NEXT
+    token, so `set -euo pipefail` is `errexit`, `nounset` and `pipefail` in one
+    line -- the spelling this repo uses almost everywhere. A parser that only
+    recognised a standalone `-o` read `-euo pipefail` as neither, which quietly
+    switched RULE 2 to its narrow (no-pipefail) reading for 8 of 8 real sites.
+    """
+    letters = {"e": "errexit", "u": "nounset", "x": "xtrace", "f": "noglob"}
+    tokens = args.split()
+    out: dict[str, bool] = {}
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if not tok.startswith(("-", "+")):
+            i += 1
+            continue
+        on = tok.startswith("-")
+        for ch in tok[1:]:
+            if ch == "o":
+                if i + 1 < len(tokens) and not tokens[i + 1].startswith(("-", "+")):
+                    out[tokens[i + 1]] = on
+                    i += 1
+            elif ch in letters:
+                out[letters[ch]] = on
+        i += 1
+    return out
+
+
+def errexit_delta(args: str) -> bool | None:
+    """Does this `set` line turn errexit on (True), off (False) or neither?"""
+    return set_options(args).get("errexit")
+
+
+def pipefail_delta(args: str) -> bool | None:
+    """Does this `set` line turn pipefail on (True), off (False) or neither?
+
+    Load-bearing for RULE 2, not decoration. WITHOUT pipefail a pipeline's
+    status is its LAST stage's, so `v="$(grep x f | cut -d'"' -f2)"` cannot
+    abort however grep exits -- `cut` answers 0 -- and the emptiness test below
+    it is perfectly live. Flagging those would be the mass-rewrite this gate is
+    written to avoid.
+    """
+    return set_options(args).get("pipefail")
+
+
+def join_logical(lines: list[str], start: int) -> tuple[str, int]:
+    """Join backslash continuations and an unbalanced `$(` run.
+
+    Returns (joined text, index of the line AFTER the statement). Crude on
+    purpose: this reads shell as text, not as a parse tree. It only has to tell
+    where the assignment ENDS so the next statement can be identified.
+    """
+    text = lines[start]
+    i = start
+    while i + 1 < len(lines):
+        stripped = text.rstrip()
+        unbalanced = text.count("$(") + text.count("`") % 2 > text.count(")")
+        if not stripped.endswith("\\") and not unbalanced:
+            break
+        i += 1
+        text += "\n" + lines[i]
+    return text, i + 1
+
+
+def pipeline_heads(rhs: str) -> list[str]:
+    """First word of each pipeline stage inside the command substitution.
+
+    Quote-aware so an alternation inside a pattern (`grep -E 'a|b'`) is not read
+    as a pipe -- the same distinction `check-pipefail-sigpipe-assertions` draws.
+    """
+    # strip to the inside of the outermost $( ... )
+    start = rhs.find("$(")
+    if start < 0:
+        start = rhs.find("`")
+        if start < 0:
+            return []
+        body = rhs[start + 1:]
+    else:
+        body = rhs[start + 2:]
+    stages: list[str] = []
+    cur: list[str] = []
+    quote = ""
+    depth = 0
+    i = 0
+    while i < len(body):
+        c = body[i]
+        if quote:
+            if quote == '"' and c == "\\" and i + 1 < len(body):
+                i += 2
+                continue
+            if c == quote:
+                quote = ""
+            cur.append(c)
+            i += 1
+            continue
+        if c == "\\" and i + 1 < len(body):
+            i += 2
+            continue
+        if c in ("'", '"'):
+            quote = c
+            i += 1
+            continue
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            if depth == 0:
+                break
+            depth -= 1
+        elif c == "|" and depth == 0:
+            if i + 1 < len(body) and body[i + 1] == "|":
+                cur.append("||")
+                i += 2
+                continue
+            stages.append("".join(cur))
+            cur = []
+            i += 1
+            continue
+        cur.append(c)
+        i += 1
+    stages.append("".join(cur))
+
+    heads: list[str] = []
+    for stage in stages:
+        words = stage.split()
+        # skip env assignments and wrappers that pass the status through
+        k = 0
+        while k < len(words) and (
+            re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", words[k])
+            or words[k] in ("env", "timeout", "nice", "ionice", "stdbuf", "cd")
+        ):
+            k += 1
+            if k and words[k - 1] == "timeout" and k < len(words):
+                k += 1  # timeout's duration argument
+        if k < len(words):
+            heads.append(Path(words[k].strip('"\'')).name)
+    return heads
+
+
+def empties_var(line: str, var: str) -> bool:
+    """Does this statement test `var` for emptiness, or `case` on it?"""
+    v = re.escape(var)
+    return bool(
+        re.search(r"\[\[?[ \t]+-[nz][ \t]+\"?\$\{?" + v + r"\b", line)
+        or re.search(r"^[ \t]*(?:if|elif)?[ \t]*case[ \t]+\"?\$\{?" + v + r"\b", line)
+    )
+
+
+class Finding(tuple):
+    pass
+
+
+def scan_text(rel: str, text: str) -> list[tuple[int, str, str, str]]:
+    """Return (lineno, rule, statement, evidence) for each violation in one file."""
+    lines = text.splitlines()
+    # A workflow `run:` block is `bash -e {0}` by GitHub's own default, so
+    # errexit is on for every line of every run block whether or not anyone
+    # wrote `set -e`. Nothing else in the file is shell.
+    is_workflow = rel.startswith(".github/workflows/")
+    is_just = rel.endswith(".just") or Path(rel).name == "justfile"
+
+    findings: list[tuple[int, str, str, str]] = []
+    # `errexit`/`pipefail` are tracked in LINE ORDER, which is what a reader
+    # sees. bash's own options are process-global rather than block-scoped, so
+    # this is an approximation; it is exact for the shapes that matter here
+    # (a prologue near the top, and `just workspace doctor`'s deliberate
+    # `set +e`).
+    errexit = is_workflow
+    pipefail = False
+    just_errexit = False
+    just_pipefail = False
+    in_just_body = False
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        if is_just:
+            if line and not line[0].isspace() and not line.startswith("#"):
+                # left a recipe body; a header opens a new one
+                in_just_body = bool(JUST_RECIPE_HEADER.match(line))
+                just_errexit = False
+                just_pipefail = False
+                i += 1
+                continue
+            if in_just_body and BASH_SHEBANG.match(line):
+                just_errexit = False
+                just_pipefail = False
+
+        m_set = SET_DIRECTIVE.match(line)
+        if m_set:
+            delta = errexit_delta(m_set.group("args"))
+            if delta is not None:
+                if is_just:
+                    just_errexit = delta
+                else:
+                    errexit = delta
+            pf = pipefail_delta(m_set.group("args"))
+            if pf is not None:
+                if is_just:
+                    just_pipefail = pf
+                else:
+                    pipefail = pf
+            i += 1
+            continue
+
+        active = just_errexit if is_just else errexit
+        pipefail_active = just_pipefail if is_just else pipefail
+        stripped = line.strip()
+        if not active or not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+
+        m = ASSIGN.match(line)
+        if not m or NOT_STATEMENT_START.match(line):
+            i += 1
+            continue
+
+        statement, nxt = join_logical(lines, i)
+        # Already spelled safely, or its status is deliberately discarded.
+        if re.search(r"\|\||&&", statement.split("=", 1)[1]):
+            i = nxt
+            continue
+
+        var = m.group("var")
+        decl = (m.group("decl") or "").strip()
+
+        # --- next effective statement ---
+        #
+        # Two searches, because the two rules ask different questions. The
+        # EMPTINESS test must be the very next statement (an emptiness check
+        # further away is about something else). The `$?` read may sit behind
+        # any number of block closers, because that is what `rc=$?` after
+        # `esac` means: the status of the last command the compound ran.
+        j = nxt
+        while j < len(lines) and (not lines[j].strip() or lines[j].strip().startswith("#")):
+            j += 1
+        following = lines[j] if j < len(lines) else ""
+
+        k = j
+        while k < len(lines) and (
+            not lines[k].strip()
+            or lines[k].strip().startswith("#")
+            or BLOCK_CLOSER.match(lines[k])
+        ):
+            k += 1
+        after_closers = lines[k] if k < len(lines) else ""
+        if not STATUS_CAPTURE.match(following) and STATUS_CAPTURE.match(after_closers):
+            following, j = after_closers, k
+
+        rule = evidence = None
+        if STATUS_CAPTURE.match(following):
+            if decl in ("local", "declare", "typeset", "export", "readonly"):
+                rule = "status-masked"
+                evidence = (
+                    f"{j + 1}: {following.strip()}  -- `{decl}` is the command, so "
+                    f"$? is ALWAYS 0 here"
+                )
+            else:
+                rule = "status"
+                evidence = f"{j + 1}: {following.strip()}  -- unreachable under set -e"
+        elif empties_var(following, var):
+            heads = pipeline_heads(statement.split("=", 1)[1])
+            # Without pipefail only the LAST stage decides the status.
+            candidates = heads if pipefail_active else heads[-1:]
+            hazard = next((h for h in candidates if h in EMPTY_IS_NONZERO), None)
+            if hazard:
+                rule = "emptiness"
+                evidence = (
+                    f"{j + 1}: {following.strip()}  -- `{hazard}` reports "
+                    f"'nothing found' as a non-zero exit"
+                )
+
+        if rule:
+            first = statement.splitlines()[0].strip()
+            allowed = {t for t, _ in ALLOWLIST.get(rel, ())}
+            if first not in allowed:
+                findings.append((i + 1, rule, first, evidence or ""))
+
+        i = nxt
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Self-test. Runs on the NORMAL path, every invocation: a negative control
+# nobody runs decays into a comment (check-board-tiers.py). The two REAL cases
+# are here in both shapes -- the before-shape must FAIL, the after-shape must
+# PASS -- because a detector that stops recognising the class it was written for
+# would otherwise report a clean sweep over a class it can no longer see.
+# ---------------------------------------------------------------------------
+SELF_TEST: tuple[tuple[str, str, int, str], ...] = (
+    (
+        "PR #780 BEFORE — workspace-fixtures-build.sh, the shape that shipped",
+        "scripts/build/fixture.sh",
+        1,
+        """#!/usr/bin/env bash
+set -euo pipefail
+build_one() {
+    local _sf_elf
+    _sf_elf="$(find "$NROS_REPO_ROOT/$dir/$out_root" -type f -name "$entry" \\
+        -path "*/$row_profile_dir/*" -print -quit 2>/dev/null)"
+    if [ -n "$_sf_elf" ]; then
+        python3 scripts/check-stack-floor.py --board-for-row "$platform" "$_sf_elf"
+    fi
+}
+""",
+    ),
+    (
+        "PR #780 AFTER — `|| true`, because an absent elf is a legitimate state",
+        "scripts/build/fixture.sh",
+        0,
+        """#!/usr/bin/env bash
+set -euo pipefail
+build_one() {
+    local _sf_elf
+    _sf_elf="$(find "$NROS_REPO_ROOT/$dir/$out_root" -type f -name "$entry" \\
+        -path "*/$row_profile_dir/*" -print -quit 2>/dev/null || true)"
+    if [ -n "$_sf_elf" ]; then
+        python3 scripts/check-stack-floor.py --board-for-row "$platform" "$_sf_elf"
+    fi
+}
+""",
+    ),
+    (
+        # VERBATIM the shape that shipped: three `case` arms, the `rc=$?`
+        # beneath `esac`. An earlier draft of this self-test used a flattened
+        # two-line version and PASSED while the real file's mutation SURVIVED —
+        # the distance between the assignment and the `$?`, and the `case`
+        # pattern in front of it, are the whole difficulty.
+        "PR #798 BEFORE — .githooks/pre-push, the rc=2 arm that had never run",
+        ".githooks/pre-push",
+        1,
+        """#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+    case "$remote_sha" in
+        *[!0]*) out="$("$reach" --changed "$remote_sha" 2>&1)" ;;
+        *)
+            if [ -n "$base" ]; then
+                out="$("$reach" --changed "$base" 2>&1)"
+            else
+                out="$("$reach" 2>&1)"
+            fi
+            ;;
+    esac
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        echo "pre-push: submodule reachability NOT verified (no network)." >&2
+        continue
+    fi
+done
+""",
+    ),
+    (
+        "PR #798 AFTER — `rc=0; ... || rc=$?` on every arm, `rc=$?` deleted",
+        ".githooks/pre-push",
+        0,
+        """#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+    rc=0
+    case "$remote_sha" in
+        *[!0]*) out="$("$reach" --changed "$remote_sha" 2>&1)" || rc=$? ;;
+        *)
+            if [ -n "$base" ]; then
+                out="$("$reach" --changed "$base" 2>&1)" || rc=$?
+            else
+                out="$("$reach" 2>&1)" || rc=$?
+            fi
+            ;;
+    esac
+    if [ "$rc" -eq 2 ]; then
+        echo "pre-push: submodule reachability NOT verified (no network)." >&2
+        continue
+    fi
+done
+""",
+    ),
+    (
+        "a `$?` behind a block closer still reads the assignment (`fi`, `done`)",
+        "scripts/thing.sh",
+        1,
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "$base" ]; then
+    out="$(some-probe "$base")"
+fi
+rc=$?
+echo "$rc"
+""",
+    ),
+    (
+        "NEGATIVE CONTROL — a failure that SHOULD abort is correct as a bare assignment",
+        "scripts/thing.sh",
+        0,
+        """#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(git rev-parse --show-toplevel)"
+tmpdir="$(mktemp -d)"
+cd "$repo_root"
+""",
+    ),
+    (
+        "NEGATIVE CONTROL — awk answers 'nothing' with exit 0, so `[ -n ]` is live",
+        ".github/workflows/docs.yml",
+        0,
+        """      run: |
+        ver="$(awk '/^\\[tool\\.mdbook\\]/{f=1;next} f && /^version/{print;exit}' nros-sdk-index.toml)"
+        [ -n "$ver" ] || { echo "could not read the version" >&2; exit 1; }
+""",
+    ),
+    (
+        "NEGATIVE CONTROL — errexit turned OFF on purpose (`just workspace doctor`)",
+        "just/workspace.just",
+        0,
+        """doctor:
+    #!/usr/bin/env bash
+    set +e
+    list_out="$(timeout 5s rustup toolchain list 2>/dev/null)"
+    rustup_rc=$?
+    echo "$rustup_rc"
+""",
+    ),
+    (
+        "NEGATIVE CONTROL — an assignment inside `if` is exempt from set -e by the shell",
+        "scripts/thing.sh",
+        0,
+        """#!/usr/bin/env bash
+set -euo pipefail
+if out="$(some-probe)"; then
+    echo "$out"
+else
+    echo "probe declined" >&2
+fi
+""",
+    ),
+    (
+        "`local x=$(cmd)` does not abort — it makes $? a constant 0, same lie",
+        "scripts/thing.sh",
+        1,
+        """#!/usr/bin/env bash
+set -euo pipefail
+probe() {
+    local out="$(some-probe --ask)"
+    local rc=$?
+    [ "$rc" -eq 0 ] || return 1
+}
+""",
+    ),
+    (
+        "a `grep` whose empty result is inspected — the #780 shape, other command",
+        "scripts/thing.sh",
+        1,
+        """#!/usr/bin/env bash
+set -euo pipefail
+hits="$(grep -n 'needle' "$file")"
+if [ -z "$hits" ]; then
+    echo "nothing to do"
+fi
+""",
+    ),
+    (
+        "a GitHub `run:` block is `bash -e {0}` with no `set -e` written anywhere",
+        ".github/workflows/gate.yml",
+        1,
+        """      run: |
+        found="$(command -v some-tool)"
+        if [ -z "$found" ]; then
+          echo "not installed" >&2
+        fi
+""",
+    ),
+)
+
+
+def self_test() -> list[str]:
+    problems: list[str] = []
+    for why, rel, expected, body in SELF_TEST:
+        got = len(scan_text(rel, body))
+        if got != expected:
+            problems.append(f"expected {expected} finding(s), got {got}: {why}")
+    return problems
+
+
+def tracked_shell() -> list[str]:
+    # `nros_clear_inherited_git_env` FIRST (issues 0986/0988): this gate is on
+    # the fast line, so the `pre-push` hook reaches it, and a push from a linked
+    # worktree exports `GIT_DIR` — which overrides both a path argument and
+    # `git -C`. A `git ls-files` answering for the wrong repository would report
+    # a clean sweep over a file set this gate never read.
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+    from git_hook_env import nros_clear_inherited_git_env  # noqa: PLC0415
+
+    nros_clear_inherited_git_env()
+    out = subprocess.run(
+        ["git", "-C", str(Path(__file__).resolve().parent.parent),
+         "ls-files", "*.sh", "*.just", "justfile", ".githooks/*", ".github/workflows/*"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    return sorted(
+        f for f in out
+        if "/third-party/" not in f and "/generated/" not in f and not f.startswith("tmp/")
+    )
+
+
+def main() -> int:
+    problems = self_test()
+    if problems:
+        print(
+            "check-set-e-bare-assignment: SELF-TEST FAILED — the detector no "
+            "longer recognises the shape it exists to find, so a green here "
+            "would mean nothing.",
+            file=sys.stderr,
+        )
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+
+    root = Path(__file__).resolve().parent.parent
+    me = Path(__file__).resolve()
+
+    violations: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    examined = 0
+    for rel in tracked_shell():
+        path = root / rel
+        if path.resolve() == me:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        examined += 1
+        allowed = {t for t, _ in ALLOWLIST.get(rel, ())}
+        for lineno, rule, statement, evidence in scan_text(rel, text):
+            if statement in allowed:
+                seen.add((rel, statement))
+                continue
+            violations.append(f"{rel}:{lineno}  [{rule}]\n      {statement}\n      -> {evidence}")
+
+    stale = sorted(
+        f"{rel}: {line}   ({why})"
+        for rel, entries in ALLOWLIST.items()
+        for line, why in entries
+        if (rel, line) not in seen
+    )
+    if stale:
+        print(
+            "check-set-e-bare-assignment: the allowlist names "
+            f"{len(stale)} line(s) that no longer match. A stale entry silences "
+            "a line that has MOVED and reads as though it still guards "
+            "something — delete it, or re-point it:",
+            file=sys.stderr,
+        )
+        for site in stale:
+            print(f"    {site}", file=sys.stderr)
+        return 1
+
+    if violations:
+        print(
+            "check-set-e-bare-assignment: FAILED (issue 1249) — "
+            f"{len(violations)} command substitution(s) whose status is meant "
+            "to be inspected, written as a bare assignment under `set -e`.",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print(
+            "\n"
+            "  Under `set -e` a bare `var=\"$(cmd)\"` whose command exits non-zero\n"
+            "  ENDS THE SCRIPT AT THE ASSIGNMENT, with no message of its own. The\n"
+            "  handling written beneath it — the `$?` read, the emptiness test,\n"
+            "  the `case` on the status — never runs. Both PR #780 and PR #798\n"
+            "  shipped this on the same day, each with a correct comment above\n"
+            "  code the shell could not reach.\n"
+            "\n"
+            "  Capture the status, or put the assignment where the shell exempts it:\n"
+            "\n"
+            "      rc=0\n"
+            "      out=\"$(cmd)\" || rc=$?\n"
+            "\n"
+            "      if out=\"$(cmd)\"; then ...; else ...; fi\n"
+            "\n"
+            "  If the failure genuinely SHOULD abort, it is not this class — but\n"
+            "  then delete the handling below it, because it is dead code that\n"
+            "  reads as coverage.\n"
+            "\n"
+            "  `local out=\"$(cmd)\"` is the quiet variant: `local` is the command,\n"
+            "  so nothing aborts and `$?` is a constant 0. Declare first, assign\n"
+            "  on its own line, then capture.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check-set-e-bare-assignment: OK ({examined} shell file(s); no "
+        "inspected command substitution written as a bare assignment under "
+        f"set -e; {sum(len(v) for v in ALLOWLIST.values())} allowlisted)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-staleness-probe-exemptions.sh
+++ b/scripts/check-staleness-probe-exemptions.sh
@@ -60,7 +60,9 @@ if [ -n "$stray" ]; then
 fi
 
 # 2. each probe entry point accounts, reports and clears.
-entries="$(grep -oE 'fn require_prebuilt_binary_fresh[a-z_]*' "$PROBES" | sed 's/^fn //' | sort -u)"
+# `|| true`: finding nothing is this gate's own negative control and grep
+# spells it exit 1, so without this the [FAIL] below never prints (issue 1249).
+entries="$(grep -oE 'fn require_prebuilt_binary_fresh[a-z_]*' "$PROBES" | sed 's/^fn //' | sort -u || true)"
 [ -n "$entries" ] || {
     echo "[FAIL] no \`require_prebuilt_binary_fresh*\` entry points found in $PROBES" >&2
     exit 1

--- a/scripts/ci/issue-ids-check.sh
+++ b/scripts/ci/issue-ids-check.sh
@@ -28,11 +28,15 @@ status=0
 # looked at `docs/issues/`. A gate narrower than the rule it enforces is
 # issue 0196's class — and it went unnoticed here for as long as it did
 # precisely because the check LOOKED like it covered the numbered-doc series.
+# `|| true` — an EMPTY series is what the `[ -n ]` below treats as "no
+# duplicates", and both `find` (missing dir) and `grep` (no input) spell empty
+# as a non-zero exit that pipefail promotes. Without it this gate would die at
+# the assignment with no message of its own (issue 1249).
 design_dups="$(
     find docs/design -maxdepth 1 -name '[0-9][0-9][0-9][0-9]-*.md' -print0 2>/dev/null |
         xargs -0 -r -n1 basename |
         grep -oE '^[0-9]{4}' |
-        sort | uniq -d
+        sort | uniq -d || true
 )"
 if [ -n "$design_dups" ]; then
     status=1
@@ -49,11 +53,12 @@ if [ -n "$design_dups" ]; then
 fi
 
 # --- 1. duplicate ids ------------------------------------------------------
+# `|| true`, same reason as above (issue 1249).
 dups="$(
     find "$issues_dir" -maxdepth 2 -name '[0-9][0-9][0-9][0-9]-*.md' -print0 |
-        xargs -0 -n1 basename |
+        xargs -0 -r -n1 basename |
         grep -oE '^[0-9]{4}' |
-        sort | uniq -d
+        sort | uniq -d || true
 )"
 if [ -n "$dups" ]; then
     status=1

--- a/scripts/installers/arm-fvp-installer.sh
+++ b/scripts/installers/arm-fvp-installer.sh
@@ -108,7 +108,9 @@ if [ ! -d "$ARM_FVP_DIR" ]; then
     exit 1
 fi
 
-found="$(find "$ARM_FVP_DIR" -name "$BIN_NAME" -type f -executable 2>/dev/null | head -1)"
+# `|| true` — an `$ARM_FVP_DIR` that does not exist is find's 1, and the
+# multi-line layout hint below is written precisely for it (issue 1249).
+found="$(find "$ARM_FVP_DIR" -name "$BIN_NAME" -type f -executable 2>/dev/null | head -1 || true)"
 if [ -z "$found" ]; then
     cat >&2 <<EOF
 arm-fvp-installer: $BIN_NAME not found anywhere under

--- a/scripts/nuttx/build-nuttx.sh
+++ b/scripts/nuttx/build-nuttx.sh
@@ -179,7 +179,9 @@ BOARD_MAKEDEFS="$(pwd)/${NUTTX_BOARD_MAKEDEFS:-boards/arm/qemu/qemu-armv7a/scrip
 #
 # Derived from the DEFCONFIG, never from `.config` — at decision time the tree
 # may still hold the other architecture, which is exactly the case this fixes.
-NUTTX_ARCH=$(grep -E '^CONFIG_ARCH=' "$DEFCONFIG" 2>/dev/null | cut -d'"' -f2)
+# `|| true` so the "declares no CONFIG_ARCH" message below can be reached:
+# grep spells "no match" as exit 1 (issue 1249).
+NUTTX_ARCH=$(grep -E '^CONFIG_ARCH=' "$DEFCONFIG" 2>/dev/null | cut -d'"' -f2 || true)
 if [ -z "$NUTTX_ARCH" ]; then
     echo "build-nuttx.sh: $DEFCONFIG declares no CONFIG_ARCH — cannot key the export" >&2
     exit 1
@@ -328,7 +330,9 @@ echo "Exporting NuttX..."
 # snapshot (phase-339 W1; the old `rm -rf nuttx-export-*` wiped it).
 rm -rf nuttx-export-*.tar.gz nuttx-export-*/
 make export
-EXPORT_TAR=$(ls nuttx-export-*.tar.gz 2>/dev/null | head -1)
+# `|| true` — `make export` producing no tarball is what the `[ -n ]` below
+# handles; an unmatched glob is `ls` exiting non-zero (issue 1249).
+EXPORT_TAR=$(ls nuttx-export-*.tar.gz 2>/dev/null | head -1 || true)
 if [ -n "$EXPORT_TAR" ]; then
     EXPORT_DIR="${EXPORT_TAR%.tar.gz}"
     rm -rf "$EXPORT_DIR"

--- a/scripts/qemu/build-zenoh-pico.sh
+++ b/scripts/qemu/build-zenoh-pico.sh
@@ -289,7 +289,9 @@ while read -r kind a b c _extra; do
         # RECURSIVELY, which is the rule the manifest states and every lane
         # expands. A listed directory with no `.c` in it is drift, not an
         # empty set.
-        found=$(find "$ZENOH_PICO_SRC/$c" -name "*.c")
+        # `|| true` — a listed directory that does not exist is find's 1, and
+        # `zenoh_manifest_die` below is the message that case earns (issue 1249).
+        found=$(find "$ZENOH_PICO_SRC/$c" -name "*.c" || true)
         if [ -z "$found" ]; then
             zenoh_manifest_die "lists directory \`$c\`, which holds no .c files"
         fi

--- a/scripts/stack-analysis-c.sh
+++ b/scripts/stack-analysis-c.sh
@@ -106,7 +106,9 @@ echo ""
 # --- Find and parse .su files ---
 # GCC .su format: <file>:<line>:<col>:<function>\t<size>\t<type>
 # where type is "static", "dynamic", or "bounded"
-SU_FILES="$(find "$BUILD_DIR" -name '*.su' 2>/dev/null)"
+# `|| true` — a `$BUILD_DIR` that does not exist is find's 1, and the
+# clang-vs-gcc hint below is written for exactly that (issue 1249).
+SU_FILES="$(find "$BUILD_DIR" -name '*.su' 2>/dev/null || true)"
 
 if [[ -z "$SU_FILES" ]]; then
     echo "No .su files found in $BUILD_DIR"

--- a/tests/c-msg-gen-tests.sh
+++ b/tests/c-msg-gen-tests.sh
@@ -83,9 +83,16 @@ if [ ! -f "$TEST_EXEC" ]; then
     exit 1
 fi
 
-# Run the test
-OUTPUT=$("$TEST_EXEC" 2>&1)
-RESULT=$?
+# Run the test.
+#
+# `RESULT=0; ... || RESULT=$?`, NOT a bare assignment: a FAILING test executable
+# is the whole point of reading `$RESULT`, and under `set -e` a bare
+# `OUTPUT=$(...)` would end this script at the assignment — so neither the
+# captured output nor the "failed with exit code" line below would ever be
+# printed, and the only evidence of a failing test would be this script's own
+# bare status (issue 1249).
+RESULT=0
+OUTPUT=$("$TEST_EXEC" 2>&1) || RESULT=$?
 
 echo "$OUTPUT"
 


### PR DESCRIPTION
Two independent defects landed on 2026-09-09, in different files, by different routes, wearing the same three lines:

```sh
out="$(cmd)"        # under `set -e`, a non-zero `cmd` ENDS THE SCRIPT HERE
rc=$?               # never runs; and if it did it would read 0
if [ "$rc" -eq 2 ]; then ...
```

- **#780** — `scripts/build/workspace-fixtures-build.sh`. A `find` on a doubled path exited 1, `set -euo pipefail` took the script down at the assignment, and the `if [ -n "$_sf_elf" ]` beneath it — whose whole purpose was to tolerate an absent elf — had never executed once. A stack-floor gate had therefore never run, and the workspace fixture build died on its first entry with `error: recipe … failed on line 234` and nothing else.
- **#798 / issue 1246** — `.githooks/pre-push`. The rc=2 arm existed to say "could not ask the remotes" and LET THE PUSH THROUGH. Pushes were refused with ZERO OUTPUT instead, which teaches `--no-verify` and so bypasses every other guard in the hook at once.

Two instances in guard/build infrastructure in one day is a fact about the idiom, not about either site. This PR is the sweep and the gate. Issue: `docs/issues/archived/1249-…`.

## Sweep — 1278 examined, 16 changed

Across 340 tracked `*.sh`, `*.just`, `justfile`, `.githooks/*` and `.github/workflows/*` files. Every one of the 16 had an explicit handler, with a diagnostic, that the shell could not reach:

| file | what could not run |
| --- | --- |
| `tests/c-msg-gen-tests.sh` | a **failing test executable produced no output at all** — `RESULT=$?`, `echo "$OUTPUT"` and "failed with exit code" were all unreachable |
| `scripts/check-kconfig-knob-forwarding.sh` | the gate's own `[FAIL] no _nros_resolve_knob() calls found` |
| `scripts/check-staleness-probe-exemptions.sh` | the gate's own `[FAIL] no entry points found` |
| `scripts/ci/issue-ids-check.sh` (×2) | `[FAIL] duplicate ids` on an empty series |
| `scripts/check-decoupling.sh` | `FAIL: no packages/*/$crate/Cargo.toml found` |
| `scripts/check-leaf-lockfiles.sh` | the `[ -z "$gv" ] && continue` skip |
| `scripts/build/host-only-members.sh` | the `[ -n "$name" ] \|\| continue` skip |
| `scripts/bump-manifest.sh` | `ERROR: could not read the git URL out of the manifests` |
| `scripts/nuttx/build-nuttx.sh` (×2) | `declares no CONFIG_ARCH`; the no-tarball branch |
| `scripts/installers/arm-fvp-installer.sh` | the whole multi-line "expected layout" hint |
| `scripts/stack-analysis-c.sh` | the clang-vs-gcc `-fstack-usage` hint |
| `scripts/qemu/build-zenoh-pico.sh` | `zenoh_manifest_die "… holds no .c files"` |
| `packages/…/alloc_free_audit.sh` | `FAIL: no libnros_rmw_cyclonedds*.rlib found` |
| `ci/nano-ros-sdk/scripts/build-arm-none-eabi-gcc.sh` | `no extracted toolchain dir` + the `ls -la` dump |

Re-run the sweep with `python3 scripts/check-set-e-bare-assignment.py`.

## Deliberately NOT changed

**Not every bare assignment is a bug**, and the value of the sweep is in what it left alone.

1. **`awk` / `sed` / `basename` / `cut` heads** answer "nothing matched" with exit 0, so the author's `[ -n "$x" ]` is live and the code is right. If their input FILE is missing they do exit non-zero — and aborting is then the right answer, because a missing input is a broken precondition, not a result.
2. **Pipelines without `pipefail`** take their last stage's status, so `v=$(grep -m1 '^version' "$f" | cut -d'"' -f2)` cannot abort however grep exits. Eight candidate sites are exactly that shape (`justfile:4587`, `just/esp_idf.just:104`, `scripts/qemu/setup-qemu-network.sh:80` among them) and an early draft of the gate flagged all of them, because its `set` parser did not read `set -euo pipefail` as a bundle.
3. **Failures that SHOULD abort** — `root="$(git rev-parse --show-toplevel)"`, `dir="$(mktemp -d)"` with nothing inspecting them. `set -e` is the correct handling and there is no handler to strand.

Also left alone: `just workspace doctor`, which runs `set +e` on purpose and reads `rustup_rc=$?` legitimately. The gate tracks `set +e`.

## Gate

`just check set-e-bare-assignment` → `scripts/check-set-e-bare-assignment.py`. Buildless, source-only, ~0.3 s, on the fast line (derived membership — no shared list touched). Two rules, each keyed on the author's OWN evidence of intent rather than on a bare assignment alone:

- **status** — the next statement is a pure `rc=$?`, reached across block closers (`fi`/`esac`/`done`), because that is how #798 was written. Needs no judgement about the command: after a bare assignment under `set -e`, `$?` is either unreachable or a constant 0.
- **emptiness** — the head command spells "nothing found" as a NON-ZERO EXIT (`find`, `grep`, `ls`, `command -v`, `readlink`, `pkg-config` — a closed list), and the variable is then tested for emptiness. Under `pipefail` any stage counts; without it, only the last.

A GitHub `run:` block is `bash -e {0}` by GitHub's own default, so workflows are always errexit whether or not anyone wrote `set -e`. Exemptions have ONE spelling (`ALLOWLIST`, keyed by line text, reason mandatory, stale entry = failure); it is currently empty. The gate clears the inherited git environment before `git ls-files` (issues 0986/0988) because the `pre-push` hook reaches it from a linked worktree.

## Mutation-tested — and the first version failed one

Self-test runs on the normal path with both real cases in both shapes plus five negative controls. Four mutations, **all killed**:

| mutation | result |
| --- | --- |
| `workspace-fixtures-build.sh` loses its `\|\| true` | killed |
| `pre-push` back to the full pre-fix shape (3 bare `case` arms, `rc=$?` after `esac`) | killed |
| detector blinded to `find` | killed by the self-test |
| detector loses closer-skipping | killed |

The second **survived the first version of the gate**, and that is the finding worth keeping: the self-test had used a flattened two-line rendering of #798 taken from the commit message, while the real file puts the assignment behind a `case` PATTERN and the `rc=$?` behind `esac`. A negative control written from your model of the bug agrees with your model, not with the bug.

## What was measured vs. reasoned

**Measured:** the 1278/16 sweep counts; `bash -n` on all 14 edited scripts; `issue-ids-check`, `check-kconfig-knob-forwarding`, `check-staleness-probe-exemptions`, `check-leaf-lockfiles`, `check-decoupling`, `host-only-members` all re-run green after edit; the four mutations above; `just check fast` → **2 of 285 gates failed, both provisioning** (`capability-conditionals` and `xrce-vendored-versions`, each reporting an uninitialised submodule in this agent worktree), plus `check-gate-selftests`, `check-gate-lists`, `check-gate-visibility`, `check-default-gates-run-somewhere` and `check-lane-contracts` green.

**Reasoned, not measured:** that each of the 16 sites would actually have hit its unreachable handler in production — I read the code and the command's status contract rather than provoking each failure. The `EMPTY_IS_NONZERO` list is chosen from documented exit-status contracts, not from a survey of every command in the tree; a hazardous head outside it is a false negative the gate will not catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzPvAy8k8yiuoGmKMzKyiJ
