### PR TITLE
phase-440 W1: one Zephyr workspace resolver, store arm added below, behaviour unchanged

### DIFF
--- a/.config/zephyr-workspace-resolvers.txt
+++ b/.config/zephyr-workspace-resolvers.txt
@@ -1,0 +1,61 @@
+# Files that spell the Zephyr workspace resolution chain themselves, instead of
+# calling `scripts/lib/zephyr-workspace.sh`.
+#
+# phase-440 W1, RFC-0095 D4. The chain is
+#
+#     $NROS_ZEPHYR_WORKSPACE
+#       -> the checkout-relative trees for the selected line
+#            3.7:  zephyr-workspace, ../nano-ros-workspace
+#            4.4:  ../nano-ros-workspace-4.4
+#       -> $NROS_STORE/workspaces/zephyr/<version>
+#
+# and until W1 it had THREE spellings that did not agree: on the 4.4 line
+# `just zephyr` named the 4.4 sibling, `scripts/build/west-fixtures.sh` resolved
+# the 3.7 in-tree workspace, and `scripts/check-tier-preconditions.sh` reported
+# no workspace at all. Those three now read the helper. This file is what stops
+# a FOURTH from landing quietly.
+#
+# It is a RATCHET, like `.config/ungated-gates.txt` and
+# `.config/gate-lane-exempt.txt`: it should only ever SHRINK. An entry is not a
+# blessing — most of these are the same fold W1 did, not yet done for a caller
+# in another language or on another lane. Folding them is phase-440 W4/W5 work.
+#
+# FORMAT: one path per line, sorted, `# reason` REQUIRED on every line.
+# `check-zephyr-workspace-resolvers` enforces the format and BOTH directions of
+# drift: a file that gains the ladder and is not listed here fails; a listed
+# file that no longer spells it fails too, so a line cannot outlive its subject.
+#
+# The gate keys on the LEGACY SIBLING literal (`nano-ros-workspace`, not
+# preceded by `-`), outside comment-only lines: nobody writes that path except
+# to state a fallback rung, whereas `zephyr-workspace` is a legitimate path
+# constant all over the tree.
+
+just/zephyr-dev.just  # the two-line sweep has its OWN override pair (NROS_ZEPHYR_WORKSPACE_37/_44) so it can drive BOTH lines in one run — the helper answers for one line at a time
+justfile  # the nextest deselect guard mirrors west-fixtures.sh's ladder inline; it runs before any `source`, inside a just recipe body. Fold with W4
+packages/cli/nros-cli-core/src/cmd/build.rs  # the CLI's own resolver, in Rust, with a `--zephyr-workspace` flag rung the shell chain does not have. RFC-0095 D2 makes this the resolver a USER meets; it needs its own fold, not a shell call
+packages/testing/nros-tests/src/fixtures/binaries/mod.rs  # Rust; picks the west BUILD root, which is the workspace only when that tree is writable — a different question with a shared first half
+packages/testing/nros-tests/src/zephyr.rs  # Rust; keys on `ZEPHYR_NANO_ROS` and accepts a `zephyr-workspace` SYMLINK, so it is a third rung set again
+packages/testing/nros-tests/tests/fvp_runtime_ws.rs  # Rust test-local copy; folds with zephyr.rs
+packages/testing/nros-tests/tests/fvp_smoke.rs  # Rust test-local copy; folds with zephyr.rs
+scripts/build/gc-zephyr-builds.py  # Python; a DEFAULT_WS constant for `--workspace`, not a ladder walk
+scripts/build/zephyr-fixture-leaves.sh  # shell ladder that picks a BUILD root; a straight fold candidate once W4 separates source from build output
+scripts/check-fixtures-stale.sh  # shell ladder inside the staleness probe; a straight fold candidate
+scripts/check-tier-priority-plan-image.py  # Python; sweeps BOTH roots at once looking for images, so it wants the candidate LIST, not the first hit
+scripts/check-zephyr-kconfig-symbols.py  # Python; needs the per-line Kconfig trees and has a `build/zephyr-kconfig/` rung of its own
+scripts/check-zephyr-workspace-checkout.sh  # the RFC-0095 D1 guard: it must sweep EVERY provisioned tree, not resolve one. phase-440 W5 generalises it away
+scripts/check-zephyr-workspace-resolvers.py  # this gate's own pattern and the prose that explains it
+scripts/ci/runner-doctor.sh  # shell ladder in the runner probe; a straight fold candidate
+scripts/lib/zephyr-workspace.sh  # THE resolver — the one place the ladder is allowed to be written
+scripts/zephyr/aarch64-rust-patch.sh  # patch script: wants the LEGACY tree specifically, to patch a checkout that predates the in-tree default
+scripts/zephyr/cargo-features-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/check-copy-out.sh  # a WORKSPACE_DEFAULT constant for the 4.4 line, not a ladder walk
+scripts/zephyr/cortex-a9-rust-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/cortex-r-rust-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/llext-edk-conditional-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/native-sim-ipproto-ip-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/nsos-adapt-ipproto-ip-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/nsos-getifaddrs-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/nsos-getsockname-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/nsos-mcjoin-mreq-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/nsos-recvmsg-patch.sh  # patch script; same legacy-tree rung
+scripts/zephyr/zephyr-lang-rust-gpio-patch.sh  # patch script; same legacy-tree rung

--- a/docs/roadmap/phase-440-nros-store-is-the-root.md
+++ b/docs/roadmap/phase-440-nros-store-is-the-root.md
@@ -1,6 +1,6 @@
 # Phase 440 — the store is the root
 
-**Status (2026-09-09). W2 CLOSED by deletion (issue 1248); W1 and W3-W8 open.** Implements
+**Status (2026-09-09). W1 LANDED; W2 CLOSED by deletion (issue 1248); W3-W8 open.** Implements
 [RFC-0095](../design/0095-nros-store-is-the-root.md). The campaign home for
 moving nano-ros from "a repository the user places" to "an artifact the user's
 CLI provisions", and for the provisioning-root cleanup that has to happen first
@@ -32,19 +32,39 @@ already paying:
 
 ## Work items
 
-### W1 — one resolver, store arm added, behaviour unchanged
+### W1 — one resolver, store arm added, behaviour unchanged — **LANDED**
 
-The Zephyr workspace chain has three copies today (`just/zephyr.just:19`,
+The Zephyr workspace chain had three copies (`just/zephyr.just:19`,
 `scripts/build/west-fixtures.sh`, `scripts/check-tier-preconditions.sh`), which
-is the two-spellings shape this repo keeps paying for. Fold them into one
-helper, add the `$NROS_STORE/workspaces/<name>/<version>` arm **below** the
-existing ones so nothing moves yet.
+is the two-spellings shape this repo keeps paying for. They now read
+`scripts/lib/zephyr-workspace.sh`, which also carries the
+`$NROS_STORE/workspaces/zephyr/<version>` arm **below** the existing ones so
+nothing moves yet. `just` cannot call a shell function, so it CALLS the helper
+as a command (`shell("scripts/lib/zephyr-workspace.sh … resolve-or-default")`)
+rather than restating the ladder.
 
-*Acceptance:* one function; the three call sites read it; `just ci gate` green;
-a gate refuses a fourth spelling (the `check-cli-source-dirs` shape). With no
-store populated, every existing host resolves exactly what it resolved before —
-proven by printing the resolved path on a provisioned host and diffing against
-the pre-change value.
+**What the fold had to decide, because the three DISAGREED.** Measured over a
+9-shape × 2-line matrix of synthetic hosts, before and after: 39 of 54 cells are
+byte-identical, and **all 15 that moved are cells where the three resolvers
+already gave different answers** — nothing the tree agreed on changed. The
+disagreements were real: on the 4.4 line `just zephyr` named the 4.4 sibling
+while west-fixtures resolved the 3.7 in-tree workspace and
+check-tier-preconditions reported no workspace at all; west-fixtures also let a
+set-but-not-yet-created `NROS_ZEPHYR_WORKSPACE` fall THROUGH to a different
+tree. The reconciliation, stated in the helper's header: the override wins
+unconditionally (it is the install target too), a candidate is a workspace when
+it holds `zephyr/`, and the ladder is version-aware one line at a time.
+
+*Acceptance:* one function; the three call sites read it; `just check fast`
+green (276 ran, 9 skipped for absent provisioning, 0 failed);
+`check-zephyr-workspace-resolvers` refuses a fourth spelling, ratcheted through
+`.config/zephyr-workspace-resolvers.txt` and mutation-tested in both directions.
+
+*What W1 did NOT do:* 29 files still spell the ladder themselves — the CLI's own
+Rust resolver, the nros-tests harness, four more shell ladders, three Python
+ones and the `scripts/zephyr/*-patch.sh` legacy-tree rung. They are recorded
+with reasons in the ratchet rather than folded, because most want the store
+inversion (W4) or the D1 generalisation (W5) first. The ratchet only shrinks.
 
 ### W2 — the box-sync gate's lane — **CLOSED by deletion (issue 1248)**
 

--- a/just/check/platform.just
+++ b/just/check/platform.just
@@ -705,6 +705,20 @@ zephyr-kconfig-symbols:
 zephyr-knob-agreement:
     @python3 scripts/check-zephyr-knob-agreement.py
 
+# phase-440 W1 / RFC-0095 D4 — the Zephyr workspace chain has ONE spelling,
+# `scripts/lib/zephyr-workspace.sh`. It had three, and they disagreed: on the
+# 4.4 line `just zephyr` named the 4.4 sibling, `west-fixtures.sh` resolved the
+# 3.7 in-tree workspace, and `check-tier-preconditions.sh` reported no workspace
+# at all. Nothing failed loudly — three answers to one question is exactly the
+# drift that stays invisible until a lane dies on it.
+#
+# A ratchet, `.config/zephyr-workspace-resolvers.txt`, and like
+# `check-cli-source-dirs` it names the DIRECTION: a file that GAINED the ladder
+# is a fourth spelling, a listed file that LOST it is a stale licence to delete.
+[private]
+zephyr-workspace-resolvers:
+    @python3 scripts/check-zephyr-workspace-resolvers.py
+
 # Issue 1016 — `require_west_leaf_in_lane` fails OPEN on a build-dir name the
 # manifest does not model, so such a name is a leaf every lane's RUN demands and
 # no lane's BUILD produces. The verdict is a STALE message nobody can tell from a

--- a/just/zephyr.just
+++ b/just/zephyr.just
@@ -12,11 +12,23 @@ NROS_ZEPHYR_VERSION := env("NROS_ZEPHYR_VERSION", "3.7")
 # West manifest for the selected line.
 ZEPHYR_MANIFEST := if NROS_ZEPHYR_VERSION == "4.4" { "west-4.4.yml" } else { "west.yml" }
 
-# Zephyr workspace path. Default: in-tree (gitignored) `zephyr-workspace/`.
-# Falls back to legacy sibling `../nano-ros-workspace` for users set up
-# before the in-tree default. The 4.4 line uses its own sibling so the
-# two trees coexist. Set $NROS_ZEPHYR_WORKSPACE to override either.
-ZEPHYR_WORKSPACE := env("NROS_ZEPHYR_WORKSPACE", if NROS_ZEPHYR_VERSION == "4.4" { "../nano-ros-workspace-4.4" } else if path_exists("zephyr-workspace") == "true" { "zephyr-workspace" } else if path_exists("../nano-ros-workspace") == "true" { "../nano-ros-workspace" } else { "zephyr-workspace" })
+# Zephyr workspace path — ONE resolver, phase-440 W1 / RFC-0095 D4.
+#
+# The ladder used to be spelled here as a `just` expression, again as a `for`
+# loop in `scripts/build/west-fixtures.sh`, and a third time in
+# `scripts/check-tier-preconditions.sh` — and the three DISAGREED (measured: on
+# the 4.4 line this arm named the 4.4 sibling while west-fixtures resolved the
+# 3.7 in-tree workspace). A `just` expression and a shell function cannot share
+# code, so `just` CALLS the helper rather than restating it. What it walks:
+# `$NROS_ZEPHYR_WORKSPACE` (wins outright — it is the INSTALL target too, so it
+# must resolve before the tree exists), the checkout-relative trees for THIS
+# line, then `$NROS_STORE/workspaces/zephyr/<version>`. The store arm is LAST
+# so W1 moves nothing; W4 inverts it. `check-zephyr-workspace-resolvers` refuses
+# a fourth spelling.
+#
+# `resolve-or-default`, not `resolve`: `just zephyr setup` needs a path whether
+# or not one is provisioned, and the default is where it will install.
+ZEPHYR_WORKSPACE := shell("scripts/lib/zephyr-workspace.sh --version $1 resolve-or-default", NROS_ZEPHYR_VERSION)
 
 # Python 3.12 venv bin for the 4.4 line (Task 2b). 4.4's
 # find_package(Python3) requires >=3.12; the venv provisions it without

--- a/scripts/build/west-fixtures.sh
+++ b/scripts/build/west-fixtures.sh
@@ -25,23 +25,21 @@ source "$repo_root/scripts/build/zephyr-toolchain.sh"
 out_root="$(nros_build_dir "$NROS_KIND_WEST_FIXTURES")"
 mkdir -p "$out_root"
 
-# ZEPHYR_BASE: discover the provisioned west workspace the same way the
-# `just zephyr` recipes resolve ZEPHYR_WORKSPACE (just/zephyr.just) — an explicit
-# `NROS_ZEPHYR_WORKSPACE`, then the in-repo `zephyr-workspace/`, then the sibling
-# `../nano-ros-workspace[-4.4]/` checkouts a `just zephyr setup` lands. Without
-# this the fixture only saw the in-repo path and skipped whenever the workspace
-# lived in the sibling (the common `just zephyr setup` layout).
+# ZEPHYR_BASE: discover the provisioned west workspace through the ONE resolver
+# (phase-440 W1 / RFC-0095 D4). This block used to be a `for` loop over the same
+# candidates `just/zephyr.just` and `check-tier-preconditions.sh` each spelled
+# separately, and the three did not agree: this one was version-BLIND, so a
+# `NROS_ZEPHYR_VERSION=4.4` run resolved the 3.7 tree while `just zephyr` used
+# the 4.4 sibling, and it let a set-but-not-yet-created `NROS_ZEPHYR_WORKSPACE`
+# fall THROUGH to a different tree instead of honouring the override.
+# `--absolute` keeps ZEPHYR_BASE the absolute `$repo_root/…` string it was.
 if [ -z "${ZEPHYR_BASE:-}" ]; then
-    for _ws in \
-        "${NROS_ZEPHYR_WORKSPACE:-}" \
-        "$repo_root/zephyr-workspace" \
-        "$repo_root/../nano-ros-workspace" \
-        "$repo_root/../nano-ros-workspace-4.4"; do
-        if [ -n "$_ws" ] && [ -d "$_ws/zephyr" ]; then
-            export ZEPHYR_BASE="$_ws/zephyr"
-            break
-        fi
-    done
+    # shellcheck source=scripts/lib/zephyr-workspace.sh
+    source "$repo_root/scripts/lib/zephyr-workspace.sh"
+    _ws="$(nros_zephyr_ws_resolve_abs "" "$repo_root" || true)"
+    if [ -n "$_ws" ]; then
+        export ZEPHYR_BASE="$_ws/zephyr"
+    fi
 fi
 
 # issue 0698 follow-up — the Zephyr venv is this lane's, not the session's.

--- a/scripts/check-tier-preconditions.sh
+++ b/scripts/check-tier-preconditions.sh
@@ -241,12 +241,19 @@ probe "corrosion in the SDK store is not at the pinned version" \
 # operator learned it from `_lane-gate` twenty minutes later as four missing
 # `.inputsig` files. WARN rather than fail: an unprovisioned host is legitimate
 # for tier 1, and only the wider tiers actually need the lane.
-_zephyr_ws="${NROS_ZEPHYR_WORKSPACE:-}"
-if [ -z "$_zephyr_ws" ]; then
-    for _cand in zephyr-workspace ../nano-ros-workspace; do
-        [ -d "$_cand/zephyr" ] && _zephyr_ws="$_cand" && break
-    done
-fi
+#
+# phase-440 W1 — through the ONE resolver (RFC-0095 D4). The copy that stood
+# here was the shortest of the three and the only one with no 4.4 arm at all,
+# so on the rolling line it reported "no Zephyr workspace" against a workspace
+# `just zephyr` was building in.
+# `resolve`, not `resolve_abs`: this file already reports relative paths and has
+# `cd "$repo_root"` at its head, so the canonical spelling is what a reader of
+# the remedy expects. The `-d` retest below still earns its keep — the OVERRIDE
+# arm is returned unconditionally, so it is the one candidate nothing has
+# checked.
+# shellcheck source=scripts/lib/zephyr-workspace.sh
+source "$repo_root/scripts/lib/zephyr-workspace.sh"
+_zephyr_ws="$(nros_zephyr_ws_resolve "" "$repo_root" || true)"
 if [ -z "$_zephyr_ws" ] || [ ! -d "$_zephyr_ws/zephyr" ]; then
     echo "check-tier-preconditions: WARNING — no Zephyr workspace, so the zephyr" >&2
     echo "  fixture lane will SKIP. Tier 1 does not need it; tier 2+ does — the" >&2

--- a/scripts/check-zephyr-workspace-resolvers.py
+++ b/scripts/check-zephyr-workspace-resolvers.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Refuse a fourth spelling of the Zephyr workspace resolution chain.
+
+phase-440 W1, RFC-0095 D4. `scripts/lib/zephyr-workspace.sh` is the ONE
+resolver: `$NROS_ZEPHYR_WORKSPACE` -> the checkout-relative trees for the
+selected line -> `$NROS_STORE/workspaces/zephyr/<version>`. Before it existed
+the chain was spelled three times — a `just` expression, a shell `for` loop and
+a third, shorter shell copy — and the three did not agree. Measured on the 4.4
+line, `just zephyr` named the 4.4 sibling while `scripts/build/west-fixtures.sh`
+resolved the 3.7 in-tree workspace and `scripts/check-tier-preconditions.sh`
+reported no workspace at all. Nothing was broken loudly; the three simply
+answered a shared question differently, which is the two-spellings shape
+CLAUDE.md says this repo keeps paying for.
+
+## What this gate keys on, and why that literal
+
+The LEGACY SIBLING spelling — `nano-ros-workspace`, not preceded by `-`.
+
+`zephyr-workspace` is the wrong signal: it is a legitimate path constant all
+over the tree (build roots, rsync excludes, `zephyr-workspace-builds`), so a
+gate keyed on it would be mostly noise. The sibling literal is different. It
+appears only where somebody restated the FALLBACK RUNG — nobody writes
+`../nano-ros-workspace` except to say "and if that is not there, look here",
+which is precisely the ladder. The `(?<!-)` guard drops the unrelated
+`--nano-ros-workspace` CLI flag of `nros metadata`, which names the nano-ros
+repository rather than a Zephyr workspace.
+
+Lines that are entirely a COMMENT are not a spelling. A gate about resolvers
+must not fire on prose describing one — including the header you are reading.
+
+## The direction of drift, both ways
+
+Like `check-cli-source-dirs` (issue 0604), the point is to say which way the
+tree moved, because both directions are wrong for different reasons:
+
+* **a file gained the literal** and is not in the ratchet — a fourth spelling.
+  Call the helper. If a consumer genuinely cannot (a Rust or Python caller, a
+  patch script wanting only the legacy tree), record it with the reason.
+* **a listed file lost the literal** — the ratchet moved the right way and its
+  line is now a lie about the tree. Delete it, so the file keeps shrinking.
+
+`.config/zephyr-workspace-resolvers.txt` is a RATCHET in the spirit of
+`.config/ungated-gates.txt` and `.config/gate-lane-exempt.txt`: it starts at
+the 31 files that spell the ladder today, it should only ever shrink, and every
+line carries a reason so a reader can tell a deliberate consumer from a backlog
+item. Folding the remaining ones is phase-440 W4/W5 work, not W1's.
+
+Run: python3 scripts/check-zephyr-workspace-resolvers.py [--list]
+"""
+
+import argparse
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from tracked import tracked  # noqa: E402  (issue 0721 — the index, never a walk)
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RATCHET = os.path.join(".config", "zephyr-workspace-resolvers.txt")
+
+# The legacy sibling rung. `(?<!-)` drops `--nano-ros-workspace`, an unrelated
+# `nros metadata` flag naming the nano-ros repo.
+LADDER = re.compile(r"(?<!-)nano-ros-workspace")
+
+# A line that is only a comment is prose about the ladder, not a spelling of it.
+# Covers `#` (sh, python, just), `//` and `///` (rust), and block-comment
+# continuation lines.
+COMMENT = re.compile(r"^\s*(#|//|/\*|\*/|\*\s|\*$)")
+
+# Prose lives here. `west.yml` documents `west init -m … ~/nano-ros-workspace`,
+# which is an upstream invocation, not our chain.
+SKIP_SUFFIX = (".md", ".yml", ".yaml", ".txt")
+SKIP_PREFIX = ("docs/", "book/", ".config/")
+
+
+def tracked_files():
+    """Every tracked path, repo-relative. The index, not a walk (issue 0721):
+    `packages/` and `examples/` hold build output measured in hundreds of GB."""
+    return [os.path.relpath(p, ROOT) for p in tracked(ROOT)]
+
+
+def ladder_lines(text):
+    """Line numbers in `text` that spell the ladder outside a comment.
+
+    Split out from the file reading so the selftest can drive it directly —
+    the classification IS the gate, and a negative control that had to lay out
+    a directory tree to reach it would be the slow kind nobody keeps."""
+    return [
+        n
+        for n, line in enumerate(text.splitlines(), 1)
+        if LADDER.search(line) and not COMMENT.match(line)
+    ]
+
+
+def spells_ladder(path):
+    """Line numbers on which `path` spells the ladder outside a comment."""
+    if path.endswith(SKIP_SUFFIX) or path.startswith(SKIP_PREFIX):
+        return []
+    full = os.path.join(ROOT, path)
+    try:
+        with open(full, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except (IsADirectoryError, FileNotFoundError):
+        # A submodule gitlink, or a path in the index but not the worktree.
+        return []
+    return ladder_lines(text)
+
+
+def current_set():
+    return {p: hits for p in tracked_files() if (hits := spells_ladder(p))}
+
+
+def drift(found, listed):
+    """(added, gone) — the two directions, as the report names them."""
+    return sorted(set(found) - set(listed)), sorted(set(listed) - set(found))
+
+
+def read_ratchet():
+    """path -> reason. Format is `.config/gate-lane-exempt.txt`'s: one entry per
+    line, sorted, a `# reason` REQUIRED on every one."""
+    path = os.path.join(ROOT, RATCHET)
+    if not os.path.exists(path):
+        sys.exit(f"check-zephyr-workspace-resolvers: {RATCHET} is missing")
+    entries, order, problems = {}, [], []
+    with open(path, encoding="utf-8") as fh:
+        for n, raw in enumerate(fh, 1):
+            line = raw.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if "#" not in line:
+                problems.append(f"  {RATCHET}:{n}: no `# reason` — one is required")
+                continue
+            name, reason = line.split("#", 1)
+            name, reason = name.strip(), reason.strip()
+            if not reason:
+                problems.append(f"  {RATCHET}:{n}: empty reason")
+            if name in entries:
+                problems.append(f"  {RATCHET}:{n}: {name} listed twice")
+            entries[name] = reason
+            order.append(name)
+    if order != sorted(order):
+        problems.append(f"  {RATCHET}: entries are not sorted")
+    return entries, problems
+
+
+def selftest(verbose=False):
+    """The negative control. Runs on the NORMAL path, every time — a selftest
+    behind a flag alone is executed once, by its author, and is prose after
+    that (phase-395, `check-gate-selftests`)."""
+    ok = fail = 0
+
+    def chk(what, cond):
+        nonlocal ok, fail
+        if cond:
+            ok += 1
+            if verbose:
+                print(f"  ok   {what}")
+        else:
+            fail += 1
+            print(f"  FAIL {what}", file=sys.stderr)
+
+    # What the gate must SEE — one rung of the ladder, in each language that
+    # spells it today.
+    chk("shell candidate", ladder_lines('ws="$root/../nano-ros-workspace"\n') == [1])
+    chk("shell 4.4 candidate", ladder_lines('ws=../nano-ros-workspace-4.4\n') == [1])
+    chk("python candidate", ladder_lines('WS = ROOT.parent / "nano-ros-workspace"\n') == [1])
+    chk("rust candidate", ladder_lines('let s = p.join("nano-ros-workspace");\n') == [1])
+    chk("just candidate", ladder_lines('X := "../nano-ros-workspace"\n') == [1])
+    chk("trailing comment does not hide it",
+        ladder_lines('ws=../nano-ros-workspace  # the sibling\n') == [1])
+    chk("every offending line is reported, not just the first",
+        ladder_lines("a=../nano-ros-workspace\nb=1\nc=../nano-ros-workspace-4.4\n")
+        == [1, 3])
+
+    # What it must NOT see. Each of these was a real false positive before the
+    # rule narrowed: the `nros metadata --nano-ros-workspace` flag names the
+    # nano-ros REPOSITORY, and prose about the ladder is not a spelling of it.
+    chk("the --nano-ros-workspace flag is not this ladder",
+        ladder_lines('  "--nano-ros-workspace <path> or set NROS_WORKSPACE"\n') == [])
+    chk("a shell comment is not a spelling",
+        ladder_lines("# falls back to ../nano-ros-workspace\n") == [])
+    chk("a rust // comment is not a spelling",
+        ladder_lines("    // 3. Sibling ../nano-ros-workspace\n") == [])
+    chk("a rustdoc /// comment is not a spelling",
+        ladder_lines("/// `../nano-ros-workspace`\n") == [])
+    chk("a block-comment body is not a spelling",
+        ladder_lines(" * then ../nano-ros-workspace\n") == [])
+    chk("an unrelated file is silent", ladder_lines("echo hello\n") == [])
+
+    # And the classifier must be reachable through the file reader, or the two
+    # halves can disagree while each looks right.
+    chk("the helper itself is seen through spells_ladder",
+        spells_ladder("scripts/lib/zephyr-workspace.sh") != [])
+    chk("prose roots are skipped wholesale",
+        spells_ladder("docs/design/0095-nros-store-is-the-root.md") == [])
+
+    # Both directions of drift, which is the whole point of the ratchet.
+    added, gone = drift({"a": [1], "b": [2]}, {"a": "r"})
+    chk("a new spelling is reported as ADDED", added == ["b"])
+    chk("a folded file is reported as GONE", drift({"a": [1]}, {"a": "r", "z": "r"})[1] == ["z"])
+    chk("agreement is silent", drift({"a": [1]}, {"a": "r"}) == ([], []))
+
+    if verbose:
+        print(f"check-zephyr-workspace-resolvers --selftest: {ok} ok, {fail} failed")
+    if fail:
+        print(
+            f"check-zephyr-workspace-resolvers: SELFTEST FAILED ({fail})",
+            file=sys.stderr,
+        )
+    return 1 if fail else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--list",
+        action="store_true",
+        help="print every file that spells the ladder, with line numbers",
+    )
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest(verbose=True)
+    # On the NORMAL path, every time. A negative control nobody runs decays
+    # into a comment.
+    if selftest():
+        return 1
+
+    found = current_set()
+
+    if args.list:
+        for path in sorted(found):
+            print(f"{path}  # lines {', '.join(str(n) for n in found[path])}")
+        print(f"\n{len(found)} file(s)")
+        return 0
+
+    listed, problems = read_ratchet()
+
+    added, gone = drift(found, listed)
+
+    if added:
+        problems.append("")
+        problems.append(
+            "  A FOURTH SPELLING of the Zephyr workspace chain (drift: the tree "
+            "GAINED one):"
+        )
+        for path in added:
+            lines = ", ".join(str(n) for n in found[path])
+            problems.append(f"    {path}:{lines}")
+        problems.append("")
+        problems.append(
+            "  Call the ONE resolver instead of restating the ladder:\n"
+            "      source scripts/lib/zephyr-workspace.sh\n"
+            "      ws=\"$(nros_zephyr_ws_resolve || true)\"          # canonical spelling\n"
+            "      ws=\"$(nros_zephyr_ws_resolve_abs '' \"$repo_root\" || true)\"\n"
+            "  or, from a non-shell caller, run it as a command:\n"
+            "      scripts/lib/zephyr-workspace.sh [--version V] [--absolute] resolve\n"
+            "  It already walks $NROS_ZEPHYR_WORKSPACE, the checkout-relative trees\n"
+            "  for the selected line, and $NROS_STORE/workspaces/zephyr/<version>\n"
+            "  (RFC-0095 D4). If this caller genuinely cannot use it, add the path\n"
+            f"  to {RATCHET} with a reason saying WHY."
+        )
+
+    if gone:
+        problems.append("")
+        problems.append(
+            "  The ratchet moved the RIGHT way (drift: the tree LOST a spelling) "
+            "— these lines are now stale:"
+        )
+        for path in gone:
+            problems.append(f"    {RATCHET}: delete `{path}`  ({listed[path]})")
+        problems.append(
+            "\n  This file only ever shrinks. A line kept after its file stopped\n"
+            "  spelling the ladder is a licence nobody needs and a claim that is\n"
+            "  no longer true of the tree."
+        )
+
+    if problems:
+        print("check-zephyr-workspace-resolvers: FAIL", file=sys.stderr)
+        for line in problems:
+            print(line, file=sys.stderr)
+        return 1
+
+    print(
+        f"check-zephyr-workspace-resolvers: OK — {len(found)} known spelling(s), "
+        "no new one"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/zephyr-workspace.sh
+++ b/scripts/lib/zephyr-workspace.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# The ONE Zephyr workspace resolver — RFC-0095 D4, phase-440 W1.
+#
+# Until this file existed the chain was spelled THREE times, and the three did
+# not agree:
+#
+#   just/zephyr.just:19            env -> (4.4 ? ../nano-ros-workspace-4.4)
+#                                      -> zephyr-workspace -> ../nano-ros-workspace
+#                                      -> "zephyr-workspace" (the install target)
+#                                  predicate: the DIRECTORY exists
+#   scripts/build/west-fixtures.sh env -> zephyr-workspace -> ../nano-ros-workspace
+#                                      -> ../nano-ros-workspace-4.4 -> ""
+#                                  predicate: <cand>/zephyr exists; version-BLIND,
+#                                  and a set-but-empty override fell THROUGH
+#   scripts/check-tier-…sh:246     env -> zephyr-workspace -> ../nano-ros-workspace -> ""
+#                                  predicate: <cand>/zephyr exists; no 4.4 arm at all
+#
+# Three ladders answering one question is the two-spellings shape this repo
+# keeps paying for (CLAUDE.md "Fix the CLASS"), and here it was already
+# observable: on the 4.4 line `just zephyr` and the west fixture builder pointed
+# at different trees. Folding them has to pick ONE answer, so the reconciliation
+# is stated rather than discovered:
+#
+#   * the OVERRIDE wins unconditionally. `$NROS_ZEPHYR_WORKSPACE` is also the
+#     INSTALL TARGET of `just zephyr setup`, so it must resolve before the tree
+#     it names exists. An override silently ignored because the tree is not
+#     there yet is the worse failure (west-fixtures had it).
+#   * a candidate is a workspace when it holds `zephyr/`. That is what
+#     `ZEPHYR_BASE` points at, so "the directory exists" (just's old predicate)
+#     accepted a half-finished `zephyr-workspace/` that west cannot use.
+#   * the ladder is VERSION-AWARE, one line at a time. A 3.7 run never resolves
+#     the 4.4 sibling and a 4.4 run never resolves the 3.7 trees — a workspace
+#     of the wrong line is a west-manifest mismatch, not a fallback.
+#
+# ## The store arm, and why it is LAST
+#
+# RFC-0095 D4 ends at `$NROS_STORE/workspaces/zephyr/<version>` FIRST and the
+# checkout-relative arms last. W1 adds the arm at the BOTTOM so that with no
+# store populated — every host today — resolution is unchanged. W4 moves the
+# trees and inverts the order. The checkout-relative arm STAYS last forever
+# (RFC-0095 D4, phase-440 non-goals): a contributor patching a Zephyr module
+# points `$NROS_ZEPHYR_WORKSPACE` at their own tree.
+#
+# The store root is `${NROS_STORE:-${NROS_HOME:-$HOME/.nros}}` — never an
+# absolute literal, and never asserted as one in a gate (RFC-0095 D2), because
+# a test naming an absolute path only passes on the machine it was written on.
+#
+# ## Two output spellings, one ladder
+#
+# `just` keeps the repo-RELATIVE spelling (`zephyr-workspace`,
+# `../nano-ros-workspace-4.4`) because its recipes `realpath` it, echo it in
+# remedies and join it into build dirs; `west-fixtures.sh` needs the ABSOLUTE
+# one for `ZEPHYR_BASE`. Both are the same ladder — `_abs` joins `<root>/` onto
+# what `nros_zephyr_ws_candidates` emits, with no normalisation, so the string
+# is byte-identical to the `"$repo_root/…"` literals it replaces.
+#
+# Usable BOTH ways: `source` it for the functions, or run it as a command
+# (that is how `just` reaches it — a `just` expression and a shell function
+# cannot literally share code, so `just` CALLS this rather than restating it).
+#
+#   scripts/lib/zephyr-workspace.sh [--version V] [--root DIR] [--absolute] \
+#       <candidates|resolve|resolve-or-default|default|store-dir|version>
+#
+# shellcheck shell=bash
+
+# The repo root, from this file's own location (`scripts/lib/…`). Physical, the
+# same derivation `west-fixtures.sh` makes for `$repo_root`, so `--absolute`
+# reproduces its old literals exactly. Callers with a root already in hand pass
+# it rather than paying for a second `cd`.
+nros_zephyr_ws_default_root() {
+    (cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+}
+
+# The selected Zephyr line. `3.7` (LTS, west.yml) is the default the whole tree
+# assumes; `4.4` is the rolling line. Same default as `just/zephyr.just`'s
+# `NROS_ZEPHYR_VERSION := env("NROS_ZEPHYR_VERSION", "3.7")`.
+nros_zephyr_ws_version() {
+    printf '%s\n' "${NROS_ZEPHYR_VERSION:-3.7}"
+}
+
+# The store root (RFC-0095 D2). Resolved through the variables, in the order
+# the tree already uses for `$NROS_HOME` — `${NROS_HOME:-$HOME/.nros}` appears
+# in `scripts/build/cargo.sh`, `scripts/ci/dep-chain-check.sh` and
+# `scripts/xrce-agent/build.sh` — with `NROS_STORE` layered on top as the name
+# RFC-0095 gives the same directory.
+nros_zephyr_ws_store_root() {
+    printf '%s\n' "${NROS_STORE:-${NROS_HOME:-$HOME/.nros}}"
+}
+
+# `$NROS_STORE/workspaces/zephyr/<version>` — the arm W4 will promote.
+nros_zephyr_ws_store_dir() {
+    local version="${1:-}"
+    [ -n "$version" ] || version="$(nros_zephyr_ws_version)"
+    printf '%s\n' "$(nros_zephyr_ws_store_root)/workspaces/zephyr/$version"
+}
+
+# THE LADDER. One candidate per line, in order, in its canonical spelling —
+# repo-relative for the checkout arms, absolute for the override and the store.
+# Every other function here is a wrapper over this one.
+#
+# Args: [version] [root]
+nros_zephyr_ws_candidates() {
+    local version="${1:-}" root="${2:-}"
+    [ -n "$version" ] || version="$(nros_zephyr_ws_version)"
+    [ -n "$root" ] || root="$(nros_zephyr_ws_default_root)"
+
+    # 1. The explicit override. It wins outright and ends the ladder: it is the
+    #    install target as well as the lookup, so it may name a tree that does
+    #    not exist yet.
+    if [ -n "${NROS_ZEPHYR_WORKSPACE:-}" ]; then
+        printf '%s\n' "$NROS_ZEPHYR_WORKSPACE"
+        return 0
+    fi
+
+    # 2. The checkout-relative trees `just zephyr setup` lands, for THIS line.
+    if [ "$version" = "4.4" ]; then
+        printf '%s\n' "../nano-ros-workspace-4.4"
+    else
+        printf '%s\n' "zephyr-workspace"
+        printf '%s\n' "../nano-ros-workspace"
+    fi
+
+    # 3. The store (RFC-0095 D2). Last for now — see the header.
+    nros_zephyr_ws_store_dir "$version"
+}
+
+# Where `just zephyr setup` would INSTALL this line if nothing is provisioned.
+# Not a lookup: it is returned whether or not it exists, which is what makes it
+# usable as a target. Args: [version]
+nros_zephyr_ws_default() {
+    local version="${1:-}"
+    [ -n "$version" ] || version="$(nros_zephyr_ws_version)"
+    if [ -n "${NROS_ZEPHYR_WORKSPACE:-}" ]; then
+        printf '%s\n' "$NROS_ZEPHYR_WORKSPACE"
+        return 0
+    fi
+    if [ "$version" = "4.4" ]; then
+        printf '%s\n' "../nano-ros-workspace-4.4"
+    else
+        printf '%s\n' "zephyr-workspace"
+    fi
+}
+
+# The first candidate that IS a workspace, in its canonical spelling.
+# Prints nothing and returns 1 when none is — callers under `set -e` want
+# `x="$(nros_zephyr_ws_resolve || true)"`. Args: [version] [root]
+nros_zephyr_ws_resolve() {
+    local version="${1:-}" root="${2:-}" cand abs
+    [ -n "$version" ] || version="$(nros_zephyr_ws_version)"
+    [ -n "$root" ] || root="$(nros_zephyr_ws_default_root)"
+
+    # The override is not existence-tested — see candidate 1.
+    if [ -n "${NROS_ZEPHYR_WORKSPACE:-}" ]; then
+        printf '%s\n' "$NROS_ZEPHYR_WORKSPACE"
+        return 0
+    fi
+
+    while IFS= read -r cand; do
+        [ -n "$cand" ] || continue
+        case "$cand" in
+            /*) abs="$cand" ;;
+            *) abs="$root/$cand" ;;
+        esac
+        if [ -d "$abs/zephyr" ]; then
+            printf '%s\n' "$cand"
+            return 0
+        fi
+    done < <(nros_zephyr_ws_candidates "$version" "$root")
+    return 1
+}
+
+# `nros_zephyr_ws_resolve`, joined onto the root. No normalisation: the point is
+# that `<root>/../nano-ros-workspace` stays the string it was.
+# Args: [version] [root]
+nros_zephyr_ws_resolve_abs() {
+    local version="${1:-}" root="${2:-}" rel
+    [ -n "$root" ] || root="$(nros_zephyr_ws_default_root)"
+    rel="$(nros_zephyr_ws_resolve "$version" "$root")" || return 1
+    case "$rel" in
+        /*) printf '%s\n' "$rel" ;;
+        *) printf '%s\n' "$root/$rel" ;;
+    esac
+}
+
+# The resolved workspace, or the install target when nothing is provisioned.
+# This is `just`'s arm: a `just zephyr setup` needs a path either way.
+# Args: [version] [root]
+nros_zephyr_ws_resolve_or_default() {
+    local version="${1:-}" root="${2:-}"
+    nros_zephyr_ws_resolve "$version" "$root" && return 0
+    nros_zephyr_ws_default "$version"
+}
+
+# ---------------------------------------------------------------------------
+# Command form. `just` cannot call a shell function, so it calls this.
+# ---------------------------------------------------------------------------
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    set -uo pipefail
+
+    _nros_zws_version=""
+    _nros_zws_root=""
+    _nros_zws_absolute=0
+    _nros_zws_mode=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --version)
+                _nros_zws_version="${2:-}"
+                shift 2
+                ;;
+            --root)
+                _nros_zws_root="${2:-}"
+                shift 2
+                ;;
+            --absolute)
+                _nros_zws_absolute=1
+                shift
+                ;;
+            -h | --help)
+                sed -n '2,60p' "${BASH_SOURCE[0]}"
+                exit 0
+                ;;
+            -*)
+                echo "zephyr-workspace.sh: unknown option $1" >&2
+                exit 2
+                ;;
+            *)
+                if [ -n "$_nros_zws_mode" ]; then
+                    echo "zephyr-workspace.sh: unexpected argument $1" >&2
+                    exit 2
+                fi
+                _nros_zws_mode="$1"
+                shift
+                ;;
+        esac
+    done
+
+    [ -n "$_nros_zws_root" ] || _nros_zws_root="$(nros_zephyr_ws_default_root)"
+
+    case "${_nros_zws_mode:-resolve-or-default}" in
+        candidates)
+            if [ "$_nros_zws_absolute" -eq 1 ]; then
+                while IFS= read -r _nros_zws_cand; do
+                    case "$_nros_zws_cand" in
+                        /*) printf '%s\n' "$_nros_zws_cand" ;;
+                        *) printf '%s\n' "$_nros_zws_root/$_nros_zws_cand" ;;
+                    esac
+                done < <(nros_zephyr_ws_candidates "$_nros_zws_version" "$_nros_zws_root")
+            else
+                nros_zephyr_ws_candidates "$_nros_zws_version" "$_nros_zws_root"
+            fi
+            ;;
+        resolve)
+            if [ "$_nros_zws_absolute" -eq 1 ]; then
+                nros_zephyr_ws_resolve_abs "$_nros_zws_version" "$_nros_zws_root"
+            else
+                nros_zephyr_ws_resolve "$_nros_zws_version" "$_nros_zws_root"
+            fi
+            ;;
+        resolve-or-default)
+            # `--absolute` is deliberately not offered here: the default arm is
+            # a path that does not exist yet, and joining a root onto it would
+            # hand `just` an absolute string where every recipe expects the
+            # relative one it prints in its own remedies.
+            nros_zephyr_ws_resolve_or_default "$_nros_zws_version" "$_nros_zws_root"
+            ;;
+        default)
+            nros_zephyr_ws_default "$_nros_zws_version"
+            ;;
+        store-dir)
+            nros_zephyr_ws_store_dir "$_nros_zws_version"
+            ;;
+        version)
+            if [ -n "$_nros_zws_version" ]; then
+                printf '%s\n' "$_nros_zws_version"
+            else
+                nros_zephyr_ws_version
+            fi
+            ;;
+        *)
+            echo "zephyr-workspace.sh: unknown mode ${_nros_zws_mode}" >&2
+            echo "  modes: candidates resolve resolve-or-default default store-dir version" >&2
+            exit 2
+            ;;
+    esac
+fi


### PR DESCRIPTION
Implements **phase-440 W1** (RFC-0095 D4). Source-only: shell, `just`, Python and one roadmap doc. Nothing compiled changes.

## What

`scripts/lib/zephyr-workspace.sh` is now the one Zephyr-workspace resolver. `just/zephyr.just`, `scripts/build/west-fixtures.sh` and `scripts/check-tier-preconditions.sh` read it. A `just` expression and a shell function cannot literally share code, so `just` **calls** the helper as a command rather than restating the ladder:

```just
ZEPHYR_WORKSPACE := shell("scripts/lib/zephyr-workspace.sh --version $1 resolve-or-default", NROS_ZEPHYR_VERSION)
```

The `$NROS_STORE/workspaces/zephyr/<version>` arm is added **below** the existing ones, so with no store populated nothing moves; W4 inverts the order. The store root resolves through `${NROS_STORE:-${NROS_HOME:-$HOME/.nros}}` — never an absolute literal, and the gate asserts no path (RFC-0095 D2). The checkout-relative arm stays **last** (RFC-0095 D4 / phase-440 non-goals): a contributor patching a Zephyr module still points `$NROS_ZEPHYR_WORKSPACE` at their own tree.

## The three did not agree, so the fold had to pick an answer

Measured before and after over a 9-shape × 2-line matrix of synthetic hosts, with each pre-change ladder extracted **verbatim from `git show HEAD:`** rather than retyped, and the store deliberately empty:

```
cells: 54   unchanged: 39   changed: 15
OK: no cell on which the three resolvers agreed changed its answer.
```

That claim is checked mechanically, not by eye: every changed cell is one where the three resolvers already gave *different* answers. On this host (nothing provisioned) the resolved path is byte-identical before and after — `just` → `zephyr-workspace`, west-fixtures → `ZEPHYR_BASE` unset, tier-preconditions → empty.

The disagreements were real, and all three are gone:

| | before | |
| --- | --- | --- |
| 4.4 line | `just zephyr` → the 4.4 sibling | `west-fixtures.sh` was version-**blind** → the 3.7 in-tree tree; `check-tier-preconditions.sh` had no 4.4 arm at all, so it reported "no Zephyr workspace" against a tree `just zephyr` was building in |
| a set-but-not-yet-created `$NROS_ZEPHYR_WORKSPACE` | honoured by `just` and tier-preconditions | **fell through** to a different tree in west-fixtures |
| the predicate | `just` tested the *directory* exists | the other two tested `<cand>/zephyr`, so a half-finished `zephyr-workspace/` beat a real sibling |

The reconciliation is stated in the helper's header rather than discovered: the override wins unconditionally (it is the install target too, so it must resolve before the tree exists), a candidate is a workspace when it holds `zephyr/`, and the ladder is version-aware one line at a time. `--absolute` joins `<root>/` with no normalisation, so `ZEPHYR_BASE` keeps the exact string it had.

## The gate

`check-zephyr-workspace-resolvers` (fast lane, 0.37 s) refuses a fourth spelling, in the `check-cli-source-dirs` shape — it names the **direction** of drift both ways: a file that *gained* the ladder is a fourth spelling; a listed file that *lost* it is a stale licence to delete. It keys on the legacy sibling literal `nano-ros-workspace` (not preceded by `-`, which drops the unrelated `nros metadata --nano-ros-workspace` flag) outside comment-only lines; `zephyr-workspace` is a legitimate path constant all over the tree and would be mostly noise.

`.config/zephyr-workspace-resolvers.txt` is the ratchet: 29 entries, one reason each, sorted, and it only shrinks. It records the **26 files W1 did not fold** and why — the CLI's own Rust resolver, the nros-tests harness, four more shell ladders, three Python ones, the `scripts/zephyr/*` legacy-tree rung — because most want W4/W5 first. The task named three call sites; the sweep found the class is 33 files.

Mutation-tested, 15 assertions, all as expected:

| | | |
| --- | --- | --- |
| M1 | a fourth spelling in an unlisted tracked file | RED |
| M2 | **the W1 fold reverted** — the old ladder back in `check-tier-preconditions.sh` | RED |
| M3 | a ratchet line deleted while its file still spells it | RED |
| M4 | a listed file stops spelling it (the shrink direction) | RED |
| M5 | a ratchet entry with no `# reason` | RED |
| M6 | the ratchet unsorted | RED |
| M7 | a comment-only mention | GREEN, by design |
| | every restore | GREEN |

The gate runs its own 18-assertion selftest on the normal path (`check-gate-selftests`), and that selftest is itself a negative control: widening `LADDER` to catch the CLI flag fails 1 assertion, disabling the comment filter fails 4.

## Verification

* `just check fast` — **273 ran, 12 skipped, 0 failed**. Skips are all environmental on this worktree (no in-tree CLI built, no Zephyr workspace, no NVIDIA FSP tree, uninitialised submodules).
* `just ci gate` stops at `check::build`, **9 of 21**, and every one of the nine (`rmw-uorb`, `sched-dim-arms`, `rmw-xrce`, `staticlib-symbols`, `cpp`, `borrowed-e2e`, `test-targets`, `cli-tests`, `workspace-features`) is listed in `.config/ungated-gates.txt`, which states that each **fails in a pristine worktree with no build artifacts**. Causes read as such: a cmake cache generated from the parent checkout's path, and `third-party/dds/cyclonedds` not checked out. None of the nine mentions any file in this diff.
* Tier 1 only — this changes no compiled code.

## Not done here, deliberately

The remaining 26 spellings are recorded in the ratchet rather than folded. Two are worth naming: `packages/cli/nros-cli-core/src/cmd/build.rs` is the resolver a **user** meets (RFC-0095 D2) and has a `--zephyr-workspace` rung the shell chain does not, so it wants its own fold rather than a shell call; `scripts/check-zephyr-workspace-checkout.sh` must *sweep* every provisioned tree rather than resolve one, which is exactly what W5 generalises away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nq9x24szjuBMqdtwhfgxiM
