### PR TITLE
fix(phase-433 W5): the live-peer lane asks for cyclonedds fixtures and never checked the submodule out

### DIFF
--- a/.github/workflows/live-peer.yml
+++ b/.github/workflows/live-peer.yml
@@ -81,6 +81,29 @@ jobs:
           source ./activate.sh
           just interop-verdicts
 
+      # Run 34300486133 (2026-09-09) died here, one step further on than the
+      # abort PR #780 fixed, and said exactly why:
+      #
+      #   ERROR: workspace fixture 'workspace-rust-native-bridge' requires the
+      #          cyclonedds submodule, which is not checked out
+      #          (third-party/dds/cyclonedds is empty).
+      #
+      # `actions/checkout@v4` above takes NO submodules, and the only
+      # `git submodule update` in this lane is the CLI step's `play_launch`.
+      # The lane then asks for cyclonedds fixtures two lines below, so the
+      # requirement was always there and nothing checked it out.
+      #
+      # `--recursive` is the error's own advice, and cyclonedds needs it: this
+      # fixture vendors C++ CycloneDDS by design. NOT `--depth 1` here — the
+      # pin is a chosen release plus our fork's patch commits (issue 0507), and
+      # a shallow clone is what makes `git merge-base --is-ancestor` unable to
+      # answer, which is the shape that cost a false data-loss alarm on
+      # 2026-08-31.
+      - name: Check out the submodules the fixtures vendor
+        id: submodules
+        run: |
+          git submodule update --init --recursive third-party/dds/cyclonedds
+
       # NOT "the fixtures those CELLS resolve", which is what this said until
       # 2026-09-09. `lane-stage.py` classifies a step by keyword, `cells` is the
       # marker for the runtime stage, and the classifier takes the most specific
@@ -124,6 +147,7 @@ jobs:
           NROS_LANE_STEPS: >-
             [{"name": "Build the nros CLI", "conclusion": "${{ steps.cli.outcome }}"},
              {"name": "Report what the ledger claims, before running anything", "conclusion": "${{ steps.ledger.outcome }}"},
+             {"name": "Check out the submodules the fixtures vendor", "conclusion": "${{ steps.submodules.outcome }}"},
              {"name": "Build the fixtures those rows resolve", "conclusion": "${{ steps.fixtures.outcome }}"},
              {"name": "Run the cells with a recorded PASS", "conclusion": "${{ steps.cells.outcome }}"}]
         run: python3 scripts/ci/lane-stage.py --report --lane "live-peer regression"

--- a/scripts/ci/lane-stage.py
+++ b/scripts/ci/lane-stage.py
@@ -101,10 +101,19 @@ STAGE_MARKERS = (
     # `ledger` is live-peer.yml's: that lane reads `.config/interop-verdicts.toml`
     # before it runs anything, and a lane that cannot read its own membership
     # has not reached a stage.
+    #
+    # `submodules` and `check out` are here beside their singular/closed
+    # spellings because the matcher uses WORD BOUNDARIES: `\bsubmodule\b` does
+    # not match "submodules", and `\bcheckout\b` does not match "check out".
+    # A step named `Check out the submodules the fixtures vendor` therefore
+    # matched NOTHING and fell out of every stage — silently, since an
+    # unclassified step is simply not a stage. Caught by the self-test when the
+    # step was added; the same boundary rule that keeps `run` out of `runner`
+    # needs every inflection spelled.
     (PROVISIONING, ("setup", "set up", "provision", "install", "checkout",
-                    "cache", "fetch", "submodule", "labels", "doctor",
-                    "ledger", "reclaim disk", "free disk", "apt", "rustup",
-                    "register")),
+                    "check out", "cache", "fetch", "submodule", "submodules",
+                    "labels", "doctor", "ledger", "reclaim disk", "free disk",
+                    "apt", "rustup", "register")),
 )
 
 # Steps that belong to no stage: housekeeping that runs `if: always()` after the
@@ -406,6 +415,17 @@ _LIVE_PEER_34186427723 = _steps(
     ("Stop containers", "success"),
     ("Complete job", "success"))
 
+# Run 34300486133 (2026-09-09), the first dispatch after PR #780 fixed the silent
+# abort. It got ONE STEP FURTHER and stopped on an honest precondition — the
+# cyclonedds submodule was never checked out — which is the failure the
+# `Check out the submodules the fixtures vendor` step was added for. Recorded
+# under the step names of that run, i.e. WITHOUT that step.
+_LIVE_PEER_34300486133 = _steps(
+    ("Build the nros CLI", "success"),
+    ("Report what the ledger claims, before running anything", "success"),
+    ("Build the fixtures those rows resolve", "failure"),
+    ("Run the cells with a recorded PASS", "skipped"))
+
 # The same run as the workflow now reports it: four steps, current names.
 _LIVE_PEER_FIXTURES_DIED = _steps(
     ("Build the nros CLI", "success"),
@@ -446,6 +466,7 @@ LANES = (
     LaneSpec("live-peer.yml", "regression", "stage", {
         "Build the nros CLI": BUILD,
         "Report what the ledger claims, before running anything": PROVISIONING,
+        "Check out the submodules the fixtures vendor": PROVISIONING,
         "Build the fixtures those rows resolve": BUILD,
         "Run the cells with a recorded PASS": CELLS,
     }),
@@ -622,6 +643,13 @@ def selftest(verbose=False):
         stage_of("Build the fixtures those rows resolve") == BUILD)
     chk("the old name turned the real run into a false cell regression",
         classify(_LIVE_PEER_34186427723, "failure").kind == "verdict-fail")
+
+    lp2 = classify(_LIVE_PEER_34300486133, "failure")
+    chk("34300486133 (2026-09-09) -> no-verdict/build, the run that proved the "
+        "stage report works",
+        lp2.kind == "no-verdict" and lp2.stage == BUILD)
+    chk("the submodule checkout step is provisioning, not a build",
+        stage_of("Check out the submodules the fixtures vendor") == PROVISIONING)
 
     chk("`Run the cells with a recorded PASS` is the cells stage",
         stage_of("Run the cells with a recorded PASS") == CELLS)


### PR DESCRIPTION
Run [34300486133](https://github.com/NEWSLabNTU/nano-ros/actions/runs/34300486133) was the first dispatch after #780 fixed the silent abort. Two results.

## #780 works

```
built: examples/workspaces/sizing/target-fixtures/.../native_entry
check-stack-floor: linux has no floor (declared); skipped.
```

One line further than the build had **ever** got. That `find` is where it used to die with no message, and the stack-floor gate ran — correctly reporting a declared skip for linux — for the first time since it landed on 2026-09-07.

## And the stage report works

The run failed, and its check-run is named

> **live-peer — NO VERDICT: stopped in the build**

not `failure`. That is #781 doing exactly the job it was written for: a reader of the run list can tell "the lane never reached a cell" from "a recorded-passing cell regressed" without opening a log.

## The new failure, which is an honest one

```
ERROR: workspace fixture 'workspace-rust-native-bridge' requires the cyclonedds submodule,
       which is not checked out (third-party/dds/cyclonedds is empty).
```

`actions/checkout@v4` in this lane takes no submodules, and its only `git submodule update` is the CLI step for `play_launch` — while two lines below it runs `fixtures-build.sh linux rust cyclonedds`. The requirement was always there and nothing checked it out; until #780 the build died before reaching the row that needed it.

`--recursive` is the error own advice, and this fixture vendors C++ CycloneDDS by design. Deliberately **not** `--depth 1`: the pin is a chosen release plus our fork patch commits (issue 0507), and a shallow clone is exactly what makes `git merge-base --is-ancestor` unable to answer — the shape that cost a false data-loss alarm on 2026-08-31.

## One thing adding the step exposed

`stage_of` matches with **word boundaries**, so `\\bsubmodule\\b` does not match "submodules" and `\\bcheckout\\b` does not match "check out". The new step matched nothing and fell out of every stage — silently, since an unclassified step simply is not a stage. The self-test caught it the moment the step was declared. Both inflections are markers now; the same boundary rule that keeps `run` out of `runner` needs every spelling written down.

## Verification

Self-test 60 checks, 0 failures, with run 34300486133 recorded verbatim beside the other real runs. `just check lane-stage-reporting`, `workflow-repo-env`, `workflow-runner-isolation`, `lane-contracts` all OK.

What this still does not prove: that the cells pass. It removes the next known blocker; the run after this one is the one that answers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzPvAy8k8yiuoGmKMzKyiJ