### PR TITLE
fix(#1250, #1187): settle the FreeRTOS C++ build on a BUILD, and clear the one defect in front of it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -730,7 +730,10 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   `*** STACK OVERFLOW ***` — heap_4 hands out the stack, so the overflow reaches
   the next block header before `configCHECK_FOR_STACK_OVERFLOW 2` gets a context
   switch. The C/C++ carrier's 512 KiB mirror stays: its C half measures 18 176,
-  its C++ half does not BUILD (issue 1187), and one number serves both.
+  its C++ half was never measured, and one number serves both. The C++ half now
+  BUILDS — issue 1187 was closed by 1240's both-probes gate, measured on the
+  pinned arm-none-eabi 13.2 (six `cpp_*` FreeRTOS images link) — so the C++
+  number is available to take, and has not been taken.
 - **Tier and transport priorities land in ONE scheduler — they now share ONE vocabulary,
   RAW FreeRTOS (issue 0623, FIXED).** `FreertosScheduling`'s `zenoh_read_priority` /
   `zenoh_lease_priority` / `poll_priority` are raw `0..configMAX_PRIORITIES-1`, the same

--- a/docs/issues/archived/1187-freertos-embedded-cpp-freestanding-string.md
+++ b/docs/issues/archived/1187-freertos-embedded-cpp-freestanding-string.md
@@ -6,7 +6,8 @@ title: "Every embedded C++ FreeRTOS image fails to compile: `<string>` reaches
 status: resolved
 type: bug
 area: cpp
-related: [0112, 0332, 1146]
+related: [0112, 0332, 1146, 1223, 1240, 1250]
+resolved_in: "(this commit)"
 ---
 
 ## Problem
@@ -187,3 +188,35 @@ after    pass=47 fail=0
 Issue 1146 can now measure the FreeRTOS app-task stack on the C++ path, so
 `cmake/templates/freertos_app_config.c.in`'s 512 KiB — one number serving C and
 C++, measured only on the C half — can be reduced to the measured figure.
+
+## A second, independent measurement — and one correction to the note above
+
+Recorded 2026-09-09 from a build run at `43fcbd964`, a tree containing PR #791
+(`c9c861360`) and **not** phase-438 W1. That tree carries the CONJUNCTION form:
+
+```c++
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<hdr>))
+```
+
+`bash scripts/build/fixtures-build.sh freertos cpp zenoh` on
+`~/.nros/sdk/arm-none-eabi-gcc/13.2-nros1` (Arm GNU Toolchain 13.2.rel1, the pin
+this issue names) came back **GREEN**: zero `requires_hosted`, zero `error:`,
+and all six role images linked — `cpp_talker` 847 064 B, `cpp_listener`
+846 788 B, `cpp_service_server` 847 184 B, `cpp_service_client` 847 100 B,
+`cpp_action_server` 847 908 B, `cpp_action_client` 847 060 B.
+
+**So the correction above is wrong where it says pairing `__has_include` with
+`__STDC_HOSTED__` "would not have worked either".** Its table is right that each
+probe alone is wrong on one embedded lane — but both wrong answers are *include
+it when you must not*, so the conjunction fails CLOSED and is correct on all
+three lanes: freestanding arm-none-eabi (`__STDC_HOSTED__` 0), Zephyr's
+`-nostdinc++` (`__has_include` false, the header genuinely absent), and hosted
+(both true).
+
+This does not undo phase-438. Its case was never that the conjunction fails —
+it is that a std surface should be **requested** by the consumer rather than
+discovered by a probe, and that argument stands on its own. What phase-438 loses
+is only its urgency: it was not the sole way to make the FreeRTOS C++ images
+build, and #791 had already made them build. Recorded here because a phase doc
+asserting a false technical claim aims the next reader at a dead end, which is
+worse than no note at all.

--- a/docs/issues/archived/1250-freertos-tier-ctx-missing-stack-bytes.md
+++ b/docs/issues/archived/1250-freertos-tier-ctx-missing-stack-bytes.md
@@ -1,0 +1,73 @@
+---
+id: 1250
+title: "Every FreeRTOS image fails to compile: `freertos_run_tiers.c` reads and
+  writes `ctx->stack_bytes`, a field `nros_freertos_tier_ctx_t` never had"
+status: resolved
+type: bug
+area: boards, freertos
+severity: high
+found: 2026-09-09
+related: [1146, 1187, 1232]
+resolved_in: "(this commit)"
+---
+
+## Problem
+
+`packages/boards/nros-board-freertos/c/freertos_run_tiers.c` does not compile,
+at `43fcbd964`, on the pinned `arm-none-eabi-gcc 13.2`:
+
+```
+freertos_run_tiers.c: In function 'freertos_tier_task':
+freertos_run_tiers.c:359:79: error: 'nros_freertos_tier_ctx_t' has no member named 'stack_bytes'
+  359 |     if (nros_cpp_executor_derive_min_stack_headroom(ctx->executor_storage, ctx->stack_bytes)
+freertos_run_tiers.c: In function 'freertos_spawn_next_tier':
+freertos_run_tiers.c:483:8: error: 'nros_freertos_tier_ctx_t' has no member named 'stack_bytes'
+  483 |     ctx->stack_bytes = (size_t)stack_words * 4u;
+```
+
+`a6aa0f721` ("feat(cpp): derive a default stack-headroom bound, so the setter
+has a caller") added BOTH accesses — the write at spawn and the read in the tier
+task — and did not add the field to the per-tier context struct. The `nros_tier_spec_t`
+mirror above it has a `stack_bytes`, which is the field the commit's own comment
+distinguishes itself from ("The EFFECTIVE stack, not the declared one"), so the
+name resolves in the reader's head and not in the compiler's.
+
+This is board glue compiled into **every** FreeRTOS image, C and C++ alike, so
+nothing under `examples/qemu-arm-freertos/` links.
+
+## Why it stayed invisible
+
+The same reason issue 1187 did, and the reason 1187 could not be settled
+without tripping over this one: no merge-gating lane builds FreeRTOS.
+`check-cpp` / `check-c` are HOST lanes; the cross build is reached only by
+`build-all` / `workspace-fixtures-build.sh`, i.e. `schedule` and
+`workflow_dispatch`. CLAUDE.md's "a red CI lane answers one of two questions"
+applies exactly: the FreeRTOS nightly was already red for 1187, so a second
+fault behind it was a first-error-only report away from invisible.
+
+## Fix
+
+Declare the field. It is written once at spawn (`stack_words * 4`, the
+EFFECTIVE stack the task was created with — not the spec's declared
+`stack_bytes`, which may be 0 and then gets the 256 KiB default) and read once
+in the tier task to derive the headroom bound.
+
+The class was checked and is one site: the Zephyr sibling
+(`packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c`) makes the same two
+`nros_cpp_executor_derive_min_stack_headroom` calls and deliberately passes the
+shim's slot size (`nros_zephyr_tier_stack_size()` / `nros_zephyr_main_stack_size()`)
+rather than any `ctx->` field — see issue 1232 for why. No other board reaches
+that entry point.
+
+## Verification
+
+`bash scripts/build/fixtures-build.sh freertos cpp zenoh` and
+`… freertos c zenoh`, with `NROS_CMAKE_EXTRA_DEFS` carrying
+`cmake/toolchain/arm-freertos-armcm3.cmake` — the same acceptance issue 1187
+names, since this defect sits directly in front of it.
+
+Both GREEN at `43fcbd964` + this fix, on
+`~/.nros/sdk/arm-none-eabi-gcc/13.2-nros1` (`Arm GNU Toolchain 13.2.rel1`):
+zero `error:` lines across the whole log, six `cpp_*` images and the C role
+images linked. That build is also what settles issue 1187 — see its
+Resolution section.

--- a/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
+++ b/docs/roadmap/phase-438-cpp-std-is-an-opt-in-porting-surface.md
@@ -88,7 +88,16 @@ The reason `__has_include` cannot be repaired in place, measured directly:
 Each probe is right on exactly one embedded lane and wrong on the other. On the
 FreeRTOS lane `__STDC_HOSTED__` is the correct probe and `__has_include` is the
 wrong one — **the exact reverse of what eleven header comments state.** Only
-`NROS_CPP_STD` is right on both, because it is not a probe.
+`NROS_CPP_STD` is right on both *as a single probe*, because it is not a probe.
+
+**CORRECTION (2026-09-09, measured).** This section then concluded that ANDing
+the two does not work either. That does not follow, and the build disproves it.
+Both wrong answers above are of the same sign — *include it when you must not* —
+so the CONJUNCTION fails closed: the FreeRTOS row dies on `__STDC_HOSTED__ == 0`,
+the Zephyr row on `__has_include` FALSE, and only the hosted row has both. Issue
+1240 shipped exactly that AND, and `fixtures-build.sh freertos cpp zenoh` is
+green on this table's own toolchain with zero `requires_hosted` diagnostics. The
+argument for the opt-in is the API-shape one above, not this one.
 
 ### Those eleven comments cite issue 0112 for something 0112 did not say
 
@@ -138,10 +147,14 @@ program — native included — is on the freestanding side already.
 
 ### What it costs today
 
-* **The FreeRTOS C++ build does not compile at all** (issue 1187), and could not
-  be measured for issue 1146's app-task stack figure, so
-  `cmake/templates/freertos_app_config.c.in`'s 512 KiB serves C and C++ from one
-  number that was only ever measured on the C half.
+* ~~**The FreeRTOS C++ build does not compile at all** (issue 1187)~~ —
+  **no longer true as of 2026-09-09.** Issue 1240's both-probes gate
+  (`NROS_CPP_STD || (__STDC_HOSTED__ && __has_include(<hdr>))`, `c9c861360`)
+  fixed it, MEASURED: `fixtures-build.sh freertos cpp zenoh` is green on the
+  pinned arm-none-eabi 13.2 and all six `cpp_*` images link. Issue 1146's C++
+  app-task stack figure is now takeable — `freertos_app_config.c.in`'s 512 KiB
+  still serves C and C++ from one number measured only on the C half, but
+  nothing structural is in the way any more.
 * **The gate that should have caught it reports green** (issue 1223).
   `check-cpp-freestanding-includes` pushes a guard frame on `#if
   defined(NROS_CPP_STD)` and pops only on `#endif`; `#elif` and `#else` match
@@ -472,9 +485,14 @@ parameter stores" is deleting from, and W4 is phase-427 W1 relocated. Doing it
 after would mean building the node merge on a layout whose conditionality is the
 thing being removed.
 
-Independently: **W0+W1+W2 close issue 1187**, which blocks issue 1146's C++ stack
-measurement. That is reason to land the first three items ahead of the rest
-rather than as one phase-sized change.
+~~Independently: **W0+W1+W2 close issue 1187**~~ — issue 1240 closed it first,
+on 2026-09-09, with the AND this doc argued could not work (see the correction
+under "Neither probe is right on both embedded lanes"). **That removes this
+phase's urgency, not its argument**: the surface is still DISCOVERED rather than
+requested, `rclcpp::Node` is still guarded on the discovered macros, and W0's
+gate blindness (issue 1223) is still real. W0-W4 have since landed on those
+merits rather than on the red lane, which is the status line at the top of this
+doc; the ordering above is recorded as history.
 
 ## Risk
 

--- a/packages/boards/nros-board-freertos/c/freertos_run_tiers.c
+++ b/packages/boards/nros-board-freertos/c/freertos_run_tiers.c
@@ -53,7 +53,6 @@ extern uint64_t nros_tier_spin_gap_step(uint64_t state, uint64_t iter_start_ns, 
                                         uint32_t spin_period_us);
 extern uint64_t nros_platform_clock_ns(void);
 
-
 /* nros_board_network_wait: weak no-op in <nros/main.h> (phase-432 W3.1 moved
  * it there from the C++ sibling main.hpp so a pure C entry links); strong
  * override on boards that need an extra poll-wait after network bring-up. On
@@ -181,6 +180,15 @@ typedef struct {
      * `xTaskCreate`; what was missing was any way to say so. */
     const char* name;
     uint32_t priority;
+    /* issue 1250 — the EFFECTIVE stack this task was created with, in bytes
+     * (`stack_words * 4`), NOT the tier spec's declared `stack_bytes`: an
+     * unset spec still gets the 256 KiB default below, and a headroom bound
+     * derived from `0` would leave the rule off on exactly the tiers that
+     * declared nothing. `freertos_spawn_next_tier` assigns it and
+     * `freertos_tier_task` reads it; both arrived in a6aa0f721 and the field
+     * itself did not, so every FreeRTOS image — C and C++ alike — failed to
+     * compile. */
+    size_t stack_bytes;
 } nros_freertos_tier_ctx_t;
 
 /* RFC-0052 W2/W5.11 — apply and ANNOUNCE the placement dim for one task.
@@ -356,8 +364,7 @@ static void freertos_tier_task(void* arg) {
      * Spawned tiers only. The boot tier runs on the caller (`app_task`, a
      * 512 KiB stack this layer never sized), so a bound derived from its spec
      * would be measured against the wrong stack. */
-    if (nros_cpp_executor_derive_min_stack_headroom(ctx->executor_storage, ctx->stack_bytes)
-        != 0) {
+    if (nros_cpp_executor_derive_min_stack_headroom(ctx->executor_storage, ctx->stack_bytes) != 0) {
         /* Same fail-loud rule as a spawn failure above: a bound that was never
          * set leaves `stack-headroom-runtime` off, and a monitor that silently
          * fails to arm is indistinguishable from a healthy system. */
@@ -664,7 +671,8 @@ int32_t nros_board_freertos_run_tiers(const char* locator, uint8_t domain_id,
      * Nothing here needs the children to exist and no other tier task exists
      * yet to be starved by a self-demotion, so this runs while the boot task
      * still owns the CPU. #144 is untouched: boot's DECLARES already ran. */
-    (void)freertos_apply_tier_priority(boot->name, (uint32_t)((boot->priority < 0) ? 0 : boot->priority));
+    (void)freertos_apply_tier_priority(boot->name,
+                                       (uint32_t)((boot->priority < 0) ? 0 : boot->priority));
 
     /* --- Kick off the chained spawn (tiers[1] carrying tiers[2..]) --- */
     /* A boot-side spawn failure is fatal: tear down boot_storage (which the


### PR DESCRIPTION
## What this settles

Issue **1187** — every embedded C++ FreeRTOS image fails to compile, because
`<string>` reaches `bits/requires_hosted.h` under `-ffreestanding` (`__has_include`
answers TRUE for a header that `#error`s on inclusion).

Issue **1240**'s fix (PR #791, `c9c861360`) landed the both-probes gate at 14 sites
across 11 `nros-cpp` headers. Its author believed it very likely fixed 1187 too,
ran no arm-none-eabi build, and correctly declined to claim it. **This PR is that
build.**

## The build

Measured at `43fcbd964` (contains `c9c861360`, does NOT contain phase-438 W1's
`std_detect.hpp`), on the pin the issue names —
`~/.nros/sdk/arm-none-eabi-gcc/13.2-nros1`, `Arm GNU Toolchain 13.2.rel1`:

```
bash scripts/build/fixtures-build.sh freertos cpp zenoh   # GREEN
bash scripts/build/fixtures-build.sh freertos c   zenoh   # GREEN
```

with `NROS_CMAKE_EXTRA_DEFS` carrying `cmake/toolchain/arm-freertos-armcm3.cmake`,
`-DCMAKE_BUILD_TYPE=Release` and the host codegen tool — exactly the acceptance
1187 specifies.

* **Zero** `error:` lines in the whole log.
* **Zero** `requires_hosted`, against the 488 diagnostics 1187 opened with.
* All six role images link: `cpp_talker` 847 064, `cpp_listener` 846 788,
  `cpp_service_server` 847 184, `cpp_service_client` 847 100,
  `cpp_action_server` 847 908, `cpp_action_client` 847 060 bytes.

1187 → `docs/issues/archived/`, `status: resolved`, with the measurement recorded.

## The defect that sat in front of it (issue 1250, filed + fixed here)

The first acceptance run did not reach 1187's question — it died on something
else, and the first error was not the specific-looking one:

```
freertos_run_tiers.c:359:79: error: 'nros_freertos_tier_ctx_t' has no member named 'stack_bytes'
freertos_run_tiers.c:483:8:  error: 'nros_freertos_tier_ctx_t' has no member named 'stack_bytes'
```

`a6aa0f721` added both the write (at spawn) and the read (in the tier task) and
never added the member. The sibling `nros_tier_spec_t` right above it *does* have
a `stack_bytes` — the very field the commit's own comment distinguishes itself
from — so the name resolves in the reader's head and not in the compiler's. This
is board glue in **every** FreeRTOS image, C and C++ alike.

Class sweep, run rather than assumed: `grep -rn derive_min_stack_headroom packages/`.
The only sibling is `nros-board-zephyr/c/zephyr_run_tiers.c`, which passes the
shim's slot size rather than any `ctx->` field, deliberately (issue 1232). One
site, fixed.

## Two corrections, because they now mislead

* **phase-438** argued that ANDing `__STDC_HOSTED__` with `__has_include` "does
  not work either". Its own table shows each probe wrong on exactly one embedded
  lane — but both wrong answers are *include it when you must not*, so the
  conjunction fails **closed** and is right on both. The green build is that,
  measured on the table's own toolchain. phase-438 keeps its API-shape argument
  (the std surface is DISCOVERED rather than requested) and loses its urgency,
  not its case.
* **CLAUDE.md**'s "its C++ half does not BUILD (issue 1187)" in the executor-arena
  entry. It builds; issue 1146's C++ stack figure is takeable and untaken.

## What this does NOT establish

* Compile-and-link only. **No QEMU cell was run**, so this is not a runtime verdict.
* Issue **1223** stands — phase-438 W0's wider gate blindness (`#elif`/`#else`
  arms) is untouched.
* The invisibility that let both defects live is unchanged: no merge-gating lane
  builds FreeRTOS, and a lane already red reports its first error only.

## Gates — stated exactly, including what is red

`just check fast`: **green**, 280 gates ran / 0 failed / 4 skipped, on the final
tree. (Before initialising two submodules it reported 1 red —
`xrce-vendored-versions`, an unprovisioned-submodule report — identically with
and without this branch.)

`just ci gate`: **FAILED at step 3 of 6** (`check::cli-fresh` ok, `check::fast`
ok, `check::build` 4 of 21 red). **None of the four is this branch** — the diff
is one C file plus three docs, and no red is in a file it touches:

| red | cause | mine? |
| --- | --- | --- |
| `check::test-targets` | `cyclonedds-sys` build script — `third-party/dds/cyclonedds` is not checked out in this worktree | no, provisioning |
| `check::workspace-features` | same `cyclonedds-sys` | no, provisioning |
| `check::cli-tests` | `plan_pipeline_e2e::fixture_workspace_plans_and_checks` panics `nros-launch-resolve not built — run just setup-launch-resolve` | no, provisioning (the CI lane builds that helper first) |
| `check::cpp` | clippy `-D missing_safety_doc` on `nros_cpp_declare_remap`, `packages/api/nros-cpp/src/lib.rs:3262` | **no — a real red on `main`** |

The last one is worth someone's attention and is NOT fixed here, deliberately:
it is `587baabb7`'s remaining fallout. That commit restored the
`#[cfg(feature = "rmw-cffi")]` gate that a doc block had displaced, and
`nros_cpp_declare_remap` came back without the `# Safety` section it used to
carry, so clippy now refuses the crate. It sits in `check-build`, which is
`schedule` / `workflow_dispatch` only, so it blocks no pull request — which is
also why it can sit. Mixing it into this PR would put an unrelated `nros-cpp`
edit inside a FreeRTOS-build settlement; it deserves its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzPvAy8k8yiuoGmKMzKyiJ
