### PR TITLE
feat(phase-440 W6): the store can be inspected and shrunk, and refuses when it cannot tell

### DIFF
--- a/book/src/start-here/setup-compared-to-ros2.md
+++ b/book/src/start-here/setup-compared-to-ros2.md
@@ -139,6 +139,17 @@ Multi-RMW bridges (one binary, two or more backends) use
   carry their own `install(TARGETS …)` for colcon compatibility.) The
   integration shells under `integrations/<rtos>/` re-export the same
   root CMake under each RTOS's native package manager.
+- **The store only grows, so there are verbs to inspect and shrink it.**
+  Provisioning never overwrites: a new version lands beside the old one, which
+  is what makes going back to a previous toolchain free. `nros store list`
+  prints every entry with its size and when it was last read; `nros store gc
+  --older-than 90d` proposes what to reclaim and **removes nothing unless you
+  add `--delete`**. It never removes an entry a pin names — it reads
+  `nros-sdk-index.toml` / `nros-sdk.lock` from the directory you run it in and
+  its ancestors, and says which files it consulted. `nros toolchain uninstall
+  <version>` removes one nano-ros toolchain under the same rule, and refuses
+  when it cannot find a pin file to check against, rather than assuming nothing
+  needs it.
 - **Generated bindings in-tree.** Message codegen lands under
   `<your-package>/generated/` (or `OUT_DIR` for Cargo builds), not in
   an installed ROS message library.

--- a/docs/roadmap/phase-440-nros-store-is-the-root.md
+++ b/docs/roadmap/phase-440-nros-store-is-the-root.md
@@ -108,7 +108,7 @@ stay exercised (nested → refuse; outside any checkout → silent; second check
 without `packages/cli` → silent; `NROS_SKIP_STALE_CHECK=1` → silent; own tree →
 silent), so it can never be stricter than the ownership guard it front-runs.
 
-### W6 — the store can be inspected and shrunk
+### W6 — the store can be inspected and shrunk — **LANDED**
 
 `nros store list` / `nros store gc --older-than <d>` / `nros toolchain uninstall
 <ver>`. Additive-by-design storage needs a verb to reclaim, and
@@ -118,6 +118,35 @@ so this is explicit and inspectable rather than clever.
 *Acceptance:* `--dry-run` is the DEFAULT and the tests assert it; `uninstall`
 refuses while a known pin names the version; `list` reports size and last-used
 so a human can decide. A test proves gc never removes an entry a pin names.
+
+**What landed** (`orchestration/store.rs` + `cmd/{store,toolchain}.rs`, 12 tests
+in `tests/store_reclaim.rs`):
+
+* the store ROOT has one resolver — `store::root()`, `$NROS_STORE` →
+  `$NROS_HOME` → `~/.nros`, with `sdk_store::{store_root,front_dir}` now derived
+  from it instead of repeating the arms (D2's "never an absolute literal");
+* `gc` removes only entries carrying `.nros-provenance`. The others are LISTED
+  with their size and left alone: the legacy flat prefix `nros sdk-path` still
+  resolves through (issue 0628) and `<version>.src` source trees, which are 1.5 G
+  of the 4.4 G store on the host this was written on — nothing needs them, but a
+  source tree is also where somebody's local patches would be;
+* **`--delete` refuses when NO pin file was consulted**, not just when one names
+  the entry. The store is shared while pins are per-project, so an empty pin set
+  from the wrong cwd means "I looked in the wrong place" at least as often as it
+  means "nothing needs these". `--ignore-pins` is the explicit way past it;
+* **`toolchain uninstall` therefore refuses on today's tree**, which is the
+  honest answer rather than a limitation: `toolchains/<ver>/` and
+  `nros-toolchain.toml` are both W7's, so nothing yet exists that could establish
+  that no project pins a version. The pin reader already accepts
+  `nros-toolchain.toml` and takes ANY string value in it as a version, so W7 may
+  choose its schema without disarming the guard;
+* "last used" is the newest `atime` over an entry's regular files, with the
+  timestamp's PROVENANCE printed beside it (`read` vs `install`) because under
+  `noatime` there is no usage signal at all and the number would otherwise read
+  as one. Two traps found by measuring rather than reasoning: the scan's own
+  read of `.nros-provenance` made every installed entry report "used 1s ago"
+  until those markers were excluded, and at one-second timestamp resolution the
+  test for that passed with the fix removed.
 
 ### W7 — `toolchains/<version>/`, the pin file, and the shim
 

--- a/packages/cli/nros-cli-core/src/cmd/mod.rs
+++ b/packages/cli/nros-cli-core/src/cmd/mod.rs
@@ -44,6 +44,10 @@ pub mod scaffold_deploy;
 pub mod sdk_front;
 pub mod sdk_path;
 pub mod setup;
+/// phase-440 W6 — `nros store list|gc` (RFC-0095 D11).
+pub mod store;
+/// phase-440 W6 — `nros toolchain uninstall` (RFC-0095 D11).
+pub mod toolchain;
 pub mod version;
 pub mod ws;
 
@@ -143,6 +147,17 @@ pub enum Cmd {
     /// the CLI itself and has no `nros setup` to run until it has.
     #[command(name = "sdk-front")]
     SdkFront(sdk_front::Args),
+
+    /// phase-440 W6 — inspect and shrink the SDK store (RFC-0095 D11). The
+    /// store is additive by design, so `list` says what is in it and `gc`
+    /// proposes what to reclaim — dry-run by default, and it never removes
+    /// anything a pin names.
+    Store(store::Args),
+
+    /// phase-440 W6 — remove one installed nano-ros toolchain (RFC-0095 D11).
+    /// Refuses while a known pin names the version, and refuses equally when no
+    /// pin file could be consulted: unestablished is not the same as false.
+    Toolchain(toolchain::Args),
 
     /// phase-336 — the cargo build-profile table (CMAKE_BUILD_TYPE mapping,
     /// flags, artifact dir, env-injected definitions). The bridge cmake/bash

--- a/packages/cli/nros-cli-core/src/cmd/store.rs
+++ b/packages/cli/nros-cli-core/src/cmd/store.rs
@@ -1,0 +1,342 @@
+//! `nros store list` / `nros store gc` — phase-440 W6, RFC-0095 D11.
+//!
+//! The store is additive by design, so it grows and nothing shrinks it. These
+//! are the two verbs that make that survivable, and they are deliberately dumb:
+//! `list` reports, `gc` proposes. The reasoning lives in
+//! [`crate::orchestration::store`]; what belongs HERE is why the flags are shaped
+//! the way they are.
+//!
+//! **`--dry-run` is the default, and removing requires `--delete`.** Not a
+//! preference — a store holds a 4 G workspace shared by three projects
+//! (RFC-0095 D2), and that is precisely the thing nobody wants deleted by a flag
+//! they misread. The inverse default would make the destructive path the one you
+//! reach by typing LESS.
+//!
+//! **`--delete` refuses when no pin file was consulted.** "No pin names this"
+//! and "I found nothing that could name anything" are different answers and used
+//! to be indistinguishable in every tool that has made this mistake. A store is
+//! shared between projects while pins are per-project, so `gc --delete` run from
+//! `/tmp` can see no pins at all — and that is the case where deleting is most
+//! likely to take out somebody's toolchain.
+
+use std::path::PathBuf;
+
+use clap::{Args as ClapArgs, Subcommand};
+use eyre::{Result, bail};
+
+use crate::orchestration::store::{self, Entry, GcPlan, KeepReason, format_age, format_size};
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    #[command(subcommand)]
+    pub command: Sub,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Sub {
+    /// What the store holds: name, version, size, when it was last read.
+    List(ListArgs),
+
+    /// Propose (and, with `--delete`, perform) removal of unused entries.
+    /// Dry-run by default.
+    Gc(GcArgs),
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct ListArgs {
+    /// Store root. Defaults to `$NROS_STORE`, else `$NROS_HOME`, else
+    /// `~/.nros` — never an absolute literal (RFC-0095 D2).
+    #[arg(long)]
+    pub root: Option<PathBuf>,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct GcArgs {
+    /// Remove entries not read for at least this long: `90d`, `12h`, `2w`.
+    /// A bare number is refused — say the unit.
+    #[arg(long, value_name = "DURATION")]
+    pub older_than: String,
+
+    /// Actually remove. Without it this only reports (the default).
+    #[arg(long)]
+    pub delete: bool,
+
+    /// Report only. The default; accept it so the safe intent can be SPELLED
+    /// rather than only implied, and so it can conflict with `--delete`
+    /// instead of one of them silently winning.
+    #[arg(long, conflicts_with = "delete")]
+    pub dry_run: bool,
+
+    /// An extra file whose contents pin versions. Repeatable. Any string value
+    /// in it protects an entry with that version.
+    #[arg(long, value_name = "PATH")]
+    pub pin_file: Vec<PathBuf>,
+
+    /// Delete without consulting any pin file. You are asserting no project
+    /// needs these.
+    #[arg(long)]
+    pub ignore_pins: bool,
+
+    /// Store root (see `list --root`).
+    #[arg(long)]
+    pub root: Option<PathBuf>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let cwd = std::env::current_dir().ok();
+    match args.command {
+        Sub::List(a) => list(a),
+        Sub::Gc(a) => gc(a, cwd.as_deref()),
+    }
+}
+
+fn resolve_root(explicit: Option<PathBuf>) -> (PathBuf, String) {
+    match explicit {
+        Some(p) => (p, "--root".to_string()),
+        None => (store::root(), store::root_origin().to_string()),
+    }
+}
+
+fn list(args: ListArgs) -> Result<()> {
+    let (root, origin) = resolve_root(args.root);
+    println!("store root: {}   (from {origin})", root.display());
+    if !root.is_dir() {
+        println!("  (no store here yet — nothing is provisioned)");
+        return Ok(());
+    }
+
+    let entries = store::scan(&root);
+    if entries.is_empty() {
+        println!("  (empty)");
+        return Ok(());
+    }
+
+    let now = std::time::SystemTime::now();
+    let rows: Vec<[String; 5]> = entries
+        .iter()
+        .map(|e| {
+            let age = now
+                .duration_since(e.last_used)
+                .unwrap_or(std::time::Duration::ZERO);
+            [
+                format_size(e.size_bytes),
+                format_age(age),
+                e.evidence.label().to_string(),
+                e.state.label().to_string(),
+                e.display_id(),
+            ]
+        })
+        .collect();
+    let header = ["SIZE", "LAST-USED", "EVIDENCE", "STATE", "ENTRY"];
+    let widths: Vec<usize> = (0..5)
+        .map(|i| {
+            rows.iter()
+                .map(|r| r[i].len())
+                .chain(std::iter::once(header[i].len()))
+                .max()
+                .unwrap_or(0)
+        })
+        .collect();
+
+    println!();
+    print_row(&header.map(String::from), &widths);
+    for row in &rows {
+        print_row(row, &widths);
+    }
+
+    let total: u64 = entries.iter().map(|e| e.size_bytes).sum();
+    let installed = entries
+        .iter()
+        .filter(|e| e.state == store::EntryState::Installed)
+        .count();
+    println!();
+    println!(
+        "{} entries, {} total — {installed} installed, {} not attributable to an install.",
+        entries.len(),
+        format_size(total),
+        entries.len() - installed
+    );
+    for line in [
+        "EVIDENCE `read` means a file in the entry was read after it was written;",
+        "  `install` means nothing was, so LAST-USED is when it landed. A `noatime`",
+        "  mount records no reads at all and every entry then reads `install` —",
+        "  check before trusting an age.",
+    ] {
+        println!("{line}");
+    }
+    for line in [
+        "`nros store gc` only ever removes `installed` entries. `legacy-flat` is the",
+        "  unversioned prefix `nros sdk-path` still resolves through (issue 0628) —",
+        "  removing one un-provisions a working host. `source-tree` is what a source",
+        "  install BUILT from: nothing needs it, but it is also where local patches",
+        "  would be, so it is reported rather than collected.",
+    ] {
+        println!("{line}");
+    }
+    let source_trees: u64 = entries
+        .iter()
+        .filter(|e| e.state == store::EntryState::SourceTree)
+        .map(|e| e.size_bytes)
+        .sum();
+    if source_trees > 0 {
+        println!(
+            "  source trees hold {} — remove one by hand when you are sure it carries",
+            format_size(source_trees)
+        );
+        println!("  nothing of yours; the next source install re-clones it.");
+    }
+    Ok(())
+}
+
+fn print_row(cells: &[String; 5], widths: &[usize]) {
+    let line: Vec<String> = cells
+        .iter()
+        .enumerate()
+        .map(|(i, c)| format!("{:<width$}", c, width = widths[i]))
+        .collect();
+    println!("  {}", line.join("  ").trim_end());
+}
+
+/// `gc`, with the directory pin discovery walks up from passed IN.
+///
+/// The public verb hands it `current_dir()`; a test hands it a tempdir. The
+/// reason is not tidiness: in this checkout every ancestor of a test's working
+/// directory holds an `nros-sdk-index.toml`, so a `current_dir()` read inside
+/// would make the "no pin file could be consulted" refusal — the one that keeps
+/// a `gc --delete` run from `/tmp` from eating another project's toolchain —
+/// impossible to test in-tree.
+pub fn gc(args: GcArgs, pin_search_from: Option<&std::path::Path>) -> Result<()> {
+    let older_than = store::parse_duration(&args.older_than)?;
+    let (root, origin) = resolve_root(args.root.clone());
+    println!("store root: {}   (from {origin})", root.display());
+    if !root.is_dir() {
+        println!("  (no store here — nothing to collect)");
+        return Ok(());
+    }
+
+    let sources = if args.ignore_pins {
+        Vec::new()
+    } else {
+        store::collect_pins(&args.pin_file, pin_search_from)?
+    };
+    if sources.is_empty() {
+        if args.ignore_pins {
+            println!("pins: NONE CONSULTED (--ignore-pins)");
+        } else {
+            println!("pins: none found");
+        }
+    } else {
+        println!("pins consulted:");
+        for s in &sources {
+            println!("  {}  ({} version(s))", s.path.display(), s.rules.len());
+        }
+    }
+
+    // The refusal is here rather than at the top so the report above is printed
+    // either way: a user who ran this in the wrong directory learns WHY from the
+    // same output that refuses them.
+    if args.delete && sources.is_empty() && !args.ignore_pins {
+        bail!(
+            "refusing to delete: no pin file was consulted, so `no pin names this entry` \
+             could not be established.\n\
+             The store is shared between projects while pins are per-project, so an empty \
+             pin set here means `I looked in the wrong place`, not `nothing needs these`.\n\
+             Fix it by one of:\n  \
+             run this from a project (looked for {} in this directory and its ancestors)\n  \
+             name one:      --pin-file <path>\n  \
+             or assert it:  --ignore-pins   (you are saying no project needs these)",
+            store::PIN_FILE_NAMES.join(", ")
+        );
+    }
+
+    let entries = store::scan(&root);
+    let now = std::time::SystemTime::now();
+    let plan = store::plan_gc(entries, older_than, &sources, now);
+
+    report_plan(&plan, now, &args.older_than);
+
+    if !args.delete {
+        println!();
+        println!(
+            "DRY RUN (the default) — nothing was removed. Re-run with --delete to remove \
+             the {} entr{} above.",
+            plan.remove.len(),
+            if plan.remove.len() == 1 { "y" } else { "ies" }
+        );
+        return Ok(());
+    }
+
+    if plan.remove.is_empty() {
+        println!();
+        println!("nothing to remove.");
+        return Ok(());
+    }
+
+    println!();
+    let mut freed = 0u64;
+    for entry in &plan.remove {
+        std::fs::remove_dir_all(&entry.path)
+            .map_err(|e| eyre::eyre!("remove {}: {e}", entry.path.display()))?;
+        freed += entry.size_bytes;
+        println!(
+            "removed {}  ({})",
+            entry.display_id(),
+            format_size(entry.size_bytes)
+        );
+    }
+    println!("freed {}.", format_size(freed));
+    Ok(())
+}
+
+fn report_plan(plan: &GcPlan, now: std::time::SystemTime, older_than: &str) {
+    let pinned: Vec<(&Entry, &[PathBuf])> = plan.pinned().collect();
+    if !pinned.is_empty() {
+        println!();
+        println!("kept — a pin names it:");
+        for (entry, files) in pinned {
+            let by: Vec<String> = files.iter().map(|f| f.display().to_string()).collect();
+            println!("  {}  ({})", entry.display_id(), by.join(", "));
+        }
+    }
+
+    let too_new = plan
+        .keep
+        .iter()
+        .filter(|(_, r)| matches!(r, KeepReason::TooNew))
+        .count();
+    let unmanaged = plan
+        .keep
+        .iter()
+        .filter(|(_, r)| matches!(r, KeepReason::NotInstalled(_)))
+        .count();
+    println!();
+    println!(
+        "kept: {} used within {older_than}, {unmanaged} not attributable to an install \
+         (never removed — see `nros store list`).",
+        too_new
+    );
+
+    println!();
+    if plan.remove.is_empty() {
+        println!("would remove: nothing.");
+        return;
+    }
+    println!(
+        "would remove {} entr{}, {}:",
+        plan.remove.len(),
+        if plan.remove.len() == 1 { "y" } else { "ies" },
+        format_size(plan.bytes_to_remove())
+    );
+    for entry in &plan.remove {
+        let age = now
+            .duration_since(entry.last_used)
+            .unwrap_or(std::time::Duration::ZERO);
+        println!(
+            "  {}  {}  last used {} ago ({})",
+            entry.display_id(),
+            format_size(entry.size_bytes),
+            format_age(age),
+            entry.evidence.label()
+        );
+    }
+}

--- a/packages/cli/nros-cli-core/src/cmd/toolchain.rs
+++ b/packages/cli/nros-cli-core/src/cmd/toolchain.rs
@@ -1,0 +1,195 @@
+//! `nros toolchain uninstall <version>` — phase-440 W6, RFC-0095 D11.
+//!
+//! ## What this can and cannot know today
+//!
+//! `toolchains/<version>/` is phase-440 **W7**'s directory and no host has one
+//! yet; `nros-toolchain.toml`, the pin that names a version, is W7's file and no
+//! project has one either. So on today's tree this verb has two honest outcomes
+//! and one dishonest one, and the dishonest one is the default a lazier
+//! implementation would take:
+//!
+//! * the directory is absent → **say so** and remove nothing. No risk, no
+//!   refusal needed;
+//! * the directory is there and a pin file names the version → **refuse**,
+//!   naming the file;
+//! * the directory is there and **no pin file could be found at all** →
+//!   **refuse**. Not "no pin names it, therefore delete": those are different
+//!   answers. The store is shared between projects while pins are per-project,
+//!   so an empty pin set means the search looked in the wrong place at least as
+//!   often as it means nothing needs the toolchain — and this is the exact
+//!   moment where being wrong costs somebody a working build.
+//!
+//! Until W7 lands, the third branch is the one a real invocation reaches, which
+//! is the correct behaviour rather than a limitation: nothing can yet establish
+//! that no project pins a version, so nothing may act as though it had.
+//!
+//! `--ignore-pins` is the way to say it anyway. It is a sentence the user has to
+//! write, which is the whole design.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Args as ClapArgs, Subcommand};
+use eyre::{Result, bail};
+
+use crate::orchestration::store::{self, format_size};
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    #[command(subcommand)]
+    pub command: Sub,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Sub {
+    /// Remove one nano-ros toolchain from the store. Refuses while a known pin
+    /// names the version — or while no pin file could be consulted at all.
+    Uninstall(UninstallArgs),
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct UninstallArgs {
+    /// The toolchain version, exactly as `toolchains/<version>` spells it.
+    //
+    // The explicit `id` is load-bearing, and a plain comment so it stays out of
+    // `--help`. The binary sets `propagate_version = true`, so clap generates a
+    // `--version` flag on EVERY subcommand, and a field named `version` collides
+    // with it — a `debug_assert` panic at startup, on this verb alone, in every
+    // build. Constructing `UninstallArgs` in a test never goes through clap, so
+    // the whole suite passed while `nros toolchain uninstall 0.6.2` could not
+    // run at all; `nros-cli/tests/store_verbs.rs` executes the real binary for
+    // exactly that reason. `value_name` keeps the help reading `<VERSION>`.
+    #[arg(id = "toolchain-version", value_name = "VERSION")]
+    pub version: String,
+
+    /// An extra file whose contents pin versions. Repeatable.
+    #[arg(long, value_name = "PATH")]
+    pub pin_file: Vec<PathBuf>,
+
+    /// Uninstall without consulting any pin file. You are asserting no project
+    /// pins this version.
+    #[arg(long)]
+    pub ignore_pins: bool,
+
+    /// Report what would happen and remove nothing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Store root. Defaults to `$NROS_STORE`, else `$NROS_HOME`, else
+    /// `~/.nros` — never an absolute literal (RFC-0095 D2).
+    #[arg(long)]
+    pub root: Option<PathBuf>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let cwd = std::env::current_dir().ok();
+    match args.command {
+        Sub::Uninstall(a) => uninstall(a, cwd.as_deref()),
+    }
+}
+
+/// `uninstall`, with the directory pin discovery walks up from passed IN — the
+/// same argument as `cmd::store::gc`: in this checkout every ancestor of a
+/// test's working directory holds a pin file, so a `current_dir()` read inside
+/// would make the refusal below untestable in-tree.
+pub fn uninstall(args: UninstallArgs, pin_search_from: Option<&Path>) -> Result<()> {
+    let root = args.root.clone().unwrap_or_else(store::root);
+    let dir = store::toolchains_dir(&root);
+
+    let Some(entry) = store::toolchain_entry(&root, &args.version) else {
+        // Nothing to delete, so the pin question does not arise. Say which of
+        // the two absences it is: a store with no `toolchains/` at all is a
+        // host phase-440 W7 has not reached, not a typo in the version.
+        if dir.is_dir() {
+            let have = store::scan(&root)
+                .into_iter()
+                .filter(|e| e.category == store::Category::Toolchains)
+                .map(|e| e.version)
+                .collect::<Vec<_>>();
+            println!(
+                "{} is not installed ({} does not exist). Installed: {}",
+                args.version,
+                dir.join(&args.version).display(),
+                if have.is_empty() {
+                    "none".to_string()
+                } else {
+                    have.join(", ")
+                }
+            );
+        } else {
+            println!(
+                "no toolchains are installed — {} does not exist.\n\
+                 (phase-440 W7 is what creates it; until then nano-ros is the checkout \
+                 you are in, and there is nothing here to uninstall.)",
+                dir.display()
+            );
+        }
+        return Ok(());
+    };
+
+    let sources = if args.ignore_pins {
+        Vec::new()
+    } else {
+        store::collect_pins(&args.pin_file, pin_search_from)?
+    };
+
+    if sources.is_empty() && !args.ignore_pins {
+        bail!(
+            "cannot verify that no project pins {}: no pin file was consulted.\n\
+             Looked for {} in this directory and its ancestors and found none, so \
+             `nothing pins it` is unestablished rather than true — and the store is \
+             shared between projects while pins are per-project.\n\
+             Refusing to remove {} ({}).\n\
+             Either name a pin file (--pin-file <path>) or assert it yourself \
+             (--ignore-pins).",
+            args.version,
+            store::PIN_FILE_NAMES.join(", "),
+            entry.path.display(),
+            format_size(entry.size_bytes)
+        );
+    }
+
+    let pinned = store::pins_naming(&entry, &sources);
+    if !pinned.is_empty() {
+        let by: Vec<String> = pinned
+            .iter()
+            .map(|p| p.path.display().to_string())
+            .collect();
+        bail!(
+            "refusing to uninstall {}: it is pinned by {}.\n\
+             Change the pin first — removing a toolchain a project names breaks that \
+             project's next build, and this verb has no way to warn it.",
+            args.version,
+            by.join(", ")
+        );
+    }
+
+    if args.ignore_pins {
+        println!("pins: NONE CONSULTED (--ignore-pins)");
+    } else {
+        println!(
+            "pins consulted ({}): none names {}",
+            sources.len(),
+            args.version
+        );
+    }
+    println!(
+        "{}  {}  state {}",
+        entry.path.display(),
+        format_size(entry.size_bytes),
+        entry.state.label()
+    );
+
+    if args.dry_run {
+        println!("DRY RUN — nothing removed.");
+        return Ok(());
+    }
+
+    std::fs::remove_dir_all(&entry.path)
+        .map_err(|e| eyre::eyre!("remove {}: {e}", entry.path.display()))?;
+    println!(
+        "removed {} ({} freed).",
+        args.version,
+        format_size(entry.size_bytes)
+    );
+    Ok(())
+}

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -193,6 +193,12 @@ pub fn run(cmd: cmd::Cmd) -> Result<()> {
         cmd::Cmd::ModelPath(args) => cmd::model_path::run(args),
         cmd::Cmd::SdkPath(args) => cmd::sdk_path::run(args),
         cmd::Cmd::SdkFront(args) => cmd::sdk_front::run(args),
+        // phase-440 W6 — deliberately NOT in `cmd_name`'s guarded set. These
+        // report on and repair the STORE, which is not a fact about any
+        // checkout, and a store verb has to work on the day the binary is stale
+        // for the same reason `doctor` does: that is when you are looking.
+        cmd::Cmd::Store(args) => cmd::store::run(args),
+        cmd::Cmd::Toolchain(args) => cmd::toolchain::run(args),
         cmd::Cmd::Profile(args) => cmd::profile::run(args),
         cmd::Cmd::Metadata(args) => cmd::metadata::run(args),
         cmd::Cmd::Plan(args) => cmd::plan::run(args),

--- a/packages/cli/nros-cli-core/src/orchestration/mod.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/mod.rs
@@ -40,6 +40,9 @@ pub mod sdk_store;
 /// phase-351 W1 — the SITE half of a deploy target (RFC-0072 §5).
 pub mod site_config;
 pub mod source_metadata;
+/// phase-440 W6 — the store's inventory, pin predicate and gc plan (RFC-0095
+/// D2 + D11). `sdk_store` is where a version GOES; this is what is there.
+pub mod store;
 pub mod tier_resolver;
 pub mod workspace;
 

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -23,16 +23,15 @@ use super::sdk_index::{SourcePackage, SourceProvision, ToolPackage};
 /// installed toolset for the workspace it's run in). Single source for the name.
 pub const LOCK_FILE: &str = "nros-sdk.lock";
 
-/// The shared SDK store root: `$NROS_HOME/sdk`, else `~/.nros/sdk`, else
-/// `./.nros/sdk`.
+/// The shared SDK store root: `<store>/sdk` — `$NROS_HOME/sdk`, else
+/// `~/.nros/sdk`, else `./.nros/sdk`.
+///
+/// phase-440 W6: the resolution itself moved to [`super::store::root`], the ONE
+/// spelling of "where is the store" (RFC-0095 D2), which also honours
+/// `$NROS_STORE`. This stays the name every existing consumer calls; it is now
+/// `sdk/` under that root rather than a second copy of the same three arms.
 pub fn store_root() -> PathBuf {
-    if let Some(h) = std::env::var_os("NROS_HOME") {
-        return PathBuf::from(h).join("sdk");
-    }
-    if let Some(h) = std::env::var_os("HOME") {
-        return PathBuf::from(h).join(".nros").join("sdk");
-    }
-    PathBuf::from(".nros").join("sdk")
+    super::store::root().join("sdk")
 }
 
 /// The versioned install prefix for a tool — identical for prebuilt + source.
@@ -128,13 +127,7 @@ pub fn tool_dir_candidates(index: &super::sdk_index::SdkIndex, tool: &str) -> Ve
 /// `scripts/sdk-path-tools.txt`, which exists for binaries something we do not
 /// control invokes by bare name.
 pub fn front_dir() -> PathBuf {
-    if let Some(h) = std::env::var_os("NROS_HOME") {
-        return PathBuf::from(h).join("bin");
-    }
-    if let Some(h) = std::env::var_os("HOME") {
-        return PathBuf::from(h).join(".nros").join("bin");
-    }
-    PathBuf::from(".nros").join("bin")
+    super::store::root().join("bin")
 }
 
 /// Order two store version strings — digit runs numerically, the rest as text.

--- a/packages/cli/nros-cli-core/src/orchestration/store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/store.rs
@@ -1,0 +1,851 @@
+//! phase-440 W6 — the store's own inventory: what is in it, how big it is, when
+//! it was last read, and which pins forbid removing it (RFC-0095 D2 + D11).
+//!
+//! The store is **additive by design** — that is what makes rollback free
+//! (RFC-0095 D7) — so nothing in it is ever overwritten and nothing shrinks it.
+//! D11 states the consequence and the shape of the remedy:
+//!
+//! > Reference-counting against pins scattered across a filesystem is not
+//! > reliable, so the honest shape is explicit and inspectable rather than
+//! > clever.
+//!
+//! Everything here is therefore a *report a human acts on*, not an authority.
+//! Two rules follow from that, and both are load-bearing:
+//!
+//! * **`gc` removes only what this module can attribute to an install.** An
+//!   entry with no `.nros-provenance` marker was written by something we do not
+//!   model — a source build tree (`corrosion/0.6.src`), the legacy flat prefix
+//!   issue 0628 still resolves through, a partial unpack — and deleting one is
+//!   how a reclaim verb becomes the thing that broke a host. They are LISTED,
+//!   loudly, so the human can decide; they are never removed for them.
+//! * **A pin protects, and an absent pin does not permit.** The predicate below
+//!   is deliberately conservative in both directions: a pin file we cannot parse
+//!   is an error rather than an empty pin set, and a generic pin file protects
+//!   any entry whose version string appears in it *anywhere*. A false "pinned"
+//!   costs a leftover directory; a false "unpinned" costs someone's toolchain.
+//!
+//! Nothing here resolves a store path by SEARCHING for a version — that rule
+//! (issue 0625, phase-365) governs *resolution*, and this module asks the
+//! opposite question. `sdk_store::installed_versions` already carries the same
+//! distinction in its own doc comment: "where does the version I pinned live"
+//! has one right answer to construct; "what is in here" is only knowable by
+//! enumerating.
+
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+
+use eyre::{Result, WrapErr, bail};
+
+use super::{
+    sdk_index::SdkIndex,
+    sdk_store::{LOCK_FILE, Provenance, SdkLock},
+};
+
+/// The store ROOT — `~/.nros`, the parent of `sdk/`, `bin/`, `toolchains/`.
+///
+/// RFC-0095 D2: "resolved via `NROS_HOME`/`NROS_STORE`, never an absolute
+/// literal". `NROS_STORE` is the name the RFC gives the root itself and takes
+/// precedence; `NROS_HOME` is what every existing consumer already sets and
+/// keeps working unchanged.
+///
+/// [`super::sdk_store::store_root`] (`<root>/sdk`) and
+/// [`super::sdk_store::front_dir`] (`<root>/bin`) are its two established
+/// children and now derive from it, so the resolution order has one spelling
+/// rather than three copies that could disagree about `NROS_STORE`.
+pub fn root() -> PathBuf {
+    if let Some(s) = std::env::var_os("NROS_STORE") {
+        return PathBuf::from(s);
+    }
+    if let Some(h) = std::env::var_os("NROS_HOME") {
+        return PathBuf::from(h);
+    }
+    if let Some(h) = std::env::var_os("HOME") {
+        return PathBuf::from(h).join(".nros");
+    }
+    PathBuf::from(".nros")
+}
+
+/// Which environment variable answered [`root`] — for the header line, so a
+/// reader never has to guess whose store they are about to shrink.
+pub fn root_origin() -> &'static str {
+    if std::env::var_os("NROS_STORE").is_some() {
+        "$NROS_STORE"
+    } else if std::env::var_os("NROS_HOME").is_some() {
+        "$NROS_HOME"
+    } else if std::env::var_os("HOME").is_some() {
+        "$HOME/.nros"
+    } else {
+        "./.nros (no $HOME)"
+    }
+}
+
+/// A top-level directory of the store, and how deep its entries sit.
+///
+/// The depths are the layout D2 fixes. `Toolchains` and `Workspaces` do not
+/// exist on any host yet (W7 and W4 create them); they are modelled here
+/// because an absent directory contributes nothing and a listing that learns
+/// about them later would be a second enumeration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Category {
+    /// `sdk/<tool>/<version>` — provisioned tools (`nros setup`).
+    Sdk,
+    /// `toolchains/<version>` — nano-ros itself (RFC-0095 D2; phase-440 W7).
+    Toolchains,
+    /// `workspaces/<name>/<version>` — provisioned SOURCE (phase-440 W4).
+    Workspaces,
+    /// `fetch/<file-or-dir>` — the download cache (today's `external/`, W3).
+    Fetch,
+    /// Anything else at the store root (`bin/`, `presets/`). Listed so the
+    /// total reconciles with `du`; never a gc candidate.
+    Other,
+}
+
+impl Category {
+    fn dir_name(self) -> &'static str {
+        match self {
+            Category::Sdk => "sdk",
+            Category::Toolchains => "toolchains",
+            Category::Workspaces => "workspaces",
+            Category::Fetch => "fetch",
+            Category::Other => "",
+        }
+    }
+
+    /// How many path components below the category dir an entry sits.
+    fn depth(self) -> usize {
+        match self {
+            Category::Sdk | Category::Workspaces => 2,
+            Category::Toolchains | Category::Fetch => 1,
+            Category::Other => 0,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Category::Other => "root",
+            other => other.dir_name(),
+        }
+    }
+
+    /// The categories a scan visits, in listing order.
+    pub const ALL: [Category; 5] = [
+        Category::Toolchains,
+        Category::Sdk,
+        Category::Workspaces,
+        Category::Fetch,
+        Category::Other,
+    ];
+}
+
+/// What we know about who wrote an entry — and therefore whether `gc` may
+/// remove it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EntryState {
+    /// Carries `.nros-provenance`: written by [`super::sdk_store::execute`].
+    /// The only state `gc` will remove.
+    Installed,
+    /// Part of the legacy FLAT prefix (`<tool>/{lib,share}` beside a
+    /// `<tool>/.installed-version`). `tool_dir_usable` still resolves through
+    /// it on hosts provisioned before phase-365 — issue 0628 — so removing one
+    /// silently un-provisions a working host.
+    LegacyFlat,
+    /// `sdk/<tool>/<version>.src` — the tree a source install was BUILT from,
+    /// written by `provision_source` as `prefix.with_extension("src")`.
+    ///
+    /// Named separately from `Unmanaged` because it is the largest reclaimable
+    /// thing in a real store (1.5 G of 4.4 G on the host this landed on) and
+    /// "unmanaged" would tell a human nothing about whether it is safe to
+    /// remove. It is still not a gc target: `execute` deletes and re-clones it
+    /// on the next source install, so nothing NEEDS it — but a source tree is
+    /// also where somebody debugging a build put their local patches, and a
+    /// reclaim verb that quietly eats those is worse than one that reclaims
+    /// less. It is reported with its size; the human deletes it.
+    SourceTree,
+    /// Everything else: partial unpacks, hand-made directories, the fetch
+    /// cache. Real disk, unknown owner, never removed.
+    Unmanaged,
+}
+
+impl EntryState {
+    pub fn label(self) -> &'static str {
+        match self {
+            EntryState::Installed => "installed",
+            EntryState::LegacyFlat => "legacy-flat",
+            EntryState::SourceTree => "source-tree",
+            EntryState::Unmanaged => "unmanaged",
+        }
+    }
+}
+
+/// Whether the timestamp in [`Entry::last_used`] is evidence of a READ, or only
+/// of the install.
+///
+/// The distinction exists because it is the difference between a number a human
+/// can act on and one that will get their 4 G workspace deleted. `atime` is only
+/// a usage signal when the filesystem records reads: under `relatime` (the
+/// default) it is, at ~24 h granularity; under `noatime` it is not, and every
+/// entry then reports its install time forever.
+///
+/// Detected rather than assumed: if no file in the entry has an `atime` later
+/// than its own `mtime`, nothing has been read since it was written, and the
+/// timestamp is the install. Only REGULAR FILES are consulted — walking the tree
+/// updates every DIRECTORY's atime, so a scan that counted those would report
+/// "used just now" for everything the moment you ran it once.
+///
+/// The same trap has a second door, and it was open on the first run of this
+/// code: deciding an entry's STATE reads its `.nros-provenance`, which updates
+/// that file's atime — so every installed entry in the store reported "last used
+/// 1s ago (read)" and gc would have found nothing to collect, forever. The
+/// marker files this tool reads for its own bookkeeping are therefore excluded
+/// from the signal ([`SELF_READ_MARKERS`]). A measurement that its own act of
+/// measuring destroys is not a measurement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UseEvidence {
+    /// A file was read after it was written.
+    Read,
+    /// No read recorded — the timestamp is when the entry was written.
+    InstallOnly,
+}
+
+impl UseEvidence {
+    pub fn label(self) -> &'static str {
+        match self {
+            UseEvidence::Read => "read",
+            UseEvidence::InstallOnly => "install",
+        }
+    }
+}
+
+/// One thing in the store that occupies disk.
+#[derive(Clone, Debug)]
+pub struct Entry {
+    pub category: Category,
+    /// The tool / workspace name, for the two-deep categories.
+    pub name: Option<String>,
+    /// The last path component — a version for `sdk`/`toolchains`/`workspaces`.
+    pub version: String,
+    pub path: PathBuf,
+    pub size_bytes: u64,
+    pub last_used: SystemTime,
+    pub evidence: UseEvidence,
+    pub state: EntryState,
+    /// The recorded version from `.nros-provenance`, when there is one. It can
+    /// differ from the directory name (nothing enforces agreement), and the
+    /// pin predicate honours BOTH so a rename cannot orphan a protection.
+    pub provenance_version: Option<String>,
+}
+
+impl Entry {
+    /// `sdk/corrosion/0.6.1-nros1` — the identity a human types back at us.
+    pub fn display_id(&self) -> String {
+        let mut s = String::from(self.category.label());
+        if let Some(name) = &self.name {
+            s.push('/');
+            s.push_str(name);
+        }
+        if !self.version.is_empty() {
+            s.push('/');
+            s.push_str(&self.version);
+        }
+        s
+    }
+
+    /// Every version string this entry answers to.
+    fn versions(&self) -> Vec<&str> {
+        let mut v = vec![self.version.as_str()];
+        if let Some(p) = self.provenance_version.as_deref() {
+            if p != self.version {
+                v.push(p);
+            }
+        }
+        v
+    }
+}
+
+/// Size + timestamps for one directory tree, measured in a single walk.
+struct Measured {
+    size_bytes: u64,
+    /// Newest mtime over regular files (or the entry itself when it has none).
+    newest_mtime: SystemTime,
+    /// Newest atime over regular files, when any exceeded its own mtime.
+    newest_read: Option<SystemTime>,
+}
+
+/// Files this tool itself opens while inventorying the store. Their `atime` is
+/// evidence of a `nros store list`, not of a build using the entry.
+const SELF_READ_MARKERS: [&str; 2] = [".nros-provenance", ".installed-version"];
+
+fn measure(path: &Path) -> Measured {
+    use std::os::unix::fs::MetadataExt;
+
+    let mut size_bytes = 0u64;
+    let mut newest_mtime = std::fs::symlink_metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let mut newest_read: Option<SystemTime> = None;
+
+    for entry in walkdir::WalkDir::new(path)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+    {
+        let Ok(md) = entry.metadata() else { continue };
+        if !md.is_file() {
+            continue;
+        }
+        size_bytes = size_bytes.saturating_add(md.len());
+        // Counted for SIZE, ignored for the timestamps: see SELF_READ_MARKERS.
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|n| SELF_READ_MARKERS.contains(&n))
+        {
+            continue;
+        }
+        // NANOSECOND precision, not `atime()`/`mtime()` seconds. At one-second
+        // resolution a file written and read in the same second compares EQUAL,
+        // so the read is invisible — which makes a test of this predicate pass
+        // whatever the code does, and it did.
+        let mtime = (md.mtime(), md.mtime_nsec());
+        let atime = (md.atime(), md.atime_nsec());
+        if let Some(t) = unix_time(mtime) {
+            newest_mtime = newest_mtime.max(t);
+        }
+        // Strictly LATER, not `>=`: a file written and never read has
+        // `atime == mtime` under every mount option, so equality is exactly the
+        // no-evidence case.
+        if atime > mtime {
+            if let Some(t) = unix_time(atime) {
+                newest_read = Some(newest_read.map_or(t, |prev: SystemTime| prev.max(t)));
+            }
+        }
+    }
+
+    Measured {
+        size_bytes,
+        newest_mtime,
+        newest_read,
+    }
+}
+
+fn unix_time((secs, nsecs): (i64, i64)) -> Option<SystemTime> {
+    let secs = u64::try_from(secs).ok()?;
+    let nsecs = u32::try_from(nsecs).unwrap_or(0);
+    Some(SystemTime::UNIX_EPOCH + Duration::new(secs, nsecs))
+}
+
+/// Every entry in the store under `root`, in category order then by path.
+///
+/// A missing category directory contributes nothing — that is how this reads a
+/// host with no `toolchains/` yet without special-casing W7.
+pub fn scan(root: &Path) -> Vec<Entry> {
+    let mut out = Vec::new();
+    for category in Category::ALL {
+        out.extend(scan_category(root, category));
+    }
+    out
+}
+
+fn scan_category(root: &Path, category: Category) -> Vec<Entry> {
+    let mut out = Vec::new();
+    match category {
+        Category::Other => {
+            // Whatever sits at the root that is not a known category: `bin/`,
+            // `presets/`. One entry each, so `list`'s total reconciles with
+            // `du -sh` on the root instead of quietly under-reporting.
+            let known: BTreeSet<&str> = Category::ALL
+                .iter()
+                .filter(|c| **c != Category::Other)
+                .map(|c| c.dir_name())
+                .collect();
+            for child in children(root) {
+                let name = file_name(&child);
+                if known.contains(name.as_str()) {
+                    continue;
+                }
+                out.push(build_entry(
+                    category,
+                    None,
+                    name,
+                    child,
+                    EntryState::Unmanaged,
+                ));
+            }
+        }
+        _ if category.depth() == 1 => {
+            for child in children(&root.join(category.dir_name())) {
+                let name = file_name(&child);
+                let state = state_of(&child, None);
+                out.push(build_entry(category, None, name, child, state));
+            }
+        }
+        _ => {
+            for group in children(&root.join(category.dir_name())) {
+                let group_name = file_name(&group);
+                let flat = flat_marker(&group);
+                for child in children(&group) {
+                    let version = file_name(&child);
+                    let state = state_of(&child, flat.then_some(EntryState::LegacyFlat));
+                    out.push(build_entry(
+                        category,
+                        Some(group_name.clone()),
+                        version,
+                        child,
+                        state,
+                    ));
+                }
+            }
+        }
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    out
+}
+
+/// Directory children only — a stray file at a category level is not an entry
+/// this module models, and reporting it as one would invite a `gc` that removes
+/// it. `fetch/` is the exception in principle (a download cache holds files),
+/// but its entries are `Unmanaged` either way, so nothing is lost by the simpler
+/// rule and a mistake there cannot delete anything.
+fn children(dir: &Path) -> Vec<PathBuf> {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = rd
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.path())
+        .collect();
+    out.sort();
+    out
+}
+
+fn file_name(p: &Path) -> String {
+    p.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// The marker the legacy flat prefix carries — the same pair
+/// [`super::sdk_store::tool_dir_candidates`] tests, because it is the same
+/// question: is this tool directory itself an install?
+fn flat_marker(tool_dir: &Path) -> bool {
+    tool_dir.join(".installed-version").is_file() || tool_dir.join(".nros-provenance").is_file()
+}
+
+fn state_of(path: &Path, legacy: Option<EntryState>) -> EntryState {
+    if Provenance::read(path).is_some() {
+        return EntryState::Installed;
+    }
+    // `<version>.src` is `provision_source`'s build tree — checked BEFORE the
+    // legacy-flat fallback, because a tool with a flat marker (corrosion here)
+    // has both shapes side by side and calling a source tree "part of the
+    // legacy prefix" would be a wrong label on the largest row in the table.
+    if path.extension().is_some_and(|e| e == "src") {
+        return EntryState::SourceTree;
+    }
+    legacy.unwrap_or(EntryState::Unmanaged)
+}
+
+fn build_entry(
+    category: Category,
+    name: Option<String>,
+    version: String,
+    path: PathBuf,
+    state: EntryState,
+) -> Entry {
+    let m = measure(&path);
+    let (last_used, evidence) = match m.newest_read {
+        Some(read) if read > m.newest_mtime => (read, UseEvidence::Read),
+        _ => (m.newest_mtime, UseEvidence::InstallOnly),
+    };
+    let provenance_version = Provenance::read(&path).map(|p| p.version);
+    Entry {
+        category,
+        name,
+        version,
+        path,
+        size_bytes: m.size_bytes,
+        last_used,
+        evidence,
+        state,
+        provenance_version,
+    }
+}
+
+/// `<root>/toolchains` — where RFC-0095 D2 puts nano-ros itself.
+///
+/// Constructed, never searched: phase-440 W7 writes `toolchains/<version>`
+/// because a pin named that version, so a consumer builds the path from the same
+/// input rather than enumerating (the `sdk_store::tool_dir` rule, issue 0625).
+pub fn toolchains_dir(root: &Path) -> PathBuf {
+    root.join(Category::Toolchains.dir_name())
+}
+
+/// The `toolchains/<version>` entry, measured, if that directory is there.
+pub fn toolchain_entry(root: &Path, version: &str) -> Option<Entry> {
+    let path = toolchains_dir(root).join(version);
+    if !path.is_dir() {
+        return None;
+    }
+    let state = state_of(&path, None);
+    Some(build_entry(
+        Category::Toolchains,
+        None,
+        version.to_string(),
+        path,
+        state,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Pins
+// ---------------------------------------------------------------------------
+
+/// One thing a pin file says is in use.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PinRule {
+    /// A structured source that names both halves: `[tool.qemu] version = …`.
+    Tool { tool: String, version: String },
+    /// A version string from a source whose schema we do not model. Matches any
+    /// entry with that version, in any category — deliberately over-broad, see
+    /// [`load_pin_file`].
+    AnyVersion(String),
+}
+
+/// A file consulted for pins, and what it said.
+#[derive(Clone, Debug)]
+pub struct PinSource {
+    pub path: PathBuf,
+    pub rules: Vec<PinRule>,
+}
+
+/// The pin files this looks for, walking up from the working directory.
+///
+/// `nros-toolchain.toml` is phase-440 W7's pin and does not exist yet; it is
+/// named here because W7 must not have to also teach the reclaim verbs about
+/// itself — a delete guard that learns about a new pin file one release LATE is
+/// a delete guard that deleted something.
+pub const PIN_FILE_NAMES: [&str; 3] = ["nros-toolchain.toml", "nros-sdk-index.toml", LOCK_FILE];
+
+/// Load one pin file, choosing the reader by NAME.
+///
+/// The two structured readers are the schemas this crate already owns, so a pin
+/// there names a `(tool, version)` pair and matches exactly. Everything else —
+/// including W7's `nros-toolchain.toml`, whose schema W7 gets to choose — is
+/// read as generic TOML and every STRING VALUE at any depth becomes a version
+/// rule.
+///
+/// That is a deliberate over-approximation, and the asymmetry is the point:
+/// this predicate guards a delete, so being wrong in the "pinned" direction
+/// costs a directory that stays, and being wrong in the "unpinned" direction
+/// costs a toolchain somebody was using. It also means W7 cannot break this by
+/// picking a key name we did not guess.
+///
+/// An unreadable or unparseable pin file is an ERROR rather than an empty pin
+/// set: "no pins" and "I could not tell" must not reach the caller as the same
+/// value.
+pub fn load_pin_file(path: &Path) -> Result<PinSource> {
+    let name = path.file_name().map(|n| n.to_string_lossy().into_owned());
+    let rules = match name.as_deref() {
+        Some("nros-sdk-index.toml") => {
+            let index = SdkIndex::load(path)?;
+            index
+                .tool
+                .iter()
+                .map(|(tool, t)| PinRule::Tool {
+                    tool: tool.clone(),
+                    version: t.version.clone(),
+                })
+                .collect()
+        }
+        Some(n) if n == LOCK_FILE => {
+            let lock = SdkLock::load(path)?;
+            lock.tool
+                .iter()
+                .map(|(tool, e)| PinRule::Tool {
+                    tool: tool.clone(),
+                    version: e.version.clone(),
+                })
+                .collect()
+        }
+        _ => {
+            let raw = std::fs::read_to_string(path)
+                .wrap_err_with(|| format!("read pin file {}", path.display()))?;
+            let value: toml::Value = toml::from_str(&raw)
+                .wrap_err_with(|| format!("parse pin file {}", path.display()))?;
+            let mut out = Vec::new();
+            collect_strings(&value, &mut out);
+            out.into_iter().map(PinRule::AnyVersion).collect()
+        }
+    };
+    Ok(PinSource {
+        path: path.to_path_buf(),
+        rules,
+    })
+}
+
+fn collect_strings(value: &toml::Value, out: &mut Vec<String>) {
+    match value {
+        toml::Value::String(s) => out.push(s.clone()),
+        toml::Value::Array(a) => a.iter().for_each(|v| collect_strings(v, out)),
+        toml::Value::Table(t) => t.values().for_each(|v| collect_strings(v, out)),
+        _ => {}
+    }
+}
+
+/// The pin files reachable from `start`, nearest first — `start` and its
+/// ancestors, taking the closest occurrence of each name.
+///
+/// Ancestors, not just the cwd, because a user runs a store verb from wherever
+/// they happen to be inside their project, the way cargo finds a workspace root.
+pub fn discover_pin_files(start: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for dir in start.ancestors() {
+        for name in PIN_FILE_NAMES {
+            if seen.contains(name) {
+                continue;
+            }
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                seen.insert(name);
+                out.push(candidate);
+            }
+        }
+    }
+    out
+}
+
+/// The pin sources a reclaim verb should consult: the files named explicitly,
+/// then whatever [`discover_pin_files`] finds from `search_from`.
+///
+/// `search_from` is a PARAMETER rather than a `current_dir()` read inside, so
+/// the decision is a pure function of its inputs and a test can exercise the
+/// "nothing to consult" case without `set_current_dir` — a process-global that
+/// leaks between parallel tests (issue 1101), and the same refactor
+/// `stale_guard::refuse_if_stale` already made for the workspace guard. In-tree
+/// it matters twice over: every ancestor of a test's working directory is inside
+/// this checkout, which HAS an `nros-sdk-index.toml`, so a discovery keyed on the
+/// process cwd can never observe an empty pin set here.
+pub fn collect_pins(explicit: &[PathBuf], search_from: Option<&Path>) -> Result<Vec<PinSource>> {
+    let mut paths = explicit.to_vec();
+    if let Some(dir) = search_from {
+        paths.extend(discover_pin_files(dir));
+    }
+    paths.iter().map(|p| load_pin_file(p)).collect()
+}
+
+/// Which of `sources` name this entry. Empty means no pin protects it —
+/// which is NOT the same as "safe to delete"; see [`plan_gc`].
+pub fn pins_naming<'a>(entry: &Entry, sources: &'a [PinSource]) -> Vec<&'a PinSource> {
+    let versions = entry.versions();
+    sources
+        .iter()
+        .filter(|src| {
+            src.rules.iter().any(|rule| match rule {
+                PinRule::Tool { tool, version } => {
+                    entry.category == Category::Sdk
+                        && entry.name.as_deref() == Some(tool.as_str())
+                        && versions.contains(&version.as_str())
+                }
+                PinRule::AnyVersion(v) => versions.contains(&v.as_str()),
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// gc
+// ---------------------------------------------------------------------------
+
+/// Why an entry survived a gc plan.
+#[derive(Clone, Debug)]
+pub enum KeepReason {
+    /// A pin names it. Carries the files that did.
+    Pinned(Vec<PathBuf>),
+    /// Younger than `--older-than`.
+    TooNew,
+    /// Not attributable to an install — `gc` never removes these.
+    NotInstalled(EntryState),
+}
+
+/// A gc decision over every entry. Nothing here touches the filesystem: the
+/// plan is computed, printed, and only then — on an explicit opt-in — applied.
+#[derive(Debug, Default)]
+pub struct GcPlan {
+    pub remove: Vec<Entry>,
+    pub keep: Vec<(Entry, KeepReason)>,
+}
+
+impl GcPlan {
+    pub fn bytes_to_remove(&self) -> u64 {
+        self.remove.iter().map(|e| e.size_bytes).sum()
+    }
+
+    pub fn pinned(&self) -> impl Iterator<Item = (&Entry, &[PathBuf])> {
+        self.keep.iter().filter_map(|(e, r)| match r {
+            KeepReason::Pinned(files) => Some((e, files.as_slice())),
+            _ => None,
+        })
+    }
+}
+
+/// Decide, for every entry, whether gc would remove it.
+///
+/// Pure — `now` is a parameter, so the age boundary is testable without
+/// sleeping and without a process-global clock. The order of the tests is the
+/// safety argument, cheapest refusal last:
+///
+/// 1. **not an install** → keep. Unknown owner (see the module header).
+/// 2. **a pin names it** → keep. This is checked BEFORE age on purpose: a
+///    pinned entry is protected however old it is, and an implementation that
+///    filtered by age first would only be *accidentally* correct — the pin test
+///    would never run for the entries that matter most.
+/// 3. **younger than the threshold** → keep.
+/// 4. otherwise → remove.
+pub fn plan_gc(
+    entries: Vec<Entry>,
+    older_than: Duration,
+    sources: &[PinSource],
+    now: SystemTime,
+) -> GcPlan {
+    let mut plan = GcPlan::default();
+    for entry in entries {
+        if entry.state != EntryState::Installed {
+            let state = entry.state;
+            plan.keep.push((entry, KeepReason::NotInstalled(state)));
+            continue;
+        }
+        let pins = pins_naming(&entry, sources);
+        if !pins.is_empty() {
+            let files = pins.iter().map(|p| p.path.clone()).collect();
+            plan.keep.push((entry, KeepReason::Pinned(files)));
+            continue;
+        }
+        let age = now
+            .duration_since(entry.last_used)
+            .unwrap_or(Duration::ZERO);
+        if age < older_than {
+            plan.keep.push((entry, KeepReason::TooNew));
+            continue;
+        }
+        plan.remove.push(entry);
+    }
+    plan
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+/// `90d`, `12h`, `30m`, `2w`, `3600s`.
+///
+/// A bare number is REFUSED rather than read as seconds: `--older-than 90` is
+/// overwhelmingly meant as days, and a tool that silently reads it as a minute
+/// and a half would delete a store the user believed was protected for a
+/// quarter.
+pub fn parse_duration(s: &str) -> Result<Duration> {
+    let trimmed = s.trim();
+    let (digits, suffix) = trimmed.split_at(
+        trimmed
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(trimmed.len()),
+    );
+    if digits.is_empty() {
+        bail!("`{s}` has no number — write a count and a unit, e.g. `90d`");
+    }
+    let n: u64 = digits
+        .parse()
+        .wrap_err_with(|| format!("`{s}`: `{digits}` is not a count"))?;
+    let unit = match suffix {
+        "s" => 1,
+        "m" => 60,
+        "h" => 60 * 60,
+        "d" => 24 * 60 * 60,
+        "w" => 7 * 24 * 60 * 60,
+        "" => bail!(
+            "`{s}` has no unit. Say which — `{s}d` (days), `{s}h`, `{s}m` \
+             (minutes), `{s}w`, `{s}s`. A bare number is refused because \
+             reading it as seconds would delete far more than the writer meant."
+        ),
+        other => bail!("`{s}`: unknown unit `{other}` — use s, m, h, d or w"),
+    };
+    Ok(Duration::from_secs(n * unit))
+}
+
+/// Binary units, because that is what `du -h` prints and this is read beside it.
+pub fn format_size(bytes: u64) -> String {
+    const UNITS: [(&str, u64); 4] = [
+        ("GiB", 1 << 30),
+        ("MiB", 1 << 20),
+        ("KiB", 1 << 10),
+        ("B", 1),
+    ];
+    for (unit, scale) in UNITS {
+        if bytes >= scale {
+            if scale == 1 {
+                return format!("{bytes} B");
+            }
+            return format!("{:.1} {unit}", bytes as f64 / scale as f64);
+        }
+    }
+    "0 B".to_string()
+}
+
+/// Coarse age — days once past a day, because that is the resolution `atime`
+/// has under `relatime` and printing minutes would overstate what we measured.
+pub fn format_age(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs >= 24 * 60 * 60 {
+        format!("{}d", secs / (24 * 60 * 60))
+    } else if secs >= 60 * 60 {
+        format!("{}h", secs / (60 * 60))
+    } else if secs >= 60 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_number_is_refused_and_units_are_exact() {
+        assert_eq!(parse_duration("90d").unwrap().as_secs(), 90 * 86_400);
+        assert_eq!(parse_duration("2w").unwrap().as_secs(), 14 * 86_400);
+        assert_eq!(parse_duration("30m").unwrap().as_secs(), 1_800);
+        assert!(
+            parse_duration("90").is_err(),
+            "a bare number must be refused"
+        );
+        assert!(parse_duration("d").is_err());
+        assert!(parse_duration("7y").is_err());
+    }
+
+    #[test]
+    fn sizes_read_the_way_du_prints_them() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1 << 20), "1.0 MiB");
+        assert_eq!(format_size(3 << 30), "3.0 GiB");
+    }
+
+    #[test]
+    fn a_generic_pin_file_yields_every_string_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nros-toolchain.toml");
+        std::fs::write(
+            &path,
+            "[toolchain]\nversion = \"0.6.2\"\nchannel = \"stable\"\n",
+        )
+        .unwrap();
+        let src = load_pin_file(&path).unwrap();
+        assert!(src.rules.contains(&PinRule::AnyVersion("0.6.2".into())));
+        assert!(src.rules.contains(&PinRule::AnyVersion("stable".into())));
+    }
+}

--- a/packages/cli/nros-cli-core/tests/store_reclaim.rs
+++ b/packages/cli/nros-cli-core/tests/store_reclaim.rs
@@ -1,0 +1,452 @@
+//! The store's reclaim verbs — `nros store list|gc` and `nros toolchain
+//! uninstall` (phase-440 W6, RFC-0095 D11).
+//!
+//! Every test here is about a REFUSAL, because that is what this feature is:
+//! the reclaim path is trivial (`remove_dir_all`) and the whole design is the
+//! set of conditions under which it does not run. The two that RFC-0095 D11
+//! states in prose are asserted directly —
+//!
+//! * `--dry-run` is the default, and
+//! * nothing a pin names is ever removed
+//!
+//! — plus the two that are one step behind them and would otherwise be
+//! "the code looks right": that an empty pin set refuses instead of permitting,
+//! and that the scan does not destroy the timestamps it reads.
+//!
+//! No test here touches `$NROS_HOME`, `$NROS_STORE` or the process working
+//! directory. The store root is a `--root` argument and the pin search
+//! directory is a parameter, so these run in parallel with everything else and
+//! observe nothing global (issue 1101's hazard).
+
+use std::{
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+
+use nros_cli_core::{
+    cmd::{store as store_cmd, toolchain as toolchain_cmd},
+    orchestration::{
+        sdk_store::{Provenance, ProvenanceKind},
+        store,
+    },
+};
+
+/// A store entry that looks exactly like one `sdk_store::execute` wrote: a
+/// payload file plus the `.nros-provenance` marker that makes it `installed`.
+fn install(root: &Path, rel: &str, version: &str, payload: &[u8]) -> PathBuf {
+    let dir = root.join(rel);
+    std::fs::create_dir_all(dir.join("bin")).unwrap();
+    std::fs::write(dir.join("bin").join("tool"), payload).unwrap();
+    Provenance {
+        kind: ProvenanceKind::Prebuilt,
+        version: version.to_string(),
+        sha256: None,
+    }
+    .write(&dir)
+    .unwrap();
+    dir
+}
+
+/// A directory in the store with no provenance marker — a partial unpack, a
+/// hand-made directory, anything this tool did not write.
+fn unattributable(root: &Path, rel: &str) -> PathBuf {
+    let dir = root.join(rel);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("stuff"), b"whatever").unwrap();
+    dir
+}
+
+fn pin_file(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+fn gc_args(root: &Path, older_than: &str) -> store_cmd::GcArgs {
+    store_cmd::GcArgs {
+        older_than: older_than.to_string(),
+        delete: false,
+        dry_run: false,
+        pin_file: Vec::new(),
+        ignore_pins: false,
+        root: Some(root.to_path_buf()),
+    }
+}
+
+fn uninstall_args(root: &Path, version: &str) -> toolchain_cmd::UninstallArgs {
+    toolchain_cmd::UninstallArgs {
+        version: version.to_string(),
+        pin_file: Vec::new(),
+        ignore_pins: false,
+        dry_run: false,
+        root: Some(root.to_path_buf()),
+    }
+}
+
+/// RFC-0095 D11's first requirement, asserted on the filesystem rather than on
+/// the flag: a `gc` that names no `--delete` must leave every byte in place,
+/// even for an entry it has just reported as collectable.
+///
+/// `--older-than 0s` makes every unpinned install a candidate, so the only
+/// thing standing between this entry and deletion is the default.
+#[test]
+fn gc_is_a_dry_run_unless_delete_is_named() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let entry = install(root, "sdk/qemu/11.0.0", "11.0.0", b"binary");
+    let pins = pin_file(
+        tmp.path(),
+        "nros-toolchain.toml",
+        "version = \"something-else\"\n",
+    );
+
+    let mut args = gc_args(root, "0s");
+    args.pin_file = vec![pins.clone()];
+    store_cmd::gc(args, None).unwrap();
+    assert!(
+        entry.is_dir(),
+        "the default must remove nothing — {} is gone",
+        entry.display()
+    );
+
+    let mut args = gc_args(root, "0s");
+    args.pin_file = vec![pins];
+    args.delete = true;
+    store_cmd::gc(args, None).unwrap();
+    assert!(
+        !entry.exists(),
+        "--delete must actually remove: {} survived",
+        entry.display()
+    );
+}
+
+/// RFC-0095 D11's second requirement. The entry is as old and as collectable as
+/// the age filter can make it (`--older-than 0s`), `--delete` is named, and it
+/// still survives — because a pin file names its version.
+///
+/// Deliberately run through the COMMAND, not through `plan_gc`: a plan that
+/// classifies correctly and a verb that deletes the right rows are two claims,
+/// and only the second one is what a user gets.
+#[test]
+fn gc_never_removes_an_entry_a_pin_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let pinned = install(root, "sdk/qemu/11.0.0-nros2", "11.0.0-nros2", b"pinned");
+    let unpinned = install(root, "sdk/qemu/9.0.0-nros1", "9.0.0-nros1", b"stale");
+
+    // The structured pin source this crate already owns: an SDK index naming a
+    // tool and the version of it that is in use.
+    let index = pin_file(
+        tmp.path(),
+        "nros-sdk-index.toml",
+        "[tool.qemu]\nversion = \"11.0.0-nros2\"\n",
+    );
+
+    let mut args = gc_args(root, "0s");
+    args.pin_file = vec![index];
+    args.delete = true;
+    store_cmd::gc(args, None).unwrap();
+
+    assert!(
+        pinned.is_dir(),
+        "a pinned entry was removed: {}",
+        pinned.display()
+    );
+    assert!(
+        !unpinned.exists(),
+        "the unpinned entry should have been collected: {}",
+        unpinned.display()
+    );
+}
+
+/// A pin protects regardless of age — asserted on the PLAN, where a synthetic
+/// `now` can push the entry a century past any threshold.
+///
+/// This is the ordering the implementation depends on: if `plan_gc` filtered by
+/// age first, the pin test would never run for exactly the entries that matter,
+/// and every test above would still pass because their entries are new.
+#[test]
+fn a_pin_protects_an_entry_however_old_it_is() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    install(root, "sdk/qemu/11.0.0-nros2", "11.0.0-nros2", b"pinned");
+    let index = pin_file(
+        tmp.path(),
+        "nros-sdk-index.toml",
+        "[tool.qemu]\nversion = \"11.0.0-nros2\"\n",
+    );
+    let sources = store::collect_pins(&[index], None).unwrap();
+
+    let a_century = Duration::from_secs(100 * 365 * 24 * 60 * 60);
+    let plan = store::plan_gc(
+        store::scan(root),
+        Duration::from_secs(1),
+        &sources,
+        SystemTime::now() + a_century,
+    );
+
+    assert!(
+        plan.remove.is_empty(),
+        "an entry a pin names was scheduled for removal: {:?}",
+        plan.remove
+            .iter()
+            .map(|e| e.display_id())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        plan.pinned().count(),
+        1,
+        "the pin should be REPORTED, not silent"
+    );
+}
+
+/// "No pin names this" and "no pin file exists to name anything" are different
+/// answers, and only the first one may authorise a delete.
+///
+/// Without this refusal, `nros store gc --older-than 90d --delete` run from a
+/// directory with no project above it would collect another project's
+/// toolchains and report success — the store is shared while pins are
+/// per-project.
+#[test]
+fn gc_refuses_to_delete_when_no_pin_file_could_be_consulted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let entry = install(root, "sdk/qemu/11.0.0", "11.0.0", b"binary");
+
+    let mut args = gc_args(root, "0s");
+    args.delete = true;
+    let err = store_cmd::gc(args, None).unwrap_err().to_string();
+
+    assert!(
+        err.contains("refusing to delete"),
+        "expected a refusal naming its reason, got: {err}"
+    );
+    assert!(
+        err.contains("--ignore-pins"),
+        "a refusal must name the way past it, got: {err}"
+    );
+    assert!(entry.is_dir(), "the refusal must not have deleted anything");
+
+    // And the override is a real door, not decoration.
+    let mut args = gc_args(root, "0s");
+    args.delete = true;
+    args.ignore_pins = true;
+    store_cmd::gc(args, None).unwrap();
+    assert!(!entry.exists(), "--ignore-pins should have collected it");
+}
+
+/// `gc` removes only what it can attribute to an install. A directory with no
+/// provenance marker was written by something this tool does not model — the
+/// legacy flat prefix `nros sdk-path` still resolves through (issue 0628), a
+/// source build tree, a partial unpack — and removing one can un-provision a
+/// working host.
+#[test]
+fn gc_leaves_entries_it_cannot_attribute_to_an_install() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let partial = unattributable(root, "sdk/corrosion/0.6.1-nros1");
+    let source_tree = unattributable(root, "sdk/corrosion/0.6.src");
+    let cache = unattributable(root, "fetch/some-tarball-dir");
+
+    let mut args = gc_args(root, "0s");
+    args.delete = true;
+    args.ignore_pins = true;
+    store_cmd::gc(args, None).unwrap();
+
+    for path in [&partial, &source_tree, &cache] {
+        assert!(
+            path.is_dir(),
+            "an entry with no provenance marker was removed: {}",
+            path.display()
+        );
+    }
+}
+
+/// `list`'s contract: a size and a last-used time per entry, and a state that
+/// says whether the number can be acted on.
+#[test]
+fn the_listing_reports_a_size_and_a_last_use_for_every_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    install(root, "sdk/qemu/11.0.0", "11.0.0", &vec![7u8; 4096]);
+    unattributable(root, "sdk/corrosion/0.6.src");
+
+    let entries = store::scan(root);
+    assert_eq!(entries.len(), 2, "scan found {entries:#?}");
+
+    let qemu = entries
+        .iter()
+        .find(|e| e.display_id() == "sdk/qemu/11.0.0")
+        .expect("the installed entry is missing from the listing");
+    assert!(
+        qemu.size_bytes >= 4096,
+        "size must count the payload, got {}",
+        qemu.size_bytes
+    );
+    assert_eq!(qemu.state, store::EntryState::Installed);
+    assert!(
+        qemu.last_used <= SystemTime::now(),
+        "last-used must be a real timestamp, not a placeholder in the future"
+    );
+
+    let src = entries
+        .iter()
+        .find(|e| e.display_id() == "sdk/corrosion/0.6.src")
+        .expect("the source tree is missing from the listing");
+    assert_eq!(
+        src.state,
+        store::EntryState::SourceTree,
+        "a `<version>.src` tree must be named as one — it is the biggest \
+         reclaimable thing in a real store and `unmanaged` tells a human nothing"
+    );
+}
+
+/// The scan must not consume the evidence it reports.
+///
+/// It did, on its first run: deciding an entry's state opens
+/// `.nros-provenance`, which updates that file's atime, so every installed
+/// entry read "last used 1s ago" and `gc --older-than 90d` would have found
+/// nothing to collect on any host, forever. Walking the tree updates every
+/// DIRECTORY's atime for the same reason. Two scans in a row must agree.
+#[test]
+fn scanning_the_store_does_not_change_what_it_measures() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    install(root, "sdk/qemu/11.0.0", "11.0.0", b"binary");
+
+    // The sleep is what gives this test its teeth, and it was missing at first:
+    // the kernel stamps timestamps from a COARSE clock (one tick, single-digit
+    // ms), so a file written and read inside one tick gets an `atime` byte-equal
+    // to its `mtime` — and the read the bug is about becomes invisible. Without
+    // the wait, this test passed with the exclusion removed. One tick is enough;
+    // 50 ms is several.
+    std::thread::sleep(Duration::from_millis(50));
+
+    let first = store::scan(root);
+    let second = store::scan(root);
+    assert_eq!(first.len(), 1);
+    assert_eq!(
+        first[0].last_used, second[0].last_used,
+        "the second scan reported a different last-used time — the scan is \
+         reading files whose atime it then measures"
+    );
+    assert_eq!(
+        first[0].evidence, second[0].evidence,
+        "the second scan reported different usage evidence"
+    );
+    assert_eq!(
+        first[0].evidence,
+        store::UseEvidence::InstallOnly,
+        "nothing has read this entry, so its timestamp is the install"
+    );
+}
+
+/// Pin discovery walks up from the directory it is given, the way cargo finds a
+/// workspace root — a user runs a store verb from wherever they are inside
+/// their project.
+#[test]
+fn pin_discovery_walks_up_from_the_directory_it_is_given() {
+    let tmp = tempfile::tempdir().unwrap();
+    pin_file(
+        tmp.path(),
+        "nros-toolchain.toml",
+        "[toolchain]\nversion = \"0.6.2\"\n",
+    );
+    let deep = tmp.path().join("src").join("nested").join("deeper");
+    std::fs::create_dir_all(&deep).unwrap();
+
+    let sources = store::collect_pins(&[], Some(&deep)).unwrap();
+    assert_eq!(sources.len(), 1, "found {sources:#?}");
+    assert!(
+        sources[0]
+            .rules
+            .contains(&store::PinRule::AnyVersion("0.6.2".into())),
+        "the pin's version did not survive the read: {:?}",
+        sources[0].rules
+    );
+}
+
+/// `toolchain uninstall` refuses while a known pin names the version — the
+/// requirement RFC-0095 D11 states for this verb.
+///
+/// The pin is `nros-toolchain.toml`, phase-440 W7's file. Its SCHEMA is W7's to
+/// choose, so the reader takes any string value in it as a version: a delete
+/// guard that a later phase's key name can silently disarm is not a guard.
+#[test]
+fn toolchain_uninstall_refuses_while_a_pin_names_the_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let entry = install(root, "toolchains/0.6.2", "0.6.2", b"toolchain");
+    let pin = pin_file(
+        tmp.path(),
+        "nros-toolchain.toml",
+        "[toolchain]\nversion = \"0.6.2\"\n",
+    );
+
+    let mut args = uninstall_args(root, "0.6.2");
+    args.pin_file = vec![pin];
+    let err = toolchain_cmd::uninstall(args, None)
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        err.contains("pinned by"),
+        "the refusal must name the pin file, got: {err}"
+    );
+    assert!(entry.is_dir(), "a pinned toolchain was removed");
+}
+
+/// The case today's tree actually reaches: no `nros-toolchain.toml` exists
+/// anywhere yet (W7 introduces it), so nothing can establish that no project
+/// pins this version — and unestablished is not the same as false.
+#[test]
+fn toolchain_uninstall_refuses_when_no_pin_file_could_be_consulted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let entry = install(root, "toolchains/0.6.2", "0.6.2", b"toolchain");
+
+    let err = toolchain_cmd::uninstall(uninstall_args(root, "0.6.2"), None)
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        err.contains("cannot verify"),
+        "the refusal must say what it could not establish, got: {err}"
+    );
+    assert!(
+        entry.is_dir(),
+        "nothing may be removed on an unverified pin set"
+    );
+}
+
+/// With a pin set that WAS consulted and does not name the version, the verb
+/// does its job — otherwise the refusals above would just be a broken command.
+#[test]
+fn toolchain_uninstall_removes_a_version_no_consulted_pin_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let keep = install(root, "toolchains/0.7.0", "0.7.0", b"current");
+    let drop = install(root, "toolchains/0.6.2", "0.6.2", b"old");
+    let pin = pin_file(
+        tmp.path(),
+        "nros-toolchain.toml",
+        "[toolchain]\nversion = \"0.7.0\"\n",
+    );
+
+    let mut args = uninstall_args(root, "0.6.2");
+    args.pin_file = vec![pin];
+    toolchain_cmd::uninstall(args, None).unwrap();
+
+    assert!(!drop.exists(), "the unpinned toolchain should be gone");
+    assert!(keep.is_dir(), "the pinned toolchain must be untouched");
+}
+
+/// An absent toolchain is reported, not an error and not a delete: there is
+/// nothing to remove, so the pin question never arises. This is the branch
+/// every invocation reaches today, since `toolchains/` is W7's directory.
+#[test]
+fn toolchain_uninstall_reports_an_absent_version_rather_than_failing() {
+    let tmp = tempfile::tempdir().unwrap();
+    toolchain_cmd::uninstall(uninstall_args(tmp.path(), "0.6.2"), None)
+        .expect("an absent toolchain is not an error — there is nothing to refuse");
+}

--- a/packages/cli/nros-cli/tests/store_verbs.rs
+++ b/packages/cli/nros-cli/tests/store_verbs.rs
@@ -1,0 +1,106 @@
+//! The store verbs as a USER reaches them — through the real `nros` binary
+//! (phase-440 W6).
+//!
+//! `nros-cli-core/tests/store_reclaim.rs` covers what these verbs decide; this
+//! file covers whether they can be invoked at all, which is a different
+//! question and was briefly answered "no".
+//!
+//! `nros toolchain uninstall <ver>` panicked at startup in every build: the
+//! binary sets `propagate_version = true`, clap therefore generates a
+//! `--version` flag on every subcommand, and the positional field named
+//! `version` collided with it — `Argument names must be unique`. Twelve tests
+//! passed throughout, because each of them constructs the `Args` struct and
+//! calls `run` directly, so nothing in the suite ever built the clap command.
+//! A verb that cannot parse is not a verb.
+//!
+//! So these run the binary. They stay cheap by asking only for `--help` and for
+//! a dry run against an EMPTY store — no fixtures, no provisioning, no `$HOME`.
+
+use std::{path::PathBuf, process::Command};
+
+fn nros() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nros"))
+}
+
+fn run(args: &[&str]) -> (bool, String) {
+    let out = nros().args(args).output().expect("failed to exec nros");
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.success(), text)
+}
+
+/// Every store verb builds its clap command. `--help` is the cheapest way to
+/// demand that: clap's `debug_assert` over the whole command tree runs before
+/// any of them can print anything.
+#[test]
+fn every_store_verb_parses() {
+    for args in [
+        vec!["store", "--help"],
+        vec!["store", "list", "--help"],
+        vec!["store", "gc", "--help"],
+        vec!["toolchain", "--help"],
+        vec!["toolchain", "uninstall", "--help"],
+    ] {
+        let (ok, text) = run(&args);
+        assert!(ok, "`nros {}` failed:\n{text}", args.join(" "));
+    }
+}
+
+/// The safe default is visible in the help, not only in the behaviour — a user
+/// deciding whether to type `--delete` reads this text, and it is the only
+/// warning they get.
+#[test]
+fn gc_help_says_the_default_removes_nothing() {
+    let (ok, text) = run(&["store", "gc", "--help"]);
+    assert!(ok, "{text}");
+    assert!(
+        text.contains("--delete"),
+        "gc must document the opt-in it requires:\n{text}"
+    );
+    assert!(
+        text.to_lowercase().contains("dry"),
+        "gc must say it is a dry run by default:\n{text}"
+    );
+}
+
+/// A duration with no unit is refused rather than read as seconds. Checked
+/// through the binary because this is the message a user actually sees, and the
+/// number in it is theirs.
+#[test]
+fn gc_refuses_a_duration_with_no_unit() {
+    let (ok, text) = run(&["store", "gc", "--older-than", "90"]);
+    assert!(!ok, "a unit-less duration must fail:\n{text}");
+    assert!(
+        text.contains("90d"),
+        "the refusal must offer the spelling the user probably meant:\n{text}"
+    );
+}
+
+/// `list` on a store that does not exist reports that and exits 0 — an
+/// inspection verb must not fail on a host that has provisioned nothing.
+///
+/// `--root` keeps this off the real store: the verb reads `$NROS_STORE` /
+/// `$NROS_HOME` / `$HOME` otherwise, and a test must not depend on, or disturb,
+/// whatever this machine has installed.
+#[test]
+fn listing_an_absent_store_is_not_an_error() {
+    // A path that does not exist and is never created — no tempdir crate, and
+    // nothing to clean up, because the whole point is that the verb finds
+    // nothing there and leaves it that way.
+    let absent: PathBuf = std::env::temp_dir().join(format!(
+        "nros-store-absent-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    assert!(!absent.exists(), "the probe path must start absent");
+    let (ok, text) = run(&["store", "list", "--root", absent.to_str().unwrap()]);
+    assert!(ok, "list on an absent store failed:\n{text}");
+    assert!(
+        text.contains("nothing is provisioned"),
+        "it should say what it found:\n{text}"
+    );
+    assert!(
+        !absent.exists(),
+        "an inspection verb must not create the store it was asked about"
+    );
+}

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -267,6 +267,10 @@ KNOB_CLASS = {
     "NROS_RMW_SUBSCRIBER_SLOTS": ("derived", "phase-412 W1 — COUNT_SUBSCRIPTION"),
     "NROS_EXTRA_BOARD_PATH": ("infra", "extra board search roots"),
     "NROS_HOME": ("infra", "path"),
+    # phase-440 W6 / RFC-0095 D2 — the store ROOT, of which `NROS_HOME` names
+    # the same directory. A path, not a knob: it configures nothing about an
+    # image, it says where provisioned artifacts live.
+    "NROS_STORE": ("infra", "path"),
     "NROS_MODEL_DIR": ("infra", "path"),
     "NROS_WORKSPACE": ("infra", "path"),
     "NROS_WORKSPACE_ROOT": ("infra", "path"),


### PR DESCRIPTION
Implements **phase-440 W6** / **RFC-0095 D11** — the store is additive by design (that is what makes rollback free), so it grows and nothing reclaims it.

```
nros store list                     name, version, size, last used
nros store gc --older-than 90d      dry run by DEFAULT; --delete opts in
nros toolchain uninstall <ver>      refuses while a pin names it
```

D11 also says what *not* to build: reference-counting against pins scattered across a filesystem is not reliable, so this is explicit and inspectable. Every interesting line is a refusal; the reclaim itself is one `remove_dir_all`.

## What it will not do, and why each is deliberate

* **`--delete` refuses when NO pin file was consulted** — not only when one names the entry. The store is shared between projects while pins are per-project, so an empty pin set run from the wrong directory means "I looked in the wrong place" at least as often as "nothing needs these", and those must not reach the caller as the same value. `--ignore-pins` is the sentence you write to say it anyway.
* **`toolchain uninstall` therefore refuses on today's tree**, which is the honest answer rather than a gap: `toolchains/<ver>/` and `nros-toolchain.toml` are both **W7**'s, so nothing yet exists that could establish that no project pins a version. The pin reader already accepts `nros-toolchain.toml` and takes any string value in it as a version, so W7 may pick its schema without disarming the guard.
* **`gc` removes only entries carrying `.nros-provenance`.** The rest are listed with their sizes and left: the legacy flat prefix `nros sdk-path` still resolves through (issue 0628), and `<version>.src` source trees — 1.5 G of the 4.4 G store on the host this was written on. Nothing needs a source tree, but it is also where somebody debugging a build put their local patches.

## What measuring corrected

* **The scan consumed its own evidence.** Classifying an entry opens its `.nros-provenance`, which updates that file's atime, so every installed entry reported "last used 1s ago" and `gc --older-than 90d` would have found nothing to collect on any host, ever. With the markers excluded from the timestamp signal, this host's oldest entry reads 63d and gc has a real candidate.
* **The test for that passed with the fix removed.** Timestamps came from `mtime()`/`atime()` *seconds*, and a file written and read inside one kernel tick compares equal. Nanoseconds plus a 50 ms wait in the test; both mutations now fail it.
* **`nros toolchain uninstall <ver>` could not run at all.** The binary sets `propagate_version = true`, so clap puts a `--version` flag on every subcommand and the positional `version` field collided with it — a `debug_assert` panic at startup. Twelve library tests passed throughout, because each constructs the `Args` struct and calls `run` directly and none ever built the clap command. `nros-cli/tests/store_verbs.rs` executes the real binary for exactly that class.

Store root resolution also gets ONE spelling — `store::root()`, `$NROS_STORE` → `$NROS_HOME` → `~/.nros` (D2's "never an absolute literal") — with `sdk_store::{store_root,front_dir}` derived from it instead of repeating the arms.

## Tests

16, all new: 12 in `nros-cli-core/tests/store_reclaim.rs` (behaviour, no env or cwd touched — the root is a `--root` argument and the pin search directory is a parameter), 4 in `nros-cli/tests/store_verbs.rs` (the binary parses and prints). Verified by **mutation**, not by green: disabling the pin check, making delete the default, restoring the marker read, and removing the clap arg id each fail a named test.

## What ran

`just check fast` (284 gates, green), `just check cli-tests` (green), CLI workspace `cargo clippy --all-targets -D warnings` (clean). The diff is confined to `packages/cli/`, one gate table and two docs, so no compile-tier lane is engaged by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nq9x24szjuBMqdtwhfgxiM
