### PR TITLE
fix(nros-cpp): two reds on main — a missing `# Safety` section, and a bisect hash the queue rebased away

### DIFF
--- a/.config/doc-commit-citations-baseline.txt
+++ b/.config/doc-commit-citations-baseline.txt
@@ -86,3 +86,15 @@ ea9fbfae9
 fe807a999
 # Keep this one permanently — foreign, like its two siblings above:
 d1d88f660
+
+# `docs/issues/1227-island-image-dtcm-overflows-on-main.md`, the DTCM bisect
+# table. Three of its four commits still resolve; `e3786749a` does not, because
+# the merge queue rebases entries SERVER-SIDE and this one's branch was
+# rewritten after the issue was written. DEAD, and deliberately not rewritten:
+# the row is a MEASUREMENT of a specific tree (DTCM 93344 B, 71.22%) and there
+# is no durable name for a commit that no longer exists — a PR number would
+# describe a different tree. The claim it supports survives without it:
+# `1976727d8` measured the identical 93344 B / 71.22% and still resolves, so
+# the "NOT environmental" argument has a live witness.
+e3786749a
+

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -1419,6 +1419,19 @@ nros_cpp_ret_t nros_cpp_executor_derive_min_stack_headroom(void *handle, size_t 
  */
 nros_cpp_ret_t nros_cpp_executor_set_min_stack_headroom(void *handle, size_t bytes);
 
+/**
+ * Declare one `from -> to` remap for a node, from the C++ side of the ABI.
+ *
+ * `node_namespace` may be NULL, which means `/`; every other pointer is
+ * required and a NULL one answers `NROS_CPP_RET_INVALID_ARGUMENT` rather than
+ * faulting. A full remap table answers `NROS_CPP_RET_FULL`.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL.
+ * `node_name`, `from` and `to` must each point at a NUL-terminated C string
+ * that stays valid for the duration of the call; `node_namespace` must too
+ * unless it is NULL.
+ */
 nros_cpp_ret_t nros_cpp_declare_remap(void *handle,
                                       const char *node_name,
                                       const char *node_namespace,

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3257,6 +3257,17 @@ pub unsafe extern "C" fn nros_cpp_executor_set_min_stack_headroom(
     NROS_CPP_RET_OK
 }
 
+/// Declare one `from -> to` remap for a node, from the C++ side of the ABI.
+///
+/// `node_namespace` may be NULL, which means `/`; every other pointer is
+/// required and a NULL one answers `NROS_CPP_RET_INVALID_ARGUMENT` rather than
+/// faulting. A full remap table answers `NROS_CPP_RET_FULL`.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL.
+/// `node_name`, `from` and `to` must each point at a NUL-terminated C string
+/// that stays valid for the duration of the call; `node_namespace` must too
+/// unless it is NULL.
 #[cfg(feature = "rmw-cffi")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_declare_remap(


### PR DESCRIPTION
Two reds sitting on `main`, found while settling issue 1187. Neither could have failed a pull request.

## 1. `nros_cpp_declare_remap` has no `# Safety` section

```
error: unsafe function's docs are missing a `# Safety` section
3262 | pub unsafe extern "C" fn nros_cpp_declare_remap(
```

Fallout from `587baabb7`, which restored the `#[cfg]` on this function without the doc block. Every other `pub unsafe extern "C"` in that file has one — **52 of them** — and the sibling immediately above is the template this follows.

**Measured both ways**, with the lane's own invocation:

```
cargo clippy -p nros-cpp --no-default-features \
  --features "std,rmw-zenoh-cffi,platform-posix,ros-humble" -- -D warnings
```

before → **exit 101** naming this function; after → **exit 0**.

**Why it could sit there:** this clippy runs in `check-build`, which is `schedule`/`workflow_dispatch` only. No merge-gating event runs it, so no PR could ever have gone red on it. CLAUDE.md documents that hazard, and issue 0896's two reds landed the same way.

The regenerated `nros_cpp_ffi.h` rides along because cbindgen emits Rust doc comments into the header — adding the section made the committed header stale (issue 0452). The diff is exactly the new doc block.

## 2. A dangling bisect citation

`check-doc-commit-citations` was red before this branch: issue 1227's DTCM bisect table cites `e3786749a`, which no longer exists. Three of its four commits still resolve; that one's branch was rewritten because **the merge queue rebases entries server-side** — precisely the failure the gate's own message describes.

**Baselined rather than rewritten**, with the reasoning recorded at the entry. The row is a *measurement of a specific tree* (DTCM 93344 B, 71.22 per cent) and there is no durable name for a commit that no longer exists; a PR number would describe a different tree. The claim it supports keeps a live witness regardless: `1976727d8` measured the identical value and still resolves, so the issue's "NOT environmental" argument does not rest on the dead hash.

The baseline is a ratchet and may only shrink; the entry carries that reasoning so the next reader does not "fix" it by inventing a hash.

## Verification

`just check fast` — green, 0 failures. Both reds were independently reproduced before fixing and confirmed cleared after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzPvAy8k8yiuoGmKMzKyiJ
