### PR TITLE
feat(phase-436 W7): ThreadX and Zephyr's Rust arm park through the seam

### DIFF
--- a/packages/api/nros/src/lib.rs
+++ b/packages/api/nros/src/lib.rs
@@ -1290,6 +1290,11 @@ pub use nros_node::{
 // type a user could name and never receive. RFC-0036's Errors row now describes
 // what these two are.
 // ---------------------------------------------------------------------------
+/// phase-436 W7 — installing a port's park primitive, with the wake-object
+/// constraint stated once. Board entries reach it through this facade because
+/// that is the dependency they already carry.
+pub use nros_node::executor::port_park;
+
 pub use nros_node::NodeError;
 pub use nros_rmw::TransportError;
 

--- a/packages/boards/nros-board-threadx/src/entry.rs
+++ b/packages/boards/nros-board-threadx/src/entry.rs
@@ -96,6 +96,30 @@ static UART_LOGGER: UartLogger = UartLogger;
 /// Install the UART `log` sink, routing records through `B::println`. Idempotent:
 /// re-arms the print fn each call and ignores a repeated `set_logger` (the second
 /// returns `Err`). Safe to call once per boot before the spin loop.
+
+/// phase-436 W7 — ThreadX's park, and the tick period that is its real floor.
+///
+/// ThreadX has no sub-tick wait: `tx_semaphore_get` counts ticks and
+/// `TX_TIMER_TICKS_PER_SECOND` is 100 on both shipped boards, so the floor is
+/// 10 ms — an order of magnitude coarser than the millisecond the ABI
+/// signature suggests. Installing this does not gain resolution; it makes the
+/// executor stop CLAIMING resolution it never had (issue 1242).
+unsafe extern "C" {
+    fn nros_platform_wake_park_until_us(w: *mut core::ffi::c_void, deadline_us: u64) -> i8;
+    fn nros_platform_wake_park_granularity_us() -> u64;
+}
+
+/// Install the park on `crt`'s executor. Advisory: a build with no wake object
+/// keeps the path it had.
+fn install_park(crt: &mut ::nros::node_runtime::ExecutorNodeRuntime) {
+    let granularity = unsafe { nros_platform_wake_park_granularity_us() };
+    let _ = ::nros::port_park::install_port_park(
+        crt.executor_mut(),
+        nros_platform_wake_park_until_us,
+        granularity,
+    );
+}
+
 fn install_uart_logger<B: BoardPrint>() {
     fn print_via_board<B: BoardPrint>(args: core::fmt::Arguments<'_>) {
         B::println(args);
@@ -222,6 +246,9 @@ struct TierTaskCtx<F> {
 /// every spawned tier so the lowering never diverges.
 fn apply_tier(crt: &mut ::nros::node_runtime::ExecutorNodeRuntime, tier: &TierSpec<'static>) {
     crt.executor_mut().set_active_groups(tier.groups);
+    // phase-436 W7 — one site, shared by the boot tier and every spawned tier,
+    // so the park never diverges from the rest of the lowering.
+    install_park(crt);
     crt.apply_tier_sched_policy(
         tier.class,
         tier.period_us,

--- a/packages/boards/nros-board-zephyr/src/entry_tiers.rs
+++ b/packages/boards/nros-board-zephyr/src/entry_tiers.rs
@@ -97,6 +97,25 @@ fn apply_tier_deadline(tier: &TierSpec<'_>) {
 #[inline]
 fn apply_tier_deadline(_tier: &TierSpec<'_>) {}
 
+/// phase-436 W7 — Zephyr's microsecond park (`k_sem_take` with `K_USEC`) and
+/// the tick period that is its real floor. Optional in the platform ABI, so a
+/// build without them simply keeps the millisecond `wake_wait_ms` path.
+unsafe extern "C" {
+    fn nros_platform_wake_park_until_us(w: *mut core::ffi::c_void, deadline_us: u64) -> i8;
+    fn nros_platform_wake_park_granularity_us() -> u64;
+}
+
+/// Install the park on `crt`'s executor. Advisory: a build with no wake object
+/// keeps the path it had.
+fn install_park(crt: &mut ::nros::node_runtime::ExecutorNodeRuntime) {
+    let granularity = unsafe { nros_platform_wake_park_granularity_us() };
+    let _ = ::nros::port_park::install_port_park(
+        crt.executor_mut(),
+        nros_platform_wake_park_until_us,
+        granularity,
+    );
+}
+
 /// The BOOT tier's placement attempt (issue 0655).
 ///
 /// phase-296 W5.5 added this as a general "pin the calling thread" consumer,
@@ -250,6 +269,7 @@ where
     let executor = unsafe { ::nros::Executor::open_with_session_handle(ctx.session) };
     let mut crt = ::nros::node_runtime::ExecutorNodeRuntime::from_executor(executor);
     crt.executor_mut().set_active_groups(ctx.tier.groups);
+    install_park(&mut crt);
     // W5.4 — lower this tier's class/budget/period/deadline onto the executor's
     // default SchedContext (Sporadic / EDF / TT), shared with every board.
     crt.apply_tier_sched_policy(
@@ -408,6 +428,7 @@ impl ZephyrBoard {
         // declare-vs-declare races the interest handshake).
         let boot_tier = &tiers[0];
         crt.executor_mut().set_active_groups(boot_tier.groups);
+        install_park(&mut crt);
         crt.apply_tier_sched_policy(
             boot_tier.class,
             boot_tier.period_us,

--- a/packages/core/nros-node/src/executor/mod.rs
+++ b/packages/core/nros-node/src/executor/mod.rs
@@ -72,8 +72,11 @@ mod node_wake;
 // where `node_wake` resolved false. The feature half lives inside the file as
 // an inner `#![cfg]`, so there is one condition per fact and no pair to keep in
 // step.
-#[cfg(any(has_rmw, test))]
 pub(crate) mod os_priority;
+#[cfg(any(has_rmw, test))]
+/// phase-436 W7 — installing a port's park primitive, with the wake-object
+/// constraint stated once instead of per board.
+pub mod port_park;
 // phase-359 W10 — the allocate/spawn/join helper moved to
 // `nros_platform_api::task`, beside the ABI it wraps, once `nros-cpp` became a
 // third caller. Reached through a `use` below rather than a module here.

--- a/packages/core/nros-node/src/executor/port_park.rs
+++ b/packages/core/nros-node/src/executor/port_park.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, NEWSLab NTU.
+// SPDX-License-Identifier: Apache-2.0
+
+//! phase-436 W7 — installing a port's park primitive, in one place.
+//!
+//! Every Rust board entry that wires the seam needs the same three steps and
+//! the same non-obvious constraint, so they live here rather than being spelt
+//! once per board and drifting.
+//!
+//! **The constraint.** A `ParkUntilFn` must wait on the executor's OWN wake
+//! object. The backend's listener signals that one, and [`spin_once`] drops
+//! its transport drain to non-blocking once a port has parked — so a park on
+//! any other object cannot be broken by data arriving, and sleeps out its full
+//! deadline with a message already waiting. That is worse than not parking at
+//! all, it passes every test, and it is invisible in a quiet run.
+//!
+//! [`spin_once`]: super::spin::Executor::spin_once
+
+#[cfg(all(feature = "alloc", feature = "rmw-cffi"))]
+use super::spin::{Executor, ParkUntilFn};
+
+/// Install `park` on `executor`, waiting on the executor's own wake object.
+///
+/// Returns `false` — and installs nothing — when this build has no wake
+/// object to park on. That build keeps the millisecond `wake_wait_ms` path it
+/// already had, which is why every caller can treat this as advisory.
+///
+/// `granularity_us` is the finest park the primitive can express. The PORT
+/// states it, because only the port knows: an RTOS tick is a coarser limit
+/// than the ABI signature (ThreadX ticks at 100 Hz) and a timespec primitive a
+/// finer one (issue 1242).
+#[cfg(all(feature = "alloc", feature = "rmw-cffi"))]
+pub fn install_port_park(
+    executor: &mut Executor<'_>,
+    park: ParkUntilFn,
+    granularity_us: u64,
+) -> bool {
+    let wake = executor.wake_raw_ptr();
+    if wake.is_null() {
+        return false;
+    }
+    executor.set_park_primitive(park, wake, granularity_us);
+    true
+}

--- a/packages/platform/nros-platform-threadx/src/platform.c
+++ b/packages/platform/nros-platform-threadx/src/platform.c
@@ -767,6 +767,53 @@ size_t nros_platform_wake_storage_align(void) {
     return __alignof__(nros_wake_t);
 }
 
+/* phase-436 W7 — the optional microsecond park.
+ *
+ * ThreadX has NO sub-tick wait: `tx_semaphore_get` counts in ticks and
+ * `TX_TIMER_TICKS_PER_SECOND` is 100 in both shipped board configs, so the
+ * real floor is 10 ms — an order of magnitude coarser than the millisecond the
+ * ABI signature suggests. That mismatch is issue 1242: the executor used to
+ * assume 1 ms for every port and therefore over-claimed here, and the W3
+ * jitter report inherited the over-claim.
+ *
+ * So this exists to report the truth, not to gain resolution. Rounding is UP,
+ * because a wait shorter than asked is a missed deadline while a longer one is
+ * merely late.
+ *
+ * `w` MUST be the executor's own wake object (`nros_cpp_executor_wake_handle`):
+ * the backend's listener signals that one, and `spin_once` drops its transport
+ * drain to non-blocking once a port has parked, so a park on anything else
+ * sleeps its whole deadline with data already waiting.
+ *
+ * Contract: 0 = signalled, 1 = deadline expired, -1 = cannot park. */
+int8_t nros_platform_wake_park_until_us(void *w, uint64_t deadline_us) {
+    if (w == NULL) return -1;
+    ULONG ticks;
+    if (deadline_us == 0u) {
+        ticks = TX_NO_WAIT;
+    } else {
+        ULONG tps = TX_TIMER_TICKS_PER_SECOND;
+        if (tps == 0u) tps = 100u;
+        /* us -> ticks, rounded UP; never zero for a non-zero request. */
+        uint64_t per_tick_us = 1000000ULL / (uint64_t) tps;
+        uint64_t n = (deadline_us + per_tick_us - 1ULL) / per_tick_us;
+        if (n == 0ULL) n = 1ULL;
+        ticks = (ULONG) n;
+    }
+    UINT rc = tx_semaphore_get((TX_SEMAPHORE *) w, ticks);
+    if (rc == TX_SUCCESS)                              return 0;
+    if (rc == TX_NO_INSTANCE || rc == TX_WAIT_ABORTED) return 1;
+    return -1;
+}
+
+/* The tick period, which is the real floor here — 10 ms on both shipped board
+ * configs, not the millisecond the ABI signature implies (issue 1242). */
+uint64_t nros_platform_wake_park_granularity_us(void) {
+    ULONG tps = TX_TIMER_TICKS_PER_SECOND;
+    if (tps == 0u) tps = 100u;
+    return (uint64_t) ((1000000ULL + (uint64_t) tps - 1ULL) / (uint64_t) tps);
+}
+
 /* phase-359 W10 — opaque-storage sizing for `task`, the sibling of the wake
  * probes above. `task_init`'s contract says the implementor decides the size;
  * these let a caller ASK instead of hard-coding it (issue 0570's trap). */


### PR DESCRIPTION
> **Stacked on #648.** Rebase to `main` once it lands. Split from #792, which merged before this commit was pushed — the work landed on a closed PR's branch and needed its own.

Both entries hold a typed `Executor`, so unlike the C arms they needed no new FFI — only the primitive and the wiring.

## One place for the constraint

`port_park::install_port_park` holds the non-obvious part instead of it being spelt per board: **a `ParkUntilFn` must wait on the executor's own wake object.** The backend's listener signals that one, and `spin_once` drops its transport drain to non-blocking once a port has parked — so a park on any other object cannot be broken by data arriving and sleeps out its full deadline with a message already waiting. Worse than not parking, invisible in a quiet run, green on every test.

## ThreadX gains the primitive and buys no resolution — that is the point

`tx_semaphore_get` counts ticks and `TX_TIMER_TICKS_PER_SECOND` is **100** on both shipped boards, so the real floor is **10 ms** — an order of magnitude coarser than its ABI signature implies. Before #1242 the executor assumed 1 ms for every port and W3's jitter report inherited the over-claim. Installing this makes the executor stop *claiming* precision ThreadX never had.

Conversion rounds **up**: a wait shorter than asked is a missed deadline; a longer one is merely late.

## Four compile problems, three the same shape

| | |
|---|---|
| `::nros::executor` doesn't exist | the facade never re-exported it → now `::nros::port_park` |
| my Zephyr insertion **split a `#[cfg(feature = "zephyr-edf")]` pair** of `apply_tier_deadline` | same class as the W7.a insertion that stole `nros_board_native_run_tiers`'s gate |
| `port_park`'s import was ungated while its function is gated | `-D warnings` rejected it — issue 0487's class |
| ThreadX's install belonged in the shared `apply_tier` | the separate boot-site call was a duplicate |

## And a green check that was not evidence

`cargo check` on the Zephyr board **passed while never compiling `entry_tiers.rs`** — it sits behind `#[cfg(feature = "tiers")]`. The real errors appeared only under `--features tiers`.

ThreadX cannot be checked standalone at all: a **pre-existing** cyclic dependency with `nros-board-threadx-linux`, verified present on an unmodified tree, so it is checked through that dependent.

## Verification

384 passed, 0 failed. `nros-board-zephyr` clean with and without `tiers`; `nros-board-threadx` clean via `nros-board-threadx-linux`.

Bare metal stays unwired — no board in the tree can arm a one-shot deadline compare, which is a hardware-code gap rather than a wiring one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPKwuBESsmHcbgkCN3odw4