### PR TITLE
fix(cpp): `just check cpp` is red on main — `nros_cpp_declare_remap` has no `# Safety`

### DIFF
--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3257,6 +3257,28 @@ pub unsafe extern "C" fn nros_cpp_executor_set_min_stack_headroom(
     NROS_CPP_RET_OK
 }
 
+/// Declare one name remapping for a node, as `ros2 run … --ros-args -r from:=to`
+/// would.
+///
+/// `node_namespace` may be NULL, which is read as `/` — the root, and the
+/// namespace a node gets when nobody names one. The other four are required;
+/// each is checked and answered with `NROS_CPP_RET_INVALID_ARGUMENT` rather
+/// than trusted.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL.
+///
+/// `node_name`, `from` and `to` must each be NULL or a pointer to a
+/// NUL-terminated C string that stays valid for the duration of the call;
+/// `node_namespace` likewise, with NULL meaning `/`. The strings are read, not
+/// retained — the remapping is copied into the executor's own storage before
+/// this returns, so the caller may free them immediately afterwards.
+///
+/// NULL is a legal argument for every parameter here and is refused, not
+/// dereferenced. What this signature cannot check, and therefore what the
+/// caller owes, is that a NON-null pointer really is a valid NUL-terminated
+/// string: a pointer into freed memory or an unterminated buffer is undefined
+/// behaviour in `cstr_to_str`, which is where the scan happens.
 #[cfg(feature = "rmw-cffi")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_declare_remap(


### PR DESCRIPTION
Found while rebasing an unrelated PR; **this is a red on `main`, not on any branch.**

Reproduced on a clean `origin/main` worktree before changing anything:

```
error: unsafe function's docs are missing a `# Safety` section
  --> packages/api/nros-cpp/src/lib.rs:3262:1
  = note: `-D clippy::missing-safety-doc` implied by `-D warnings`
error: recipe `cpp` failed with exit code 101
```

The function has been undocumented since `7e3e15b4d` moved it into `packages/api/`. `just check` is the only lane that runs the nros-cpp clippy step — the shape issue 0319 named: a correct check on a path nothing traverses, red for as long as nobody runs it locally.

## The section is written to this signature, not pasted from a neighbour

The usual one here is *"`handle` must be a live executor handle from this ABI, or NULL"*, and that alone would be wrong for this function. It takes **five** parameters and NULL is **legal for every one**: `node_namespace` NULL means `/` (the namespace a node gets when nobody names one), and the other four are checked and answered with `NROS_CPP_RET_INVALID_ARGUMENT` rather than dereferenced.

So the obligation the caller actually carries is the one the signature cannot express — that a **non**-null pointer really is a valid NUL-terminated string, because a pointer into freed memory or an unterminated buffer is UB inside `cstr_to_str`, which is where the scan happens. The section also records that the strings are read and not retained: the remapping is copied into the executor's own storage before the call returns, so a caller may free them immediately.

## Swept for siblings

A walker over every `pub unsafe extern "C" fn` in the file reported two more without a section — `nros_board_native_run_components` and `..._named`. Both are **false positives**: they do carry it, and my walker stopped early on the `// phase-359 W10 …` plain comment sitting between the doc block and the `#[cfg]`. Verified by reading both. One genuine gap in 53 sections.

## Verified

`just check cpp` — **All C++ checks passed!** (exit 0, against 101 before). `cargo +nightly fmt --check --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N