### PR TITLE
feat(phase-440 W3): third-party/ holds tracked submodules and nothing else

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,6 @@ tools/*
 /.claude/*
 !/.claude/skills/
 /external/
-/third-party/make/
-/third-party/ninja/
 # phase-362 — the vendored zenoh router is retired; the router comes from ROS
 # (`rmw_zenoh_cpp/rmw_zenohd`). An existing checkout still has the submodule's
 # working tree on disk after the gitlink is dropped, and leaving it untracked

--- a/docs/roadmap/phase-440-nros-store-is-the-root.md
+++ b/docs/roadmap/phase-440-nros-store-is-the-root.md
@@ -86,15 +86,35 @@ gone; `ros2-box-env.sh` is 48 lines from 260 and sets only the store split;
 `check-gate-lists` 283 fast / 21 build-serial and `check-gate-visibility` 21
 acknowledged both green. Issue #0925 closed as moot.
 
-### W3 — `third-party/` holds tracked submodules and nothing else
+### W3 — `third-party/` holds tracked submodules and nothing else — **LANDED, one exception declared**
 
-Move `make/`, `ninja/`, `ros/` to the store; retire `external/` into
-`$NROS_STORE/fetch/`; **delete** the 23 M `external/PX4-Autopilot`, a stray
-duplicate of the 68 G tracked submodule at `third-party/px4/PX4-Autopilot`.
+Measured rather than assumed, and most of it was already done: `make/` and
+`ninja/` provision into the store and their consumers already read it there
+("the store rather than `third-party/make/`", `jobserver-pool.sh`). What
+remained was 1.2 MB of residue and two `.gitignore` lines that made the
+directory look like it still held provisioning.
 
-*Acceptance:* every path under `third-party/` is a tracked submodule or tracked
-content — asserted by a gate, so a fourth provisioning root cannot land there
-quietly. `.gitignore` loses the corresponding entries rather than gaining any.
+`external/` turned out to be provisioned by NOTHING and consumed by NOTHING —
+every apparent consumer is NuttX's own `apps/external/` or prose. It is 287 MB
+of debris on this host; its `.gitignore` entry stays for now because deleting
+another operator's untracked data is not this phase's call to make.
+
+`check-third-party-is-submodules` is the ratchet. Submodule parents come from
+`.gitmodules`, never a directory walk, so an uninitialised submodule still
+counts (a bare clone has empty dirs), and an unreadable `.gitmodules` REFUSES
+rather than reporting OK over a reading that found nothing.
+
+**One declared exception: `ros`.** `[source.rosidl]` has
+`dest = "third-party/ros/rosidl"` and `msg_to_cyclone_idl.py` resolves it as its
+last ladder rung so the cyclone msg→IDL step works with no ROS install. Moving
+it needs `dest` to be able to name the STORE — RFC-0095 D2/D4, which is W4. So
+it is declared with a reason and somewhere to go, rather than the rule being
+weakened to fit it. The list may only shrink.
+
+*Acceptance (met):* gate green (9 submodule parents, 1 exception). Mutations —
+a new provisioning root under `third-party/` → RED naming it and its size; an
+unreadable `.gitmodules` → rc 2, refusing rather than passing. `.gitignore`
+loses two entries and gains none.
 
 ### W4 — provisioned workspaces move to the store, version-keyed
 

--- a/just/check/cargo.just
+++ b/just/check/cargo.just
@@ -325,6 +325,23 @@ path-env-fingerprints:
 # Issue 0336 — a retired submodule path must not survive anywhere that a user or
 # a CI job would follow it. RFC-0060's sweep missed scripts/bootstrap.sh, nine
 # doc copies and eight workflow refs; this grep would have caught all of them.
+# phase-440 W3 — `third-party/` holds TRACKED SUBMODULES and nothing else.
+#
+# It carried two kinds of thing at once: 20 submodules whose pins are DECISIONS,
+# and gitignored provisioning `nros setup` writes. "Pinned source or
+# provisioning?" then had no answer from the path, and every consumer that
+# walked the directory had to encode the distinction itself. That is the same
+# shape that made the box mirror unfixable (issue 1248) — rules telling source
+# from build output BY NAME, where the two live together.
+#
+# `make/` and `ninja/` are gone: both provision into the store and their
+# consumers already read it there. One declared exception remains — `ros`, whose
+# `[source.rosidl]` dest cannot name the store until W4 — and the list may only
+# shrink.
+[private]
+third-party-is-submodules:
+    @bash scripts/check-third-party-is-submodules.sh
+
 [private]
 retired-submodule-refs:
     @bash scripts/check-retired-submodule-refs.sh

--- a/scripts/check-third-party-is-submodules.sh
+++ b/scripts/check-third-party-is-submodules.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# `third-party/` holds TRACKED SUBMODULES and nothing else (phase-440 W3).
+#
+# WHY THIS EXISTS
+#
+# The directory carried two kinds of thing at once: 20 tracked submodules whose
+# pins are DECISIONS (cyclonedds tracks the version ROS ships; moving it is how
+# you stop interoperating), and gitignored provisioning that `nros setup` writes.
+# "Is this pinned source or provisioning?" then had no answer from the path — a
+# reader had to consult `.gitmodules` AND `.gitignore` to tell them apart, and
+# every consumer that walked the directory had to encode the distinction itself.
+#
+# That is also what made the box mirror unfixable (issue 1248): its rules told
+# source from build output BY NAME, in directories where the two lived together.
+#
+# `make/` and `ninja/` are gone — both are provisioned into the store and their
+# consumers already read it there ("the store rather than `third-party/make/`",
+# jobserver-pool.sh). The residue was 1.2 MB of nothing.
+#
+# THE ONE DECLARED EXCEPTION, and why it is not fixed here
+#
+# `[source.rosidl]` still has `dest = "third-party/ros/rosidl"`, and
+# `msg_to_cyclone_idl.py` resolves it as its last ladder rung so the cyclone
+# msg->IDL step works with no ROS install. Moving it needs `dest` to be able to
+# name the STORE, which is RFC-0095 D2/D4 and lands with phase-440 W4. Declaring
+# it here rather than deleting the rule keeps the ratchet honest: the exception
+# is visible, has a reason, and has somewhere to go.
+#
+# The list may only SHRINK. A new name here is a new provisioning root inside a
+# directory that is supposed to have none.
+set -uo pipefail
+
+# `grep -q` cannot tell "no match" (1) from "grep failed" (>=2), and the two
+# natural spellings fail in OPPOSITE directions (issue 0726). One helper.
+# shellcheck source=scripts/lib/grep-q.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grep-q.sh"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$repo_root" || exit 2
+
+EXCEPTIONS="ros"   # -> phase-440 W4, when `dest` can name the store
+
+# Submodule PARENTS: the first path component under third-party/ for every
+# declared submodule. Read from .gitmodules, never from a directory walk, so an
+# uninitialised submodule still counts as one (a bare clone has empty dirs).
+parents="$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null \
+    | awk '{print $2}' | grep '^third-party/' | cut -d/ -f2 | sort -u)"
+
+if [ -z "$parents" ]; then
+    echo "check-third-party-is-submodules: no submodules declared under third-party/ —" >&2
+    echo "  refusing to report OK over a reading that found nothing." >&2
+    exit 2
+fi
+
+# ONE classification, called by the loop AND the selftest. Two copies would let
+# the halves disagree: with the predicate inlined in the loop, mutating it to a
+# substring match left the selftest green (measured), so the selftest was
+# proving `nros_grep_q` behaves rather than that this gate uses it.
+is_parent()    { nros_grep_q -x -- "$1" <<< "$2"; }
+is_exception() { nros_grep_q -w -- "$1" <<< "$2"; }
+
+# SELFTEST, called unconditionally below — not behind a flag. A selftest nobody
+# runs decays into a comment (check-gate-selftests). These drive the same two
+# predicates the loop uses, over synthetic inputs, so a refactor that breaks
+# classification fails HERE rather than passing silently over a real tree.
+selftest() {
+    local fail=0
+    _st() { # name, want, got
+        [ "$2" = "$3" ] || { echo "  selftest FAIL: $1 (want $2, got $3)" >&2; fail=1; }
+    }
+    local parents=$'dds\nfreertos\nnuttx'
+    _st "a submodule parent is recognised"      0 "$(is_parent dds    "$parents"; echo $?)"
+    _st "a non-parent is not"                   1 "$(is_parent newsdk "$parents"; echo $?)"
+    _st "a PREFIX of a parent is not a parent"  1 "$(is_parent dd     "$parents"; echo $?)"
+    _st "a declared exception is recognised"    0 "$(is_exception ros    "ros"; echo $?)"
+    _st "an undeclared name is not exempt"      1 "$(is_exception notros "ros"; echo $?)"
+    return "$fail"
+}
+
+selftest || {
+    echo "check-third-party-is-submodules: SELFTEST FAILED — not reporting on the tree" >&2
+    exit 2
+}
+
+problems=0
+for d in third-party/*/; do
+    [ -d "$d" ] || continue
+    name="$(basename "$d")"
+    is_parent    "$name" "$parents"    && continue
+    is_exception "$name" "$EXCEPTIONS" && continue
+    problems=$((problems + 1))
+    echo "check-third-party-is-submodules: third-party/$name is not a submodule parent" >&2
+    echo "    $(du -sh "$d" 2>/dev/null | cut -f1) — provisioning belongs in the store" >&2
+    echo "    (\$NROS_STORE), not beside pinned source. RFC-0095 D2/D3." >&2
+done
+
+# A declared exception that no longer exists is a stale rule, and a stale rule
+# protects nothing while reading as though it does.
+for e in $EXCEPTIONS; do
+    [ -d "third-party/$e" ] || {
+        echo "check-third-party-is-submodules: '$e' is declared an exception but" >&2
+        echo "    third-party/$e does not exist here — if it has moved to the store," >&2
+        echo "    delete it from EXCEPTIONS (the list may only shrink)." >&2
+        # Not a failure: the directory is provisioned, so its absence is normal
+        # on a host that has not run `nros setup --source rosidl`.
+        :
+    }
+done
+
+[ "$problems" -eq 0 ] || exit 1
+echo "check-third-party-is-submodules: OK ($(wc -l <<< "$parents") submodule parent(s), $(wc -w <<< "$EXCEPTIONS") declared exception(s))"


### PR DESCRIPTION
`third-party/` carried two kinds of thing at once: 20 tracked submodules whose
pins are **decisions** (cyclonedds tracks the version ROS ships — moving it is
how you stop interoperating), and gitignored provisioning that `nros setup`
writes. "Pinned source or provisioning?" then had no answer from the path, and
every consumer walking the directory encoded the distinction itself.

That is the shape that made the box mirror unfixable one directory over (#1248):
rules telling source from build output **by name**, where the two live together.

## Measured first — most of it was already done

`make/` and `ninja/` provision into the store and their consumers already read
it there. Both said so in the **past tense**:

- `jobserver-pool.sh` — *"the store rather than `third-party/make/`"*
- `check-tier-preconditions.sh` — *"this block used to read `third-party/make/make`"*

What remained was 1.2 MB of residue and two `.gitignore` lines that made the
directory look like it still held provisioning. Removed.

**`external/` is provisioned by nothing and consumed by nothing** — every
apparent consumer is NuttX's own `apps/external/` or prose. 287 MB of debris.
Its `.gitignore` entry **stays**: deleting another operator's untracked data is
not this phase's call, and the gate covers `third-party/` only.

## The ratchet, and two things it deliberately does not do

`check-third-party-is-submodules` reads submodule parents from `.gitmodules`,
**never a directory walk** — so an uninitialised submodule still counts, because
a bare clone has empty dirs. And an unreadable `.gitmodules` exits **2** rather
than reporting OK over a reading that found nothing.

## One declared exception: `ros`

`[source.rosidl]` has `dest = "third-party/ros/rosidl"`, and
`msg_to_cyclone_idl.py` resolves it as its last ladder rung so the cyclone
msg→IDL step works with **no ROS install**. Moving it needs `dest` to be able to
name the store — RFC-0095 D2/D4, which is W4. So it is declared with a reason
and somewhere to go, rather than the rule being weakened to fit it. The list may
only shrink, and a stale entry says so.

## What testing corrected

The first selftest **passed with the fix removed.** It exercised `nros_grep_q`
in isolation while the loop had the predicate inlined, so mutating the loop to a
substring match — where a *prefix* of a parent would wrongly pass — left it
green. There is now one `is_parent` / `is_exception` that both the loop and the
selftest call, and the same mutation now fails it:

```
selftest FAIL: a PREFIX of a parent is not a parent (want 1, got 0)   rc=2
```

Two other gates caught this script before it could land, both correctly: it used
bare `grep -q` (which cannot tell "no match" from "grep failed" — issue 0726,
and the two spellings fail in opposite directions), and its selftest was
flag-only rather than on the normal path.

Mutations: a new provisioning root under `third-party/` → RED naming it and its
size; `.gitmodules` unreadable → rc 2.

`check-fast`: 286 gates ran, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZwZdvRHvXxozmr8KPsv82