### PR TITLE
feat(phase-440 W4): the store is preferred, and new provisioning lands there

### DIFF
--- a/docs/roadmap/phase-440-nros-store-is-the-root.md
+++ b/docs/roadmap/phase-440-nros-store-is-the-root.md
@@ -96,15 +96,45 @@ duplicate of the 68 G tracked submodule at `third-party/px4/PX4-Autopilot`.
 content — asserted by a gate, so a fourth provisioning root cannot land there
 quietly. `.gitignore` loses the corresponding entries rather than gaining any.
 
-### W4 — provisioned workspaces move to the store, version-keyed
+### W4 — provisioned workspaces move to the store — **RESOLUTION INVERTED; the data move is operational**
 
-`zephyr-workspace/{zephyr,modules}` (4.1 G of source; the sibling 140 G is build
-output and stays with whoever built it) becomes
-`$NROS_STORE/workspaces/zephyr/<version>/`. Same for esp-idf.
+W1 built the store arm and left it last. W4 promotes it, which is RFC-0095 D4:
 
-*Acceptance:* a second checkout on the same host provisions **nothing** and
-builds; `du` of the store shows one copy; the box-sync gate needs zero
-`--include` rules for provisioned trees, because none sit under the sync root.
+```
+$NROS_ZEPHYR_WORKSPACE  ->  $NROS_STORE/workspaces/zephyr/<version>  ->  <checkout-relative>
+```
+
+and moves the INSTALL target (`nros_zephyr_ws_default`) into the store, so the
+next `just zephyr setup` provisions there rather than beside a clone.
+
+**Nothing breaks on a host provisioned before this.** An absent candidate is
+skipped, so a populated `zephyr-workspace/` still resolves exactly as it did —
+measured on this host: `resolved` unchanged for both the 3.7 and 4.4 lines,
+`default` moved to the store. The store starts mattering the first time `setup`
+runs, which is when it becomes the answer.
+
+The checkout arm STAYS, last, on purpose (D4): a host provisioned earlier keeps
+working with no migration step, and a contributor patching a Zephyr module still
+points `NROS_ZEPHYR_WORKSPACE` at their own tree.
+
+*Acceptance (met, for the resolution half):* ladder order asserted directly —
+store above the checkout arms on both version lines, and an override ends the
+ladder. With the store populated it wins over a populated checkout tree; with it
+empty the checkout tree still resolves.
+
+*Not done here, deliberately — the DATA move is operational, not a code change.*
+Relocating 4.1 GB of provisioned source is `mv` plus a re-resolve on whichever
+host runs it, and it is safe to do at any time BECAUSE the ladder now prefers
+the store: a host that moves its tree is answered by the store arm, and one that
+does not is answered by the checkout arm. Neither needs this repo to change
+again. The 140 GB of build output beside it belongs to whoever built it and does
+not move.
+
+*Still open, and it is the last mechanism this phase needs:* `[source.rosidl]`
+has `dest = "third-party/ros/rosidl"`, and `dest` cannot name the store, so the
+`ros` exception W3 declared cannot be retired yet. That is one mechanism —
+store-aware `dest` in `nros-sdk-index.toml` — and it serves every future
+`[source.*]`, not just rosidl.
 
 ### W5 — D1 gated for every provisioned tree — **LANDED (generalised ahead of W4)**
 

--- a/scripts/lib/zephyr-workspace.sh
+++ b/scripts/lib/zephyr-workspace.sh
@@ -34,7 +34,7 @@
 #
 # ## The store arm, and why it is LAST
 #
-# RFC-0095 D4 ends at `$NROS_STORE/workspaces/zephyr/<version>` FIRST and the
+# RFC-0095 D4 puts `$NROS_STORE/workspaces/zephyr/<version>` above the
 # checkout-relative arms last. W1 adds the arm at the BOTTOM so that with no
 # store populated — every host today — resolution is unchanged. W4 moves the
 # trees and inverts the order. The checkout-relative arm STAYS last forever
@@ -112,16 +112,26 @@ nros_zephyr_ws_candidates() {
         return 0
     fi
 
-    # 2. The checkout-relative trees `just zephyr setup` lands, for THIS line.
+    # 2. The store (RFC-0095 D2/D4, phase-440 W4). PROMOTED above the checkout
+    #    arms: a provisioned tree belongs to the host, not to one clone, so two
+    #    checkouts share one and neither provisions it twice.
+    #
+    #    Promoting it changes nothing on a host that has not populated it — an
+    #    absent candidate is skipped, so every existing tree still resolves
+    #    exactly as before. It starts mattering the first time `setup` runs,
+    #    which is when the store becomes the answer.
+    nros_zephyr_ws_store_dir "$version"
+
+    # 3. The checkout-relative trees earlier `just zephyr setup` runs landed.
+    #    LAST, and kept, for two reasons: a host provisioned before W4 keeps
+    #    working with no migration step, and a contributor patching a Zephyr
+    #    module still points at their own tree (D4 keeps this arm on purpose).
     if [ "$version" = "4.4" ]; then
         printf '%s\n' "../nano-ros-workspace-4.4"
     else
         printf '%s\n' "zephyr-workspace"
         printf '%s\n' "../nano-ros-workspace"
     fi
-
-    # 3. The store (RFC-0095 D2). Last for now — see the header.
-    nros_zephyr_ws_store_dir "$version"
 }
 
 # Where `just zephyr setup` would INSTALL this line if nothing is provisioned.
@@ -134,11 +144,15 @@ nros_zephyr_ws_default() {
         printf '%s\n' "$NROS_ZEPHYR_WORKSPACE"
         return 0
     fi
-    if [ "$version" = "4.4" ]; then
-        printf '%s\n' "../nano-ros-workspace-4.4"
-    else
-        printf '%s\n' "zephyr-workspace"
-    fi
+    # phase-440 W4 — the store, not the checkout. A workspace `setup` creates is
+    # provisioning, and provisioning belongs to the host: RFC-0095 D1 (never
+    # inside a checkout, so no second checkout can own it) and D2 (version-keyed,
+    # so 3.7 and 4.4 coexist and a project pinning either still builds).
+    #
+    # An ALREADY-provisioned checkout tree keeps resolving — it is still on the
+    # ladder — so this moves where the NEXT install goes rather than orphaning
+    # anything today.
+    nros_zephyr_ws_store_dir "$version"
 }
 
 # The first candidate that IS a workspace, in its canonical spelling.


### PR DESCRIPTION
W1 built the store arm and left it last, marked *"the arm W4 will promote"*.
This promotes it (RFC-0095 D4) and moves the **install target** into the store:

```
$NROS_ZEPHYR_WORKSPACE  →  $NROS_STORE/workspaces/zephyr/<ver>  →  <checkout-relative>
```

A provisioned tree belongs to the **host**, not to one checkout — D1 (never
inside a checkout, so no second checkout can own it: the tier-2 blocker) and D2
(version-keyed, so 3.7 and 4.4 coexist and two checkouts share one copy).

## Nothing breaks on a host provisioned before this — measured, not argued

An absent candidate is skipped, so a populated `zephyr-workspace/` resolves
exactly as it did. On this host:

| | before | after |
|---|---|---|
| 3.7 resolved | `zephyr-workspace` | `zephyr-workspace` *(unchanged)* |
| 4.4 resolved | `../nano-ros-workspace-4.4` | `../nano-ros-workspace-4.4` *(unchanged)* |
| 3.7 default | `zephyr-workspace` | `$NROS_STORE/workspaces/zephyr/3.7` |
| 4.4 default | `../nano-ros-workspace-4.4` | `$NROS_STORE/workspaces/zephyr/4.4` |

The store starts mattering the first time `setup` runs, which is when it becomes
the answer. The **checkout arm stays, last**, on purpose: a host provisioned
earlier keeps working with no migration step, and a contributor patching a
Zephyr module still points at their own tree (D4 keeps this arm deliberately).

Ladder **order** is asserted directly rather than inferred from a resolve —
store above both checkout arms on both version lines, and an override ends the
ladder. My first harness didn't isolate the checkout (the script anchors to its
own repo root), so the order assertion is what actually backs the claim.

## The data move is deliberately not here

Relocating 4.1 GB of provisioned source is `mv` plus a re-resolve on whichever
host runs it, and it is safe **at any time** precisely because the ladder now
prefers the store: a host that moves its tree is answered by the store arm, one
that does not is answered by the checkout arm, and neither needs this repo to
change again. The 140 GB of build output beside it belongs to whoever built it
and does not move.

## Still open — the last mechanism this phase needs

`[source.rosidl]` has `dest = "third-party/ros/rosidl"` and `dest` cannot name
the store, which is exactly why W3 had to **declare** `ros` an exception rather
than move it. One mechanism — store-aware `dest` in `nros-sdk-index.toml` —
serves every future `[source.*]`, not just rosidl.

## Note

Pushing this surfaced a stale `play_launch` submodule in my checkout, not a lock
problem: `just lock-update` initially proposed rewinding
`nros-launch-resolve/Cargo.lock` from rlm **v0.1.33 → v0.1.23**, because my
checkout was *behind* the recorded pin. `git submodule update` fixed the actual
cause and the lock needed **no change**. Not part of this diff.

`check-fast`: 286 gates ran, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZwZdvRHvXxozmr8KPsv82