### PR TITLE
docs(roadmap): archive phases 422, 431, 435 and 437 — every work item landed

### DIFF
--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -42,7 +42,7 @@ docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
 docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
 docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md:1080
 docs/issues/1186-executor-backing-latch-test-races-siblings.md:0417
-docs/roadmap/phase-431-ship-the-nros-binary.md:1110
+docs/roadmap/archived/phase-431-ship-the-nros-binary.md:1110
 docs/roadmap/phase-432-codegen-one-producer-many-packs.md:1080
 just/check/docs.just:1110
 scripts/build/rustdoc-set.sh:1110

--- a/docs/reference/retired-board-names.md
+++ b/docs/reference/retired-board-names.md
@@ -107,6 +107,6 @@ board, and its name must then not be an arch or an ISA alone.
 ## See also
 
 * [RFC-0093 — A board name states the reach of its build](../design/0093-board-naming-states-reach.md)
-* [phase-437 — rename every board to the reach its build has](../roadmap/phase-437-board-name-reach-rename.md)
+* [phase-437 — rename every board to the reach its build has](../roadmap/archived/phase-437-board-name-reach-rename.md)
 * [Supported boards](../../book/src/reference/supported-boards.md) — the
   user-facing table

--- a/docs/roadmap/archived/phase-422-provisioning-one-path.md
+++ b/docs/roadmap/archived/phase-422-provisioning-one-path.md
@@ -8,6 +8,8 @@ sweep and its ratchet arm), W4 (the nightly zephyr jobs walk the user path), W5
 W6 (the scope verb reports the system closure), W7 (the additive board entries
 plus the gate), W8 (scoped to `infra`).
 
+**Archived 2026-09-10 — the one open decision is closed.** W7's deferred question (which board vocabulary is canonical) was answered by RFC-0093 and applied by [phase-437](phase-437-board-name-reach-rename.md), which collapsed the two namespaces with a rule — a board name states the reach of its build — and landed `check-board-vocabulary` at zero mirrored pairs. The paragraph below is kept as the record of why it was deferred.
+
 **OPEN BY DECISION, not by omission:** W7's true unification — the index
 namespace is what users type while the cmake namespace is what the build uses,
 and neither is obviously the one to keep. That is the only one left: W2's
@@ -358,7 +360,7 @@ finding them: `[prereq.*]` OS packages are a different class with a different
 rule — composing the install command is nano-ros's job and running it is the
 user's (RFC-0062), which `check-sysdep-remedies` enforces. The audit did find
 one thing worth recording there, filed as
-[#1128](../issues/archived/1128-prereq-apt-name-is-distro-parametric-and-the-index-cannot-say-so.md)
+[#1128](../../issues/archived/1128-prereq-apt-name-is-distro-parametric-and-the-index-cannot-say-so.md)
 and **fixed**: `just ci provision-zenohd` composed
 `ros-${ROS_DISTRO}-rmw-zenoh-cpp` itself because the index could only spell one
 distro, and the two agreed only on humble. `{ros_distro}` makes the parameter

--- a/docs/roadmap/archived/phase-431-ship-the-nros-binary.md
+++ b/docs/roadmap/archived/phase-431-ship-the-nros-binary.md
@@ -2,15 +2,15 @@
 
 **Status (2026-09-06). Every work item is landed.** No release has been cut:
 W5 is manual dispatch, and cutting one is a decision, not a consequence — the distribution
-mechanics proper. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
+mechanics proper. [Phase-429](../phase-429-the-codegen-version-is-enforced-everywhere.md)
 removed the correctness blocker; what remains is distribution mechanics plus one
 hazard that shipping CREATES and that is worth fixing before the first release
 rather than after.
 
-**Implements:** [RFC-0014](../design/0014-nros-setup-toolchain-management.md)
+**Implements:** [RFC-0014](../../design/0014-nros-setup-toolchain-management.md)
 (provisioning) extended to the CLI itself, and
-[RFC-0040](../design/0040-distribution-and-scaffolding-deps.md).
-**Unblocks:** [#0171](../issues/archived/0171-no-external-distribution-path.md)'s
+[RFC-0040](../../design/0040-distribution-and-scaffolding-deps.md).
+**Unblocks:** [#0171](../../issues/archived/0171-no-external-distribution-path.md)'s
 D1/D2 — *"ship the `nros` CLI as an installable artifact … the single
 highest-leverage unlock"*, blocked since phase-287/288.
 **Depends on:** phase-429, which answers *can this binary's output work with this

--- a/docs/roadmap/archived/phase-435-provisioning-resolves-by-axis.md
+++ b/docs/roadmap/archived/phase-435-provisioning-resolves-by-axis.md
@@ -2,7 +2,7 @@
 
 **Status (2026-09-06). Every work item landed.** W1–W5 complete; the two axes
 that already worked were left alone. Implements
-[RFC-0062 amendment 4](../design/0062-unified-dependency-ssot.md), which answers
+[RFC-0062 amendment 4](../../design/0062-unified-dependency-ssot.md), which answers
 phase-413 W6 (rosdep parity) and closes the `ros-<distro>` question phase-422
 left open.
 

--- a/docs/roadmap/archived/phase-437-board-name-reach-rename.md
+++ b/docs/roadmap/archived/phase-437-board-name-reach-rename.md
@@ -5,7 +5,7 @@
 mirrored pairs**. Nineteen `[board.*]` keys are fourteen (five duplicate pairs
 collapsed, the three W3 added kept). NOT verified: any build — see "What is
 unverified" at the end. Implements
-[RFC-0093](../design/0093-board-naming-states-reach.md). Nothing has moved yet;
+[RFC-0093](../../design/0093-board-naming-states-reach.md). Nothing has moved yet;
 the measurements below are from `main` at `9c0702322`.
 
 Phase-422 W7 made both board vocabularies RESOLVE and deferred the question of
@@ -383,7 +383,7 @@ not.
 retired name appears in the ledger with its replacement.
 
 **LANDED.** The ledger is
-[`docs/reference/retired-board-names.md`](../reference/retired-board-names.md),
+[`docs/reference/retired-board-names.md`](../../reference/retired-board-names.md),
 linked from RFC-0093 §4, from `docs/design/README.md`'s RFC-0093 row and from
 the book's CLI reference. It carries all eleven retired spellings (the nine
 index keys plus the two `mps2-an385` / `esp32-c3` bare names), the two fixture

--- a/docs/roadmap/phase-429-the-codegen-version-is-enforced-everywhere.md
+++ b/docs/roadmap/phase-429-the-codegen-version-is-enforced-everywhere.md
@@ -26,7 +26,7 @@ correctness question that blocked it since phase-287/288 — *can this binary's
 output work with this runtime?* — now has an answer asserted at every layer and a
 negative control proving each refusal fires. The remaining work is distribution,
 and it has its own home:
-[phase-431](phase-431-ship-the-nros-binary.md).
+[phase-431](archived/phase-431-ship-the-nros-binary.md).
 
 **Implements:** [RFC-0090](../design/0090-codegen-version-is-the-compatibility-token.md).
 **Closes:** the residue of [#1018](../issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md).


### PR DESCRIPTION
Four phases whose status line already said complete move to `docs/roadmap/archived/`.

| phase | why it is done |
| --- | --- |
| 422 | every item landed or open by decision; the one open decision (W7, which board vocabulary is canonical) was answered by RFC-0093 and applied by phase-437 — recorded in its status block |
| 431 | every item landed; cutting a release is a decision, not a work item |
| 435 | W1–W5 landed |
| 437 | W1–W7 landed; `check-board-name-reach` 0, `check-board-vocabulary` 0 |

**Phase-413 stays active** — its W2 acceptance is a green verdict from each lane, and `host-tests` and `run-matrix` are both still red (fixes in flight).

Links retargeted both ways: relative links inside the moved docs gain a level, the one active sibling (phase-429) gains `../`, and the two inbound links plus the prose-issue-ref baseline path follow the move.

Verified: `check-markdown-links` (786 live docs resolve, archived ratchet unchanged at 422), `check-doc-refs`, `check-roadmap-status`, `check-roadmap-boxes`, `check-roadmap-claims`, `check-prose-issue-refs` — all OK. Docs-only; pre-push `check-fast` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK