### PR TITLE
fix(phase-433 W5): the vendoring gate had one arm, and my submodule fix had one path — both are the class now

### DIFF
--- a/.github/workflows/live-peer.yml
+++ b/.github/workflows/live-peer.yml
@@ -102,7 +102,25 @@ jobs:
       - name: Check out the submodules the fixtures vendor
         id: submodules
         run: |
-          git submodule update --init --recursive third-party/dds/cyclonedds
+          # EVERY backend this lane builds, not the one that happened to fail
+          # first. Run 34443301413 fixed cyclonedds and then died on XRCE — the
+          # same requirement one backend over, because the fix had been aimed at
+          # the reported site instead of the class.
+          #
+          # The set is derived from the three build lines below: the workspace
+          # rows cover zenoh/cyclonedds/xrce, and each vendors its own C or C++
+          # source. `zenoh-pico`/`mbedtls` already arrive with the container
+          # image, and re-initialising them is a no-op that costs nothing and
+          # stops this list from depending on that staying true.
+          #
+          # NOT `submodules: recursive` on `actions/checkout` — that is all 20,
+          # including `PX4-Autopilot` and `qemu`, none of which this lane builds.
+          git submodule update --init --recursive \
+              third-party/dds/cyclonedds \
+              packages/rmw/xrce/xrce-sys/micro-xrce-dds-client \
+              packages/rmw/xrce/xrce-sys/micro-cdr \
+              packages/rmw/zenoh/zpico-sys/zenoh-pico \
+              packages/rmw/zenoh/zpico-sys/mbedtls
 
       # NOT "the fixtures those CELLS resolve", which is what this said until
       # 2026-09-09. `lane-stage.py` classifies a step by keyword, `cells` is the

--- a/scripts/build/workspace-fixtures-build.sh
+++ b/scripts/build/workspace-fixtures-build.sh
@@ -271,20 +271,52 @@ build_workspace() {
     # nros_board_linux`. Fail LOUD + actionable here instead. Scoped to the host:
     # the embedded cyclonedds lanes (freertos/threadx/zephyr) have their own
     # graceful idlc/submodule skips and must not be turned into hard failures.
-    case "$defs" in
-        *NROS_RMW=cyclonedds*)
-            if [ "$platform" = "linux" ] && \
-               [ ! -e "$repo_root/third-party/dds/cyclonedds/CMakeLists.txt" ]; then
-                echo "ERROR: workspace fixture '$id' requires the cyclonedds submodule," >&2
-                echo "       which is not checked out (third-party/dds/cyclonedds is empty)." >&2
-                echo "       This fixture vendors C++ CycloneDDS by design and cannot build" >&2
-                echo "       without it. Run:" >&2
-                echo "         nros setup --source cyclonedds-src" >&2
-                echo "       (or: git submodule update --init --recursive third-party/dds/cyclonedds)" >&2
-                return 2
-            fi
-            ;;
-    esac
+    # ONE gate over every vendoring backend, not one arm per backend. The
+    # cyclonedds arm was written alone (issue 0120) and the reason it gives —
+    # "the build otherwise fails DEEP and cryptically" — is a property of
+    # VENDORING, not of cyclonedds. XRCE vendors the same way and had no arm,
+    # so on 2026-09-10 the live-peer lane died in a `build.rs` panic four frames
+    # down:
+    #
+    #   thread 'main' panicked at nros-rmw-xrce-cffi/build.rs:129:13:
+    #   vendored `micro-xrce-dds-client` source root .../src/c is missing or
+    #   has no .c files
+    #
+    # which is exactly the failure this gate exists to replace with a sentence
+    # naming the fix. Issue-0196's shape: the gate's REACH was narrower than the
+    # rule it enforces.
+    #
+    # Scoped to the host: the embedded lanes (freertos/threadx/zephyr) have
+    # their own graceful idlc/submodule skips and must not become hard failures.
+    if [ "$platform" = "linux" ]; then
+        _wf_rmw=""
+        case "$defs" in
+            *NROS_RMW=cyclonedds*) _wf_rmw=cyclonedds ;;
+            *NROS_RMW=xrce*)       _wf_rmw=xrce ;;
+            *NROS_RMW=zenoh*)      _wf_rmw=zenoh ;;
+        esac
+        case "$_wf_rmw" in
+            cyclonedds) _wf_probe=third-party/dds/cyclonedds/CMakeLists.txt
+                        _wf_dir=third-party/dds/cyclonedds
+                        _wf_src="nros setup --source cyclonedds-src" ;;
+            xrce)       _wf_probe=packages/rmw/xrce/xrce-sys/micro-xrce-dds-client/CMakeLists.txt
+                        _wf_dir=packages/rmw/xrce/xrce-sys/micro-xrce-dds-client
+                        _wf_src="" ;;
+            zenoh)      _wf_probe=packages/rmw/zenoh/zpico-sys/zenoh-pico/CMakeLists.txt
+                        _wf_dir=packages/rmw/zenoh/zpico-sys/zenoh-pico
+                        _wf_src="" ;;
+            *)          _wf_probe="" ;;
+        esac
+        if [ -n "$_wf_probe" ] && [ ! -e "$repo_root/$_wf_probe" ]; then
+            echo "ERROR: workspace fixture '$id' requires the $_wf_rmw submodule," >&2
+            echo "       which is not checked out ($_wf_dir is empty)." >&2
+            echo "       This fixture vendors $_wf_rmw by design and cannot build" >&2
+            echo "       without it. Run:" >&2
+            [ -n "$_wf_src" ] && echo "         $_wf_src" >&2
+            echo "         git submodule update --init --recursive $_wf_dir" >&2
+            return 2
+        fi
+    fi
 
     # `codegen_out` is required for the BAKE path (`nros codegen-system`). A
     # pure-cargo `nros::main!` entry bakes the system at proc-macro expansion


### PR DESCRIPTION
Run [34443301413](https://github.com/NEWSLabNTU/nano-ros/actions/runs/34443301413) got past cyclonedds and died on XRCE:

```
thread 'main' panicked at nros-rmw-xrce-cffi/build.rs:129:13:
vendored `micro-xrce-dds-client` source root .../src/c is missing or has no .c files
```

Two separate one-site fixes, both mine to answer for.

## The lane

#808 added `git submodule update --init --recursive third-party/dds/cyclonedds` — the submodule the error happened to name. But the lane builds **zenoh, cyclonedds and xrce** rows, and each backend vendors its own C/C++ source, so the requirement was never cyclonedds-specific. All five are initialised now, derived from the three build lines the lane actually runs.

Deliberately **not** `submodules: recursive` on `actions/checkout` — that is all 20, including `PX4-Autopilot` and `qemu`, none of which this lane builds. `zenoh-pico`/`mbedtls` already arrive with the container image; re-initialising them is a no-op that costs nothing and stops the list from depending on that staying true.

## The gate

`workspace-fixtures-build.sh` has carried a dependency gate since issue 0120, and its comment states its own reason: an absent vendored submodule makes *"the build otherwise fail DEEP and cryptically"*. That reason is a property of **vendoring**, not of cyclonedds — but the gate was written with a single `*NROS_RMW=cyclonedds*` arm.

XRCE vendors the same way, had no arm, and failed exactly as the comment predicted: four frames down in a build script, naming a path instead of a fix. Issue-0196's shape again — the gate's reach narrower than the rule it enforces.

One gate over all three host backends now, each with its own probe path and remedy line. Still scoped to `linux`: the embedded lanes have graceful idlc/submodule skips and must not become hard failures.

## One thing not changed, recorded because it cost time

`check-submodule-pinned-locks` was red here for a reason that is **not a defect**: `ros-launch-manifest` v0.1.33 is a git-tag dep absent from this host's cargo cache, and the PATH shim injects `--locked`, so resolution failed under `--offline`. One fetch and the gate is green with no file touched.

A cold cache and a stale lock look identical through that gate — worth knowing before anyone reaches for `just lock-update` on it.

## Verification

`just check fast` green, 0 failures. `lane-stage.py --selftest` 60/60.

What this does not prove: that the cells run. It removes the next known blocker — same as #808 did, one backend over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
