### PR TITLE
feat(phase-440 W7, RFC-0095 D8/D9): the pin is per-project, and the launcher reads it before clap

### DIFF
--- a/.github/workflows/release-nros.yml
+++ b/.github/workflows/release-nros.yml
@@ -143,6 +143,14 @@ jobs:
           cp packages/cli/target/release/nros "$stage/bin/nros"
           printf '%s\n' '${{ inputs.version }}' >"$stage/share/nros/VERSION"
           cp nros-sdk-index.toml "$stage/share/nros/nros-sdk-index.toml"
+          # phase-440 W7 / RFC-0095 D8 job 2: the launcher fetches a pinned
+          # toolchain by running THIS installer, so the fetch has one
+          # implementation rather than a Rust reimplementation of "which asset,
+          # which checksum, which prefix". `orchestration::dispatch` looks for
+          # it at exactly this path and refuses (naming the remedy) when an
+          # asset predating this line does not carry it.
+          cp scripts/install.sh "$stage/share/nros/install.sh"
+          chmod +x "$stage/share/nros/install.sh"
           # Prefix-rooted, the mirror shape every other dist in the index uses,
           # so `sdk_store::execute`'s default unpack lands it unchanged.
           tar --zstd -cf "$RUNNER_TEMP/nros-linux-x86_64.tar.zst" -C "$stage" bin share

--- a/docs/design/0095-nros-store-is-the-root.md
+++ b/docs/design/0095-nros-store-is-the-root.md
@@ -296,9 +296,12 @@ environment that shares `$HOME` needs a hand-set `NROS_HOME`.
 * **Store sharing across users on one machine.** `~/.nros` is per-user; a CI
   host with two accounts provisions everything twice. A shared read-only store
   with a per-user overlay is the usual answer; out of scope here.
-* **Where the pin lives for a multi-package workspace.** One
-  `nros-toolchain.toml` at the workspace root is the obvious shape, but it must
-  survive `nros build` invoked from a subdirectory.
+* ~~**Where the pin lives for a multi-package workspace.**~~ **ANSWERED
+  (phase-440 W7).** One `nros-toolchain.toml` at the workspace root, found by
+  walking UP from wherever the build was invoked — the walk `cargo` does for a
+  workspace root and the one `store::discover_pin_files` already did for the
+  reclaim verbs. `nros build` from a subdirectory therefore uses the root pin
+  and does not write a second one beside itself.
 * ~~**What a release artifact contains.**~~ **ANSWERED by the tree, not by this
   RFC.** `scripts/install.sh` (phase-431 W4) already downloads a versioned
   `.tar.zst` into `$NROS_HOME/sdk/nros/<version>` and fronts it via the

--- a/docs/roadmap/phase-440-nros-store-is-the-root.md
+++ b/docs/roadmap/phase-440-nros-store-is-the-root.md
@@ -258,6 +258,49 @@ generated code through the existing input signature (#182) rather than a second
 mechanism; rollback re-downloads nothing. The shim keeps working when older than
 its toolchain — tested, not assumed.
 
+**LANDED.** `orchestration::pin` is the file, `orchestration::dispatch` is the
+launcher, and it runs from `main` **before clap** — that ordering is what "older
+than what it launches" means in code, not a style choice, and
+`an_older_launcher_execs_the_newer_pinned_toolchain` proves it by handing the
+launcher a flag its OWN clap would reject and asserting the stub received it.
+Four things worth recording, each of which a reading-only implementation would
+have got wrong:
+
+* **The pin names the STORE version (`0.5.0-nros1`), never the crate version
+  (`0.5.0`).** Its whole job is to name a directory, so
+  `pin::running_version` reads it off the running binary's own store prefix —
+  both `toolchains/<v>` and today's `sdk/nros/<v>`, because D2's rename has not
+  happened and a launcher taught only the new name recognises no installed host.
+  A binary in NEITHER shape (a contributor's `packages/cli/target/**` build)
+  has no store version and pins NOTHING, loudly. Inventing one would write a
+  pin whose next build dispatches to a directory nobody can create.
+* **`write` refuses to overwrite, and that is the D9 half easy to leave out.**
+  "Write the version it used" on every build moves the pin on every
+  `nros self update` — the silent rebuild D7 exists to forbid.
+* **D8 job 2 delegates to `scripts/install.sh`, which the release asset now
+  carries at `share/nros/install.sh`** (`release-nros.yml`, one `cp`). A Rust
+  downloader would be a second answer to "which asset, which checksum, which
+  prefix", in the one place that cannot see the store accumulate — the same
+  argument `cmd::sdk_front` already makes for the front. An asset predating that
+  staging carries no installer and REFUSES, naming the pin, the paths it looked
+  in and the `install.sh --version <v>` line; that is the arm the real-binary
+  test exercises, because a copied binary brings no `share/`.
+* **A dispatched child is marked (`NROS_TOOLCHAIN_DISPATCH=<version>`).** A
+  store entry whose directory name disagrees with the binary inside it is
+  otherwise an exec loop — the one failure mode a launcher must not have.
+
+The stale/ownership guard is untouched (RFC-0095 D5, and this phase's own
+non-goal). Dispatch reaches the same conclusion independently and at a different
+seam: it declines whenever `abi_guard::find_monorepo_root` answers, so a
+contributor never meets it.
+
+*Still open, and named rather than implied:* the acceptance line's "a pin bump
+re-stales generated code through #182" is ARGUED, not measured — #182 keys the
+contributor path on the source stamp, and the user path would key on the
+toolchain version, which is the same machinery pointed at a different input but
+has no test on this side of the line. Two projects building side by side needs a
+real release asset, so it belongs with W8's remaining user-path probe.
+
 ### W8 — the one-line installer — **ALREADY LANDED (phase-431 W4)**
 
 `curl -fsSL …/scripts/install.sh | sh` exists and is gated by

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "clap_complete",
  "eyre",
  "nros-cli-core",
+ "tempfile",
 ]
 
 [[package]]

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -871,7 +871,42 @@ pub fn run(args: Args) -> Result<()> {
     crate::abi_guard::check_workspace(&guard_anchor, crate::abi_guard::Verb::Build)?;
 
     let plans = plan_builds(&args)?;
+    pin_this_project(&args)?;
     drive(&plans, args.dry_run, &mut perform)
+}
+
+/// RFC-0095 D9 — the first `nros build` writes the pin it used and says so.
+///
+/// AFTER planning and BEFORE the handoff, and both halves are deliberate. After,
+/// because a directory that turns out not to be a workspace should not be left
+/// carrying a toolchain pin; before, because stage 5 `exec`s and nothing can run
+/// after it (issue 1206's lesson, one line over).
+///
+/// `--dry-run` writes nothing: a flag whose whole promise is "print, change
+/// nothing" cannot be the thing that pins a project.
+///
+/// The workspace root is resolved the same way [`plan_builds`] resolves it. It
+/// is deliberately NOT a second walk: the pin belongs beside the workspace the
+/// build actually ran on, and `pin::find` then walks UP from there, which is how
+/// `nros build` from a subdirectory finds a root-level pin rather than writing a
+/// second one.
+fn pin_this_project(args: &Args) -> Result<()> {
+    if args.dry_run {
+        return Ok(());
+    }
+    let root = match &args.workspace {
+        Some(w) => w.clone(),
+        None => std::env::current_dir().wrap_err("resolving cwd as the workspace root")?,
+    };
+    let root = std::fs::canonicalize(&root).unwrap_or(root);
+    let Ok(exe) = std::env::current_exe() else {
+        return Ok(());
+    };
+    let outcome = crate::orchestration::pin::pin_on_first_build(&root, &exe)?;
+    if let Some(line) = crate::orchestration::pin::describe(&outcome) {
+        eprintln!("{line}");
+    }
+    Ok(())
 }
 
 /// How one plan's native command reaches the operating system.

--- a/packages/cli/nros-cli-core/src/orchestration/dispatch.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/dispatch.rs
@@ -1,0 +1,275 @@
+//! The launcher: read the pin, ensure that toolchain, `exec` it (RFC-0095 D8,
+//! phase-440 W7).
+//!
+//! ```text
+//!   $NROS_STORE/bin/nros   ->  sdk/nros/<newest>/bin/nros     the launcher
+//!                              read nros-toolchain.toml
+//!                              ensure sdk/nros/<pinned>
+//!                              exec  sdk/nros/<pinned>/bin/nros "$@"
+//! ```
+//!
+//! D8 states the whole design in one line — *"1. read the pin; 2. ensure that
+//! toolchain exists; 3. `exec` it. Everything else lives in the toolchain's own
+//! binary. A shim that does more becomes a shim-versus-toolchain compatibility
+//! matrix, which is the problem it exists to avoid — and it must keep working
+//! when it is OLDER than what it launches."*
+//!
+//! ## What "older than what it launches" forces
+//!
+//! It forces the decision to happen BEFORE clap. An older launcher does not
+//! know the newer toolchain's flags, subcommands, or defaults, so anything it
+//! parses it can get wrong, and anything it gets wrong it gets wrong for a
+//! binary that would have got it right. So [`redispatch`] runs at the top of
+//! `main`, reads only `nros-toolchain.toml` and the process's own path, and
+//! forwards `argv` byte for byte. There is no arm in this module that inspects
+//! a subcommand. That is the property [`decide`] exists to make testable.
+//!
+//! ## When it does nothing at all, and why each case
+//!
+//! * **the running binary is not a store toolchain** — a contributor's
+//!   `packages/cli/target/**` build. It has no store version ([`pin::running_version`]),
+//!   so there is no "am I already the pinned one?" to answer and no launcher
+//!   role to play. This also means a contributor never meets dispatch by
+//!   accident;
+//! * **the cwd is inside a nano-ros checkout** — RFC-0095 D0: a contributor's
+//!   nano-ros is their clone at whatever HEAD is, and D5's ownership guard
+//!   already refuses a foreign binary there. Dispatching would fight it;
+//! * **no pin** — the project floats; `nros build` will write one (D9) and the
+//!   binary that writes it is the one that runs;
+//! * **the pin names this binary** — the common steady state, and the one that
+//!   must cost nothing: one `stat` of the pin file and no exec;
+//! * **`NROS_TOOLCHAIN_DISPATCH` is already set** — we ARE the exec'd
+//!   toolchain. Without this a pin naming a version whose directory holds a
+//!   binary that disagrees about its own version is an exec loop, which is the
+//!   one failure mode a launcher must not have.
+//!
+//! ## Ensure
+//!
+//! D6's second row makes fetching the toolchain automatic, *conditional on
+//! D8's release artifact* — a condition `scripts/install.sh` (phase-431 W4)
+//! already meets. So ensure DELEGATES to that installer rather than
+//! reimplementing "which asset, which checksum, which prefix" in Rust: the
+//! release asset carries it at `share/nros/install.sh`, and this runs it with
+//! `NROS_INSTALL_VERSION` set to the pin. One implementation of the fetch, the
+//! same argument `cmd::sdk_front` makes for one implementation of the front.
+//!
+//! A launcher whose asset predates that staging finds no installer and REFUSES,
+//! naming the pin, the paths it looked in, and the command that fixes it. That
+//! is RFC-0065 D2's shape, and it is the honest answer: a launcher that cannot
+//! fetch must not pretend the version is missing for some other reason.
+
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+use eyre::{Result, bail};
+
+use super::pin;
+
+/// Set on the child by [`redispatch`]. Its VALUE is the version that was asked
+/// for, so a child that finds it disagreeing with its own store version can say
+/// so rather than silently being the wrong toolchain.
+pub const DISPATCHED_ENV: &str = "NROS_TOOLCHAIN_DISPATCH";
+
+/// The deliberate-experiment escape hatch, in the same spelling family as
+/// `NROS_SKIP_STALE_CHECK`.
+pub const SKIP_ENV: &str = "NROS_SKIP_TOOLCHAIN_DISPATCH";
+
+/// Everything [`decide`] needs, gathered once so the decision itself touches no
+/// process state.
+#[derive(Clone, Debug)]
+pub struct Context {
+    /// The running binary.
+    pub exe: PathBuf,
+    /// Where the project is — the cwd, in production.
+    pub cwd: PathBuf,
+    /// The store root (`store::root()` in production).
+    pub store: PathBuf,
+    /// `$NROS_TOOLCHAIN_DISPATCH`, if set.
+    pub dispatched: Option<String>,
+    /// `$NROS_SKIP_TOOLCHAIN_DISPATCH` is set.
+    pub skip: bool,
+}
+
+/// What the launcher should do. Every arm names its reason, because "nothing
+/// happened" has five causes here and a user debugging one needs to know which.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Decision {
+    /// Carry on in this process. The `&'static str` is why.
+    Proceed(&'static str),
+    /// Replace this process with `bin`, which is the pinned toolchain.
+    Exec { version: String, bin: PathBuf },
+    /// The pin names a version this store does not have.
+    Missing {
+        version: String,
+        pin_path: PathBuf,
+        looked_in: Vec<PathBuf>,
+    },
+}
+
+/// The launcher decision — a pure function of [`Context`] and the filesystem.
+///
+/// Reads exactly two things off disk: whether a pin file exists on the walk up
+/// from `cwd`, and whether the pinned version's binary exists in the store. It
+/// never reads `argv`.
+pub fn decide(ctx: &Context) -> Result<Decision> {
+    if ctx.skip {
+        return Ok(Decision::Proceed("$NROS_SKIP_TOOLCHAIN_DISPATCH is set"));
+    }
+    if ctx.dispatched.is_some() {
+        return Ok(Decision::Proceed(
+            "this process IS the dispatched toolchain",
+        ));
+    }
+    // A checkout is the contributor audience (RFC-0095 D0). Asked before the
+    // pin, because an in-tree workspace may legitimately carry one for a test
+    // and it must not aim a contributor at the store.
+    if crate::abi_guard::find_monorepo_root(&ctx.cwd).is_some() {
+        return Ok(Decision::Proceed("the cwd is inside a nano-ros checkout"));
+    }
+    let Some((mine, _origin)) = pin::running_version(&ctx.exe) else {
+        return Ok(Decision::Proceed(
+            "this binary is not a store toolchain, so it is not a launcher",
+        ));
+    };
+    let Some(p) = pin::find_and_load(&ctx.cwd)? else {
+        return Ok(Decision::Proceed("this project names no toolchain"));
+    };
+    if p.version == mine {
+        return Ok(Decision::Proceed("the pin names this binary"));
+    }
+    match pin::installed_bin(&ctx.store, &p.version) {
+        Some(bin) => Ok(Decision::Exec {
+            version: p.version,
+            bin,
+        }),
+        None => Ok(Decision::Missing {
+            looked_in: pin::candidate_bins(&ctx.store, &p.version),
+            version: p.version,
+            pin_path: p.path,
+        }),
+    }
+}
+
+/// The installer this launcher's own release asset carries, if it carries one.
+///
+/// `<prefix>/share/nros/install.sh`, beside the `share/nros/VERSION` the asset
+/// already ships. Not a search of the filesystem and not `$PATH`: the installer
+/// that fetches a toolchain must be the one that came with this launcher, or
+/// "one implementation of the fetch" is not a claim this can make.
+#[must_use]
+pub fn bundled_installer(exe: &Path) -> Option<PathBuf> {
+    let prefix = exe.parent()?.parent()?;
+    let script = prefix.join("share").join("nros").join("install.sh");
+    script.is_file().then_some(script)
+}
+
+/// D8 job 2, performed: fetch the pinned toolchain through the installer that
+/// shipped with this launcher.
+///
+/// Returns the binary it installed. `Err` names the pin and the remedy — never
+/// a bare "not found", because at this point the user has a pin they wrote (or
+/// that `nros build` wrote for them) and a store that does not answer it, and
+/// the two commands that fix it are different.
+fn fetch(ctx: &Context, version: &str, pin_path: &Path, looked_in: &[PathBuf]) -> Result<PathBuf> {
+    let looked = looked_in
+        .iter()
+        .map(|p| format!("\n\x20     {}", p.display()))
+        .collect::<String>();
+    let Some(installer) = bundled_installer(&ctx.exe) else {
+        bail!(
+            "this project pins nano-ros {version} and the store does not have it.{looked}\n\
+             \x20   pinned by: {}\n\
+             This `nros` ships no installer, so it cannot fetch it. Install that \
+             version and build again:\n\
+             \x20   curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh \
+             | sh -s -- --version {version}",
+            pin_path.display()
+        );
+    };
+    eprintln!(
+        "nros: {version} is pinned by {} and not installed — fetching it ({})",
+        pin_path.display(),
+        installer.display()
+    );
+    let status = std::process::Command::new("sh")
+        .arg(&installer)
+        .arg("--version")
+        .arg(version)
+        .env("NROS_INSTALL_VERSION", version)
+        .status()
+        .map_err(|e| eyre::eyre!("running {}: {e}", installer.display()))?;
+    if !status.success() {
+        bail!(
+            "could not install the pinned nano-ros {version} ({} exited {status}).\n\
+             \x20   pinned by: {}\n\
+             Fix the pin, or install that version by hand.",
+            installer.display(),
+            pin_path.display()
+        );
+    }
+    pin::installed_bin(&ctx.store, version).ok_or_else(|| {
+        eyre::eyre!(
+            "the installer reported success but {version} is still not in the store.{looked}\n\
+             \x20   pinned by: {}",
+            pin_path.display()
+        )
+    })
+}
+
+/// The whole launcher, for production: gather, decide, act.
+///
+/// On success it either RETURNS (this process continues as the toolchain) or
+/// NEVER RETURNS (it has become the pinned one). Called from `main` before
+/// clap — see the module header for why that is not an optimisation.
+pub fn redispatch() -> Result<()> {
+    let Ok(exe) = std::env::current_exe() else {
+        return Ok(());
+    };
+    let Ok(cwd) = std::env::current_dir() else {
+        return Ok(());
+    };
+    let ctx = Context {
+        exe,
+        cwd,
+        store: super::store::root(),
+        dispatched: std::env::var(DISPATCHED_ENV).ok(),
+        skip: std::env::var_os(SKIP_ENV).is_some(),
+    };
+    let bin = match decide(&ctx)? {
+        Decision::Proceed(_) => return Ok(()),
+        Decision::Exec { bin, .. } => bin,
+        Decision::Missing {
+            version,
+            pin_path,
+            looked_in,
+        } => fetch(&ctx, &version, &pin_path, &looked_in)?,
+    };
+    let version = pin::running_version(&bin)
+        .map(|(v, _)| v)
+        .unwrap_or_default();
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    exec(&bin, &version, &args)
+}
+
+/// Become `bin`. Never returns on success.
+#[cfg(unix)]
+fn exec(bin: &Path, version: &str, args: &[OsString]) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    let err = std::process::Command::new(bin)
+        .args(args)
+        .env(DISPATCHED_ENV, version)
+        .exec();
+    Err(eyre::eyre!("exec {}: {err}", bin.display()))
+}
+
+#[cfg(not(unix))]
+fn exec(bin: &Path, version: &str, args: &[OsString]) -> Result<()> {
+    let status = std::process::Command::new(bin)
+        .args(args)
+        .env(DISPATCHED_ENV, version)
+        .status()
+        .map_err(|e| eyre::eyre!("run {}: {e}", bin.display()))?;
+    std::process::exit(status.code().unwrap_or(1));
+}

--- a/packages/cli/nros-cli-core/src/orchestration/mod.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/mod.rs
@@ -11,6 +11,9 @@ pub mod bridge_gen;
 pub mod cargo_metadata_schema;
 pub mod cmake_preset;
 pub mod config;
+/// phase-440 W7 (RFC-0095 D8) — the launcher: read the pin, ensure that
+/// toolchain, `exec` it. Three jobs; a fourth is a bug.
+pub mod dispatch;
 pub mod facade;
 /// phase-383 W1 — `[image.<id>]`, the buildable unit (RFC-0065 D6).
 pub mod image;
@@ -30,6 +33,8 @@ pub mod model_ingest;
 pub mod names;
 pub mod nros_config;
 pub mod params;
+/// phase-440 W7 (RFC-0095 D7/D9) — `nros-toolchain.toml`, the per-project pin.
+pub mod pin;
 pub mod plan;
 pub mod planner;
 pub mod prereq_resolve;

--- a/packages/cli/nros-cli-core/src/orchestration/pin.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/pin.rs
@@ -1,0 +1,392 @@
+//! `nros-toolchain.toml` — the per-project pin (phase-440 W7, RFC-0095 D7/D9).
+//!
+//! The user-audience twin of `rust-toolchain.toml`: a file beside a project
+//! that names which nano-ros builds it. Its shape mirrors Rust's deliberately,
+//! because the question it answers is the same one and a reader who knows the
+//! other should not have to learn a second idiom:
+//!
+//! ```toml
+//! [toolchain]
+//! version = "0.5.0-nros1"
+//! ```
+//!
+//! ## Which version string this is, and why it matters
+//!
+//! The STORE prefix (`0.5.0-nros1`), not the crate version `nros --version`
+//! prints (`0.5.0`). They differ by the `-nrosN` repackaging counter, and
+//! `scripts/install.sh` already had to state the same distinction for the same
+//! reason: the pin's whole job is to name a directory — `toolchains/<version>`
+//! (RFC-0095 D2) or today's `sdk/nros/<version>` — so a pin in the other
+//! spelling names nothing.
+//!
+//! [`running_version`] therefore reads the version off the running binary's own
+//! store PREFIX, or out of the `share/nros/VERSION` the release asset carries,
+//! and never off the crate version. A binary that is in neither shape — a
+//! contributor's `packages/cli/target/**` build — has no store version, and
+//! this module says so rather than inventing one. Pinning a version that is not
+//! in any store is worse than not pinning: the next build dispatches to a
+//! directory nobody can create.
+//!
+//! ## Pin on first build (D9)
+//!
+//! > A project with no `nros-toolchain.toml` floats, which for embedded output
+//! > is a reproducibility bug waiting to be discovered on someone else's
+//! > machine.
+//!
+//! So the first `nros build` WRITES the pin it used and says so — the
+//! `Cargo.lock` rule of issues 0359/0378, one layer up. [`write`] refuses to
+//! overwrite, which is the other half of that rule: a pin moves only when a dev
+//! means it. Nothing in this crate calls [`write`] on an existing file, so
+//! `nros self update` — which moves the fronted binary and nothing else
+//! (RFC-0095 D7) — cannot move a pin even by accident.
+//!
+//! ## What W6 already assumed about this file
+//!
+//! `store::PIN_FILE_NAMES` names `nros-toolchain.toml` and reads any file it
+//! does not have a schema for as generic TOML, taking every string value at any
+//! depth as a version rule (see `store::load_pin_file`). That was written
+//! before this schema existed, deliberately, so that W7 could not disarm the
+//! delete guard by picking a key name W6 did not guess. The schema above stays
+//! inside that envelope: `version` is a string value, so
+//! `nros toolchain uninstall` sees it without being taught anything.
+
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr, bail};
+use serde::Deserialize;
+
+/// The pin file's name. `store::PIN_FILE_NAMES` names the same constant, so
+/// there is one spelling of it in the crate.
+pub const FILE_NAME: &str = "nros-toolchain.toml";
+
+/// The `[toolchain]` table.
+#[derive(Debug, Deserialize)]
+struct PinFile {
+    toolchain: ToolchainTable,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolchainTable {
+    version: String,
+}
+
+/// A pin that was found and read.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Pin {
+    /// The file it came from — printed in every message, because "which pin"
+    /// is the first question when two projects disagree.
+    pub path: PathBuf,
+    /// The store version it names.
+    pub version: String,
+}
+
+/// The nearest `nros-toolchain.toml` at or above `start`.
+///
+/// Ancestors, not just `start`: RFC-0095's own open question — *"one
+/// `nros-toolchain.toml` at the workspace root is the obvious shape, but it
+/// must survive `nros build` invoked from a subdirectory"* — and this is the
+/// answer. Same walk `cargo` does for a workspace root, and the same one
+/// `store::discover_pin_files` already does for the reclaim verbs.
+#[must_use]
+pub fn find(start: &Path) -> Option<PathBuf> {
+    for dir in start.ancestors() {
+        let candidate = dir.join(FILE_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Read one pin file.
+///
+/// A file that exists and cannot be read as this schema is an ERROR, never an
+/// absent pin — the same asymmetry `store::load_pin_file` states: "no pin" and
+/// "I could not tell" must not reach a caller as one value.
+pub fn load(path: &Path) -> Result<Pin> {
+    let raw = std::fs::read_to_string(path)
+        .wrap_err_with(|| format!("read the toolchain pin {}", path.display()))?;
+    let parsed: PinFile = toml::from_str(&raw).wrap_err_with(|| {
+        format!(
+            "parse the toolchain pin {} — it must carry\n\n    [toolchain]\n    version = \"<store version>\"\n",
+            path.display()
+        )
+    })?;
+    let version = parsed.toolchain.version.trim().to_string();
+    if version.is_empty() {
+        bail!(
+            "{} names an empty `[toolchain] version`. A pin with no version is \
+             not a floating project, it is an unreadable one — delete the file \
+             to float, or name a version.",
+            path.display()
+        );
+    }
+    Ok(Pin {
+        path: path.to_path_buf(),
+        version,
+    })
+}
+
+/// [`find`] then [`load`]. `Ok(None)` means "no pin here"; `Err` means "there
+/// is one and it is broken".
+pub fn find_and_load(start: &Path) -> Result<Option<Pin>> {
+    match find(start) {
+        Some(p) => load(&p).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// The file this writes, byte for byte. Split out so a test can assert the
+/// schema without a filesystem, and so the header lives in one place.
+#[must_use]
+pub fn render(version: &str) -> String {
+    format!(
+        "# nano-ros toolchain pin — written by `nros build` on the first build\n\
+         # of this project (RFC-0095 D9). It names the nano-ros that builds it,\n\
+         # the way `rust-toolchain.toml` names a Rust.\n\
+         #\n\
+         # It is SOURCE: commit it. Without it the build floats, and firmware\n\
+         # built from a floating toolchain is only reproducible by accident.\n\
+         #\n\
+         # To move it, edit this line. Nothing else does — `nros self update`\n\
+         # moves the launcher and no pin (RFC-0095 D7), so an update never\n\
+         # silently rebuilds your image with a different codegen.\n\
+         [toolchain]\n\
+         version = \"{version}\"\n"
+    )
+}
+
+/// Write a pin into `dir`. REFUSES if one is already there.
+///
+/// The refusal is the D9 half that is easy to leave out: writing "the version
+/// it used" every build would move a pin on every `nros self update`, which is
+/// exactly the silent rebuild D7 forbids.
+pub fn write(dir: &Path, version: &str) -> Result<PathBuf> {
+    let path = dir.join(FILE_NAME);
+    if path.exists() {
+        bail!(
+            "{} already exists — refusing to overwrite a pin. A pin moves only \
+             when a dev means it (issues 0359/0378, one layer up); edit the \
+             file to change it.",
+            path.display()
+        );
+    }
+    std::fs::write(&path, render(version))
+        .wrap_err_with(|| format!("write the toolchain pin {}", path.display()))?;
+    Ok(path)
+}
+
+/// How [`running_version`] learned the version — printed beside it, because a
+/// version with no provenance is a number a reader has to trust.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VersionOrigin {
+    /// The binary sits at `<store>/{toolchains,sdk/nros}/<version>/bin/nros`,
+    /// so the store itself named the version.
+    StorePrefix,
+    /// `<prefix>/share/nros/VERSION`, written into the release asset by
+    /// `.github/workflows/release-nros.yml` from `nros-sdk-index.toml`.
+    VersionFile,
+}
+
+impl VersionOrigin {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            VersionOrigin::StorePrefix => "store prefix",
+            VersionOrigin::VersionFile => "share/nros/VERSION",
+        }
+    }
+}
+
+/// The STORE version of the running binary, if it has one.
+///
+/// `None` for a checkout build (`packages/cli/target/**`) and for any other
+/// layout we do not model — which is the honest answer, not a gap: such a
+/// binary corresponds to no store entry, so there is nothing a pin naming it
+/// could dispatch to.
+///
+/// The store prefix wins over the VERSION file when both are available. They
+/// agree in every asset `install.sh` writes (it reads the file to CHOOSE the
+/// prefix), and where they could disagree the directory is the one that
+/// resolves.
+#[must_use]
+pub fn running_version(exe: &Path) -> Option<(String, VersionOrigin)> {
+    if let Some(v) = version_from_store_prefix(exe) {
+        return Some((v, VersionOrigin::StorePrefix));
+    }
+    let prefix = exe.parent()?.parent()?;
+    let file = prefix.join("share").join("nros").join("VERSION");
+    let raw = std::fs::read_to_string(file).ok()?;
+    let v = raw.trim().to_string();
+    if v.is_empty() {
+        return None;
+    }
+    Some((v, VersionOrigin::VersionFile))
+}
+
+/// `<version>` when `exe` is `<...>/toolchains/<version>/bin/nros` or
+/// `<...>/sdk/nros/<version>/bin/nros`.
+///
+/// Both spellings, because RFC-0095 D2's `toolchains/<version>` is a RENAME of
+/// the `sdk/nros/<version>` `scripts/install.sh` writes today and W7 is not the
+/// wave that performs it. A reader who only taught this the new name would have
+/// written a dispatcher that cannot recognise a single installed host.
+fn version_from_store_prefix(exe: &Path) -> Option<String> {
+    // .../<version>/bin/<exe>
+    let bin = exe.parent()?;
+    if bin.file_name()? != "bin" {
+        return None;
+    }
+    let version_dir = bin.parent()?;
+    let version = version_dir.file_name()?.to_str()?.to_string();
+    let category = version_dir.parent()?;
+    match category.file_name()?.to_str()? {
+        "toolchains" => Some(version),
+        "nros" if category.parent().and_then(Path::file_name)? == "sdk" => Some(version),
+        _ => None,
+    }
+}
+
+/// Where a pinned toolchain's binary would live under `root`, newest layout
+/// first. CONSTRUCTED from the version, never searched for — the
+/// `sdk_store::tool_dir` rule (issue 0625).
+#[must_use]
+pub fn candidate_bins(root: &Path, version: &str) -> Vec<PathBuf> {
+    vec![
+        root.join("toolchains")
+            .join(version)
+            .join("bin")
+            .join("nros"),
+        root.join("sdk")
+            .join("nros")
+            .join(version)
+            .join("bin")
+            .join("nros"),
+    ]
+}
+
+/// The first candidate that is actually there.
+#[must_use]
+pub fn installed_bin(root: &Path, version: &str) -> Option<PathBuf> {
+    candidate_bins(root, version)
+        .into_iter()
+        .find(|p| p.is_file())
+}
+
+/// What [`pin_on_first_build`] did, so the caller prints it and a test asserts
+/// it without reading stdout.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PinOutcome {
+    /// A pin was already there. Never touched.
+    Already(Pin),
+    /// D9's case: none existed, so one was written.
+    Wrote { path: PathBuf, version: String },
+    /// The workspace is inside a nano-ros checkout — the contributor audience
+    /// (RFC-0095 D0/D5), whose nano-ros is that clone at whatever HEAD is.
+    /// There is no version to name and nothing a pin would change.
+    InCheckout(PathBuf),
+    /// The running binary has no store version, so there is no honest version
+    /// to write. Reported, not silent: an unpinned project is D9's bug, and the
+    /// user needs to know they still have it.
+    NoRunningVersion,
+}
+
+/// RFC-0095 D9, performed.
+///
+/// `exe` is passed in rather than read from `current_exe()` so the decision is
+/// a pure function of two paths and its tests need no installed store on the
+/// host running them — the same argument `stale_guard::refuse_if_stale` makes
+/// for `workspace`, and `store_reclaim.rs` for the pin search directory.
+pub fn pin_on_first_build(workspace: &Path, exe: &Path) -> Result<PinOutcome> {
+    if let Some(root) = crate::abi_guard::find_monorepo_root(workspace) {
+        return Ok(PinOutcome::InCheckout(root));
+    }
+    if let Some(existing) = find_and_load(workspace)? {
+        return Ok(PinOutcome::Already(existing));
+    }
+    let Some((version, _origin)) = running_version(exe) else {
+        return Ok(PinOutcome::NoRunningVersion);
+    };
+    let path = write(workspace, &version)?;
+    Ok(PinOutcome::Wrote { path, version })
+}
+
+/// The line `nros build` prints for an outcome — one place, so the message and
+/// the decision cannot drift.
+#[must_use]
+pub fn describe(outcome: &PinOutcome) -> Option<String> {
+    match outcome {
+        PinOutcome::Already(p) => Some(format!(
+            "nros build: toolchain {} (pinned by {})",
+            p.version,
+            p.path.display()
+        )),
+        PinOutcome::Wrote { path, version } => Some(format!(
+            "nros build: pinned this project to nano-ros {version}\n\
+             \x20   wrote {}\n\
+             \x20   Commit it. It is what makes this build reproducible on \
+             another machine (RFC-0095 D9).",
+            path.display()
+        )),
+        // A contributor is told nothing: their nano-ros is the clone they are
+        // standing in, they know it, and a line on every build would be noise.
+        PinOutcome::InCheckout(_) => None,
+        PinOutcome::NoRunningVersion => Some(
+            "nros build: warning: this project is UNPINNED and this `nros` has no \
+             store version to pin it to.\n\
+             \x20   A floating toolchain builds different firmware on a different \
+             machine.\n\
+             \x20   Install a released nros (scripts/install.sh) and build again, \
+             or write nros-toolchain.toml yourself."
+                .to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_round_trips_through_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(dir.path(), "0.5.0-nros1").unwrap();
+        let pin = load(&path).unwrap();
+        assert_eq!(pin.version, "0.5.0-nros1");
+    }
+
+    #[test]
+    fn a_pin_with_no_version_is_an_error_not_an_absent_pin() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(FILE_NAME);
+        std::fs::write(&path, "[toolchain]\nversion = \"\"\n").unwrap();
+        assert!(load(&path).is_err());
+        // And a file that is not this schema at all.
+        std::fs::write(&path, "channel = \"stable\"\n").unwrap();
+        assert!(load(&path).is_err());
+    }
+
+    #[test]
+    fn store_prefix_beats_a_version_file_and_a_checkout_has_neither() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path();
+        for rel in ["toolchains/1.2.3-nros4", "sdk/nros/9.9.9-nros7"] {
+            let bin = store.join(rel).join("bin");
+            std::fs::create_dir_all(&bin).unwrap();
+            std::fs::write(bin.join("nros"), b"x").unwrap();
+        }
+        assert_eq!(
+            running_version(&store.join("toolchains/1.2.3-nros4/bin/nros")),
+            Some(("1.2.3-nros4".to_string(), VersionOrigin::StorePrefix))
+        );
+        assert_eq!(
+            running_version(&store.join("sdk/nros/9.9.9-nros7/bin/nros")),
+            Some(("9.9.9-nros7".to_string(), VersionOrigin::StorePrefix))
+        );
+        // A checkout build corresponds to no store entry.
+        let checkout = store.join("packages/cli/target/debug");
+        std::fs::create_dir_all(&checkout).unwrap();
+        std::fs::write(checkout.join("nros"), b"x").unwrap();
+        assert_eq!(running_version(&checkout.join("nros")), None);
+    }
+}

--- a/packages/cli/nros-cli-core/src/orchestration/store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/store.rs
@@ -524,11 +524,12 @@ pub struct PinSource {
 
 /// The pin files this looks for, walking up from the working directory.
 ///
-/// `nros-toolchain.toml` is phase-440 W7's pin and does not exist yet; it is
-/// named here because W7 must not have to also teach the reclaim verbs about
-/// itself — a delete guard that learns about a new pin file one release LATE is
-/// a delete guard that deleted something.
-pub const PIN_FILE_NAMES: [&str; 3] = ["nros-toolchain.toml", "nros-sdk-index.toml", LOCK_FILE];
+/// `nros-toolchain.toml` was named here before phase-440 W7 wrote it, because
+/// W7 must not have to also teach the reclaim verbs about itself — a delete
+/// guard that learns about a new pin file one release LATE is a delete guard
+/// that deleted something. W7 landed and this now takes the name from
+/// [`super::pin::FILE_NAME`], so there is one spelling of it in the crate.
+pub const PIN_FILE_NAMES: [&str; 3] = [super::pin::FILE_NAME, "nros-sdk-index.toml", LOCK_FILE];
 
 /// Load one pin file, choosing the reader by NAME.
 ///

--- a/packages/cli/nros-cli-core/tests/toolchain_pin_dispatch.rs
+++ b/packages/cli/nros-cli-core/tests/toolchain_pin_dispatch.rs
@@ -1,0 +1,379 @@
+//! The per-project pin and the launcher that dispatches by it — phase-440 W7,
+//! RFC-0095 D7/D8/D9.
+//!
+//! Every test here builds a FAKE STORE in a tempdir and asks a pure function
+//! about it. Nothing reads `$NROS_HOME`, `$NROS_STORE` or the process working
+//! directory: the store root, the running-binary path and the project directory
+//! are all parameters, so these run in parallel with everything else and observe
+//! nothing global (issue 1101's hazard, and the rule `store_reclaim.rs` already
+//! follows one module over).
+//!
+//! The three properties the wave was asked to prove, and where:
+//!
+//! * a pin is written on first build and NOT moved by a second —
+//!   `first_build_writes_a_pin` + `a_second_build_does_not_move_the_pin`;
+//! * a pin is found from a SUBDIRECTORY — `a_pin_is_found_from_a_subdirectory`
+//!   and, through the launcher, `dispatch_finds_the_pin_from_a_subdirectory`;
+//! * a launcher OLDER than the toolchain it launches still dispatches —
+//!   `an_older_launcher_dispatches_to_a_newer_toolchain`.
+
+use std::path::{Path, PathBuf};
+
+use nros_cli_core::orchestration::{
+    dispatch::{self, Context, Decision},
+    pin::{self, PinOutcome},
+};
+
+/// A store entry that looks like one `scripts/install.sh` wrote: a prefix with
+/// `bin/nros` in it. Returns the binary path, which is what a launcher execs
+/// and what `pin::running_version` reads a version out of.
+fn install_toolchain(store: &Path, version: &str) -> PathBuf {
+    let bin = store.join("sdk").join("nros").join(version).join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let exe = bin.join("nros");
+    std::fs::write(&exe, b"#!/bin/sh\nexit 0\n").unwrap();
+    exe
+}
+
+/// A user's project: a directory with nothing nano-ros in it. Explicitly NOT a
+/// checkout — no `packages/core/nros-core/Cargo.toml` anywhere above it, which
+/// the tempdir root guarantees.
+fn project(dir: &Path, rel: &str) -> PathBuf {
+    let p = dir.join(rel);
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn ctx(exe: &Path, cwd: &Path, store: &Path) -> Context {
+    Context {
+        exe: exe.to_path_buf(),
+        cwd: cwd.to_path_buf(),
+        store: store.to_path_buf(),
+        dispatched: None,
+        skip: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// D9 — pin on first build
+// ---------------------------------------------------------------------------
+
+/// RFC-0095 D9's first half: a project with no pin gets one, naming the version
+/// that actually built it — read off the running binary's store prefix, not off
+/// the crate version, so the string names a directory.
+#[test]
+fn first_build_writes_a_pin() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    let outcome = pin::pin_on_first_build(&proj, &exe).unwrap();
+    let PinOutcome::Wrote { path, version } = outcome else {
+        panic!("expected a pin to be written, got {outcome:?}");
+    };
+    assert_eq!(version, "0.5.0-nros1");
+    assert_eq!(path, proj.join("nros-toolchain.toml"));
+    assert_eq!(pin::load(&path).unwrap().version, "0.5.0-nros1");
+}
+
+/// The half that is easy to leave out, and the reason D9 cites `Cargo.lock`:
+/// writing "the version it used" on EVERY build would move the pin the first
+/// time the launcher was updated, which is the silent rebuild RFC-0095 D7
+/// forbids. A second build with a DIFFERENT binary must leave the file alone.
+///
+/// This is also the `nros self update` invariant, tested at the only place that
+/// writes a pin: an update moves the fronted binary, which is exactly what the
+/// second `exe` below is.
+#[test]
+fn a_second_build_does_not_move_the_pin() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let old = install_toolchain(&store, "0.5.0-nros1");
+    let new = install_toolchain(&store, "0.6.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    pin::pin_on_first_build(&proj, &old).unwrap();
+    let before = std::fs::read_to_string(proj.join("nros-toolchain.toml")).unwrap();
+
+    let outcome = pin::pin_on_first_build(&proj, &new).unwrap();
+    let PinOutcome::Already(p) = &outcome else {
+        panic!("a second build must find the pin, not rewrite it: {outcome:?}");
+    };
+    assert_eq!(p.version, "0.5.0-nros1");
+    let after = std::fs::read_to_string(proj.join("nros-toolchain.toml")).unwrap();
+    assert_eq!(before, after, "the pin file changed on a second build");
+}
+
+/// `write` itself refuses, so the only-if-absent rule does not depend on every
+/// caller remembering to check first.
+#[test]
+fn write_refuses_to_overwrite_a_pin() {
+    let tmp = tempfile::tempdir().unwrap();
+    pin::write(tmp.path(), "0.5.0-nros1").unwrap();
+    let err = pin::write(tmp.path(), "9.9.9-nros9")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("refusing to overwrite"),
+        "expected a refusal naming the rule, got: {err}"
+    );
+    assert_eq!(
+        pin::load(&tmp.path().join("nros-toolchain.toml"))
+            .unwrap()
+            .version,
+        "0.5.0-nros1"
+    );
+}
+
+/// RFC-0095's own open question — *"it must survive `nros build` invoked from a
+/// subdirectory"*. One pin at the root, found from three levels down, and NOT a
+/// second pin written beside the subdirectory.
+#[test]
+fn a_pin_is_found_from_a_subdirectory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let root = project(tmp.path(), "my-robot");
+    let deep = project(tmp.path(), "my-robot/src/talker_pkg/src");
+
+    pin::pin_on_first_build(&root, &exe).unwrap();
+    let found = pin::find(&deep).expect("the walk up must reach the root pin");
+    assert_eq!(found, root.join("nros-toolchain.toml"));
+
+    let outcome = pin::pin_on_first_build(&deep, &exe).unwrap();
+    assert!(
+        matches!(outcome, PinOutcome::Already(_)),
+        "a build from a subdirectory must use the root pin, not write its own: {outcome:?}"
+    );
+    assert!(
+        !deep.join("nros-toolchain.toml").exists(),
+        "a second pin was written at {}",
+        deep.display()
+    );
+}
+
+/// A binary with no store version — a contributor's `packages/cli/target/**`
+/// build run outside its checkout — must not invent one. Pinning a version that
+/// is in no store is worse than floating: the next build dispatches to a
+/// directory nobody can create.
+#[test]
+fn a_binary_with_no_store_version_pins_nothing_and_says_so() {
+    let tmp = tempfile::tempdir().unwrap();
+    let exe = tmp.path().join("elsewhere/target/debug/nros");
+    std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+    std::fs::write(&exe, b"x").unwrap();
+    let proj = project(tmp.path(), "my-robot");
+
+    let outcome = pin::pin_on_first_build(&proj, &exe).unwrap();
+    assert_eq!(outcome, PinOutcome::NoRunningVersion);
+    assert!(!proj.join("nros-toolchain.toml").exists());
+    assert!(
+        pin::describe(&outcome).unwrap().contains("UNPINNED"),
+        "the user must be told they still have D9's bug"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// D8 — dispatch
+// ---------------------------------------------------------------------------
+
+/// The property the whole wave turns on (RFC-0095 D8): *"it must keep working
+/// when it is OLDER than what it launches"*.
+///
+/// The launcher is 0.5.0-nros1 — the version `$NROS_STORE/bin/nros` was fronted
+/// at before the newer one was installed. The project pins 0.6.0-nros1. The
+/// decision must be `Exec` at the NEWER binary, and it must be reached without
+/// parsing anything: `decide` takes no `argv`, which is what makes "older" a
+/// property this test can assert rather than a hope.
+#[test]
+fn an_older_launcher_dispatches_to_a_newer_toolchain() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_toolchain(&store, "0.5.0-nros1");
+    let newer = install_toolchain(&store, "0.6.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    pin::write(&proj, "0.6.0-nros1").unwrap();
+
+    let d = dispatch::decide(&ctx(&launcher, &proj, &store)).unwrap();
+    assert_eq!(
+        d,
+        Decision::Exec {
+            version: "0.6.0-nros1".to_string(),
+            bin: newer,
+        }
+    );
+}
+
+/// The steady state, and the one that must cost nothing: a launcher that IS the
+/// pinned version carries on in this process rather than exec'ing itself.
+#[test]
+fn the_pinned_launcher_runs_in_place() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    pin::write(&proj, "0.5.0-nros1").unwrap();
+
+    assert!(matches!(
+        dispatch::decide(&ctx(&exe, &proj, &store)).unwrap(),
+        Decision::Proceed(_)
+    ));
+}
+
+/// Dispatch answers the same subdirectory question the pin does — a user runs
+/// `nros build` from inside a package, not always from the workspace root.
+#[test]
+fn dispatch_finds_the_pin_from_a_subdirectory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_toolchain(&store, "0.5.0-nros1");
+    let newer = install_toolchain(&store, "0.6.0-nros1");
+    let root = project(tmp.path(), "my-robot");
+    let deep = project(tmp.path(), "my-robot/src/talker_pkg");
+    pin::write(&root, "0.6.0-nros1").unwrap();
+
+    assert_eq!(
+        dispatch::decide(&ctx(&launcher, &deep, &store)).unwrap(),
+        Decision::Exec {
+            version: "0.6.0-nros1".to_string(),
+            bin: newer,
+        }
+    );
+}
+
+/// The exec loop a launcher must not have. A store entry whose directory name
+/// disagrees with the binary inside it would otherwise dispatch to itself
+/// forever; the marker the child inherits ends it in one step.
+#[test]
+fn a_dispatched_child_never_dispatches_again() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_toolchain(&store, "0.5.0-nros1");
+    install_toolchain(&store, "0.6.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    pin::write(&proj, "0.6.0-nros1").unwrap();
+
+    let mut c = ctx(&launcher, &proj, &store);
+    c.dispatched = Some("0.6.0-nros1".to_string());
+    assert!(matches!(
+        dispatch::decide(&c).unwrap(),
+        Decision::Proceed(_)
+    ));
+}
+
+/// RFC-0095 D0/D5: a contributor inside a nano-ros checkout uses that clone's
+/// own build, pin or no pin. A pin sitting in an in-tree workspace — a fixture,
+/// a test, a user's project someone copied in — must not aim them at the store.
+#[test]
+fn a_checkout_is_never_dispatched_away_from() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_toolchain(&store, "0.5.0-nros1");
+    install_toolchain(&store, "0.6.0-nros1");
+    // The marker `abi_guard::find_monorepo_root` looks for.
+    let checkout = project(tmp.path(), "nano-ros");
+    std::fs::create_dir_all(checkout.join("packages/core/nros-core")).unwrap();
+    std::fs::write(
+        checkout.join("packages/core/nros-core/Cargo.toml"),
+        "[package]\nname = \"nros-core\"\n",
+    )
+    .unwrap();
+    let ws = project(tmp.path(), "nano-ros/examples/workspaces/rust");
+    pin::write(&ws, "0.6.0-nros1").unwrap();
+
+    let d = dispatch::decide(&ctx(&launcher, &ws, &store)).unwrap();
+    assert_eq!(
+        d,
+        Decision::Proceed("the cwd is inside a nano-ros checkout")
+    );
+    // And the same directory pins nothing, for the same reason.
+    assert!(matches!(
+        pin::pin_on_first_build(&ws, &launcher).unwrap(),
+        PinOutcome::InCheckout(_)
+    ));
+}
+
+/// A pin naming a version the store does not have is `Missing`, carrying the
+/// paths it looked in — never a silent proceed, which would build the project
+/// with the wrong toolchain and never say so.
+#[test]
+fn a_pin_the_store_cannot_answer_is_reported_with_the_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_toolchain(&store, "0.5.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    pin::write(&proj, "0.6.0-nros1").unwrap();
+
+    let Decision::Missing {
+        version, looked_in, ..
+    } = dispatch::decide(&ctx(&launcher, &proj, &store)).unwrap()
+    else {
+        panic!("an absent toolchain must be reported, not proceeded past");
+    };
+    assert_eq!(version, "0.6.0-nros1");
+    // Both layouts: RFC-0095 D2's `toolchains/<version>` and the
+    // `sdk/nros/<version>` `scripts/install.sh` writes today.
+    assert!(
+        looked_in
+            .iter()
+            .any(|p| p.starts_with(store.join("toolchains")))
+    );
+    assert!(looked_in.iter().any(|p| p.starts_with(store.join("sdk"))));
+}
+
+/// D8 job 2's implementation is the installer the asset carries, not a second
+/// downloader in Rust. Assert the path it is looked for at, in both directions
+/// — a release that stops staging it must break this test rather than degrade
+/// to a launcher that cannot fetch and does not say why.
+#[test]
+fn the_fetch_is_the_installer_the_asset_carries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    assert_eq!(dispatch::bundled_installer(&exe), None);
+
+    let share = exe.parent().unwrap().parent().unwrap().join("share/nros");
+    std::fs::create_dir_all(&share).unwrap();
+    std::fs::write(share.join("install.sh"), b"#!/bin/sh\n").unwrap();
+    assert_eq!(
+        dispatch::bundled_installer(&exe),
+        Some(share.join("install.sh"))
+    );
+}
+
+/// A project with no pin floats, and the launcher must be transparent about it
+/// rather than guessing a version. `nros build` is what ends that state (D9).
+#[test]
+fn an_unpinned_project_proceeds_in_the_running_binary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    assert_eq!(
+        dispatch::decide(&ctx(&exe, &proj, &store)).unwrap(),
+        Decision::Proceed("this project names no toolchain")
+    );
+}
+
+/// W6's `nros toolchain uninstall` reads any string value in this file as a
+/// version, deliberately, so that W7 could not disarm the delete guard by
+/// choosing a key it did not guess. The schema W7 chose stays inside that
+/// envelope — asserted here rather than assumed, because the failure mode is a
+/// toolchain somebody was using being deleted.
+#[test]
+fn w6s_delete_guard_still_sees_this_schema() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = pin::write(tmp.path(), "0.5.0-nros1").unwrap();
+    let source = nros_cli_core::orchestration::store::load_pin_file(&path).unwrap();
+    assert!(
+        source
+            .rules
+            .contains(&nros_cli_core::orchestration::store::PinRule::AnyVersion(
+                "0.5.0-nros1".to_string()
+            )),
+        "the reclaim verbs cannot see the pin: {:?}",
+        source.rules
+    );
+}

--- a/packages/cli/nros-cli/Cargo.toml
+++ b/packages/cli/nros-cli/Cargo.toml
@@ -27,3 +27,8 @@ clap = { workspace = true }
 clap_complete = "4.5"
 eyre = "0.6"
 nros-cli-core = { path = "../nros-cli-core" }
+
+[dev-dependencies]
+# `tests/toolchain_dispatch.rs` builds a fake store in a tempdir: the launcher
+# must be tested against a store that is NOT the developer's `~/.nros`.
+tempfile = "3.10"

--- a/packages/cli/nros-cli/src/main.rs
+++ b/packages/cli/nros-cli/src/main.rs
@@ -45,6 +45,18 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
+    // phase-440 W7 / RFC-0095 D8 — the launcher, BEFORE clap.
+    //
+    // Not an optimisation and not a style choice: D8 requires this binary to
+    // keep working when it is OLDER than the toolchain it launches, and an
+    // older binary does not know a newer one's flags. Anything parsed here
+    // could be parsed wrong on behalf of a binary that would have got it right,
+    // so nothing is parsed here — the decision reads `nros-toolchain.toml` and
+    // this process's own path, and `argv` is forwarded byte for byte.
+    //
+    // Returns when this process should carry on (no pin, the pin names it, a
+    // contributor's checkout, a non-store build); otherwise it never returns.
+    nros_cli_core::orchestration::dispatch::redispatch()?;
     let cli = Cli::parse();
     if cli.codegen_version {
         println!("{}", nros_cli_core::abi_guard::EMITTED_VERSION);

--- a/packages/cli/nros-cli/tests/toolchain_dispatch.rs
+++ b/packages/cli/nros-cli/tests/toolchain_dispatch.rs
@@ -1,0 +1,196 @@
+//! Dispatch as it actually happens — through the real `nros` binary
+//! (phase-440 W7, RFC-0095 D8).
+//!
+//! `nros-cli-core/tests/toolchain_pin_dispatch.rs` covers what the launcher
+//! DECIDES. This file covers whether the decision reaches an `exec`, and it is
+//! the only place that can answer the property D8 actually states:
+//!
+//! > it must keep working when it is OLDER than what it launches.
+//!
+//! The same argument `store_verbs.rs` makes one wave back — twelve tests passed
+//! while `nros toolchain uninstall` could not be invoked at all, because each of
+//! them constructed the `Args` and called `run`. A launcher that cannot exec is
+//! not a launcher.
+//!
+//! Shape: the REAL binary is installed as the launcher at
+//! `<store>/sdk/nros/0.5.0-nros1/bin/nros`, and a shell script stands in for the
+//! NEWER toolchain at `<store>/sdk/nros/0.6.0-nros1/bin/nros`. A script is the
+//! right stand-in and not a shortcut: what is being tested is that the launcher
+//! hands over to whatever is at the pinned path, and a script can PROVE what it
+//! received in a way a second copy of the same binary cannot.
+//!
+//! Cheap by construction: no fixtures, no provisioning, no network, and the
+//! store is a tempdir named by `$NROS_STORE`.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Install the real binary as the launcher for `version`.
+fn install_launcher(store: &Path, version: &str) -> PathBuf {
+    let bin = store.join("sdk/nros").join(version).join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let exe = bin.join("nros");
+    std::fs::copy(env!("CARGO_BIN_EXE_nros"), &exe).unwrap();
+    exe
+}
+
+/// A stand-in toolchain that reports what it was handed: its own name, then one
+/// line per argument. Written as a script so the assertions can be about the
+/// HANDOVER rather than about a second binary's behaviour.
+fn install_stub(store: &Path, version: &str) -> PathBuf {
+    let bin = store.join("sdk/nros").join(version).join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let exe = bin.join("nros");
+    std::fs::write(
+        &exe,
+        "#!/bin/sh\n\
+         echo \"STUB-TOOLCHAIN\"\n\
+         echo \"DISPATCH=${NROS_TOOLCHAIN_DISPATCH:-unset}\"\n\
+         for a in \"$@\"; do echo \"ARG=$a\"; done\n",
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&exe).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o755);
+    }
+    std::fs::set_permissions(&exe, perms).unwrap();
+    exe
+}
+
+fn pin(project: &Path, version: &str) {
+    std::fs::create_dir_all(project).unwrap();
+    std::fs::write(
+        project.join("nros-toolchain.toml"),
+        format!("[toolchain]\nversion = \"{version}\"\n"),
+    )
+    .unwrap();
+}
+
+/// Run `launcher` from `cwd` against `store`, with a clean-enough environment
+/// that no developer's real `~/.nros` or `$NROS_HOME` can decide the answer.
+fn run(launcher: &Path, cwd: &Path, store: &Path, args: &[&str]) -> (bool, String) {
+    let out = Command::new(launcher)
+        .args(args)
+        .current_dir(cwd)
+        .env("NROS_STORE", store)
+        .env_remove("NROS_HOME")
+        .env_remove("NROS_TOOLCHAIN_DISPATCH")
+        .env_remove("NROS_SKIP_TOOLCHAIN_DISPATCH")
+        .output()
+        .expect("failed to exec the launcher");
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.success(), text)
+}
+
+/// D8, end to end, through a real `exec`.
+///
+/// The argument is deliberately one the launcher's OWN clap would reject
+/// (`--a-flag-this-binary-does-not-have`). If dispatch happened after parsing,
+/// this invocation could not reach the stub at all — so a passing test is
+/// evidence for the ordering the module header claims, not only for the
+/// handover. It also proves `argv` is forwarded verbatim and that the child is
+/// marked, which is what stops an exec loop.
+#[test]
+fn an_older_launcher_execs_the_newer_pinned_toolchain() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store, "0.5.0-nros1");
+    install_stub(&store, "0.6.0-nros1");
+    let proj = tmp.path().join("my-robot");
+    pin(&proj, "0.6.0-nros1");
+
+    let (ok, text) = run(
+        &launcher,
+        &proj,
+        &store,
+        &["--a-flag-this-binary-does-not-have"],
+    );
+    assert!(ok, "the launcher did not hand over cleanly:\n{text}");
+    assert!(
+        text.contains("STUB-TOOLCHAIN"),
+        "the pinned toolchain never ran:\n{text}"
+    );
+    assert!(
+        text.contains("DISPATCH=0.6.0-nros1"),
+        "the child was not marked as dispatched, so it could exec again:\n{text}"
+    );
+    assert!(
+        text.contains("ARG=--a-flag-this-binary-does-not-have"),
+        "argv was not forwarded verbatim — so the decision was made after \
+         parsing, which is what D8 forbids:\n{text}"
+    );
+}
+
+/// The pin is found from a SUBDIRECTORY here too, through the real binary: a
+/// user runs `nros build` from inside a package as often as from the root.
+#[test]
+fn the_launcher_finds_the_pin_from_a_subdirectory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store, "0.5.0-nros1");
+    install_stub(&store, "0.6.0-nros1");
+    let proj = tmp.path().join("my-robot");
+    pin(&proj, "0.6.0-nros1");
+    let deep = proj.join("src/talker_pkg/src");
+    std::fs::create_dir_all(&deep).unwrap();
+
+    let (ok, text) = run(&launcher, &deep, &store, &["--version"]);
+    assert!(ok, "{text}");
+    assert!(
+        text.contains("STUB-TOOLCHAIN"),
+        "a build from a subdirectory did not reach the pinned toolchain:\n{text}"
+    );
+}
+
+/// An unpinned project runs in the launcher itself — the version it prints is
+/// the launcher's own, and no stub is reached even though one is installed.
+///
+/// The negative control for the test above: without it, a stub that never ran
+/// and a launcher that always dispatches would be indistinguishable.
+#[test]
+fn an_unpinned_project_runs_in_the_launcher() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store, "0.5.0-nros1");
+    install_stub(&store, "0.6.0-nros1");
+    let proj = tmp.path().join("my-robot");
+    std::fs::create_dir_all(&proj).unwrap();
+
+    let (ok, text) = run(&launcher, &proj, &store, &["--version"]);
+    assert!(ok, "{text}");
+    assert!(
+        !text.contains("STUB-TOOLCHAIN"),
+        "an unpinned project must not be dispatched anywhere:\n{text}"
+    );
+    assert!(text.contains("nros"), "expected a version line:\n{text}");
+}
+
+/// A pin the store cannot answer must REFUSE, naming the version and the pin
+/// file — never proceed silently in whatever binary happens to be fronted,
+/// which would build the project with a toolchain nobody chose.
+///
+/// This launcher carries no bundled installer (the copy above brings no
+/// `share/nros/install.sh`), so it is the refusal arm rather than the fetch
+/// arm — which is exactly the state an asset built before phase-440 W7 is in.
+#[test]
+fn a_pin_naming_an_absent_toolchain_refuses_and_names_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store, "0.5.0-nros1");
+    let proj = tmp.path().join("my-robot");
+    pin(&proj, "0.7.0-nros3");
+
+    let (ok, text) = run(&launcher, &proj, &store, &["--version"]);
+    assert!(!ok, "an unanswerable pin must not succeed:\n{text}");
+    assert!(text.contains("0.7.0-nros3"), "{text}");
+    assert!(text.contains("nros-toolchain.toml"), "{text}");
+    assert!(
+        text.contains("install.sh"),
+        "the refusal must name the remedy:\n{text}"
+    );
+}

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -141,6 +141,18 @@ KNOB_CLASS = {
     "NROS_ALLOW_INFRA_DEPS": ("infra", "policy flag"),
     "NROS_BOOT_REPORT": ("infra", "diagnostic toggle; a bool, so it has no rung"),
     "NROS_BUILD_ROOT": ("infra", "path"),
+    # phase-440 W7 — `orchestration::dispatch` SETS this on the installer it
+    # execs to fetch a pinned toolchain (RFC-0095 D8 job 2). Infra, and the
+    # decision the census forces is worth stating: it is not a size, not a
+    # sizing knob, and NOT ladder material either — a rung gives a global a
+    # per-platform default, and "which nano-ros version" is per-PROJECT
+    # (`nros-toolchain.toml`) rather than per-platform. Its owner is
+    # `scripts/install.sh`, which reads it; nothing here reads it back.
+    "NROS_INSTALL_VERSION": (
+        "infra",
+        "the version handed to scripts/install.sh when the launcher fetches a "
+        "pinned toolchain; the pin is per-project, so it has no rung",
+    ),
     # Issue 1102 — regenerates the entry-codegen goldens. A test-only escape
     # hatch, not a build input: it configures nothing about an image, and the
     # goldens it rewrites are compared byte-for-byte on every other run.


### PR DESCRIPTION
## What this is

**phase-440 W7** — the per-project pin and dispatch by it (RFC-0095 **D7/D8/D9**).

## The two thirds that already existed — VERIFIED, not restated

* `scripts/install.sh` downloads a versioned `.tar.zst` (`NROS_INSTALL_VERSION`,
  `NROS_INSTALL_URL`), checksum **mandatory**, into `$NROS_HOME/sdk/nros/<version>`,
  and fronts `$BIN/nros` through the binary's own `sdk-front --front bin/nros` —
  not a symlink the installer writes. Read at `scripts/install.sh:222`.
* The prefix name comes from `share/nros/VERSION` **inside** the asset, written by
  `release-nros.yml:144` from `[tool.nros] version` — so the store is already
  version-keyed for the CLI and **D8's condition is met**: auto-fetch is a
  download, not a ten-minute `cargo build`.
* W6's `store::load_pin_file` reads any file it has no schema for as generic TOML
  and takes every string value as a version rule, so W7 could pick a schema
  without disarming the delete guard. **Asserted, not assumed** —
  `w6s_delete_guard_still_sees_this_schema`.

## The missing half

**`orchestration::pin`** — `nros-toolchain.toml`, `[toolchain] version`, mirroring
`rust-toolchain.toml`. The version is the **store prefix** (`0.5.0-nros1`), never
the crate version (`0.5.0`): the pin's job is to name a directory. Read off the
running binary's own prefix, both `toolchains/<v>` and `sdk/nros/<v>` — D2's rename
has not happened, and a launcher taught only the new name recognises no installed
host. A binary in **neither** shape (a contributor's `packages/cli/target/**` build)
has no store version and pins **nothing**, loudly.

**D9 pin-on-first-build** in `nros build`: after planning (do not pin a directory
that is not a workspace), before the handoff (stage 5 execs). `--dry-run` writes
nothing. `write` **refuses to overwrite** — the half easy to leave out, since
"write the version it used" every build moves the pin on every `nros self update`.

**`orchestration::dispatch`** — the launcher, called from `main` **before clap**.
That is what "must keep working when it is OLDER than what it launches" means in
code: an older binary does not know a newer one's flags, so nothing is parsed and
`argv` is forwarded byte for byte. Job 2 delegates to `scripts/install.sh`, which
the asset now carries at `share/nros/install.sh` (one `cp`); a Rust downloader
would be a second answer to "which asset, which checksum, which prefix" in the one
place that cannot see the store accumulate. The child is marked
`NROS_TOOLCHAIN_DISPATCH=<version>` — otherwise a store entry whose directory name
disagrees with the binary inside it is an exec loop.

`store::PIN_FILE_NAMES` now takes the filename from `pin::FILE_NAME`: one spelling.

## The ownership guard is untouched

RFC-0095 D5 and this phase's own non-goal. `stale_guard.rs` is not in the diff.
Dispatch reaches the same conclusion independently at a different seam — it
declines whenever `abi_guard::find_monorepo_root` answers.

## Tests — 18, each verified by MUTATION

`nros-cli-core/tests/toolchain_pin_dispatch.rs` (14, pure decisions over a fake
store in a tempdir; no `$NROS_HOME`, no cwd) and `nros-cli/tests/toolchain_dispatch.rs`
(4, the **real binary** exec'ing a stub toolchain).

`an_older_launcher_execs_the_newer_pinned_toolchain` hands the launcher a flag its
OWN clap would reject and asserts the stub received it — so a pass is evidence for
the before-clap ordering, not only for the handover.

8 mutations, each red on exactly the tests that name it, with
`an_unpinned_project_runs_in_the_launcher` green throughout as the negative control:
the overwrite refusal, the ancestor walk, the existing-pin return, the checkout
guard, the dispatched-child guard, the version comparison, the store-prefix arm,
and the `redispatch()` call in `main`.

## Ran

* `just check fast` — **288 gates green**, 2 environmental skips. It caught one
  real thing: `config-knob-census` refused `NROS_INSTALL_VERSION` as unclassified,
  now classified `infra` with the reason (per-PROJECT, so it has no ladder rung).
  The other two initial reds were uninitialised zenoh-pico/xrce submodules in the
  agent worktree; initialised, both green.
* `cargo nextest run --workspace` in `packages/cli` — 1393 pass. One red,
  `fixture_workspace_plans_and_checks`, refusing on an uninitialised `play_launch`
  submodule (issue 0409's rule working, pre-existing, not this diff).
* `cargo clippy --workspace --all-targets` clean; `cargo +nightly fmt`.

## Left open, named rather than implied

The acceptance line's *"a pin bump re-stales generated code through #182"* is
**argued, not measured**: #182 keys the contributor path on the source stamp and
the user path would key on the toolchain version — same machinery, different input,
no test on this side. Two projects building side by side needs a real release
asset, so both belong with W8's remaining user-path probe. Recorded in the phase doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZwZdvRHvXxozmr8KPsv82
