### PR TITLE
ci: `workspace-all` moves to the pull-request lane, where its failures cost one PR

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -617,8 +617,9 @@ jobs:
       # THE ARRANGEMENT, phase-395. This job is ONE required status context and
       # it deliberately does DIFFERENT WORK per event:
       #
-      #   pull_request  ->  check-fast + compile-smoke + cli-tests  ~5 min
-      #   merge_group   ->  + test-unit + workspace-all             per BATCH
+      #   pull_request  ->  check-fast + compile-smoke + cli-tests
+      #                     + workspace-all                         ~5 min
+      #   merge_group   ->  + test-unit                             per BATCH
       #   schedule      ->  + check-build, no-std — the full tier, daily
       #
       # NOTE `check-build` is schedule/dispatch ONLY. It was on the merge group
@@ -1084,12 +1085,38 @@ jobs:
       # merge-gating event before and could never pass there, which is what
       # `check-lane-contracts` now enforces.
       #
-      # merge_group, deliberately NOT pull_request: same "PR cheap, batch
-      # thorough" split as `test-unit` above. A surprise here ejects a batch,
-      # which is visible and recoverable; on the PR lane it would block every
-      # pull request at once.
+      # ON THE PULL-REQUEST LANE SINCE 2026-09-10, reversing this step's own
+      # earlier reasoning. That reasoning was: "same `PR cheap, batch thorough`
+      # split as `test-unit` above. A surprise here ejects a batch, which is
+      # visible and recoverable; on the PR lane it would block every pull
+      # request at once." Both halves were re-measured and neither survived.
+      #
+      # NOT CHEAP-VERSUS-EXPENSIVE. This step is **28 s** on the runner
+      # (07:39:56 -> 07:40:24 on run 34449411245) inside a `check` job that
+      # takes ~9 minutes. `test-unit` in the same job is 3 m 37 s and
+      # `test-lane-contracts` 1 m 15 s. Grouping it with `test-unit` under one
+      # cost argument was the error: it is ~5 % of the lane, not a tier.
+      #
+      # "VISIBLE AND RECOVERABLE" UNDERCOUNTS BY THE BATCH. An ejection is not
+      # one PR's problem: `grouping_strategy` is ALLGREEN and
+      # `max_entries_to_build` is 5, so a failing entry takes its batch-mates
+      # down and they rebuild. Measured over 2026-09-09/10, when exactly two
+      # entries were at fault: #741 was ejected 8 times, #768 and #779 7 times
+      # each, with no defect of their own. One of the two culprits was a single
+      # `clippy::derivable_impls` error THIS STEP catches — it cost a batch of
+      # five, where on the PR lane it costs one 28 s run.
+      #
+      # "WOULD BLOCK EVERY PULL REQUEST AT ONCE" is a claim about a break that
+      # is already on `main` — a toolchain bump surfacing new `-D warnings`
+      # lints is the real case (CLAUDE.md says so). But that blocks everything
+      # either way: on `merge_group` nothing merges, it just fails later and
+      # louder. Running here does not create that failure mode, it relocates
+      # the report to the PR that caused it.
+      #
+      # `test-unit` deliberately STAYS on the batch lane: 3 m 37 s per push is
+      # the cost "PR cheap, batch thorough" was actually written for.
       - name: just check workspace-all (feature combinations)
-        if: ${{ contains(fromJSON('["merge_group","schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
+        if: ${{ contains(fromJSON('["pull_request","merge_group","schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |
           source ./activate.sh
           just check workspace-all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,9 +99,15 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     **CI runs a SUBSET of it, deliberately, and the subset DIFFERS BY EVENT**
     (phase-395 "PR cheap, batch thorough"; phase-396/399). On `pull_request` the
     required `CI` context is `check-fast` + `check-submodule-commits-reachable` +
-    `check-compile-smoke` + `check-cli-tests`. **`test-unit` is NOT in it** — it
-    runs on `merge_group` (and schedule/dispatch), where it costs a measured
-    ~3.5 min per batch instead of per PR push. So a green `CI` on a pull request
+    `check-compile-smoke` + `check-cli-tests` + `check-workspace-all`.
+    **`test-unit` is NOT in it** — it runs on `merge_group` (and
+    schedule/dispatch), where it costs a measured ~3.5 min per batch instead of
+    per PR push. **`workspace-all` moved the other way on 2026-09-10**, out of
+    the batch lane and onto the PR: it is 28 s against `test-unit`'s 3.5 min, so
+    it never belonged under the same cost argument, and a feature-combination
+    break there costs a batch rather than a PR — `grouping_strategy` is ALLGREEN
+    over 5 entries, so one `clippy::derivable_impls` error took #741, #768 and
+    #779 down 7-8 times each with no defect of their own. So a green `CI` on a pull request
     means "it compiles and the source gates hold", NOT "the unit tests pass";
     nothing broken lands, because the queue runs them before the merge, but the
     feedback arrives at the queue and an ejection is how you hear about it


### PR DESCRIPTION
`workspace-all` runs on `merge_group` today. This moves it to the pull-request lane as well, so a feature-combination break costs one PR instead of a batch.

## The step argued against this, and I re-measured both halves

Its own comment said:

> merge_group, deliberately NOT pull_request: same "PR cheap, batch thorough" split as `test-unit` above. A surprise here ejects a batch, which is visible and recoverable; on the PR lane it would block every pull request at once.

**It is not the expensive half.** 28 seconds on the runner — 07:39:56 → 07:40:24 on run `34449411245` — inside a `check` job that takes about nine minutes. In that same job `test-unit` is 3 m 37 s and `test-lane-contracts` 1 m 15 s. Grouping this with `test-unit` under one cost argument was the error: it is ~5 % of the lane, not a tier. **`test-unit` stays on the batch lane**, because 3.5 min per push is the cost that argument was actually written for.

**"Visible and recoverable" undercounts by the batch.** `grouping_strategy` is ALLGREEN and `max_entries_to_build` is 5, so a failing entry takes its batch-mates with it and they rebuild against a base that is no longer happening. Measured across 2026-09-09/10, when exactly two entries were ever at fault:

| PR | ejections | own defect? |
|---|---|---|
| #741 | 8 | no |
| #768 | 7 | no |
| #779 | 7 | no |

One of the two culprits was a single `clippy::derivable_impls` error that **this step catches** (#462, `AliveState`), and it cost a batch of five. On the PR lane it costs one 28-second run.

**"Would block every pull request at once"** is a claim about a break already on `main` — a toolchain bump surfacing new `-D warnings` lints is the real instance, and CLAUDE.md warns about it. But that blocks everything either way: on `merge_group` nothing merges, it just fails later and more expensively. Running here does not create that failure mode, it relocates the report to the PR that caused it.

## Why it is eligible for an affordability tier

The step resolves no prebuilt fixture and no generated binding. That is the rule `check-build` broke when it sat on the merge group and could never pass there, and `check-lane-contracts` enforces it — it passes with this change: 15 test targets, 18 CI lane invocations, none resolving an artifact its job does not build.

## Also in this commit

CLAUDE.md enumerates the required `CI` context on a pull request. It would be wrong the moment this lands, so it is updated here rather than left to drift.

## Verified

Workflow parses. `lane-contracts`, `gate-lists`, `workflow-doctor-after-setup`, `doc-refs`, `doc-recipe-refs`, `issue-ids`, `prose-issue-refs` all OK. `just check fast` 288/290 — the two reds are `capability-conditionals` and `xrce-vendored-versions`, which refuse in a fresh worktree for want of a checked-out submodule and `nros setup --source` trees; `capability-conditionals` passes once zenoh-pico is populated.

**This PR is its own first test**: `workspace-all` should now appear in its own `check` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
