### PR TITLE
fix(host-tests): the CI image had no rmw_cyclonedds_cpp, so both cyclone ros2 cells could never pass

### DIFF
--- a/ci/docker/ci-base/Dockerfile
+++ b/ci/docker/ci-base/Dockerfile
@@ -106,6 +106,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         `# by NO workflow, on any event. That is how phase-421's two` \
         `# serialization_format accessors landed unledgered.` \
         ros-humble-example-interfaces \
+        ros-humble-rmw-cyclonedds-cpp \
+        `# ^ the STOCK Cyclone RMW the interop cells talk to. ros-base does` \
+        `# not carry it: rmw-implementation depends on "rmw-fastrtps-cpp |` \
+        `# rmw-cyclonedds-cpp | rmw-connextdds" and apt takes the first, so` \
+        `# /opt/ros/humble/lib had librmw_fastrtps_cpp.so and nothing else.` \
+        `# check-rmw-cyclonedds's two ros2 cells (ros2_pubsub_e2e,` \
+        `# ros2_srv_e2e) then failed on EVERY host-tests run that reached` \
+        `# them -- the ros2 peer died in rcl on "librmw_cyclonedds_cpp.so:` \
+        `# cannot open shared object file" and the cells spent 126 s and` \
+        `# 600 s on deadlines. Same package docker/ros-editions installs.` \
+        `# Installs into /opt/ros/humble only; its hooks touch only` \
+        `# AMENT_PREFIX_PATH and PATH, so the ENV snapshot above holds.` \
+        ros-humble-demo-nodes-cpp \
+        `# ^ the stock add_two_ints_server ros2_srv_e2e's B.2 sub-case calls` \
+        `# (nros client -> stock server). Without it B.2 printed "SKIP" and` \
+        `# the cell still passed, so that direction had never run in CI.` \
     && rm -rf /var/lib/apt/lists/*
 
 # uv (Python 3.12 venvs) + just (recipe runner) via their canonical installers.

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_e2e_common.sh
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_e2e_common.sh
@@ -199,3 +199,67 @@ nros_export_cyclone_config() {
     echo "  bus pinned to loopback (issue 1009; NROS_DDS_ALLOW_LAN=1 to opt out)"
     return 0
 }
+
+# The ros2 PEER must be able to load the RMW this cell names. That is a
+# precondition, not a delivery result, so it is asked up front and fails in
+# milliseconds with the cause -- instead of surfacing as a deadline expiring.
+#
+# Measured on host-tests (run 34432822434, and every run that reached these
+# cells since 2026-09-08): `ghcr.io/newslabntu/nano-ros-ci:humble` is `FROM
+# ros:humble-ros-base`, and apt satisfies `ros-humble-rmw-implementation`'s
+# `rmw-fastrtps-cpp | rmw-cyclonedds-cpp | rmw-connextdds` with the FIRST
+# alternative, so that image had no `librmw_cyclonedds_cpp.so`. Every `ros2`
+# invocation died in rcl with "RMW implementation not installed" and nothing
+# said so until a deadline ran out: 126 s for the pub/sub cell, 600 s for the
+# service cell, whose log showed only the server's "timeout waiting for
+# request" -- the client's dlopen error was never printed at all.
+#
+# The probe is a real dlopen, through the SAME LD_LIBRARY_PATH the scripts give
+# the ros2 CLI, because that is the operation rcl performs
+# (`rcpputils::SharedLibrary("lib<rmw>.so")`). A file-existence check would be
+# a second opinion about the loader's search rules; this asks the loader. The
+# ament index is read only afterwards, to say WHICH cause it is: not installed
+# (a provisioning gap in the image or host), or installed but not loadable from
+# this path (issue 0774's class -- the environment, not the package).
+#
+# FAILS, never skips: a cell that cannot run in an image is a red on that
+# image, not a green (CLAUDE.md, "tests must fail on unmet preconditions").
+#
+# Usage: `nros_require_ros2_rmw_loadable <rmw> <ld-library-path>`. Returns 1,
+# having printed the FAIL reason, when the library does not load.
+nros_require_ros2_rmw_loadable() {
+    local rmw="$1" ld_path="$2"
+    local lib="lib${rmw}.so"
+    local err=""
+    local rc=0
+    err=$(env LD_LIBRARY_PATH="$ld_path" python3 -c \
+        'import ctypes, sys; ctypes.CDLL(sys.argv[1])' "$lib" 2>&1) || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "  ros2 peer can load $lib"
+        return 0
+    fi
+
+    local prefix
+    local installed=""
+    local -a prefixes=()
+    IFS=':' read -r -a prefixes <<< "${AMENT_PREFIX_PATH:-}"
+    for prefix in "${prefixes[@]}"; do
+        [ -n "$prefix" ] || continue
+        if [ -e "$prefix/share/ament_index/resource_index/packages/$rmw" ]; then
+            installed="$prefix"
+            break
+        fi
+    done
+
+    echo "FAIL: precondition -- the ros2 peer cannot load $lib (RMW_IMPLEMENTATION=$rmw)"
+    if [ -n "$installed" ]; then
+        echo "  $rmw IS installed (ament prefix $installed), but $lib does not load"
+        echo "  with the LD_LIBRARY_PATH the ros2 CLI is given here:"
+        echo "    ${ld_path:-<empty>}"
+    else
+        echo "  $rmw is not installed in any AMENT_PREFIX_PATH prefix (${AMENT_PREFIX_PATH:-<unset>})."
+        echo "  Install it -- on apt: ros-${ROS_DISTRO:-<distro>}-${rmw//_/-}"
+    fi
+    echo "  loader: $(printf '%s\n' "$err" | tail -n 1)"
+    return 1
+}

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_pubsub_e2e.sh
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_pubsub_e2e.sh
@@ -7,8 +7,10 @@
 #   1. nano-ros publisher → `ros2 topic echo` (consumer)
 #   2. `ros2 topic pub` (producer) → nano-ros subscriber
 #
-# Skips cleanly with [SKIPPED] (exit 0) when /opt/ros/humble or
-# rmw_cyclonedds_cpp aren't on PATH.
+# Skips with [SKIPPED] (exit 0) when /opt/ros/humble or the ros2 CLI is
+# absent. FAILS at once when the ros2 peer cannot load rmw_cyclonedds_cpp
+# (`nros_require_ros2_rmw_loadable`): this header used to promise a skip there
+# too, nothing implemented it, and the cell timed out instead.
 #
 # Required env (set by the CTest harness):
 #   NROS_RMW_CYCLONEDDS_PUB_BIN   absolute path to ros2_pub binary
@@ -110,6 +112,10 @@ NROS_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
 ROS_LD_LIBRARY_PATH="${LD_LIBRARY_PATH#*build/install/lib:}"
 ros2_run() { LD_LIBRARY_PATH="$ROS_LD_LIBRARY_PATH" ros2 "$@"; }
 nros_run() { LD_LIBRARY_PATH="$NROS_LD_LIBRARY_PATH" "$@"; }
+
+# Asked BEFORE either deadline starts, through the path the CLI will actually
+# get. See the helper for the host-tests measurement that put it here.
+nros_require_ros2_rmw_loadable "$RMW_IMPLEMENTATION" "$ROS_LD_LIBRARY_PATH" || exit 1
 
 failed=0
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_srv_e2e.sh
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_srv_e2e.sh
@@ -6,8 +6,10 @@
 #
 #   1. nano-ros service server ↔ `ros2 service call` (stock client)
 #
-# Skips cleanly with [SKIPPED] (exit 0) when /opt/ros/humble or
-# rmw_cyclonedds_cpp aren't on PATH.
+# Skips with [SKIPPED] (exit 0) when /opt/ros/humble or the ros2 CLI is
+# absent. FAILS at once when the ros2 peer cannot load rmw_cyclonedds_cpp
+# (`nros_require_ros2_rmw_loadable`): this header used to promise a skip there
+# too, nothing implemented it, and the cell timed out instead.
 
 set -u
 
@@ -64,6 +66,10 @@ ros2 daemon stop >/dev/null 2>&1 || true
 NROS_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
 ROS_LD_LIBRARY_PATH="${LD_LIBRARY_PATH#*build/install/lib:}"
 
+# Asked BEFORE the server starts, through the path the CLI will actually get.
+# See the helper for the host-tests measurement that put it here.
+nros_require_ros2_rmw_loadable "$RMW_IMPLEMENTATION" "$ROS_LD_LIBRARY_PATH" || exit 1
+
 failed=0
 
 echo "=== 117.12.B.1: ros2 service call → nros server ==="
@@ -86,13 +92,38 @@ timeout 15 env LD_LIBRARY_PATH="$ROS_LD_LIBRARY_PATH" \
     > "$CALL_OUT" 2>&1
 CALL_RC=$?
 
-# Server should reply + exit on its own. Give it a moment.
-wait $SRV_PID
+# The server's own budget is 600 s (`ros2_srv_server.cpp`). Waiting that out
+# is right only while a client might still call. Once `ros2 service call` has
+# RETURNED -- replied, errored, or been killed by `timeout` -- the one request
+# this sub-case sends has either reached the server or never will, so the
+# server gets a short grace to reply and exit and is then stopped. The bare
+# `wait` this replaces cost 600 s on every host-tests run, for a CLI that had
+# died within its first second.
+NROS_E2E_SERVER_GRACE_S="${NROS_E2E_SERVER_GRACE_S:-10}"
+srv_grace_deadline=$(( SECONDS + NROS_E2E_SERVER_GRACE_S ))
+while kill -0 "$SRV_PID" 2>/dev/null && [ "$SECONDS" -lt "$srv_grace_deadline" ]; do
+    sleep 0.2
+done
+srv_abandoned=0
+if kill -0 "$SRV_PID" 2>/dev/null; then
+    srv_abandoned=1
+    kill "$SRV_PID" 2>/dev/null || true
+fi
+wait "$SRV_PID"
 SRV_RC=$?
 
 if [ "$SRV_RC" -ne 0 ]; then
-    echo "  FAIL: nros server exited rc=$SRV_RC"
+    if [ "$srv_abandoned" -eq 1 ]; then
+        echo "  FAIL: nros server still had no request ${NROS_E2E_SERVER_GRACE_S}s after the client returned; stopped it"
+    else
+        echo "  FAIL: nros server exited rc=$SRV_RC"
+    fi
+    echo "    --- nros server ---"
     sed 's/^/    /' "$SERVER_OUT"
+    # The CLIENT is usually why the server saw nothing, and this branch never
+    # printed it -- which is how a dead `ros2` CLI read as a server timeout.
+    echo "    --- ros2 service call (rc=$CALL_RC) ---"
+    sed 's/^/    /' "$CALL_OUT"
     failed=$((failed + 1))
 elif [ "$CALL_RC" -ne 0 ]; then
     echo "  FAIL: ros2 service call exited rc=$CALL_RC"


### PR DESCRIPTION
## Root cause
`ghcr.io/newslabntu/nano-ros-ci:humble` is built `FROM ros:humble-ros-base`, whose `ros-humble-rmw-implementation` depends on `fastrtps | cyclonedds | connextdds` — apt takes the first. The public base image ships `librmw_fastrtps_cpp.so` and **no** Cyclone RMW, and `ci/docker/ci-base/Dockerfile` added only `example-interfaces`. Not the 0774/1137 loader-path class: both scripts source `/opt/ros/humble/setup.bash` themselves.

`nros_rmw_cyclonedds_ros2_srv_e2e`'s 600 s is the same cause: the server's own deadline waiting for a request the dead `ros2` client never sent. The log hid the client's dlopen error because the server-failure branch never printed it.

These cells were first REACHED on 2026-09-08 (run 34278146099) and failed every run after — never green in this lane; earlier runs died before them.

## Changes
- `ci/docker/ci-base/Dockerfile` — add `ros-humble-rmw-cyclonedds-cpp` and `ros-humble-demo-nodes-cpp` (srv_e2e's second sub-case calls the stock `add_two_ints_server`; CI always skipped it).
- `ros2_e2e_common.sh` — one shared `nros_require_ros2_rmw_loadable`: dlopens `lib<rmw>.so` with the same `LD_LIBRARY_PATH` `ros2` gets, BEFORE any deadline, and FAILS in 0 s naming which it is (not installed vs installed-but-unloadable). Both script headers promised a skip that was never implemented; this fails instead, per CLAUDE.md.
- `ros2_pubsub_e2e.sh`, `ros2_srv_e2e.sh` — call it; srv stops the server 10 s after the client returns instead of 600 s, and prints the client output on server failure.

## Before / after (docker, public base + `example-interfaces` = the CI image's ROS set, fresh binaries)
| | pubsub | srv |
|---|---|---|
| CI-like image, old scripts | FAIL 124 s (CI log line-for-line) | FAIL 600 s |
| CI-like image, new scripts | FAIL 0 s "not installed … apt: ros-humble-rmw-cyclonedds-cpp" | FAIL 0 s |
| + the two packages | PASS 3 s | PASS 7 s, both sub-cases |

This host: `just check rmw-cyclonedds` 28/28.

## After merge
`images.yml` rebuilds `ci-base` on a push to main touching `ci/docker/ci-base/**`, so the merge republishes the image. Until the `humble` tag moves these cells fail in 0 s with the precondition message rather than 126 s + 600 s.

**New coverage, unmeasured in this image:** once tier1 gets past `check build`, `rust-rtos-link-check` and `test-all` run in this lane for the first time, and the Rust cyclone interop tests that currently skip on the absent RMW start running. A next red there is progress, not a regression.

Local: `check fast` 287/287, `cli-tests`, `api-parity`, `test-lane-contracts`, `test-unit` (1236 pass). `check build` stopped on a FreeRTOS `stack_bytes` red that was on the base; it is fixed on current main by #1250.

Part of phase-413 W2 (each lane green once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK