### PR TITLE
fix(tier2, #1253): the Zephyr lane checked images it did not build, and compiled another checkout's module

### DIFF
--- a/docs/issues/1253-zephyr-workspace-manifest-binds-foreign-module.md
+++ b/docs/issues/1253-zephyr-workspace-manifest-binds-foreign-module.md
@@ -1,0 +1,137 @@
+---
+id: 1253
+title: "A Zephyr workspace compiles the nano-ros MODULE of whichever checkout
+  provisioned it — tier 2 built another checkout's headers beside this tree's
+  entries, and judged images no run of this tree made"
+status: open
+type: bug
+area: ci, zephyr, build
+related: [issue-1158, phase-440, phase-431, rfc-0095, rfc-0079]
+---
+
+## Problem
+
+`run-matrix` (tier 2) produced no verdict for eight straight runs; the last
+seven stopped in `just build tier2`, in the Zephyr family. They did not all stop
+on the same thing, and none of the failure texts named the real cause:
+
+| run (2026-09) | SHA | stopped at |
+| --- | --- | --- |
+| 06, 06, 07 | efb6db9 / a7c92da / 055b843 | `this nros does not belong to the checkout` — the phase-431 W1 guard, checkout `/mnt/evo/…/nano-ros` |
+| 08, 08, 10 | 3e96069 / 6e7779b / **b5097a4** | `tier-priority-plan-image: FAILED (160 pin-check(s) over 40 image(s))` after every leaf BUILT |
+| 09 | **b5097a4** | `build-cpp-action-server-xrce` compile, error line not in the printed tail |
+
+Same SHA, two different failures (09 vs 10): the lane's outcome depended on
+something outside the commit under test.
+
+That something is the runner's Zephyr workspace. It sits at
+`/mnt/evo/<user>/nano-ros/zephyr-workspace` — inside a SECOND nano-ros
+checkout — and the runner's checkout is `/home/<user>/actions-runner/_work/…`.
+Three consequences, only the first of which anything checked:
+
+1. **The CLI ownership guard** (phase-431 W1) refuses a `nros` from one tree
+   operating inside the other. `check-zephyr-workspace-checkout.sh` (f33c584)
+   front-runs it — but mirrors its silent cases exactly, including
+   `NROS_SKIP_STALE_CHECK=1` and "that checkout has no `packages/cli`". From
+   2026-09-08 neither the guard nor the front-run fired on the runner, so one of
+   those two became true there, and the lane went on building.
+
+2. **The nano-ros Zephyr MODULE comes from the workspace's west manifest, not
+   from the checkout that runs the build.** `.west/config` says
+   `[manifest] path = nano-ros`, a symlink to whichever checkout ran
+   `west init -l`; west lists it as the `nros` module
+   (`build-*/zephyr_modules.txt`: `"nros":"<ws>/nano-ros":"<ws>/nano-ros/zephyr"`),
+   and `zephyr/CMakeLists.txt` sets `NROS_REPO_DIR` to that module's parent. So
+   every image compiled `/mnt/evo`'s `zephyr/`, platform sources and nros-cpp
+   headers next to entry code the runner's CLI generated. Run 34319241943
+   printed `/mnt/evo/…/packages/api/nros-cpp/include/nros/main.hpp` inside
+   `build-cpp-action-server-xrce`, and failed; the next night, same SHA, it
+   built. A mixed tree is not a result about either tree. Nothing asked this
+   question — it does not depend on the CLI guard at all.
+
+3. **`check-tier-priority-plan-image.py` judged every `build-*/` in the
+   workspace**, not the images the run built. A shared, long-lived workspace
+   holds images from other trees and older commits; those still carrying the
+   pre-issue-0852 zenoh band (`CONFIG_NROS_ZENOH_READ_PRIORITY=16` on the old
+   0-31 scale → transport `[14, 14]`) fail the realtime workspaces' tier pins
+   (`9`, `10`), which pass against every freshly built image (`[4, 4]`,
+   pool `[5, 14]`). Reproduced on the dev host: its 72 images date from
+   2026-08-28 and ALL fail discovery mode, including leaves with no tiers.
+
+And behind all three, the printers showed tails only: the fixture fan-out's
+`tail -40` and the Zephyr scheduler's `tail -n 80`. Under a parallel ninja the
+failing unit's `error:` scrolls above the warnings every other in-flight unit
+keeps printing, so run 34319241943's "log tail" was eighty lines of
+`-Wunused-result` notes and no error. Issue 1158's rule — a lane's failure text
+must name the failure — one level down.
+
+## What landed (fix/tier2-zephyr-cpp-build)
+
+- `check-zephyr-workspace-checkout.sh` asks the MODULE question too: it
+  resolves the workspace through the one resolver (`scripts/lib/zephyr-workspace.sh`),
+  reads its west manifest, and refuses one that resolves to a different
+  nano-ros checkout. `NROS_SKIP_STALE_CHECK=1` does not silence that half — it
+  is not the CLI guard's question. Runs at the head of
+  `check-tier-preconditions`, so the runner now stops there, naming both paths,
+  instead of 15-25 minutes into the build with a mixed-tree answer.
+- `check-tier-priority-plan-image.py --images-from <list>`: the Zephyr lane
+  passes the build dirs of the records it just built (field 12). Discovery mode
+  stays for the operator's `just check tier-priority-plan-image`. A listed dir
+  with no `.config` is an error, not a skip. The summary line names the failing
+  images (the per-image `[FAIL]` blocks scroll above any tail).
+- `scripts/build/log-first-errors.sh`, called by all THREE fixture failure
+  printers before their tails: the fan-out in `justfile`, the Zephyr leaf
+  scheduler, and `scripts/build/fixture-make-driver.sh` (found by sweeping
+  `tail -n` in the fixture scripts, not reported).
+- `zephyr/cmake/nros_cargo_build.cmake`: stale `NROS_RESOLVED_*` knob values
+  are cleared at the top of every configure — see below.
+- `main.hpp`: the ten `nros::shutdown()` calls that discarded a `[[nodiscard]]`
+  `nros::Result` (the warnings that filled the 09-09 tail) are `(void)`-cast.
+
+## The failure behind the first one (issue 1070's shape)
+
+Rebuilding tier 2's seven Zephyr leaves on a dev host whose workspace IS its
+own checkout, with the fixes above, the six `cpp-*-xrce` leaves built and
+`build-cortex-m-c-talker-zenoh` failed its configure:
+
+    CONFIG_MAX_PTHREAD_MUTEX_COUNT=32 is too small for 8 subscribers.
+      need at least 34 = 8 subscribers + 22 zenoh-pico fixed + 4 headroom
+
+— two lines after the same configure logged `NROS_RMW_SUBSCRIBER_SLOTS left to
+its crate default -- no value stated and none derivable`. The 8 was a
+2026-08-28 configure's: `_nros_resolve_knob` stores every value
+`CACHE INTERNAL`, `nros_resolve_knobs` cleared only the LIST of knobs, and
+`_nros_resolve_derivable_knob`'s rung 4 deliberately resolves nothing — so a
+knob that was stated or derived once and is neither now kept its old
+`NROS_RESOLVED_<knob>` forever in a reused build dir. The phase-412 mutex floor
+(822538ed5, 2026-09-05) is the first reader that FAILS on it; every other
+reader silently used the stale number. Fixed by clearing every INTERNAL
+`NROS_RESOLVED_*` cache entry at the top of `nros_resolve_knobs`, enumerated
+from the cache (a configure that dies mid-way leaves values with no list
+naming them). Verified in place, no wipe: re-configure clears the 8 (25 → 20
+entries), the floor stays quiet, and the leaf links.
+
+## What still needs a human
+
+The runner itself. Per `check-zephyr-workspace-checkout.sh`, the sanctioned fix
+moves the JOB, not the directory: run it contained
+(`just runner-up nros-qemu,nros-sdk-zephyr,nros-big`), where
+`runner-provision.sh` provisions the workspace INTO the runner's own checkout.
+Until then tier 2 fails at preconditions — loudly, with the paths — which is the
+honest state: it has been certifying `/mnt/evo`'s module, not the commit.
+
+Also unshared by construction: the Zephyr fixture build lock
+(`zephyr-fixture-make-driver.sh`, issue #19) lives under the CHECKOUT's
+`build/`, so two checkouts building into one workspace do not serialise on the
+same `build-*` dirs at all.
+
+## Option not taken
+
+`zephyr_module.py` keys modules by NAME and processes `ZEPHYR_EXTRA_MODULES`
+after west's list, so `-DZEPHYR_EXTRA_MODULES=<this checkout>` would re-bind
+the `nros` module to the tree under test even with a foreign manifest. Not done
+here: the build dirs would still live inside the other checkout (so the CLI
+guard still refuses, correctly) and the lock would still not serialise, so it
+would fix one of three consequences while making the shared layout look
+supported. Worth revisiting only if a shared workspace becomes a supported
+configuration (RFC-0095's store-resolved workspace is the likelier home).

--- a/just/zephyr-ci.just
+++ b/just/zephyr-ci.just
@@ -349,13 +349,14 @@ build-fixtures:
         zephyr_leaf_args+=(--filter "$fixture_filter")
     fi
     normal_records=0
-    probe_records="$(mktemp)"
+    # Kept until the end: the tier-priority check below judges exactly the
+    # images THESE records build (field 12 is each leaf's build dir).
+    probe_records="$log_dir/records-$$.tsv"
     if scripts/build/zephyr-fixture-leaves.sh --emit records "${zephyr_leaf_args[@]}" >"$probe_records" 2>/dev/null; then
         if [ -s "$probe_records" ]; then
             normal_records=1
         fi
     fi
-    rm -f "$probe_records"
 
     failures=()
     if [ "$normal_records" = "1" ]; then
@@ -402,4 +403,18 @@ build-fixtures:
     # check `check::tier-priority-plan` DEFERS. Zephyr's reserved transport band
     # is derived per image, so this is the only place it CAN be judged, and a
     # deferral nobody discharges is just an unchecked pin with better wording.
-    python3 scripts/check-tier-priority-plan-image.py
+    #
+    # It judges the images THIS invocation built, named by the records above,
+    # never every `build-*/` the workspace happens to hold. Discovery read a
+    # SHARED workspace: on the tier-2 runner 40 images, some from before issue
+    # 0852 moved the zenoh band to 0-255 (`.config` still saying
+    # `READ_PRIORITY=16` -> transport [14, 14]), so pins that pass against every
+    # image this run produced failed against images no run of this tree made —
+    # three runs red (two on 2026-09-08, one on -10) at a gate the build had
+    # already passed. "A gate may only resolve artifacts the job itself builds."
+    # (issue 1253)
+    images_list="$log_dir/tier-priority-images-$$.txt"
+    awk -F '\t' 'NF >= 12 && $12 != "" { print $12 }' "$probe_records" >"$images_list"
+    rm -f "$probe_records"
+    python3 scripts/check-tier-priority-plan-image.py --images-from "$images_list"
+    rm -f "$images_list"

--- a/justfile
+++ b/justfile
@@ -1972,8 +1972,8 @@ build-test-fixtures-leaves lane="all": _require-leaf-includes
             # variable unset, is therefore NAMED, and fails instead. Unset =
             # NAMED is the deliberate default: a driver that forgets this
             # assignment goes red rather than quietly staying green.
-            printf '\t+@start=$$(date +%%s); status=0; echo "== %s =="; ( env %s NROS_LANE_INCLUDED=%q NROS_BUILD_JOBS=%q just %q build-fixtures ) >%q 2>&1 || status=$$?; end=$$(date +%%s); printf "%%s\\t%%s\\t%%s\\t%%s\\t%%s\\n" %q "$$start" "$$end" "$$((end - start))" "$$status" >>%q; if [ "$$status" -eq 78 ]; then echo "== %s == SKIPPED ($$(sed -n "s/^NROS_LANE_SKIP: //p" %q | tail -1))"; else if [ "$$status" -ne 0 ]; then echo "== %s == FAILED (rc=$$status); log tail:"; tail -40 %q || true; exit "$$status"; fi; echo "== %s == OK"; fi\n\n' \
-                "$platform" "$NROS_STAGE_ENV" "$platform" "$child_jobs" "$platform" "$log" "$platform" "$joblog" "$platform" "$log" "$platform" "$log" "$platform"
+            printf '\t+@start=$$(date +%%s); status=0; echo "== %s =="; ( env %s NROS_LANE_INCLUDED=%q NROS_BUILD_JOBS=%q just %q build-fixtures ) >%q 2>&1 || status=$$?; end=$$(date +%%s); printf "%%s\\t%%s\\t%%s\\t%%s\\t%%s\\n" %q "$$start" "$$end" "$$((end - start))" "$$status" >>%q; if [ "$$status" -eq 78 ]; then echo "== %s == SKIPPED ($$(sed -n "s/^NROS_LANE_SKIP: //p" %q | tail -1))"; else if [ "$$status" -ne 0 ]; then echo "== %s == FAILED (rc=$$status)"; bash scripts/build/log-first-errors.sh %q; echo "== %s == log tail:"; tail -40 %q || true; exit "$$status"; fi; echo "== %s == OK"; fi\n\n' \
+                "$platform" "$NROS_STAGE_ENV" "$platform" "$child_jobs" "$platform" "$log" "$platform" "$joblog" "$platform" "$log" "$platform" "$log" "$platform" "$log" "$platform"
         done
     } > "$makefile"
     # issue 0762 — run the fan-out under ONE process group, so killing this

--- a/packages/api/nros-cpp/include/nros/main.hpp
+++ b/packages/api/nros-cpp/include/nros/main.hpp
@@ -204,11 +204,11 @@ class LinuxBoard {
         if (!r.ok()) return static_cast<int32_t>(r.raw());
         int32_t rc = setup();
         if (rc != 0) {
-            nros::shutdown();
+            (void)nros::shutdown();
             return rc;
         }
         int32_t sc = detail::component_spin_loop();
-        nros::shutdown();
+        (void)nros::shutdown();
         return sc;
     }
 
@@ -310,11 +310,11 @@ class ZephyrBoard {
         if (!r.ok()) return static_cast<int32_t>(r.raw());
         int32_t rc = setup();
         if (rc != 0) {
-            nros::shutdown();
+            (void)nros::shutdown();
             return rc;
         }
         int32_t sc = detail::component_spin_loop();
-        nros::shutdown();
+        (void)nros::shutdown();
         return sc;
     }
 
@@ -402,11 +402,11 @@ class NuttxBoard {
         if (!r.ok()) return static_cast<int32_t>(r.raw());
         int32_t rc = setup();
         if (rc != 0) {
-            nros::shutdown();
+            (void)nros::shutdown();
             return rc;
         }
         int32_t sc = detail::component_spin_loop();
-        nros::shutdown();
+        (void)nros::shutdown();
         return sc;
     }
 
@@ -490,11 +490,11 @@ class ThreadxBoard {
         if (!r.ok()) return static_cast<int32_t>(r.raw());
         int32_t rc = setup();
         if (rc != 0) {
-            nros::shutdown();
+            (void)nros::shutdown();
             return rc;
         }
         int32_t sc = detail::component_spin_loop();
-        nros::shutdown();
+        (void)nros::shutdown();
         return sc;
     }
 
@@ -547,11 +547,11 @@ class FreertosBoard {
         if (!r.ok()) return static_cast<int32_t>(r.raw());
         int32_t rc = setup();
         if (rc != 0) {
-            nros::shutdown();
+            (void)nros::shutdown();
             return rc;
         }
         int32_t sc = detail::component_spin_loop();
-        nros::shutdown();
+        (void)nros::shutdown();
         return sc;
     }
 

--- a/scripts/build/fixture-make-driver.sh
+++ b/scripts/build/fixture-make-driver.sh
@@ -6,6 +6,11 @@
 # make leaf.
 set -euo pipefail
 
+# A failing leaf prints its FIRST error lines before the tail — the tail alone
+# can be all warnings (tier-2 run 34319241943). One helper, shared with the
+# Zephyr scheduler and the fixture fan-out in `justfile` (issue 1253).
+first_errors_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/log-first-errors.sh"
+
 usage() {
     cat >&2 <<'EOF'
 usage: scripts/build/fixture-make-driver.sh [--dry-run] [--keep] <platform|all|linux-cyclonedds-rust|linux-cmake-rmw|linux-cyclonedds-cmake>
@@ -226,7 +231,7 @@ leaf_details=()
         status_file="$status_dir/$name.status"
         printf '%s:\n' "$target"
         printf '\t+@echo "fixture: %s"\n' "$label"
-        printf '\t+@start=$$(date +%%s); status=0; echo "running" >%s; ( %s ) >%s 2>&1 || status=$$?; end=$$(date +%%s); duration=$$((end - start)); if [ "$$status" -eq 0 ]; then state=ok; else state=fail; fi; printf "target=%%s\\nplatform=%%s\\nlang=%%s\\nrmw=%%s\\nstatus=%%s\\nstart_epoch=%%s\\nend_epoch=%%s\\nduration_s=%%s\\nlog=%%s\\n" "%s" "%s" "%s" "%s" "$$state" "$$start" "$$end" "$$duration" "%s" >%s; printf "%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\n" "%s" "%s" "%s" "%s" "$$state" "$$start" "$$end" "$$duration" "%s" >>%s; if [ "$$status" -ne 0 ]; then echo "fixture-make-driver: %s failed; tail of %s:" >&2; tail -n "$${NROS_FIXTURE_FAIL_TAIL:-80}" %s >&2 || true; exit "$$status"; fi\n' "$status_file" "$command" "$log" "$target" "$platform" "$lang" "$rmw_value" "$log" "$status_file" "$target" "$platform" "$lang" "$rmw_value" "$log" "$joblog" "$target" "$log" "$log"
+        printf '\t+@start=$$(date +%%s); status=0; echo "running" >%s; ( %s ) >%s 2>&1 || status=$$?; end=$$(date +%%s); duration=$$((end - start)); if [ "$$status" -eq 0 ]; then state=ok; else state=fail; fi; printf "target=%%s\\nplatform=%%s\\nlang=%%s\\nrmw=%%s\\nstatus=%%s\\nstart_epoch=%%s\\nend_epoch=%%s\\nduration_s=%%s\\nlog=%%s\\n" "%s" "%s" "%s" "%s" "$$state" "$$start" "$$end" "$$duration" "%s" >%s; printf "%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\n" "%s" "%s" "%s" "%s" "$$state" "$$start" "$$end" "$$duration" "%s" >>%s; if [ "$$status" -ne 0 ]; then echo "fixture-make-driver: %s failed" >&2; bash %q %s >&2; echo "fixture-make-driver: tail of %s:" >&2; tail -n "$${NROS_FIXTURE_FAIL_TAIL:-80}" %s >&2 || true; exit "$$status"; fi\n' "$status_file" "$command" "$log" "$target" "$platform" "$lang" "$rmw_value" "$log" "$status_file" "$target" "$platform" "$lang" "$rmw_value" "$log" "$joblog" "$target" "$first_errors_script" "$log" "$log" "$log"
     done <"$leaf_file"
 } >"$makefile"
 

--- a/scripts/build/log-first-errors.sh
+++ b/scripts/build/log-first-errors.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Print the FIRST error lines of a build log, before anyone prints its tail.
+#
+# A failing fixture printed `tail -n 80` of its log and nothing else. Under a
+# parallel ninja the failing translation unit's `error:` is printed when that
+# unit fails, and every unit still in flight keeps printing warnings after it,
+# so the tail is the warnings and the error is above it. Run 34319241943
+# (tier 2, 2026-09-09) read exactly like that: `== zephyr == FAILED`, eighty
+# lines of `-Wunused-result` notes, `ninja: build stopped`, and no error line.
+# issue 1158's rule, one level down: a lane's failure text must NAME the
+# failure, and "it failed, here are some lines near the end" does not.
+#
+# One spelling, called by BOTH printers (the fixture fan-out in `justfile` and
+# the Zephyr leaf scheduler in `scripts/build/zephyr-fixture-make-driver.sh`),
+# because two hand-written greps drift apart and the class is "a failure
+# printer shows the tail only", not either site.
+#
+# Usage: log-first-errors.sh <log> [max-lines]
+# Always exits 0: it is a diagnostic inside an already-failing path, and a
+# missing log must not replace the real exit status.
+set -uo pipefail
+
+log="${1:-}"
+max="${2:-${NROS_FIXTURE_FIRST_ERRORS:-12}}"
+
+[ -n "$log" ] && [ -f "$log" ] || exit 0
+
+# What counts as an error line, across the toolchains a fixture log carries:
+#   gcc/clang   `file:1:2: error: ...`, `fatal error: ...`
+#   rustc/cargo `error: ...`, `error[E0425]: ...`
+#   cmake       `CMake Error at ...`
+#   west        `FATAL ERROR: ...`
+#   ld          `undefined reference to ...`
+#   our gates   `[FAIL] ...`
+# `[-Werror=...]` inside a warning does not match: the pattern needs `error`
+# followed by `:` or `[`.
+pattern='(^|[^A-Za-z_-])(fatal )?error(\[E[0-9]+\])?:|CMake Error|FATAL ERROR|undefined reference to|\[FAIL\]'
+
+matches="$(grep -n -m "$max" -E "$pattern" "$log" 2>/dev/null || true)"
+if [ -n "$matches" ]; then
+    printf 'first error line(s) in %s:\n' "$log"
+    printf '%s\n' "$matches" | cut -c1-400 | sed 's/^/  /'
+else
+    printf 'no error line matched in %s — read the tail below\n' "$log"
+fi
+exit 0

--- a/scripts/build/zephyr-fixture-make-driver.sh
+++ b/scripts/build/zephyr-fixture-make-driver.sh
@@ -51,6 +51,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 leaves_script="$repo_root/scripts/build/zephyr-fixture-leaves.sh"
 runner_script="$repo_root/scripts/build/zephyr-fixture-run-one.sh"
+first_errors_script="$repo_root/scripts/build/log-first-errors.sh"
 
 if [ ! -x "$leaves_script" ]; then
     echo "zephyr-fixture-make-driver: missing executable $leaves_script" >&2
@@ -217,8 +218,16 @@ fi
             "$(shell_quote "$target")" "$(shell_quote "$id")" "$(shell_quote "$scheduler_log")" "$(shell_quote "$zephyr_log")" "$(shell_quote "$record_file")" "$(shell_quote "$status_file")"
         printf 'printf "%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\t%%s\\n" %s %s "$$state" "$$start" "$$end" "$$duration" %s %s %s >>%s; ' \
             "$(shell_quote "$target")" "$(shell_quote "$id")" "$(shell_quote "$scheduler_log")" "$(shell_quote "$zephyr_log")" "$(shell_quote "$record_file")" "$(shell_quote "$joblog")"
-        printf 'if [ "$$status" -ne 0 ]; then echo "zephyr-fixture-make-driver: %s failed; scheduler log tail:" >&2; tail -n "$${NROS_FIXTURE_FAIL_TAIL:-80}" %s >&2 || true; if [ -f %s ]; then echo "zephyr-fixture-make-driver: Zephyr log tail:" >&2; tail -n "$${NROS_FIXTURE_FAIL_TAIL:-80}" %s >&2 || true; fi; exit "$$status"; fi\n' \
-            "$target" "$(shell_quote "$scheduler_log")" "$(shell_quote "$zephyr_log")" "$(shell_quote "$zephyr_log")"
+        # The FIRST error lines go out before either tail: under a parallel
+        # ninja the failing unit's `error:` scrolls above the warnings every
+        # other in-flight unit keeps printing, so a tail alone can show no
+        # error at all (tier-2 run 34319241943). One helper, shared with the
+        # fixture fan-out's printer in `justfile`.
+        printf 'if [ "$$status" -ne 0 ]; then echo "zephyr-fixture-make-driver: %s failed" >&2; bash %s %s >&2; if [ -f %s ]; then bash %s %s >&2; fi; echo "zephyr-fixture-make-driver: scheduler log tail:" >&2; tail -n "$${NROS_FIXTURE_FAIL_TAIL:-80}" %s >&2 || true; if [ -f %s ]; then echo "zephyr-fixture-make-driver: Zephyr log tail:" >&2; tail -n "$${NROS_FIXTURE_FAIL_TAIL:-80}" %s >&2 || true; fi; exit "$$status"; fi\n' \
+            "$target" \
+            "$(shell_quote "$first_errors_script")" "$(shell_quote "$scheduler_log")" \
+            "$(shell_quote "$zephyr_log")" "$(shell_quote "$first_errors_script")" "$(shell_quote "$zephyr_log")" \
+            "$(shell_quote "$scheduler_log")" "$(shell_quote "$zephyr_log")" "$(shell_quote "$zephyr_log")"
     done <"$records_file"
 } >"$makefile"
 

--- a/scripts/check-preconditions-provisioned.py
+++ b/scripts/check-preconditions-provisioned.py
@@ -72,8 +72,12 @@ CLASSIFICATION = {
         "unships whatever the skipped commits fixed, and setup must never "
         "silently pick a side.",
     ),
-    "the Zephyr workspace lives inside a DIFFERENT": (
+    "the Zephyr workspace belongs to a DIFFERENT": (
         "manual",
+        # issue 1253 — the probe now also asks which checkout's Zephyr MODULE
+        # the workspace's west manifest names; the same reasoning applies: the
+        # manifest is fixed when the workspace is provisioned, by whoever ran
+        # `west init -l`, and setup must not re-point someone else's symlink.
         "This is a statement about WHERE THE JOB RUNS, not about a directory "
         "`just setup` could create. On a self-hosted runner it means the job "
         "is on the bare host; the sanctioned path is contained "

--- a/scripts/check-tier-preconditions.sh
+++ b/scripts/check-tier-preconditions.sh
@@ -74,8 +74,15 @@ probe "cross Rust target(s) declared by this tree are not installed" \
 # fix. That shape cost the tier-2 lane two consecutive nights (2026-09-06/-07).
 # The probe mirrors the guard's three silent cases exactly, so it can never be
 # stricter than the thing it front-runs.
-probe "the Zephyr workspace lives inside a DIFFERENT nano-ros checkout" \
-    "move it out of any checkout — see the message; do NOT reach for NROS_SKIP_STALE_CHECK=1" \
+#
+# It also asks which checkout's Zephyr MODULE the workspace compiles (its west
+# manifest). A workspace provisioned by another checkout builds that tree's
+# `zephyr/` and nros-cpp headers into every image beside this tree's generated
+# entries — tier-2 run 34319241943 failed on exactly that mix. That half does
+# not mirror the CLI guard, so `NROS_SKIP_STALE_CHECK=1` does not silence it
+# (issue 1253).
+probe "the Zephyr workspace belongs to a DIFFERENT nano-ros checkout (location or west manifest)" \
+    "build against a workspace THIS checkout provisioned (runner: just runner-up <labels>) — see the message; do NOT reach for NROS_SKIP_STALE_CHECK=1" \
     bash scripts/check-zephyr-workspace-checkout.sh
 
 probe "a submodule is not at the commit this superproject records" \

--- a/scripts/check-tier-priority-plan-image.py
+++ b/scripts/check-tier-priority-plan-image.py
@@ -89,13 +89,80 @@ def check_one(dotconfig, tier_key, plans):
     return 0, ok
 
 
+def images_from(listing):
+    """`.config` paths for the build dirs named in `listing`, one per line.
+
+    The LANE's mode. `discover()` answers "what does this workspace hold",
+    which on a shared or long-lived workspace includes images no run of this
+    tree produced — and a derived band read off a museum `.config` fails pins
+    that pass against every image the run actually built. Tier 2 was red three
+    nights on exactly that (images still carrying the pre-0852 0-31 zenoh band,
+    transport [14, 14]). The lane knows which leaves it built, so it says so.
+
+    A listed dir with no `.config` is an ERROR, not a skip: the lane only gets
+    here after every listed leaf built, so a missing `.config` means the list
+    and the build disagree, and silently checking fewer images is how a green
+    comes to mean less than it looks.
+    """
+    configs, missing = [], []
+    for raw in Path(listing).read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        p = Path(line)
+        cfg = p if p.name == ".config" else p / "zephyr" / ".config"
+        (configs if cfg.is_file() else missing).append(cfg)
+    return configs, missing
+
+
+def check_many(configs, tier_key, plans, origin):
+    plan = plans.get(tier_key)
+    if plan is None or not plan.get("derived"):
+        print(f"{tier_key!r} has no DERIVED plan")
+        return 2
+    rc, total, failed = 0, 0, []
+    print(f"check-tier-priority-plan-image: {len(configs)} image(s) ({origin})")
+    for c in configs:
+        r, n = check_one(c, tier_key, plans)
+        if r:
+            failed.append(c.parent.parent.name)
+        rc = max(rc, r)
+        total += n
+    verdict = "FAILED" if rc else "OK"
+    print(f"\ntier-priority-plan-image: {verdict} "
+          f"({total} pin-check(s) over {len(configs)} image(s))")
+    if failed:
+        # Named in the LAST lines on purpose: a failing lane prints the tail of
+        # this output, and the per-image [FAIL] blocks are above it. The tier-2
+        # log showed forty `[ok]` lines and a bare FAILED, with every failing
+        # image scrolled off.
+        print(f"  failing image(s): {', '.join(failed)}")
+    return rc
+
+
 def main(argv):
     plans = load_plans()
     tier_key = "zephyr"
+    if len(argv) >= 3 and argv[1] == "--images-from":
+        configs, missing = images_from(argv[2])
+        if len(argv) > 3:
+            tier_key = argv[3]
+        if missing:
+            print("check-tier-priority-plan-image: listed image(s) have no .config:")
+            for m in missing:
+                print(f"  {m}")
+            return 2
+        if not configs:
+            print(f"check-tier-priority-plan-image: {argv[2]} names no image — "
+                  "the caller built nothing, so there is nothing to check")
+            return 2
+        return check_many(configs, tier_key, plans, f"listed in {argv[2]}")
     if len(argv) < 2:
-        # Lane mode: check every image this tree has built. A tree with no
-        # Zephyr workspace SKIPS loudly rather than passing — issue 0599's
-        # rule, and the difference between "checked nothing" and "checked".
+        # Discovery mode (the operator's `just check tier-priority-plan-image`):
+        # every image the workspace holds. A tree with no Zephyr workspace
+        # SKIPS loudly rather than passing — issue 0599's rule, and the
+        # difference between "checked nothing" and "checked". Lanes do NOT use
+        # this mode: they name the images they built (`--images-from`).
         configs = discover()
         if not configs:
             print("check-tier-priority-plan-image: SKIPPED — no built Zephyr image "
@@ -103,19 +170,7 @@ def main(argv):
             print("  The DEFERRED pins reported by check-tier-priority-plan stay "
                   "unchecked on this host.")
             return 0
-        plan = plans.get(tier_key)
-        if plan is None or not plan.get("derived"):
-            print(f"{tier_key!r} has no DERIVED plan")
-            return 2
-        rc, total = 0, 0
-        print(f"check-tier-priority-plan-image: {len(configs)} built image(s)")
-        for c in configs:
-            r, n = check_one(c, tier_key, plans)
-            rc = max(rc, r)
-            total += n
-        print(f"\ntier-priority-plan-image: {'FAILED' if rc else 'OK'} "
-              f"({total} pin-check(s) over {len(configs)} image(s))")
-        return rc
+        return check_many(configs, tier_key, plans, "every image in the workspace")
     dotconfig = Path(argv[1])
     tier_key = argv[2] if len(argv) > 2 else "zephyr"
     if not dotconfig.is_file():

--- a/scripts/check-zephyr-workspace-checkout.sh
+++ b/scripts/check-zephyr-workspace-checkout.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Refuse a Zephyr workspace that lives inside a DIFFERENT nano-ros checkout.
+# Refuse a Zephyr workspace that belongs to a DIFFERENT nano-ros checkout —
+# either because it lives inside one, or because its west manifest (the nano-ros
+# Zephyr module every image compiles) IS one (issue 1253).
 #
 # phase-431 W1 gave the CLI an ownership guard: if the directory `nros` is
 # operating on sits inside a nano-ros checkout, the running binary must be that
@@ -34,11 +36,70 @@
 # could have built a CLI to be foreign to. `NROS_SKIP_STALE_CHECK=1` disables
 # the guard, so it disables this too — otherwise this would fail a host that
 # has deliberately opted out.
+#
+# A SECOND question, independent of the CLI guard (tier-2, 2026-09-09): which
+# checkout's nano-ros Zephyr MODULE does this workspace compile? West lists the
+# manifest repo (`[manifest] path` in `.west/config`, usually a `nano-ros`
+# symlink back to the checkout that ran `west init -l`) as the `nros` module,
+# and `zephyr/CMakeLists.txt` sets `NROS_REPO_DIR` to that module's parent. So
+# every Zephyr image built against a workspace provisioned by ANOTHER checkout
+# compiles that checkout's `zephyr/`, platform sources and nros-cpp headers,
+# whatever commit it is at, beside this tree's generated entry code. Run
+# 34319241943 compiled `<other>/packages/api/nros-cpp/include/nros/main.hpp`
+# into a leaf of this tree and failed; the next night, same SHA, it built.
+# A mixed tree is not a result about either tree. That question does not
+# depend on the CLI guard, so `NROS_SKIP_STALE_CHECK=1` does NOT silence it.
 set -uo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
-[ "${NROS_SKIP_STALE_CHECK:-}" = "1" ] && exit 0
+# The checkout a west workspace's manifest resolves to, or empty when the
+# manifest is not a nano-ros checkout (a user workspace whose manifest is
+# their own app repo pulls nano-ros in some other way; not this check's case).
+manifest_checkout_of() {
+    local ws="$1" cfg path dir
+    cfg="$ws/.west/config"
+    [ -f "$cfg" ] || return 0
+    path="$(awk '
+        /^\[/ { in_manifest = ($0 ~ /^\[manifest\][[:space:]]*$/); next }
+        in_manifest && $1 == "path" { sub(/^[^=]*=[[:space:]]*/, ""); print; exit }
+    ' "$cfg")"
+    [ -n "$path" ] || return 0
+    dir="$(cd "$ws/$path" 2>/dev/null && pwd -P)" || return 0
+    [ -f "$dir/zephyr/module.yml" ] && [ -f "$dir/packages/core/nros-core/Cargo.toml" ] || return 0
+    printf '%s' "$dir"
+}
+
+module_problems=0
+# The ONE resolver (phase-440 W1) — the same tree `just zephyr` and the fixture
+# builders compile against, never a fourth ladder.
+# shellcheck source=scripts/lib/zephyr-workspace.sh
+. "$repo_root/scripts/lib/zephyr-workspace.sh"
+zephyr_ws="$(nros_zephyr_ws_resolve_abs "" "$repo_root" 2>/dev/null || true)"
+if [ -n "$zephyr_ws" ] && [ -d "$zephyr_ws" ]; then
+    module_checkout="$(manifest_checkout_of "$zephyr_ws")"
+    if [ -n "$module_checkout" ] && [ "$module_checkout" != "$repo_root" ]; then
+        module_problems=1
+        cat >&2 <<EOF
+  zephyr workspace: $(cd "$zephyr_ws" && pwd -P)
+      its west manifest (the nano-ros Zephyr module) is $module_checkout
+      this tree:                                         $repo_root
+
+Every Zephyr image built against that workspace compiles $module_checkout's
+\`zephyr/\` module, platform sources and nros-cpp headers — not this tree's —
+next to entry code THIS tree generates. Whatever that checkout's commit is
+decides the result, so a failure (or a pass) is not a fact about this tree.
+
+Build against a workspace whose manifest is this checkout: the in-tree
+\`zephyr-workspace/\` from \`just zephyr setup\`, or, on a runner, the contained
+runner (\`just runner-up <labels>\`), which provisions it into its own checkout.
+EOF
+    fi
+fi
+
+if [ "${NROS_SKIP_STALE_CHECK:-}" = "1" ]; then
+    exit "$module_problems"
+fi
 
 # EVERY provisioned root, not just Zephyr (phase-440 W5). The ownership guard
 # does not care which tree it is handed: any path inside a FOREIGN checkout is
@@ -103,9 +164,8 @@ while IFS= read -r entry; do
     printf '%s\n' "      owned by $owner" >&2
 done <<< "$PROVISIONED_ROOTS"
 
-[ "$problems" -eq 0 ] && exit 0
+[ "$problems" -eq 0 ] && exit "$module_problems"
 
-cat >&2 <<EOF
 cat >&2 <<EOF
 The provisioned root(s) listed above sit inside a DIFFERENT nano-ros
 checkout, so every \`nros\` invocation against them will be refused by the

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -430,9 +430,37 @@ endfunction()
 # nros_rmw_zenoh.cmake emits its compile definitions at include time.
 # =============================================================================
 function(nros_resolve_knobs)
-    # Drop last configure's list so a backend switch cannot leave stale knobs
-    # behind (the per-knob values are overwritten, but the list would grow).
-    unset(NROS_RESOLVED_KNOBS CACHE)
+    # Drop last configure's list AND every value it names. The per-knob values
+    # are NOT all overwritten: `_nros_resolve_derivable_knob`'s rung 4 resolves
+    # nothing on purpose, so a knob that was stated or derived last configure
+    # and is neither now kept its old `NROS_RESOLVED_<knob>` CACHE INTERNAL
+    # value, and every reader took it as this configure's answer. Measured
+    # (issue 1253): build-cortex-m-c-talker-zenoh logged "NROS_RMW_SUBSCRIBER_SLOTS
+    # left to its crate default" and then failed the phase-412 mutex floor "for
+    # 8 subscribers" — the 8 was a 2026-08-28 configure's. Only a REUSED build
+    # dir shows it, which is every incremental fixture build.
+    #
+    # Enumerated from the CACHE, not from `NROS_RESOLVED_KNOBS`: the list is
+    # unset at the top of every configure, so a configure that dies after this
+    # point (that one did — the floor is a FATAL_ERROR) leaves per-knob values
+    # in the cache with no list naming them, and a list-driven sweep would
+    # clear nothing next time.
+    #
+    # Only INTERNAL entries: `_nros_resolve_knob` writes every value CACHE
+    # INTERNAL, while `NROS_RESOLVED_DIR` (cmake/NanoRosResolved.cmake) shares
+    # the prefix and is a CALLER's `-D` on the cmake/west handoff — clearing it
+    # would discard an input, not a stale answer. Named as well, in case a
+    # handoff ever types it INTERNAL.
+    get_property(_nros_cache_vars GLOBAL PROPERTY CACHE_VARIABLES)
+    foreach(_nros_cache_var IN LISTS _nros_cache_vars)
+        if(_nros_cache_var MATCHES "^NROS_RESOLVED_"
+           AND NOT _nros_cache_var STREQUAL "NROS_RESOLVED_DIR")
+            get_property(_nros_cache_type CACHE ${_nros_cache_var} PROPERTY TYPE)
+            if(_nros_cache_type STREQUAL "INTERNAL")
+                unset(${_nros_cache_var} CACHE)
+            endif()
+        endif()
+    endforeach()
 
     # phase-403 W8 (issue 0940) -- the size knobs' rung-3 values, if this image
     # has an inventory to derive them from. Loaded once, before any resolution,


### PR DESCRIPTION
## What actually stopped tier 2
The two `nros::shutdown()` `-Wunused-result` warnings in the 09-09 log tail were noise (no `-Werror`). The real error lines across the last seven `run-matrix` runs:

| runs | stopped by |
|---|---|
| 09-06, 09-06, 09-07 | CLI ownership guard: `this nros does not belong to the checkout … /mnt/evo/aeon/nano-ros` |
| 09-08, 09-08, 09-10 (HEAD) | every Zephyr leaf built, then `tier-priority-plan-image: FAILED (160 pin-check(s) over 40 image(s))` |
| 09-09 | `cpp-action-server-xrce` — the job log holds NO error line; the printer showed only the tail |

## Root cause (issue 1253)
The runner's `zephyr-workspace` belongs to a SECOND checkout (`/mnt/evo`), and west takes the nano-ros module from the workspace manifest — a symlink to whoever set it up. So:
1. the image gate swept EVERY build dir in the workspace, not the ones this run built; pre-issue-0852 images there report transport band [14,14] and fail the realtime workspaces' tier pins (fresh images give [4,4] and pass);
2. every runner image compiled `/mnt/evo`'s `zephyr/` module and nros-cpp headers beside this tree's generated entry code — the 09-09 log names `/mnt/evo/…/nros-cpp/include/nros/main.hpp`, and the same SHA passed the next night.

**Second failure behind the first:** `cortex-m-c-talker-zenoh` failed configure on `CONFIG_MAX_PTHREAD_MUTEX_COUNT=32 is too small for 8 subscribers` — the 8 a cached knob from an 08-28 configure. A knob that later goes unset kept its old value in a reused build dir; the 09-05 mutex floor is just the first reader to fail on it.

## Changes
- `check-tier-priority-plan-image.py` + `just/zephyr-ci.just` — `--images-from`: the lane passes exactly the build dirs it built; the summary names the failing images.
- `check-zephyr-workspace-checkout.sh` — also refuses a workspace whose manifest is a DIFFERENT nano-ros checkout (via the shared resolver; `NROS_SKIP_STALE_CHECK=1` does not silence it). Label mirrored in `check-tier-preconditions.sh` / `check-preconditions-provisioned.py`.
- `scripts/build/log-first-errors.sh` (new) — all three fixture-failure printers (`justfile`, `zephyr-fixture-make-driver.sh`, `fixture-make-driver.sh`) show the first error lines before the tail. Issue 1158's class: a lane's failure text must name the failure.
- `zephyr/cmake/nros_cargo_build.cmake` — clears stale cached knob values at each configure (leaves caller-supplied `NROS_RESOLVED_DIR`).
- `nros-cpp/include/nros/main.hpp` — all 10 discarded `nros::shutdown()` results `(void)`-cast (noise cleanup, not the cause).
- `docs/issues/1253-…md` — new issue.

## Verified
- Tier-2 Zephyr family rebuilt as `lane=tier2` narrows it: all six `cpp-*-xrce` leaves incl. `cpp-action-server-xrce`, no `-Wunused-result`; `cortex-m-c-talker-zenoh` re-configured IN PLACE with the cmake fix and linked (no wipe).
- Image gate over those 7 images: OK, 8 pin checks.
- Workspace check on synthetic workspaces of each shape.
- `check fast` rc=0; `test-lane-contracts` 17/17. Non-Zephyr tier-2 families NOT built.

## Needs a human
**Tier 2 will now stop at PRECONDITIONS on the current runner**, with a message naming both checkouts — the honest state, since it has been certifying `/mnt/evo`'s module. Fix: move the runner into a contained one, `just runner-up nros-qemu,nros-sdk-zephyr,nros-big`.

Part of phase-413 W2 (each lane green once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK