### PR TITLE
test(phase-441 W1): the live peer, one BOARD over — and the gate that refused it

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -440,6 +440,31 @@ filter = "binary(qos_zephyr_ros2_interop_e2e)"
 test-group = "matrix-consumers-serial"
 slow-timeout = { period = "180s", terminate-after = 3 }
 
+# phase-441 W1 — issue-#141-shaped RESOURCE, on the Cortex-M board: one baked
+# image serves two tests. `build-cortex-m-c-talker-zenoh` bakes
+# `CONFIG_NROS_ZENOH_LOCATOR="tcp/10.0.2.2:10700"`, and BOTH
+# `zephyr_cortex_m_qemu::zephyr_cortex_m_c_zenoh_pubsub_e2e` (the baked
+# `matrix::CELLS` cell) and `pubsub_zephyr_cortex_m_ros2_interop_e2e` (the
+# live-peer `interop::CELLS` cell) start a router on that port. That is not a
+# mere collision: `ZenohRouter::start_on` calls `kill_listeners_on_port` first,
+# so whichever starts second KILLS the other test's router mid-run.
+#
+# The filter names both BINARIES rather than the two test NAMES, deliberately.
+# A `test(...)` clause that stops matching goes SILENTLY INERT — that is exactly
+# how the retired `zephyr-qos-port` group lost its protection (see the block
+# above), and `zephyr_cortex_m_qemu`'s other two cells are cheap enough that
+# serializing all four is the conservative choice that cannot be wrong.
+#
+# THIS OVERRIDE MUST STAY AHEAD of the `binary(~zephyr)` → `qemu-emulated` one
+# far below, for the same first-match-wins reason its neighbour above documents:
+# `~zephyr` is a SUBSTRING match and would claim both of these binaries first.
+# Verify membership with `cargo nextest show-config test-groups`, never by
+# reading the filter.
+[[profile.default.overrides]]
+filter = "binary(zephyr_cortex_m_qemu) or binary(pubsub_zephyr_cortex_m_ros2_interop_e2e)"
+test-group = "zephyr-cortex-m-baked-port"
+slow-timeout = { period = "180s", terminate-after = 3 }
+
 # Issue #34 — host-integration "compile-shape" tests shell out to cargo / nros
 # to build a generated crate or workspace, so a COLD build legitimately exceeds
 # the 60s default kill (period 30s × terminate-after 2). Measured: a single
@@ -957,6 +982,14 @@ slow-timeout = { period = "60s", terminate-after = 10 }
 # script; this list is its manual twin and must move with it.
 [test-groups.qemu-emulated]
 max-threads = 4
+
+# phase-441 W1 — RESOURCE: the `build-cortex-m-*-talker-zenoh` leaves' baked
+# router ports (allocator 10600/10700/10800). The live-peer interop cell and the
+# baked pubsub cell of the SAME language start a router on the same port, and
+# `ZenohRouter::start_on` kills whoever holds it. Serialize the family; the
+# override that selects into it is far above, ahead of `binary(~zephyr)`.
+[test-groups.zephyr-cortex-m-baked-port]
+max-threads = 1
 
 [[profile.default.overrides]]
 filter = "binary(~freertos) or binary(~nuttx) or binary(~threadx) or binary(~zephyr) or binary(~esp32) or binary(~fvp)"

--- a/book/src/reference/board-support-tiers.md
+++ b/book/src/reference/board-support-tiers.md
@@ -33,7 +33,7 @@ Asserted runtime coverage and a nightly lane, but not in `just ci`. Breakage is 
 | `nros-board-nuttx-qemu` | NuttxArm | *unassigned* |  |
 | `nros-board-nuttx-qemu` | NuttxRiscv | *unassigned* | HONEST LABEL: C runtime-proven; Rust and C++ Pubsub are explicit CarveOuts and every EntryPubsub row is BuildOnly. |
 | `nros-board-threadx-qemu-riscv64` | ThreadxRiscv64 | *unassigned* | All three Action rows are BuildOnly by a deliberate wall-clock choice (182.5), not by breakage. |
-| `nros-board-zephyr` | ZephyrQemuCortexM | *unassigned* | C and C++ pubsub are Runtime; service/action are BuildOnly pending the runner's peer half. NO RUST ROW: `zephyr-lang-rust` cannot compile for any board whose devicetree has gpio nodes (issue 0432), so a rust cell would not build and BuildOnly would be a lie. Tier 2 rather than 1 because `just ci` is host-only and this needs QEMU. |
+| `nros-board-zephyr` | ZephyrQemuCortexM | *unassigned* | C, C++ and Rust pubsub are Runtime; service/action are BuildOnly pending the runner's peer half. It also carries the tree's first non-native_sim live-peer interop cell (phase-441 W1, `zephyr-cortex-m-pubsub-c-zenoh`). This note used to say NO RUST ROW, because `zephyr-lang-rust` could not compile for any board whose devicetree has gpio nodes — issue 0432, RESOLVED 2026-08-12 by phase-346 W2/W3, after which the Rust leaf built and `zephyr_cortex_m_rust_zenoh_pubsub_e2e` ran it while four documents still said it could not. Tier 2 rather than 1 because `just ci` is host-only and this needs QEMU. |
 
 ## Tier 3 — build-only
 

--- a/docs/design/0064-board-support-organization.md
+++ b/docs/design/0064-board-support-organization.md
@@ -760,12 +760,20 @@ all: `mps2_an385` is `cmake/zephyr/mps2-an385.conf`, the FVP is
 `nros-board-zephyr/boards/fvp-aemv8r-smp/`. Adding a Zephyr architecture really
 did become adding a conf bundle.
 
-**One caveat worth carrying forward.** The Cortex-M witness's cells are C and
+~~**One caveat worth carrying forward.** The Cortex-M witness's cells are C and
 C++ only. The pinned `zephyr-lang-rust` cannot compile the `zephyr` crate for ANY
 board whose devicetree has gpio nodes (issue 0432) — essentially every real
-board — so Rust-on-Zephyr remains native_sim-only until that is fixed upstream.
-Nothing in this RFC's structure causes it, and nothing in this RFC's structure can
-fix it.
+board — so Rust-on-Zephyr remains native_sim-only until that is fixed upstream.~~
+
+**The caveat is RETIRED.** Issue 0432 was resolved 2026-08-12 by phase-346 W2/W3
+(`scripts/zephyr/zephyr-lang-rust-gpio-patch.sh` plus a `zephyr/patches.yml`
+entry, the first non-`zephyr` module in that file), and the Cortex-M witness has
+carried a Rust Runtime cell since. Rust-on-Zephyr is not native_sim-only. The
+paragraph above outlived its fact by four weeks in FOUR places at once — this
+RFC, `board-support.toml`, `matrix.rs` and `binaries/mod.rs` — and phase-441 read
+one of them as a design constraint before measuring it. Nothing in this RFC's
+structure caused that either; the lesson is that a caveat naming an OPEN issue
+needs the issue's status re-read before it is quoted, not after.
 
 **Deleted (12):** `native`, `posix` (→ `linux`), `nuttx-qemu-riscv` (→ merged),
 `rtic-mps2-an385` (→ feature), `fvp-aemv8r-smp` (→ conf bundle), `stm32f4`,

--- a/docs/roadmap/phase-441-rmw-on-target-verification.md
+++ b/docs/roadmap/phase-441-rmw-on-target-verification.md
@@ -1,7 +1,9 @@
 # Phase 441 — the one "on-target" live-peer cell runs on host sockets
 
-**Status (2026-09-10). W2 ANSWERED (yes — see below); W1 and W3–W5 not started.
-Analysis below; work items W1–W5 proposed.**
+**Status (2026-09-10). W2 ANSWERED (Cyclone crosses slirp, with four settings — see
+below). W4 and W5 LANDED (the lane split, the phrase audit). W1 and W3 cells WRITTEN —
+#829 Zephyr Cortex-M, #835 FreeRTOS/MPS2 — and unproven by design: no on-target cell
+has met a live peer yet.**
 
 Phase-433 closed with twenty of twenty Runtime interop cells carrying a live
 verdict, and named its own remainder:
@@ -33,6 +35,10 @@ platform, one language, one RMW, one workload.**
 `ThreadxRiscv64`, `Esp32Qemu`, `QemuBaremetal`, `Fvp`, `Px4` and
 `ZephyrQemuCortexM` have **no live-peer cell at all**. Whatever those ports do
 against a stock ROS 2 node is unobserved.
+
+*(As of W1, `ZephyrQemuCortexM` has one — `zephyr-cortex-m-pubsub-c-zenoh`. The
+count above is the pre-W1 measurement and is left as written, because it is the
+argument the phase was opened on. Ten platforms remain.)*
 
 ## The part that changes the argument
 
@@ -94,13 +100,17 @@ yes, with four settings and a `hostfwd` — see W2 below.**
 
 ## One constraint that is already written down
 
-`ZephyrQemuCortexM`'s doc comment: *"Cells here are C/C++ only: the pinned
+~~`ZephyrQemuCortexM`'s doc comment: *"Cells here are C/C++ only: the pinned
 `zephyr-lang-rust` cannot compile for any board whose devicetree has gpio nodes
 (issue 0432)."* So the natural first target — the same QoS workload, moved from
-native_sim to the Cortex-M board — **cannot be the Rust image**. It is a C or
-C++ cell, which also means it exercises a different half of our API surface than
-the existing row. That is a feature, not a problem, but it must be planned for
-rather than discovered.
+native_sim to the Cortex-M board — **cannot be the Rust image**.~~
+
+**REFUTED 2026-09-10 (W1).** Issue 0432 was RESOLVED 2026-08-12 by phase-346
+W2/W3; the Rust leaf has built since and `zephyr_cortex_m_rust_zenoh_pubsub_e2e`
+runs it. The quoted doc comment was stale when this phase quoted it, and so were
+two more copies of the same sentence — see "W1 as built" below. All three are
+corrected. W1 still landed as a C cell, but for a different and smaller reason:
+C is what the west lane already builds at that coordinate.
 
 ## Work items
 
@@ -123,6 +133,91 @@ membership in the `live-peer.yml` lane that follows from that ledger entry.
 five defects moving a non-interop workload across this same boundary. If W1
 finds none, that is itself worth writing down — it would mean the earlier five
 were about the build, not the wire.
+
+### W1 as built (2026-09-10) — two amendments and a gate defect
+
+The cell landed as `zephyr-cortex-m-pubsub-c-zenoh` in `interop::CELLS`
+(`Tier::Runtime`, `RosEdition(Zenoh)`, `NanoToRos`, `ZephyrWestLeaves`), run by
+`tests/pubsub_zephyr_cortex_m_ros2_interop_e2e.rs` and aimable with
+`just zephyr test-ros2-cortex-m`. Two things in the plan above were wrong and
+one thing in the tree was.
+
+**Amendment 1 — the C/C++-only constraint no longer exists.** The section "One
+constraint that is already written down" quotes `ZephyrQemuCortexM`'s doc
+comment on issue 0432. **0432 was RESOLVED 2026-08-12 by phase-346 W2/W3**;
+`build-cortex-m-rust-talker-zenoh` has built since and
+`zephyr_cortex_m_rust_zenoh_pubsub_e2e` runs it. Three places still asserted the
+constraint (`matrix.rs`'s `ZephyrQemuCortexM` doc, `binaries/mod.rs`'s
+`build_zephyr_cortex_m_example` doc — which says "there is no rust arm" in a
+function the Rust cell calls with `"rust"` — and this phase doc); all three are
+corrected. The sentence outlived its fact by four weeks and was still being read
+as a design constraint, which is precisely the W5 problem one series over.
+
+**Amendment 2 — the workload moves, because the board cannot hold the
+workload still.** W1 says "same RMW, same workload, same peer, same crossing
+mechanism, one axis moved". The workload could not stay `Qos`: there is no QoS
+workspace entry for any board but `native_sim/native/64`, in ANY language
+(`examples/workspaces/features/src/` holds `zephyr_rust_{lifecycle,params,qos}_entry`,
+all native_sim). A QoS cell on `mps2_an385` therefore means authoring an entry
+package, a `[[workspace_fixture]]` row, a west build name and a port bake —
+four new artifacts, none of which is the axis W1 exists to move, and all of
+which would ship unbuilt on a host with no Zephyr SDK. So the cell reuses the
+`build-cortex-m-c-talker-zenoh` leaf the west lane ALREADY builds at exactly
+this coordinate (locator `tcp/10.0.2.2:10700` = `port_of(ZephyrQemuCortexM, C,
+Pubsub)`) and adds a live peer and nothing else. **`Pubsub`, not `Qos`.** The
+axis W1 is about — host sockets → Zephyr's in-kernel stack over `eth_smsc911x`,
+64-bit host pointers → 32-bit ARMv7-M — moves exactly as planned.
+
+The test asserts TWO things, and the first is what makes the coordinate a
+witness rather than a second spelling of native_sim: `IPv4 address: 10.0.2.15`
+from Zephyr's own `net_config` (only the in-kernel stack driving a real
+ethernet controller prints it), then `ros2 topic echo --once /chatter` receiving
+a sample. The second is the interop claim and the first alone would not do —
+the existing baked pubsub cell asserts the image PRINTS `Publishing:`, which the
+C talker does whenever `nros_cpp_publish_raw` returns 0, a local return code.
+Nothing in the tree had observed a sample LEAVE this board.
+
+**The gate defect — G5's reach was narrower than its rule.**
+`matrix_fixture_coverage.rs`'s `interop_bindings_g5_cells_are_lane_narrowable`
+rejected the new cell with "produced by NO fixtures.toml row, so no lane can
+narrow it", and its doc comment declared that verdict deliberate: "a Runtime
+cell that could only be backed by a west row would therefore still fail here —
+correctly, because nothing could narrow it". That was true when G5 was written
+and had already stopped being true: **issue 0713** put
+`require_west_leaf_in_lane(build_name, …)` at the head of
+`require_prebuilt_binary_fresh_zephyr`, so every zephyr resolver narrows by
+build-dir NAME against `fixtures::lane::west_leaves()` — the same
+`examples/fixtures.toml`, read through a different subcommand. G5 was checking
+only the PATH-attribution table (`manifest_rows()`), which by construction omits
+west rows. Its diagnosis was one the resolver contradicts. G5 now counts all
+three backing mechanisms (path rows, workspace rows, west leaves), with a
+vacuity precondition on each table. The 0196 shape, in the direction that reads
+as correctness.
+
+**Defect count across the board crossing: ZERO in nano-ros itself.** The
+expected-finding paragraph above is therefore answered, with a caveat that
+weakens it: the crossing was NOT run live here — this host has no `/opt/ros`,
+no Zephyr SDK and no west workspace, so the cell reaches its `require_ros2()`
+skip and stops. What IS established is that the cell is bound and
+coordinate-correct (all 10 `matrix_fixture_coverage` gates, including the
+repaired G5), that its runner is named (`check-interop-cell-runners`: 23/23,
+ledger still empty), that its nextest group resolves and actually holds both
+sharers of the baked port (`cargo nextest show-config test-groups`), and that
+the skip fires for the right reason. The five phase-337 W2 defects were BUILD
+defects — a header conflict, an arch-gated feature, a missing allocator, a
+duplicated cmake string, a missing entropy device — and this cell adds no build,
+which is consistent with finding none. **A live verdict is still owed**: the
+`.config/interop-verdicts.toml` `pass` and the `live-peer.yml` membership that
+W1's acceptance names need a host with ROS 2, a Zephyr SDK and the west lane.
+Until that runs, "zero defects on the wire" is unmeasured, not established.
+
+**Incidental, and pre-existing:** `ci_lane::tests::documented_lane_table_is_live`
+was already red before this work — four of its six gated numbers had drifted.
+It is excluded from `just ci gate` (`test-unit` passes `--exclude nros-tests`),
+so it only fires in a sweep. Recomputed and corrected in the same commit,
+because adding an interop cell moves one of those numbers (tier 2's cell count
+13→12: `cells()` is a greedy set cover, so a cell covering more singles at once
+finishes the cover in FEWER picks).
 
 ### W2 — is Cyclone reachable from a QEMU guest at all?
 

--- a/just/zephyr-dev.just
+++ b/just/zephyr-dev.just
@@ -424,6 +424,24 @@ test-xrce verbose="":
 test-ros2-qos verbose="":
     @just _test-focused 'binary(=qos_zephyr_ros2_interop_e2e)' {{verbose}}
 
+# phase-441 W1 — the same crossing, one BOARD over: an nros zenoh-pico publisher
+# on a 32-bit Cortex-M3 (`mps2_an385`, Zephyr's IN-KERNEL IP stack over
+# `eth_smsc911x`, QEMU SLIRP) reaches a stock `ros2 topic echo` subscriber.
+#
+# Its sibling `test-ros2-qos` runs the same shape on `native_sim/native/64`,
+# where the sockets are the HOST's — so that cell says nothing about an RTOS
+# network stack and this one is the first live-peer cell that does.
+#
+# Same aiming contract as `test-ros2-qos`: deliberately NOT sequenced after
+# `build-fixtures`, because running the whole west lane to reach one cell is not
+# something anyone would type. Build the leaf
+# (`just zephyr build-fixtures`, `build-cortex-m-c-talker-zenoh`), then aim.
+#
+# Needs ROS 2 + `rmw_zenoh_cpp` + `qemu-system-arm`; skips on any of them.
+[group("debug")]
+test-ros2-cortex-m verbose="":
+    @just _test-focused 'binary(=pubsub_zephyr_cortex_m_ros2_interop_e2e)' {{verbose}}
+
 # Run Zephyr C examples test
 [group("debug")]
 test-c:

--- a/packages/boards/board-support.toml
+++ b/packages/boards/board-support.toml
@@ -195,7 +195,7 @@ nightly_token = "zephyr"
 tier = 2
 execution_class = "cross-run"
 maintainers = []
-notes = "C and C++ pubsub are Runtime; service/action are BuildOnly pending the runner's peer half. NO RUST ROW: `zephyr-lang-rust` cannot compile for any board whose devicetree has gpio nodes (issue 0432), so a rust cell would not build and BuildOnly would be a lie. Tier 2 rather than 1 because `just ci` is host-only and this needs QEMU."
+notes = "C, C++ and Rust pubsub are Runtime; service/action are BuildOnly pending the runner's peer half. It also carries the tree's first non-native_sim live-peer interop cell (phase-441 W1, `zephyr-cortex-m-pubsub-c-zenoh`). This note used to say NO RUST ROW, because `zephyr-lang-rust` could not compile for any board whose devicetree has gpio nodes — issue 0432, RESOLVED 2026-08-12 by phase-346 W2/W3, after which the Rust leaf built and `zephyr_cortex_m_rust_zenoh_pubsub_e2e` ran it while four documents still said it could not. Tier 2 rather than 1 because `just ci` is host-only and this needs QEMU."
 
 [[board]]
 crate = "nros-board-esp32-qemu"

--- a/packages/testing/nros-tests/src/ci_lane.rs
+++ b/packages/testing/nros-tests/src/ci_lane.rs
@@ -37,10 +37,29 @@
 //!
 //! | lane | selection | cells | coords | cost |
 //! | --- | --- | --- | --- | --- |
-//! | [`CiLane::Tier1`] | host-exec, 1-wise p,w,k + pairwise l × r | 17 | 12 | 26 % |
-//! | [`CiLane::Tier2`] | 1-wise p, l, r, k | 13 | 13 | 26 % |
-//! | [`CiLane::Tier2Nightly`] | pairwise p × l × r × k | 36 | 36 | 72 % |
-//! | tier 3 | everything | 194 | 50 | 100 % |
+//! | [`CiLane::Tier1`] | host-exec, 1-wise p,w,k + pairwise l × r | 19 | 12 | 24 % |
+//! | [`CiLane::Tier2`] | 1-wise p, l, r, k | 12 | 12 | 24 % |
+//! | [`CiLane::Tier2Nightly`] | pairwise p × l × r × k | 36 | 35 | 71 % |
+//! | tier 3 | everything | 205 | 49 | 100 % |
+//!
+//! Re-measured 2026-09-10 (phase-441 W1). FOUR of the six gated numbers had
+//! drifted before that commit touched anything — tier 1's cells (17→19), tier
+//! 2's coords (13→12), nightly's coords (36→35) and the tier-3 denominator
+//! (50→49) — which is the drift this test exists to catch and does catch: it is
+//! excluded from `just ci gate` (`test-unit` passes `--exclude nros-tests`), so
+//! it only fires in a sweep and had been sitting red there. The fifth number
+//! moved WITH phase-441 W1: adding `zephyr-cortex-m-pubsub-c-zenoh` took tier
+//! 2's cell count 13→12, which reads backwards until you remember `cells()` is a
+//! GREEDY set cover — a cell covering more singles at once lets the cover finish
+//! in fewer picks. Cell count is not monotone in the candidate set and never was
+//! (see `the_ladder_is_monotone_in_fixture_cost`, which asserts on coordinates
+//! for exactly this reason).
+//!
+//! NOT updated, and not gated by anything: the prose in `just/ci.just` and
+//! `justfile` that quotes these covers ("14 of 50 coordinates", "37 of 194
+//! cells", "34 of 47", "10 of 50"). Those carry three different denominators and
+//! none of them is current — a separate cleanup, because guessing which era each
+//! sentence describes would make them confidently wrong rather than visibly old.
 //!
 //! **These numbers are GATED, not transcribed** — `documented_lane_table_is_live`
 //! recomputes them and fails if this table drifts (phase-342 W3). They had:
@@ -869,9 +888,9 @@ _tier-build:
 
         // (lane, cells, coords) exactly as the module docs above state them.
         let documented = [
-            (CiLane::Tier1, 17, 12),
-            (CiLane::Tier2, 13, 13),
-            (CiLane::Tier2Nightly, 36, 36),
+            (CiLane::Tier1, 19, 12),
+            (CiLane::Tier2, 12, 12),
+            (CiLane::Tier2Nightly, 36, 35),
         ];
         for (lane, want_cells, want_coords) in documented {
             assert_eq!(
@@ -890,8 +909,8 @@ _tier-build:
             );
         }
         assert_eq!(
-            total_coords, 50,
-            "the table's tier-3 denominator (50 coordinates) is stale; recomputed \
+            total_coords, 49,
+            "the table's tier-3 denominator (49 coordinates) is stale; recomputed \
              {total_coords}"
         );
     }

--- a/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
@@ -4246,8 +4246,13 @@ fn zephyr_build_root() -> PathBuf {
 ///   is the thing that distinguishes them, and it has to appear in the path or
 ///   the two builds collide in one directory.
 ///
-/// `lang` is `"c"` or `"cpp"`. There is no rust arm: issue 0432 blocks the
-/// `zephyr` crate on any board with gpio nodes.
+/// `lang` is `"rust"`, `"c"` or `"cpp"`. This used to say "there is no rust arm:
+/// issue 0432 blocks the `zephyr` crate on any board with gpio nodes" — **0432
+/// was RESOLVED 2026-08-12 by phase-346 W2/W3**, the west lane has built
+/// `build-cortex-m-rust-talker-zenoh` since, and
+/// `zephyr_cortex_m_rust_zenoh_pubsub_e2e` calls this function with `"rust"`.
+/// The sentence outlived its fact by four weeks and was still being read as a
+/// constraint in phase-441 (corrected there, W1).
 pub fn build_zephyr_cortex_m_example(lang: &str, case: &str, rmw: Rmw) -> TestResult<PathBuf> {
     let root = project_root();
     let example_dir = root.join(format!("examples/zephyr/{}/{}", lang, case));

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -32,9 +32,14 @@ pub enum BuildChannel {
     /// Native example / workspace-entry binaries (`just native build-fixtures`
     /// families). Host platform only.
     NativeFixtures,
-    /// Zephyr workspace entry via the west leaves lane
+    /// Zephyr workspace entry or example leaf via the west leaves lane
     /// (`scripts/build/zephyr-fixture-leaves.sh`, driven by `just zephyr
     /// build-fixtures`).
+    ///
+    /// One channel, two BOARDS. The lane emits `native_sim/native/64` leaves and
+    /// `mps2_an385` leaves from the same manifest loop, so both
+    /// `PlatformId::ZephyrNativeSim` and `PlatformId::ZephyrQemuCortexM` are
+    /// producible here (phase-441 W1) — the board is a row field, not a channel.
     ZephyrWestLeaves,
 }
 
@@ -62,7 +67,10 @@ impl BuildChannel {
     pub const fn builds_platform(self, p: PlatformId) -> bool {
         match self {
             BuildChannel::NativeFixtures => matches!(p, PlatformId::Linux),
-            BuildChannel::ZephyrWestLeaves => matches!(p, PlatformId::ZephyrNativeSim),
+            BuildChannel::ZephyrWestLeaves => matches!(
+                p,
+                PlatformId::ZephyrNativeSim | PlatformId::ZephyrQemuCortexM
+            ),
         }
     }
 }
@@ -327,6 +335,39 @@ pub const CELLS: &[InteropCell] = &[
          CarveOut("no zephyr Cpp/Cyclonedds QoS-interop lane; the QoS zephyr \
                    interop test runs Rust/Zenoh (zenoh-pico). File a lane if wanted.")),
        ZephyrWestLeaves, RosEdition(Cyclonedds), BiDir, NO_TEST),
+
+    // ── phase-441 W1 — the live peer, one BOARD over ─────────────────────
+    // The row above is `ZephyrNativeSim`, i.e. `native_sim/native/64`:
+    // `CONFIG_NET_SOCKETS_OFFLOAD=y`, so its sockets, its libc and its 64-bit
+    // pointers are the HOST's and no RTOS network stack is ever in the path.
+    // Until this row, that was the whole of our non-Linux live-peer coverage —
+    // one platform, one language, one RMW, one workload — and calling it
+    // "on-target" was doing work the artifact did not support.
+    //
+    // This cell is `mps2_an385`: a 32-bit Cortex-M3 running Zephyr's IN-KERNEL
+    // IP stack over `eth_smsc911x`, reaching a host router through QEMU SLIRP.
+    // Everything else is deliberately held still — same RMW (zenoh-pico), same
+    // peer, same direction, same crossing mechanism (a baked TCP locator, not
+    // multicast: SLIRP is unicast-only and TAP needs root).
+    //
+    // Two axes move rather than one, and the second is forced. The workload is
+    // `Pubsub`, not the sibling's `Qos`, because no QoS workspace entry exists
+    // for any board but native_sim in ANY language — a QoS cell here would mean
+    // authoring an entry, a `[[workspace_fixture]]` row, a west build name and
+    // a port bake, none of which is the axis W1 exists to move. The C talker
+    // leaf is already built by the west lane at exactly this coordinate
+    // (`build-cortex-m-c-talker-zenoh`, locator `tcp/10.0.2.2:10700`), so this
+    // row adds a live peer and nothing else.
+    //
+    // The language is C, and NOT for the reason phase-441 gives: issue 0432
+    // (`zephyr-lang-rust` cannot build for a board with gpio nodes) was
+    // RESOLVED 2026-08-12 by phase-346 W2/W3 and the Rust leaf has run since.
+    // C is what the existing lane-built leaf is; it also exercises the other
+    // half of our API surface from the Rust sibling above.
+    ic("zephyr-cortex-m-pubsub-c-zenoh",
+       c(ZephyrQemuCortexM, C, Zenoh, Pubsub, Interop, Runtime),
+       ZephyrWestLeaves, RosEdition(Zenoh), NanoToRos,
+       "pubsub_zephyr_cortex_m_ros2_interop_e2e"),
 
     // ── Declarative cross-RMW bridges ───────────────────────────────────
     // The nano bridge is a `ws-bridge-*-rust` native_entry; a ROS 2 peer sits on

--- a/packages/testing/nros-tests/src/matrix.rs
+++ b/packages/testing/nros-tests/src/matrix.rs
@@ -48,8 +48,13 @@ pub enum PlatformId {
     /// handler off native_sim, a duplicated cmake feature string, and a board
     /// with no entropy device), every one of them invisible to native_sim.
     ///
-    /// Cells here are C/C++ only: the pinned `zephyr-lang-rust` cannot compile
-    /// for any board whose devicetree has gpio nodes (issue 0432).
+    /// This used to read "cells here are C/C++ only: the pinned
+    /// `zephyr-lang-rust` cannot compile for any board whose devicetree has gpio
+    /// nodes (issue 0432)". **0432 was RESOLVED 2026-08-12 by phase-346 W2/W3**;
+    /// the Rust leaf has built since and `zephyr_cortex_m_rust_zenoh_pubsub_e2e`
+    /// runs it. Corrected phase-441 W1, which read the sentence as a constraint
+    /// and had to measure it to find out otherwise. All three languages are
+    /// live here.
     ZephyrQemuCortexM,
     /// FreeRTOS on QEMU MPS2-AN385 (lwIP).
     FreertosMps2,

--- a/packages/testing/nros-tests/tests/matrix_fixture_coverage.rs
+++ b/packages/testing/nros-tests/tests/matrix_fixture_coverage.rs
@@ -658,33 +658,67 @@ fn interop_bindings_g4_peer_consistent_with_cell() {
 /// that kind reported two false violations while this gate was being written
 /// (`ZephyrNativeSim` → `zephyrnativesim`, which matches nothing).
 ///
-/// # Two exemptions, both load-bearing
+/// # Three backing tables, and one exemption
 ///
-/// **`workspace_fixture` rows count.** They carry a coordinate and narrow
-/// through `attribute_workspace_id` / `require_workspace_in_lane` rather than
-/// by path, which is a different mechanism but the same guarantee. Counting
-/// only `kind = "fixture"` falsely flagged `zephyr-qos-rust-zenoh`, whose
-/// coordinate is backed by seven workspace rows and zero plain ones.
+/// The question is never "does a `[[fixture]]` row exist" — it is "can the
+/// resolver this cell reaches report `[SKIPPED:lane]`". There are three ways to
+/// earn that, and all three count:
+///
+/// **`fixture` rows** narrow by PATH (`attribute_path` → `row_artifact_root`).
+///
+/// **`workspace_fixture` rows** carry a coordinate and narrow through
+/// `attribute_workspace_id` / `require_workspace_in_lane` — a different
+/// mechanism, the same guarantee. Counting only `kind = "fixture"` falsely
+/// flagged `zephyr-qos-rust-zenoh`, whose coordinate is backed by seven
+/// workspace rows and zero plain ones.
+///
+/// **West leaves** narrow by BUILD-DIR NAME. This third arm was missing, and
+/// its absence was written down as a deliberate exemption:
+///
+/// > Note what is NOT exempted: `builder = "west"` rows are absent from
+/// > `manifest_rows()` because west leaves are built module-level and are
+/// > deliberately unattributable. A Runtime cell that could only be backed by a
+/// > west row would therefore still fail here — correctly, because nothing
+/// > could narrow it.
+///
+/// That was true when this gate was written and had already stopped being true:
+/// **issue 0713** put `require_west_leaf_in_lane(build_name, …)` at the head of
+/// `require_prebuilt_binary_fresh_zephyr`, so EVERY zephyr resolver — including
+/// `build_zephyr_cortex_m_example` — narrows by looking the build name up in
+/// `fixtures::lane::west_leaves()`, which is `fixtures-manifest.py west-leaves`,
+/// which is `examples/fixtures.toml`. The rows are absent from `manifest_rows()`
+/// only because that table is the PATH-attribution one; they are not absent
+/// from the manifest, and they are not unnarrowable.
+///
+/// So the gate's REACH was narrower than the rule it enforces (the 0196 shape),
+/// in the direction that reads as correctness: it rejected the first interop
+/// cell whose nano side is a west EXAMPLE leaf (phase-441 W1,
+/// `zephyr-cortex-m-pubsub-c-zenoh`) with a diagnosis — "no lane can narrow
+/// it" — that the resolver contradicts. Note the west arm is only as good as the
+/// build NAME being modelled: `require_west_leaf_in_lane` fails OPEN on a name
+/// it cannot find (issue 1016), which is what `check-west-leaf-vocabulary`
+/// exists to prevent and why matching here is on the manifest's own leaf table
+/// rather than on a name this file invents.
 ///
 /// **`Tier::CarveOut` cells are skipped.** A carve-out records a lane that
 /// deliberately does not exist, so demanding a fixture row for it would be
 /// demanding the thing the carve-out exists to say we do not build. That is
 /// what `zephyr-qos-cpp-cyclone-CARVED` is, and its recorded reason says so.
-///
-/// Note what is NOT exempted: `builder = "west"` rows are absent from
-/// `manifest_rows()` because west leaves are built module-level and are
-/// deliberately unattributable. A Runtime cell that could only be backed by a
-/// west row would therefore still fail here — correctly, because nothing could
-/// narrow it.
 #[test]
 fn interop_bindings_g5_cells_are_lane_narrowable() {
     let rows = nros_tests::fixtures::lane::manifest_rows();
+    let leaves = nros_tests::fixtures::lane::west_leaves();
     // Precondition, not decoration: an empty manifest would make every cell
     // below "unbacked" and this test would fail for the wrong reason — or, if
-    // the loop were inverted, pass having checked nothing.
+    // the loop were inverted, pass having checked nothing. Both tables, because
+    // either one going empty is the same vacuity from the other direction.
     assert!(
         rows.iter().any(|r| r.kind == "fixture"),
         "no fixture rows parsed from the manifest — the check below would be vacuous"
+    );
+    assert!(
+        !leaves.is_empty(),
+        "no west leaves parsed from the manifest — the west arm below would be vacuous"
     );
 
     let mut bad = Vec::new();
@@ -696,17 +730,22 @@ fn interop_bindings_g5_cells_are_lane_narrowable() {
         }
         let platform_tokens = c.cell.platform.fixture_tokens();
         let lang = c.cell.lang.as_str();
+        let coord_matches = |coord: &nros_tests::fixtures::lane::Coord| {
+            platform_tokens.contains(&coord.0.as_str())
+                && coord.1 == lang
+                && rmw_from_str(&coord.2) == Some(c.cell.rmw)
+        };
         let backed = rows.iter().any(|r| {
-            (r.kind == "fixture" || r.kind == "workspace_fixture")
-                && platform_tokens.contains(&r.coord.0.as_str())
-                && r.coord.1 == lang
-                && rmw_from_str(&r.coord.2) == Some(c.cell.rmw)
-        });
+            (r.kind == "fixture" || r.kind == "workspace_fixture") && coord_matches(&r.coord)
+        })
+        // The west arm — see the doc comment. A west leaf narrows by build-dir
+        // NAME through `require_west_leaf_in_lane`, which reads this same table.
+            || leaves.iter().any(|l| coord_matches(&l.coord));
         if !backed {
             bad.push(format!(
-                "{}: coordinate {:?}/{}/{:?} is produced by NO fixtures.toml row, \
-                 so no lane can narrow it — it will be required fresh in every \
-                 lane whose build may not cover it",
+                "{}: coordinate {:?}/{}/{:?} is produced by NO fixtures.toml row and \
+                 NO west leaf, so no lane can narrow it — it will be required fresh \
+                 in every lane whose build may not cover it",
                 c.id, platform_tokens, lang, c.cell.rmw
             ));
         }

--- a/packages/testing/nros-tests/tests/pubsub_zephyr_cortex_m_ros2_interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/pubsub_zephyr_cortex_m_ros2_interop_e2e.rs
@@ -1,0 +1,210 @@
+//! phase-441 W1 — the live-peer crossing, one BOARD over.
+//!
+//! ## What this cell is for
+//!
+//! `interop::CELLS` had exactly one non-Linux runnable row before this file:
+//! `zephyr-qos-rust-zenoh` on `PlatformId::ZephyrNativeSim`. native_sim is
+//! `native_sim/native/64` — `CONFIG_NET_SOCKETS_OFFLOAD=y`, so the sockets are
+//! the HOST's, the libc is the host's and the pointers are the host's 64 bits.
+//! That cell proves our zenoh-pico code talks to `rmw_zenoh_cpp`; it does not
+//! prove it does so from a device, because no RTOS network stack is ever in the
+//! path.
+//!
+//! This cell moves the one axis that changes: the image is a 32-bit Cortex-M3
+//! (`mps2_an385`) running Zephyr's IN-KERNEL IP stack over the `eth_smsc911x`
+//! driver against QEMU's lan9118, reaching the host through SLIRP. Same RMW
+//! (zenoh-pico), same peer (a stock `rmw_zenoh_cpp` node), same direction
+//! (nano → ROS), same crossing mechanism (a baked TCP locator to a router on
+//! the host, no multicast discovery — SLIRP is unicast-only and TAP would need
+//! `ip tuntap add`, i.e. root).
+//!
+//! ## Two assertions, and both are load-bearing
+//!
+//! 1. `IPv4 address: 10.0.2.15` — Zephyr's own `net_config` announcing the
+//!    static address from `cmake/zephyr/mps2-an385.conf`. Only the in-kernel
+//!    stack driving a real ethernet controller can print it, so it is the
+//!    evidence that this coordinate is a second witness rather than a second
+//!    spelling of native_sim. Its sibling `zephyr_cortex_m_qemu` asserts the
+//!    same line for the same reason.
+//! 2. `ros2 topic echo` receives `/chatter`. That is the interop claim, and the
+//!    reason the first assertion alone would not do: the pubsub cell in
+//!    `matrix::CELLS` asserts the image PRINTS `Publishing:`, which the C talker
+//!    does whenever `nros_cpp_publish_raw` returns 0 — a local return code, not
+//!    a delivery. Nothing in the tree observed a sample leaving this board until
+//!    this test.
+//!
+//! ## Why C and not the Rust QoS entry the phase doc names
+//!
+//! Two reasons, one of them a correction. The correction: phase-441's W1 text
+//! (and `matrix.rs`, and `binaries/mod.rs`) says Rust cannot build for this
+//! board because of issue 0432. **0432 was RESOLVED 2026-08-12 by phase-346
+//! W2/W3** and `zephyr_cortex_m_rust_zenoh_pubsub_e2e` has run the Rust leaf
+//! since; the three stale statements are corrected in the same commit as this
+//! file.
+//!
+//! The reason that survives is minimality. There is no C, C++ *or* Rust QoS
+//! workspace entry for any board but `native_sim/native/64`
+//! (`examples/workspaces/features/src/` has three zephyr entries, all
+//! native_sim), so a QoS cell here means authoring an entry, a
+//! `[[workspace_fixture]]` row, a west build name and a port bake — four new
+//! things, none of them the axis W1 exists to move. The C talker leaf is
+//! ALREADY built by the west lane at this exact coordinate
+//! (`examples/fixtures.toml`, `build-cortex-m-c-talker-zenoh`, locator
+//! `tcp/10.0.2.2:10700`), so this cell adds a peer and nothing else. The
+//! workload axis moves from `Qos` to `Pubsub`; the board axis moves, which is
+//! what the phase is about.
+//!
+//! ## Prerequisites
+//!
+//! - ROS 2 + `rmw_zenoh_cpp` (skips when absent — a host with no `/opt/ros`
+//!   cannot run this cell at all)
+//! - `just zephyr build-fixtures` (the west leaves lane builds
+//!   `build-cortex-m-c-talker-zenoh`)
+//! - `qemu-system-arm` with `mps2-an385` machine support
+//!
+//! Run with: `just zephyr test-ros2-cortex-m`, or
+//! `cargo nextest run -p nros-tests --test pubsub_zephyr_cortex_m_ros2_interop_e2e`
+
+use nros_tests::{
+    alloc::port_of,
+    fixtures::{QemuProcess, Rmw, ZenohRouter, build_zephyr_cortex_m_example, is_qemu_available},
+    matrix::{Lang, PlatformId, Workload},
+    ros2::{DEFAULT_ROS_DISTRO, require_ros2, ros2_env_setup_with_locator},
+    skip,
+};
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
+
+/// The router port baked into the C talker leaf — the allocator's
+/// (zephyr-cortex-m, C, Pubsub) number, matching the west lane's
+/// `west_zenoh_locator = "tcp/10.0.2.2:10700"` bake in `examples/fixtures.toml`.
+/// Derived rather than spelled so a platform-index change moves the bake and
+/// this test together instead of leaving one behind.
+const CORTEX_M_C_TALKER_PORT: u16 =
+    port_of(PlatformId::ZephyrQemuCortexM, Lang::C, Workload::Pubsub);
+
+/// Zephyr's `net_config` announcing the static SLIRP address. See the module
+/// docs: this is the distinguishing evidence of the board.
+const NET_STACK_READY_MARKER: &str = "IPv4 address: 10.0.2.15";
+
+/// How long to wait for the guest to reach "network ready". The board reaches
+/// it at ~2.15 s; 60 s is generous headroom for a loaded host without becoming
+/// the nextest per-test timeout.
+const NET_READY_BUDGET: Duration = Duration::from_secs(60);
+
+/// How long to poll `ros2 topic echo` for. Each attempt pays multi-second ros2
+/// CLI startup, so this is a handful of attempts, not many.
+const ECHO_BUDGET: Duration = Duration::from_secs(45);
+
+#[test]
+fn nros_zephyr_cortex_m_publisher_reaches_ros2_topic_echo() {
+    if !require_ros2() {
+        skip!(
+            "ROS 2 / rmw_zenoh_cpp not available — install it from apt \
+             (`ros-$ROS_DISTRO-rmw-zenoh-cpp`, declared in nros-sdk-index.toml). \
+             This cell's peer IS a stock ROS 2 node; there is nothing to measure \
+             without one."
+        );
+    }
+    if !is_qemu_available() {
+        skip!("qemu-system-arm not found — this cell boots an mps2_an385 guest");
+    }
+
+    // Not a `skip!` on error: since issue 0584 an absent IN-LANE fixture is a
+    // hard failure, because the lane gate already promised it exists, and the
+    // resolver raises its own `[SKIPPED]` for an out-of-lane coordinate. See
+    // the same comment in `zephyr_cortex_m_qemu.rs` (issues 0806/0807) — a skip
+    // here relabels STALE as missing and the cell silently stops running.
+    let binary = build_zephyr_cortex_m_example("c", "talker", Rmw::Zenoh).unwrap_or_else(|e| {
+        panic!(
+            "zephyr/c/talker for mps2_an385 did not resolve. The lane gate already \
+             asserted this fixture is built, so this is a real failure, not a setup \
+             condition — read the verdict before rebuilding: {e:?}"
+        )
+    });
+
+    // Bind 0.0.0.0, not loopback: the guest reaches the host through SLIRP's
+    // 10.0.2.2 gateway and a loopback-only listener leaves those SYNs
+    // unreachable. `locator()` still hands the HOST-side peer
+    // `tcp/127.0.0.1:<port>`, which is the same router.
+    let router = ZenohRouter::start_slirp(CORTEX_M_C_TALKER_PORT).unwrap_or_else(|e| {
+        panic!("failed to start zenohd on {CORTEX_M_C_TALKER_PORT} for the SLIRP guest: {e:?}")
+    });
+    let locator = router.locator();
+
+    let mut qemu = QemuProcess::start_mps2_an385_networked(&binary)
+        .expect("spawn Zephyr Cortex-M zenoh talker");
+
+    // Wait for the in-kernel stack before asking ROS 2 anything: until
+    // `net_config` has assigned 10.0.2.15 the guest cannot have opened its TCP
+    // session to the router, so every echo attempt before this point is spent
+    // on a session that does not exist yet.
+    let boot = qemu.collect_until(NET_STACK_READY_MARKER, NET_READY_BUDGET);
+    assert!(
+        boot.contains(NET_STACK_READY_MARKER),
+        "Zephyr's in-kernel net stack never assigned the static address — the \
+         eth_smsc911x driver did not come up, so nothing this cell measures had \
+         a chance to happen.\nOutput:\n{boot}"
+    );
+
+    // Poll `ros2 topic echo --once` until a sample lands. Same shape as
+    // `qos_zephyr_ros2_interop_e2e`: each attempt pays the ros2 CLI startup, so
+    // budget generously and bail on the first success.
+    let (env, _config_guard) = ros2_env_setup_with_locator(DEFAULT_ROS_DISTRO, &locator);
+    let deadline = Instant::now() + ECHO_BUDGET;
+    let mut last = String::new();
+    let mut delivered = false;
+    while Instant::now() < deadline {
+        let script = format!(
+            "{env} && timeout 12 ros2 topic echo --once /chatter std_msgs/msg/String \
+             --no-daemon --spin-time 2 2>&1"
+        );
+        let out = Command::new("bash")
+            .args(["-c", &script])
+            .output()
+            .expect("failed to spawn bash for ros2 invocation");
+        last = String::from_utf8_lossy(&out.stdout).into_owned();
+        if last.contains("data:") {
+            delivered = true;
+            break;
+        }
+    }
+
+    // Read up to the guest's NEXT publish before killing it, so a failure
+    // message carries the board's own transcript from the window ros2 was
+    // polling in rather than only the boot. The talker's timer is 500 ms, so a
+    // healthy image returns here immediately; an image that died mid-run
+    // returns the whole 2 s window, which is itself the answer.
+    let tail = qemu.collect_until(
+        nros_tests::output::TALKER_LOG_PREFIX,
+        Duration::from_secs(2),
+    );
+    qemu.kill();
+
+    assert!(
+        delivered,
+        "`ros2 topic echo` (rmw_zenoh_cpp) never received /chatter from the Zephyr \
+         Cortex-M talker. The board's IP stack came up (the assertion above passed), \
+         so this is the WIRE, not the boot: a 32-bit guest publishing through \
+         zenoh-pico over Zephyr's own TCP stack did not reach a stock ROS 2 \
+         subscriber.\nrouter: {}\nlast ros2 output:\n{last}\nguest boot:\n{boot}\nguest tail:\n{tail}",
+        router.launch_line()
+    );
+}
+
+// Issue 0352 / phase-324 — bind this test to `interop::CELLS`. The coordinates
+// below must equal what the list declares for
+// `pubsub_zephyr_cortex_m_ros2_interop_e2e`; adding/retiring an interop cell for
+// this test, or drifting a cell's coordinate (issue 0341 defect 2), turns this
+// RED. Needs no fixtures — runs in tier 1.
+#[test]
+fn cases_bound_to_interop_cells() {
+    #[allow(unused_imports)]
+    use nros_tests::matrix::{Lang::*, PlatformId::*, Rmw::*, Workload::*};
+    nros_tests::interop::assert_test_bound(
+        "pubsub_zephyr_cortex_m_ros2_interop_e2e",
+        &[(ZephyrQemuCortexM, C, Zenoh, Pubsub)],
+    );
+}


### PR DESCRIPTION
## What

phase-441 **W1**: move the proven live-peer cell one **board** over.

`interop::CELLS` had exactly one non-Linux runnable row — `zephyr-qos-rust-zenoh`
on `ZephyrNativeSim`. native_sim is `native_sim/native/64` with
`CONFIG_NET_SOCKETS_OFFLOAD=y`, so its sockets, libc and 64-bit pointers are the
**host's** and no RTOS network stack is ever in the path. That cell proves our
zenoh-pico code talks to `rmw_zenoh_cpp`; it does not prove it does so from a
device. "On-target verification" was doing work the artifact did not support.

New cell **`zephyr-cortex-m-pubsub-c-zenoh`** (`Tier::Runtime`,
`RosEdition(Zenoh)`, `NanoToRos`, `ZephyrWestLeaves`), run by
`tests/pubsub_zephyr_cortex_m_ros2_interop_e2e.rs`, aimable with
`just zephyr test-ros2-cortex-m`: a 32-bit Cortex-M3 (`mps2_an385`) running
Zephyr's **in-kernel** IP stack over `eth_smsc911x`, reaching a host router
through QEMU SLIRP, against a stock `ros2 topic echo`. Same RMW, same peer, same
direction, same crossing mechanism (a baked TCP locator — SLIRP is unicast-only
and TAP needs root, which CLAUDE.md forbids).

Two assertions, both load-bearing:

1. `IPv4 address: 10.0.2.15` from Zephyr's `net_config` — only the in-kernel
   stack driving a real ethernet controller prints it. That is the evidence the
   coordinate is a second **witness** rather than a second spelling of
   native_sim.
2. `ros2 topic echo --once /chatter` receives a sample. The existing baked
   pubsub cell asserts the image *prints* `Publishing:`, which the C talker does
   whenever `nros_cpp_publish_raw` returns 0 — a local return code. Nothing in
   the tree had observed a sample **leave** this board.

**Zero new fixtures.** The cell reuses `build-cortex-m-c-talker-zenoh`, already
built by the west lane at exactly this coordinate (`tcp/10.0.2.2:10700` =
`port_of(ZephyrQemuCortexM, C, Pubsub)`); it adds a live peer and nothing else.

## Two amendments to W1 as planned

**The workload moves, `Qos` → `Pubsub`.** No QoS workspace entry exists for any
board but native_sim in **any** language, so a QoS cell on `mps2_an385` means
authoring an entry package, a `[[workspace_fixture]]` row, a west build name and
a port bake — four new artifacts, none of them the axis W1 exists to move, all
of which would ship unbuilt on a host with no Zephyr SDK. The axis W1 *is* about
(host sockets → Zephyr's own stack; 64-bit → 32-bit) moves exactly as planned.

**The C/C++-only constraint no longer exists.** phase-441 quoted
`ZephyrQemuCortexM`'s doc comment on issue **0432**. 0432 was **resolved
2026-08-12** by phase-346 W2/W3; the Rust leaf has built since and
`zephyr_cortex_m_rust_zenoh_pubsub_e2e` runs it. **Five** places still asserted
it — `matrix.rs`, `binaries/mod.rs` (in the very function that cell calls with
`"rust"`), `board-support.toml` (generated into
`book/src/reference/board-support-tiers.md`, so the book asserted it too),
RFC-0064, and phase-441 itself. All corrected; sweep in the commit message.
The cell is still C, but for a smaller reason: C is what the west lane already
builds at that coordinate.

## A gate defect this surfaced

`interop_bindings_g5_cells_are_lane_narrowable` rejected the cell with *"produced
by NO fixtures.toml row, so no lane can narrow it"*, and its doc comment declared
that verdict deliberate for west rows. True when G5 was written, and already
false: **issue 0713** put `require_west_leaf_in_lane` at the head of
`require_prebuilt_binary_fresh_zephyr`, so every zephyr resolver *does* narrow —
by build-dir **name** against `fixtures::lane::west_leaves()`, the same
`examples/fixtures.toml` read through a different subcommand. G5 was checking
only the path-attribution table, which by construction omits west rows, so its
diagnosis was one the resolver contradicts. The 0196 shape, in the direction that
reads as correctness. G5 now counts all three backing mechanisms, each with its
own vacuity precondition.

## Incidental

* nextest group `zephyr-cortex-m-baked-port` (max-threads 1).
  `ZenohRouter::start_on` **kills** whoever holds the port, and both cells of a
  language start a router on the same baked one. Placed ahead of
  `binary(~zephyr)` (a substring match that would claim it first); membership
  verified with `cargo nextest show-config test-groups`, not by reading the
  filter.
* `ci_lane`'s gated cost table recomputed. **Four** of its six numbers had
  already drifted (tier-1 cells 17→19, tier-2 coords 13→12, nightly coords
  36→35, denominator 50→49) — the test is excluded from `just ci gate`
  (`test-unit` passes `--exclude nros-tests`), so it only fires in a sweep. The
  fifth moved with this PR: tier 2's cell count 13→12, which reads backwards
  until you remember `cells()` is a **greedy set cover**.

## Defects the board crossing exposed: **zero** in nano-ros

Stated with its caveat, because the expected finding was five. This host has no
`/opt/ros`, no Zephyr SDK and no west workspace, so the cell reaches its
`require_ros2()` skip and stops — **the wire was not run**. The five phase-337
W2 defects were *build* defects (a header conflict, an arch-gated feature, a
missing allocator, a duplicated cmake string, a missing entropy device) and this
cell adds no build, which is consistent with finding none, but does not
establish it.

**Verified here**

* all 10 `matrix_fixture_coverage` gates, including the repaired G5
* `check-interop-cell-runners`: 23/23 Runtime cells have a named runner, ledger
  still empty
* `check-nextest-binary-filters`, `check-west-leaf-vocabulary`,
  `check-board-tiers`
* all 207 `nros-tests` lib tests
* `just check fast`: **287 gates green**, 3 skipped for unprovisioned tooling
  (Orin FSP, nuttx leaf locks, `arm-none-eabi-*`)
* the skip firing for the right reason via `just zephyr test-ros2-cortex-m` —
  `Real failures: 0`, and the interop tracker reports *"This run reached 1 of
  them — 0 produced a result, 1 skipped wholesale"*

**Needs a ROS 2 host** (with a Zephyr SDK and the west lane): a live verdict, the
`.config/interop-verdicts.toml` `pass` W1's acceptance names, and the
`live-peer.yml` membership that follows from it. Until then "zero defects on the
wire" is *unmeasured*, not established — and the phase doc says so in those
words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
