### PR TITLE
feat(phase-440): dest can name the store, and third-party/ has no exceptions left

### DIFF
--- a/.config/gate-selftest-baseline.txt
+++ b/.config/gate-selftest-baseline.txt
@@ -114,6 +114,5 @@ scripts/gen-support-status.py
 scripts/lib/grep-q.sh
 scripts/reserve-claim.sh
 scripts/sdk/check-qemu-configure.sh
-scripts/sdk/verify-index.py
 scripts/stack-analysis-c.sh
 scripts/stack-analysis.sh

--- a/docs/roadmap/phase-440-nros-store-is-the-root.md
+++ b/docs/roadmap/phase-440-nros-store-is-the-root.md
@@ -315,6 +315,30 @@ user path — install, pin, build a `nros new` project **without cloning
 nano-ros** — is what W7's pin makes testable, so it lands with W7 rather than
 here.
 
+### Store-aware `dest` — **LANDED. The last mechanism, and W3's exception is retired**
+
+`[source.*]` had one shape, a workspace-relative `dest`, so a provisioned source
+could only land inside a checkout. That is what forced W3 to DECLARE `ros` an
+exception in a ratchet whose whole point is that `third-party/` holds tracked
+submodules and nothing else.
+
+`SourceLocation` is `workspace` (default) or `store`. A store source's path is
+DERIVED — `$NROS_STORE/sources/<name>/<version>`, off W6's `store::root()` so
+there is one spelling — mirroring `tool_dir` rather than inventing path syntax.
+The validator refuses both directions: a workspace source with no `dest`, and a
+store source WITH one.
+
+`nros sdk-path --source <name>` is the consumer bridge, for the reason the tool
+arm exists: a consumer asks, never spells. rosidl flipped, and
+`msg_to_cyclone_idl.py` asks — with the pre-phase-440 `third-party/ros/rosidl`
+kept BELOW the store rung, the same shape W4 used for workspaces, so a host
+provisioned earlier needs no migration step.
+
+**`EXCEPTIONS` in W3's ratchet is now EMPTY** (`0 declared exception(s)`), and
+the gate still refuses a new provisioning root — verified with the list empty,
+because an exemption list that has stopped being exercised is where a rule
+quietly stops applying.
+
 ## Order, and what is worth doing regardless
 
 W1 → W3 → W4 → W5 is the cleanup, and it stands on its own: it fixes the tier-2

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -1321,7 +1321,17 @@ packages = ["arm-none-eabi-gcc", "qemu", "freertos-kernel", "lwip"]
 version = "humble-5621b26"
 git = "https://github.com/ros2/rosidl"
 ref = "5621b26eff54596a356ad8abd72c06e7650d21f7"
-dest = "third-party/ros/rosidl"
+# phase-440 / RFC-0095 D1+D2. `third-party/` holds TRACKED SUBMODULES and
+# nothing else (W3's ratchet), and this was the one declared exception in it.
+# In the store the path is DERIVED — `$NROS_STORE/sources/rosidl/<version>` —
+# so it is outside every checkout (D1: no second checkout can own it) and keyed
+# by version (D2: two versions coexist, and two checkouts share one copy
+# instead of provisioning it twice).
+#
+# `dest` is deliberately gone rather than kept alongside: a store path is
+# derived, and leaving an authored one would be a second spelling of a location
+# the store already knows.
+location = "store"
 
 # --- OS packages (phase-327 W1, RFC-0062) -----------------------------------
 #

--- a/packages/cli/nros-cli-core/Cargo.toml
+++ b/packages/cli/nros-cli-core/Cargo.toml
@@ -22,6 +22,13 @@ default = []
 # Maintainer-only release subcommands (`nros release detect|publish|tag`).
 # Hidden from `nros --help` unless this feature is on at build time.
 release = []
+# Issue 0476, phase-443 — makes `test_support` public so an INTEGRATION test in
+# a sibling crate can reach `write_executable_stub`. `tests/toolchain_dispatch.rs`
+# writes a launcher and a stub and then EXECS them, which is exactly the ETXTBSY
+# race that helper exists to remove; without this the only alternative was a
+# second copy of the discipline in that file, and a second spelling of a fix is
+# how #282 became #326. Off by default, so a release build still ships nothing.
+test-support = []
 
 # Issue 0379: `planner.rs` still carries `#[cfg(feature = "play-launch-parser")]`
 # gates around dormant tests for the launch path RFC-0060 retired (the feature

--- a/packages/cli/nros-cli-core/src/cmd/sdk_path.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sdk_path.rs
@@ -30,8 +30,23 @@ use crate::orchestration::{sdk_index::SdkIndex, sdk_store};
 
 #[derive(Debug, Parser)]
 pub struct Args {
-    /// Tool name, as spelled by `[tool.<name>]` in the SDK index.
+    /// Tool name, as spelled by `[tool.<name>]` in the SDK index — or, with
+    /// `--source`, a `[source.<name>]`.
     pub tool: String,
+
+    /// Ask about a `[source.*]` instead of a `[tool.*]` (phase-440).
+    ///
+    /// A source with `location = "store"` is provisioned to
+    /// `$NROS_STORE/sources/<name>/<version>`, DERIVED from the index exactly
+    /// as a tool's prefix is. A consumer that needs to find one must ask rather
+    /// than spell it — the same rule this command exists to enforce for tools,
+    /// and the reason `msg_to_cyclone_idl.py` no longer carries a literal
+    /// `third-party/ros/rosidl`.
+    ///
+    /// A `location = "workspace"` source has no store path, so this reports
+    /// that rather than inventing one.
+    #[arg(long)]
+    pub source: bool,
 
     /// Path to the SDK index.
     #[arg(long, default_value = "nros-sdk-index.toml")]
@@ -44,6 +59,10 @@ pub struct Args {
 
 pub fn run(args: Args) -> Result<()> {
     let index = SdkIndex::load(&crate::cmd::setup::resolve_index(&args.index))?;
+
+    if args.source {
+        return run_source(&index, &args);
+    }
 
     let Some(dir) = sdk_store::tool_dir(&index, &args.tool) else {
         // Name what IS pinned: a typo and an unprovisioned tool look identical
@@ -98,5 +117,48 @@ pub fn run(args: Args) -> Result<()> {
     // installed: the caller asked where the tool goes, and an empty answer is
     // harder to act on than a path that does not exist yet.
     println!("{}", usable.unwrap_or(dir).display());
+    Ok(())
+}
+
+/// `--source` — the store path of a `[source.*]`, phase-440.
+///
+/// Deliberately narrower than the tool arm: there is no legacy flat shape to
+/// fall back to, because store sources are new, so "where it goes" and "where a
+/// consumer reads it" are the same directory and one derivation answers both.
+fn run_source(index: &SdkIndex, args: &Args) -> Result<()> {
+    let Some(src) = index.source.get(&args.tool) else {
+        let known: Vec<&str> = index.source.keys().map(String::as_str).collect();
+        bail!(
+            "no `[source.{}]` in {} — the index names: {}",
+            args.tool,
+            args.index.display(),
+            known.join(", ")
+        );
+    };
+
+    let Some(dir) = sdk_store::source_dir(index, &args.tool) else {
+        // Not an error the caller can fix by provisioning: this source lives in
+        // the workspace by declaration, so say WHICH declaration rather than
+        // printing a store path nothing will ever write.
+        bail!(
+            "`[source.{}]` has location = \"workspace\" (dest = {}), so it has no \
+             store path. Ask for its workspace path, or set location = \"store\" \
+             in {}.",
+            args.tool,
+            src.dest.as_deref().unwrap_or("<unset>"),
+            args.index.display()
+        );
+    };
+
+    if args.require && !dir.is_dir() {
+        bail!(
+            "`[source.{}]` {} is not provisioned at {} — run: nros setup --source {}",
+            args.tool,
+            src.version,
+            dir.display(),
+            args.tool
+        );
+    }
+    println!("{}", dir.display());
     Ok(())
 }

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -911,13 +911,40 @@ fn provision_named_sources(
 /// #0390 — is a `[source.*]` provisioned on disk? An uninitialised submodule is
 /// an absent or EMPTY directory; a provisioned one has entries. `dest` is
 /// workspace-relative.
-fn source_present(src: &crate::orchestration::sdk_index::SourcePackage, workspace: &Path) -> bool {
-    let Some(dest) = src.dest.as_deref() else {
-        return false;
-    };
-    std::fs::read_dir(workspace.join(dest))
+fn source_present(
+    name: &str,
+    src: &crate::orchestration::sdk_index::SourcePackage,
+    workspace: &Path,
+) -> bool {
+    source_dir_of(name, src, workspace)
+        .and_then(|d| std::fs::read_dir(d).ok())
         .map(|mut d| d.next().is_some())
         .unwrap_or(false)
+}
+
+/// The directory a `[source.*]` is provisioned into — phase-440, RFC-0095
+/// D1/D2. ONE derivation, so "where is it?" has one answer for the installer,
+/// the presence probe and `nros sdk-path --source`.
+///
+/// `location = "store"` derives `$NROS_STORE/sources/<name>/<version>` from the
+/// index rather than reading a path out of it; `workspace` (the default) keeps
+/// the historical workspace-relative `dest`, so every existing entry means what
+/// it meant.
+pub(crate) fn source_dir_of(
+    name: &str,
+    src: &crate::orchestration::sdk_index::SourcePackage,
+    workspace: &Path,
+) -> Option<std::path::PathBuf> {
+    use crate::orchestration::sdk_index::SourceLocation;
+    match src.location {
+        SourceLocation::Store => Some(
+            crate::orchestration::store::root()
+                .join("sources")
+                .join(name)
+                .join(&src.version),
+        ),
+        SourceLocation::Workspace => src.dest.as_deref().map(|d| workspace.join(d)),
+    }
 }
 
 /// #0390 — provision (or with `check`, VERIFY) the repo build stage's source
@@ -953,7 +980,7 @@ fn run_build_sources(
         let missing: Vec<&str> = index
             .build_sources
             .iter()
-            .filter(|n| !source_present(&index.source[n.as_str()], &workspace))
+            .filter(|n| !source_present(n.as_str(), &index.source[n.as_str()], &workspace))
             .map(String::as_str)
             .collect();
         if missing.is_empty() {

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -54,8 +54,12 @@ pub mod stale_guard;
 // Issue 0455 — one `scratch_dir` for every unit test in this crate. Nine
 // hand-written `temp_dir().join(...)` spellings raced each other; the
 // differences between them WERE the bug. Test-only, so it ships nothing.
-#[cfg(test)]
-mod test_support;
+// `test-support` additionally exposes it to integration tests in sibling
+// crates (phase-443): `nros-cli`'s launcher tests exec what they write, which
+// is the same ETXTBSY race, and the rule is one helper rather than a second
+// spelling of it.
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 // Phase 219.A — Entry-pkg codegen (`nros codegen entry`). The shared
 // pkg-index walk + launch.xml parser also live here so the cmake-fn
 // path (`nano_ros_entry(LAUNCH …)`), the Rust proc-macro

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
@@ -921,6 +921,17 @@ pub struct ToolSource {
 ///
 /// A source with no fetch fields at all has no provisioning step (e.g. a
 /// host-built package whose tree already lives in the workspace).
+/// Where a `[source.*]` is provisioned. Defaults to `Workspace` so every
+/// existing entry keeps its meaning with no edit — the migration is opt-in, one
+/// source at a time, which is what makes it reviewable.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceLocation {
+    #[default]
+    Workspace,
+    Store,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SourcePackage {
@@ -934,8 +945,22 @@ pub struct SourcePackage {
     pub git_ref: Option<String>,
     /// Workspace-relative destination the source is provisioned into. The
     /// index is the SSOT — never a path baked into the `nros` binary.
+    ///
+    /// Ignored when [`Self::location`] is `Store`: a store entry's path is
+    /// DERIVED from name + version, never authored, so two versions cannot
+    /// collide and nobody can spell it two ways (RFC-0095 D2).
     #[serde(default)]
     pub dest: Option<String>,
+    /// WHERE this source is provisioned — phase-440, RFC-0095 D1/D2.
+    ///
+    /// `workspace` (the default) keeps the historical behaviour: a
+    /// workspace-relative `dest`, which for `third-party/*` sits beside PINNED
+    /// SUBMODULE SOURCE and is what phase-440 W3's ratchet exists to stop
+    /// growing. `store` puts it in `$NROS_STORE/sources/<name>/<version>`,
+    /// outside every checkout (D1, so no second checkout can own it) and keyed
+    /// by version (D2, so two versions coexist and two checkouts share one).
+    #[serde(default)]
+    pub location: SourceLocation,
     /// `.gitmodules` path when the canonical source is a committed submodule;
     /// `nros setup` runs `git submodule update --init <path>` instead of a
     /// fresh clone. `git`/`ref` still record the pin (SSOT) in this mode.
@@ -971,6 +996,11 @@ impl Default for SourcePackage {
             git: None,
             git_ref: None,
             dest: None,
+            // phase-440 — matches `#[serde(default)]`, so a hand-built default
+            // and a TOML-parsed entry with no `location` agree. This impl exists
+            // BECAUSE `#[derive(Default)]` would diverge on the bools; a new
+            // field that disagrees here is the same bug one row down.
+            location: SourceLocation::Workspace,
             submodule: None,
             shallow: true,
             recursive: true,
@@ -1281,8 +1311,21 @@ impl SdkIndex {
                     if src.git_ref.is_none() {
                         bail!("source '{name}' has `git` but no `ref` (clone needs a pinned ref)");
                     }
-                    if src.dest.is_none() {
-                        bail!("source '{name}' has `git` but no `dest` (where to provision it)");
+                    // phase-440 — a STORE source derives its path from name +
+                    // version, so `dest` is not merely optional there: it is
+                    // meaningless, and an authored one would be a second
+                    // spelling of a location the store already knows. Both
+                    // directions are refused so the two cannot disagree.
+                    match src.location {
+                        SourceLocation::Workspace if src.dest.is_none() => bail!(
+                            "source '{name}' has `git` but no `dest` (where to provision it). \
+                             A store source needs no `dest` — set location = \"store\"."
+                        ),
+                        SourceLocation::Store if src.dest.is_some() => bail!(
+                            "source '{name}' has location = \"store\" AND a `dest`. The store \
+                             path is DERIVED from name + version; drop the `dest`."
+                        ),
+                        _ => {}
                     }
                 }
                 SourceProvision::Submodule => {

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -17,7 +17,7 @@ use std::{
 use eyre::{Result, WrapErr, bail, eyre};
 use serde::{Deserialize, Serialize};
 
-use super::sdk_index::{SourcePackage, SourceProvision, ToolPackage};
+use super::sdk_index::{SourceLocation, SourcePackage, SourceProvision, ToolPackage};
 
 /// The lockfile name (written in cwd by `nros setup` / auto-setup — pins the
 /// installed toolset for the workspace it's run in). Single source for the name.
@@ -76,7 +76,7 @@ pub fn tool_prefix(root: &Path, tool: &str, version: &str) -> PathBuf {
 /// does not live in the store.
 pub fn source_dir(index: &super::sdk_index::SdkIndex, source: &str) -> Option<PathBuf> {
     let src = index.source.get(source)?;
-    if src.location != super::sdk_index::SourceLocation::Store {
+    if src.location != SourceLocation::Store {
         return None;
     }
     // The STORE root, not the SDK root: `sources/` is a sibling of `sdk/`,
@@ -1637,6 +1637,10 @@ mod tests {
             git: Some("https://example/lwip.git".into()),
             git_ref: Some("STABLE-2_2_0".into()),
             dest: Some(dest_rel.into()),
+            // Named rather than `..Default::default()`: this literal is
+            // exhaustive on purpose, so a new field makes the test state its
+            // answer instead of inheriting one (phase-440 added this one).
+            location: SourceLocation::Workspace,
             submodule: None,
             shallow: true,
             recursive: true,

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -61,6 +61,34 @@ pub fn tool_prefix(root: &Path, tool: &str, version: &str) -> PathBuf {
 ///
 /// Returns `None` when the index has no such tool; the caller reports it with
 /// the provisioning command, and must NEVER substitute another version.
+/// Where a `[source.*]` with `location = "store"` is provisioned —
+/// `$NROS_STORE/sources/<name>/<version>` (phase-440, RFC-0095 D1/D2).
+///
+/// DERIVED, never authored: the same reason [`tool_dir`] derives rather than
+/// reading a path out of the index. An authored store path is a second spelling
+/// of a location the store already knows, and two spellings of one location is
+/// how the tool prefix ended up with a legacy flat shape nobody meant (issue
+/// 0628).
+///
+/// Returns `None` for a source the index does not have, or one whose
+/// `location` is `workspace` — the caller then wants the workspace-relative
+/// `dest`, and asking here would silently invent a store path for a source that
+/// does not live in the store.
+pub fn source_dir(index: &super::sdk_index::SdkIndex, source: &str) -> Option<PathBuf> {
+    let src = index.source.get(source)?;
+    if src.location != super::sdk_index::SourceLocation::Store {
+        return None;
+    }
+    // The STORE root, not the SDK root: `sources/` is a sibling of `sdk/`,
+    // `workspaces/` and `bin/` (RFC-0095 D2), and W6 gave that one spelling.
+    Some(
+        super::store::root()
+            .join("sources")
+            .join(source)
+            .join(&src.version),
+    )
+}
+
 pub fn tool_dir(index: &super::sdk_index::SdkIndex, tool: &str) -> Option<PathBuf> {
     let version = &index.tool.get(tool)?.version;
     Some(tool_prefix(&store_root(), tool, version))

--- a/packages/cli/nros-cli-core/src/test_support.rs
+++ b/packages/cli/nros-cli-core/src/test_support.rs
@@ -53,13 +53,13 @@ fn scratch_root() -> PathBuf {
 
 /// A unique scratch path that does NOT exist. Nothing is created — for the
 /// callers that want to hand a missing directory to the code under test.
-pub(crate) fn scratch_path(tag: &str) -> PathBuf {
+pub fn scratch_path(tag: &str) -> PathBuf {
     let n = SEQ.fetch_add(1, Ordering::Relaxed);
     scratch_root().join(format!("{tag}-{n}"))
 }
 
 /// A unique, EMPTY scratch directory, created and ready to write into.
-pub(crate) fn scratch_dir(tag: &str) -> PathBuf {
+pub fn scratch_dir(tag: &str) -> PathBuf {
     let dir = scratch_path(tag);
     // Fresh by construction (SEQ never repeats), so this only matters if a
     // previous run of THIS pid left something behind — a pid the OS reused.
@@ -102,7 +102,41 @@ pub(crate) fn scratch_dir(tag: &str) -> PathBuf {
 /// A retry-on-`ETXTBSY` loop also works (0 escapes, 141 backoffs in the same
 /// experiment) but masks the race instead of removing it, and pays latency on
 /// every hit.
-pub(crate) fn write_executable_stub(path: &std::path::Path, script: &str) {
+/// Issue 0476, the same rule for a binary that already exists.
+///
+/// [`write_executable_stub`] removes the ETXTBSY race by never holding a write
+/// descriptor in THIS process. `std::fs::copy` holds one, so a test that copies
+/// a real binary into a store and then execs it is exposed exactly as a test
+/// that wrote a script would be — and it is the harder case to spot, because
+/// nothing about `fs::copy` looks like writing an executable.
+///
+/// `cp` preserves the mode of a source that is already executable; the explicit
+/// `chmod` is for a source whose mode does not survive (a fixture checked out
+/// without the bit, a `CARGO_BIN_EXE_*` on a filesystem that drops it).
+pub fn copy_executable(src: &std::path::Path, dst: &std::path::Path) {
+    let ok = std::process::Command::new("cp")
+        .arg(src)
+        .arg(dst)
+        .status()
+        .unwrap_or_else(|e| panic!("spawn cp {} -> {}: {e}", src.display(), dst.display()))
+        .success();
+    assert!(
+        ok,
+        "cp failed copying {} -> {}",
+        src.display(),
+        dst.display()
+    );
+
+    let ok = std::process::Command::new("chmod")
+        .arg("755")
+        .arg(dst)
+        .status()
+        .unwrap_or_else(|e| panic!("spawn chmod for {}: {e}", dst.display()))
+        .success();
+    assert!(ok, "chmod failed on {}", dst.display());
+}
+
+pub fn write_executable_stub(path: &std::path::Path, script: &str) {
     let src = path.with_extension("stub-src");
     std::fs::write(&src, script)
         .unwrap_or_else(|e| panic!("write stub source {}: {e}", src.display()));

--- a/packages/cli/nros-cli/Cargo.toml
+++ b/packages/cli/nros-cli/Cargo.toml
@@ -32,3 +32,7 @@ nros-cli-core = { path = "../nros-cli-core" }
 # `tests/toolchain_dispatch.rs` builds a fake store in a tempdir: the launcher
 # must be tested against a store that is NOT the developer's `~/.nros`.
 tempfile = "3.10"
+# Issue 0476 — that same test writes a launcher and a stub and then EXECS them.
+# `test-support` exposes the ONE helper that removes the ETXTBSY race, rather
+# than this file growing a second copy of the discipline.
+nros-cli-core = { path = "../nros-cli-core", features = ["test-support"] }

--- a/packages/cli/nros-cli/tests/toolchain_dispatch.rs
+++ b/packages/cli/nros-cli/tests/toolchain_dispatch.rs
@@ -32,7 +32,14 @@ fn install_launcher(store: &Path, version: &str) -> PathBuf {
     let bin = store.join("sdk/nros").join(version).join("bin");
     std::fs::create_dir_all(&bin).unwrap();
     let exe = bin.join("nros");
-    std::fs::copy(env!("CARGO_BIN_EXE_nros"), &exe).unwrap();
+    // NOT `fs::copy` — issue 0476. This binary is EXEC'd a few lines later, and
+    // a write descriptor held in this process is inherited by any sibling
+    // thread's fork until that child execs, which the kernel reports as
+    // ETXTBSY. It passes on an idle machine and fails on a loaded CI runner.
+    nros_cli_core::test_support::copy_executable(
+        std::path::Path::new(env!("CARGO_BIN_EXE_nros")),
+        &exe,
+    );
     exe
 }
 
@@ -43,21 +50,15 @@ fn install_stub(store: &Path, version: &str) -> PathBuf {
     let bin = store.join("sdk/nros").join(version).join("bin");
     std::fs::create_dir_all(&bin).unwrap();
     let exe = bin.join("nros");
-    std::fs::write(
+    // Same rule as `install_launcher`, and this is the shape issue 0476 was
+    // filed against: written here, exec'd there.
+    nros_cli_core::test_support::write_executable_stub(
         &exe,
         "#!/bin/sh\n\
          echo \"STUB-TOOLCHAIN\"\n\
          echo \"DISPATCH=${NROS_TOOLCHAIN_DISPATCH:-unset}\"\n\
          for a in \"$@\"; do echo \"ARG=$a\"; done\n",
-    )
-    .unwrap();
-    let mut perms = std::fs::metadata(&exe).unwrap().permissions();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        perms.set_mode(0o755);
-    }
-    std::fs::set_permissions(&exe, perms).unwrap();
+    );
     exe
 }
 

--- a/scripts/check-third-party-is-submodules.sh
+++ b/scripts/check-third-party-is-submodules.sh
@@ -38,7 +38,12 @@ set -uo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "$repo_root" || exit 2
 
-EXCEPTIONS="ros"   # -> phase-440 W4, when `dest` can name the store
+# EMPTY, and that is the point. `ros` was the one declared exception: its
+# `[source.rosidl]` could only name a workspace-relative `dest`, so it had
+# nowhere else to go. `dest` can name the STORE now (phase-440), rosidl went
+# there, and the rule holds with no exemption. A name reappearing here is a new
+# provisioning root inside a directory that is supposed to have none.
+EXCEPTIONS=""
 
 # Submodule PARENTS: the first path component under third-party/ for every
 # declared submodule. Read from .gitmodules, never from a directory walk, so an

--- a/scripts/cyclonedds/msg_to_cyclone_idl.py
+++ b/scripts/cyclonedds/msg_to_cyclone_idl.py
@@ -46,11 +46,49 @@ from pathlib import Path
 # cyclone lanes must work on a host with NO ROS install):
 #   1. `NROS_ROSIDL_ADAPTER_BIN_DIR` env (explicit override);
 #   2. the ROS install (`/opt/ros/humble/lib/rosidl_adapter`);
-#   3. the vendored `[source.rosidl]` tree (`third-party/ros/rosidl`,
-#      provisioned by `nros setup --source rosidl`) — its scripts import the
-#      module from source, so PYTHONPATH is injected for that case.
+#   3. the vendored `[source.rosidl]` tree, provisioned by
+#      `nros setup --source rosidl` — its scripts import the module from
+#      source, so PYTHONPATH is injected for that case.
+#
+# Rung 3 is DERIVED, not spelled (phase-440, RFC-0095 D1/D2). `[source.rosidl]`
+# now has `location = "store"`, so it lands in `$NROS_STORE/sources/rosidl/
+# <version>` — outside every checkout and keyed by version — and the path is a
+# function of the index rather than a literal here. A literal would be a second
+# spelling that goes stale the moment the index moves, which is the class
+# `nros sdk-path` exists to prevent for tools.
+#
+# The pre-phase-440 location is kept BELOW it: a host provisioned earlier still
+# has `third-party/ros/rosidl` and keeps working with no migration step, exactly
+# as W4 kept the checkout arm below the store arm for workspaces.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-_VENDORED_ROSIDL = _REPO_ROOT / "third-party/ros/rosidl"
+
+
+def _vendored_rosidl_candidates() -> "list[Path]":
+    """Store first (derived), then the legacy in-tree location."""
+    out = []
+    try:
+        import subprocess
+
+        r = subprocess.run(
+            ["nros", "sdk-path", "--source", "rosidl"],
+            capture_output=True,
+            text=True,
+            cwd=str(_REPO_ROOT),
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            out.append(Path(r.stdout.strip()))
+    except OSError:
+        # No `nros` on PATH is normal for a consumer that has not sourced
+        # activate.sh; fall through to the legacy rung rather than failing.
+        pass
+    out.append(_REPO_ROOT / "third-party/ros/rosidl")
+    return out
+
+
+_VENDORED_ROSIDL = next(
+    (p for p in _vendored_rosidl_candidates() if p.is_dir()),
+    _REPO_ROOT / "third-party/ros/rosidl",
+)
 
 
 def _adapter_importable(env: "dict") -> bool:

--- a/scripts/sdk/verify-index.py
+++ b/scripts/sdk/verify-index.py
@@ -10,8 +10,10 @@ Run in nano-ros CI on any PR that touches `nros-sdk-index.toml` (or
      `[tool]`/`[source]`/`[gated]` entry (mirrors `SdkIndex::validate`, but
      statically — no `nros` build needed) (Phase 191.x);
    - every `[source.*]` provisioning recipe is coherent: submodule mode needs a
-     `dest`; clone mode (a `git` with no `submodule`) needs both `ref` + `dest`
-     (Phase 195.B);
+     `dest`; clone mode (a `git` with no `submodule`) needs a `ref`, plus a
+     `dest` when it is provisioned into the WORKSPACE and no `dest` when it is
+     provisioned into the STORE, whose path is derived from name + version
+     (Phase 195.B; phase-440 / RFC-0095 D1+D2);
    - every `[source.*].submodule` path is a real submodule in `.gitmodules`, and
      a declared `git` URL matches that submodule's URL — so the index and
      `.gitmodules` **can't drift** (the 195.B SSOT guarantee).
@@ -124,8 +126,28 @@ def verify_structure(index, index_path):
         elif git is not None:  # clone mode
             if ref is None:
                 failures.append(f"source '{name}' has `git` but no `ref` (clone needs a pinned ref)")
-            if dest is None:
-                failures.append(f"source '{name}' has `git` but no `dest`")
+            # phase-440 / RFC-0095 D1+D2 — WHERE decides whether `dest` is
+            # authored at all, and BOTH directions are refused so the index and
+            # the store can never disagree about one source's path. Mirrors
+            # `SdkIndex::validate` in
+            # packages/cli/nros-cli-core/src/orchestration/sdk_index.rs; the two
+            # must move together or the gate passes what the CLI refuses.
+            location = src.get("location", "workspace")
+            if location not in ("workspace", "store"):
+                failures.append(
+                    f"source '{name}' has location = {location!r} "
+                    f"(expected \"workspace\" or \"store\")"
+                )
+            elif location == "workspace" and dest is None:
+                failures.append(
+                    f"source '{name}' has `git` but no `dest` (where to provision "
+                    f"it). A store source needs no `dest` — set location = \"store\"."
+                )
+            elif location == "store" and dest is not None:
+                failures.append(
+                    f"source '{name}' has location = \"store\" AND a `dest`. The "
+                    f"store path is DERIVED from name + version; drop the `dest`."
+                )
     return failures
 
 
@@ -157,7 +179,48 @@ def verify_dist(index):
     return failures, checked
 
 
+def selftest() -> None:
+    """Prove the `location` rule fires in BOTH directions, on the normal path.
+
+    This exists because the rule already drifted once: phase-440 moved
+    `[source.rosidl]` into the store — dropping its `dest`, which the CLI's own
+    validator accepts — and this gate, which claims to mirror that validator,
+    still demanded a `dest` and failed the PR. A gate whose rule lives in two
+    languages needs a case in each, or one of them rots silently.
+
+    Runs on every invocation (it is five dict literals), so there is no lane in
+    which the gate ships unexercised.
+    """
+    import tempfile
+
+    def problems(src):
+        # An empty dir: clone-mode sources never consult `.gitmodules`, and a
+        # missing one is the read `parse_gitmodules` already tolerates.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "nros-sdk-index.toml")
+            return verify_structure({"source": {"probe": src}}, path)
+
+    git = "https://example.invalid/x"
+    ref = "0" * 40
+    cases = [
+        # (source table, must a `location`/`dest` problem be reported?)
+        ({"git": git, "ref": ref, "dest": "third-party/x"}, False),
+        ({"git": git, "ref": ref}, True),
+        ({"git": git, "ref": ref, "location": "store"}, False),
+        ({"git": git, "ref": ref, "location": "store", "dest": "third-party/x"}, True),
+        ({"git": git, "ref": ref, "location": "elsewhere"}, True),
+    ]
+    for src, want_fail in cases:
+        got = problems(src)
+        if bool(got) != want_fail:
+            raise SystemExit(
+                f"verify-index selftest: source {src!r} expected "
+                f"{'a failure' if want_fail else 'no failure'}, got {got!r}"
+            )
+
+
 def main(path: str, structure_only: bool) -> int:
+    selftest()
     with open(path, "rb") as f:
         index = tomllib.load(f)
 


### PR DESCRIPTION
The last mechanism this phase needed.

`[source.*]` had **one** shape — a workspace-relative `dest` — so a provisioned
source could only land inside a checkout. That is what forced W3 to *declare*
`ros` an exception in a ratchet whose whole point is that `third-party/` holds
tracked submodules and nothing else.

## The mechanism

`SourceLocation` is `workspace` (default) or `store`. Defaulting to workspace
means every existing entry keeps its meaning with no edit, so the migration is
opt-in one source at a time — which is what makes it reviewable.

A store source's path is **derived** — `$NROS_STORE/sources/<name>/<version>` —
mirroring `tool_dir` rather than inventing path syntax. Authoring it would be a
second spelling of a location the store already knows, and two spellings of one
location is exactly how the tool prefix acquired a legacy flat shape nobody
meant (issue 0628). The derivation hangs off **W6's `store::root()`** — the one
spelling W6 introduced precisely so this could not diverge, and `sources/` is a
sibling of `sdk/`, `workspaces/` and `bin/` per RFC-0095 D2.

The validator refuses **both** directions: a workspace source with no `dest` (as
before), and now a store source *with* one — so the two cannot disagree.

`nros sdk-path --source <name>` is the consumer bridge, for the reason the tool
arm exists: a consumer asks, never spells.

```
$ nros sdk-path --source rosidl
/home/aeon/.nros/sources/rosidl/humble-5621b26
$ NROS_STORE=/tmp/st nros sdk-path --source rosidl
/tmp/st/sources/rosidl/humble-5621b26
```

A `workspace` source (`zenoh-pico`) is refused *with its `dest` named*, rather
than handed a store path nothing will ever write.

## rosidl moves, and nothing has to migrate

`msg_to_cyclone_idl.py` now asks instead of carrying a literal. Its
pre-phase-440 rung (`third-party/ros/rosidl`) is kept **below** the store rung —
the same shape W4 used to keep the checkout arm below the store arm — so a host
provisioned earlier keeps working with no migration step. No `nros` on PATH
falls through to that rung rather than failing, because a consumer that has not
sourced `activate.sh` is a normal state.

## W3's exception list is now empty

`0 declared exception(s)`. And the gate was **re-verified with the list empty** —
a new provisioning root under `third-party/` still exits 1. An exemption list
that has stopped being exercised is where a rule quietly stops applying, so the
negative control matters more now than it did with one entry in it.

## Three things the tree caught, all mine

- My enum landed **between** `SourcePackage`'s `#[derive]` and the struct,
  orphaning it — seven `cannot find attribute serde` errors pointing at
  unrelated lines.
- The index validator refused the flip (`git` requires `dest`). Rather than
  weakening it, I taught it both directions.
- I used the **SDK** root instead of the **store** root, putting sources at
  `~/.nros/sdk/sources/`. Caught by reading the output rather than assuming.

`check-fast`: 289 gates ran, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)