### PR TITLE
docs(#1254, #1255, #1256): file the Zephyr SDK store gap and the two open QoS/arena items

### DIFF
--- a/docs/issues/1254-zephyr-sdk-installs-inside-the-checkout.md
+++ b/docs/issues/1254-zephyr-sdk-installs-inside-the-checkout.md
@@ -1,0 +1,100 @@
+---
+id: 1254
+title: "The Zephyr SDK is provisioned INSIDE the nano-ros checkout, not in the
+  store -- so a downstream workspace binds to whichever clone ran setup"
+status: open
+type: bug
+area: zephyr, tooling
+severity: medium
+related: [issue-1248]
+---
+
+## Symptom
+
+A downstream project (Autoware Safety Island) whose Zephyr 4.4 workspace was
+made by `NROS_ZEPHYR_VERSION=4.4 just zephyr setup` carries this in the
+workspace's generated `env.sh`:
+
+```
+export ZEPHYR_SDK_INSTALL_DIR="/home/aeon/repos/nano-ros/scripts/zephyr/sdk/zephyr-sdk-1.0.1"
+```
+
+That path is a SIBLING nano-ros clone, not the submodule the project pins.
+Every board build of that project has depended on a second checkout existing,
+on its `scripts/zephyr/sdk/` never being cleaned, and on nobody running
+`just clean-setup` there (`justfile:5075` removes `scripts/zephyr/sdk`). Nothing
+reports the dependency; it surfaces only when the other clone goes away.
+
+## Cause
+
+RFC-0095 D2 draws the store as
+
+```
+$NROS_STORE/
+|-- sdk/zephyr-sdk/0.16.8/         # unchanged from today
+```
+
+which is not what the tree does. `scripts/zephyr/setup.sh:73` sets
+
+```
+SDK_INSTALL_DIR="$SCRIPT_DIR/sdk"
+```
+
+and passes it to `nros setup --tool "$ZEPHYR_SDK_TOOL" --prefix
+"$SDK_INSTALL_DIR"`, so the fetch goes through the index (issue 0610) but the
+INSTALL lands in the checkout. `--prefix` is the out-of-store escape hatch
+(`cmd/setup.rs:757`: "places it outside the shared store"), and a prefix
+install is not recorded in `nros-sdk.lock` (`cmd/setup.rs:871`), so
+`nros sdk-path zephyr-sdk-1-0-1` cannot find it either.
+
+Without `--prefix` the same command installs where RFC-0095 says it should.
+Measured 2026-09-10:
+
+```
+$ nros setup --tool zephyr-sdk-1-0-1
+nros setup --tool zephyr-sdk-1-0-1: prebuilt 1.0.1 (dist linux-x86_64) -> ~/.nros/sdk/zephyr-sdk-1-0-1/1.0.1
+```
+
+with the SDK one level down, at `.../1.0.1/zephyr-sdk-1.0.1/` (the tarball has
+a top-level directory and is unpacked without `--strip-components`). That extra
+level is what `ZEPHYR_SDK_INSTALL_DIR` must name, and is the one thing a
+consumer cannot get from `nros sdk-path` alone today.
+
+## Every reader of the checkout path
+
+The workspace resolver moved to the store in phase-440 W4; the SDK did not, so
+these still construct or search the checkout-relative path (sweep:
+`git grep -n -E 'scripts/zephyr/sdk|SCRIPT_DIR/sdk'`):
+
+| site | what it does |
+| --- | --- |
+| `scripts/zephyr/setup.sh:73` | the install target |
+| `just/zephyr-setup.just:169,321` | `sdk="$(pwd)/scripts/zephyr/sdk/zephyr-sdk-0.16.8"` |
+| `just/zephyr-setup.just:280,435` | `export ZEPHYR_SDK_INSTALL_DIR="$nros_root/scripts/zephyr/sdk/zephyr-sdk-0.16.8"` |
+| `packages/testing/nros-tests/src/zephyr.rs:701` | searches `scripts/zephyr/sdk/zephyr-sdk-*` after `ZEPHYR_SDK_INSTALL_DIR` |
+| `scripts/ci/runner-doctor.sh:198` | "checkout default" arm of the SDK ladder |
+| `scripts/ci/runner-sweep.sh:607` | reclaims `scripts/zephyr/sdk` |
+| `justfile:5075` | `clean-setup` removes it |
+
+The 0.16.8 literals are also a second copy of the per-line SDK version that
+`setup.sh`'s `case "$MANIFEST"` already owns.
+
+## Fix shape
+
+One resolver, same as the workspace (RFC-0095 D4): the store arm first, the
+checkout arm last so a host provisioned earlier keeps working.
+
+- `setup.sh` installs into the store (drop `--prefix`) and writes the resolved
+  SDK dir into `env.sh`.
+- Consumers ask for the SDK dir instead of constructing it. Either
+  `nros sdk-path` learns the tarball's inner directory, or a helper beside
+  `scripts/lib/zephyr-workspace.sh` answers "the SDK for Zephyr line V" from the
+  same `case` that picks the version today.
+- The test harness and runner doctor read that answer rather than globbing.
+
+## Acceptance
+
+- A fresh `NROS_ZEPHYR_VERSION=4.4 just zephyr setup` writes nothing under
+  `scripts/zephyr/sdk/` and its `env.sh` names a store path.
+- `nros store list` shows the SDK and `nros store gc` respects it.
+- A host with only the legacy `scripts/zephyr/sdk/` still builds (checkout arm).

--- a/docs/issues/1255-arena-prices-every-subscription-slot-at-one-global-type-bound.md
+++ b/docs/issues/1255-arena-prices-every-subscription-slot-at-one-global-type-bound.md
@@ -1,0 +1,77 @@
+---
+id: 1255
+title: "The derived arena prices every subscription slot at ONE global message
+  bound, not at each subscription's own type"
+status: open
+type: enhancement
+area: executor, build
+severity: medium
+related: [issue-1227, issue-1179, issue-1190]
+---
+
+## What is true today
+
+Per-type bounds exist and are generated. Codegen emits
+`_TX_MAX_SERIALIZED_SIZE` / `_RX_MAX_SERIALIZED_SIZE` per message and a
+per-package `nros_message_bounds.cmake` fragment (the chain `6852548c1`,
+`afeab01d5`, `36622cadd`, `5c4eed203`). At RUNTIME, C++ `bind_subscription`
+already allocates from the type's own bound (phase-392 W3a/W3b).
+
+The BUILD-TIME arena does not use them. They are collapsed into two image-wide
+maxima before `nros-node/build.rs` sees anything:
+
+| knob | meaning | reference island |
+| --- | --- | --- |
+| `NROS_SUBSCRIBER_BUFFER_SIZE` | largest type the image SUBSCRIBES to | 880 |
+| `NROS_SUBSCRIPTION_BUFFER_SIZE` | largest type the image LINKS | 1,496 |
+
+and `subs_arena()` (`build.rs:52-83`, issue 1227) prices every declared
+subscription as `buffered_region(depth, rx_recv_size) + entry_struct` with the
+same `rx_recv_size`. The declared-depth triples are `type|topic=depth`, and the
+parse keeps only the depth:
+
+```rust
+.filter_map(|t| t.rsplit_once('=').map(|(_, d)| d))
+```
+
+so the type is on the wire into the build script and is discarded there.
+
+## Cost
+
+On the reference island (11 subscriptions, all `depth: 1`, so each is a
+`TripleBuffer` of three slots) every slot is billed at the 880-byte class.
+Most of those subscriptions carry small control/status messages. The over-bill
+is `3 x (880 - bound(type))` per subscription, which the arena model already
+knows how to compute and does not. The image fits today (DTCM 74.8%), so this
+is headroom, not a blocker; it becomes one the next time a subscription is
+added to a part with 128 KB of DTCM.
+
+## Why it is open, and who owns it
+
+phase-392 W3c deferred it explicitly (phase-392 "W3 remainder"): a mem-report
+delta "needs the BUILD-TIME arena derivation to learn the per-type bounds,
+which is `nros-node/build.rs`'s `rx_recv_size` term and
+`nros_derive_message_bound_knobs` -- phase-403 step 3's lane, not this one, and
+deliberately deferred there". phase-403 step 3 then landed without it. No work
+item in phase-394's ledger names it, so nothing currently owns it.
+
+The design question phase-403 recorded still stands: the per-type size
+reaches cmake under a BACKEND name (`ZPICO_SUBSCRIBER_BUFFER_SIZE`), which the
+backend-agnostic crate must not read. Carrying the bound INSIDE the triple
+(`type|topic=depth|bytes`) sidesteps that: one producer (the entity inventory,
+which already resolves each type) and one consumer.
+
+## Also stale
+
+`build.rs:335-347` says the receive class is "NOT WIRED YET" and falls back to
+the closure knob. It is wired: `nros_cargo_build.cmake:666` forwards
+`NROS_SUBSCRIBER_BUFFER_SIZE`, and the reference island's build shows
+`PUBSUB_REGION = 9768` (11 x 880 + 88). The comment should go with this fix.
+
+## Acceptance
+
+- `subs_arena()` sums `buffered_region(depth_i, bound(type_i)) + entry_struct`
+  over declared subscriptions, and falls back to today's global bound for any
+  subscription whose type bound is absent (absence is not zero).
+- The host oracle (`cargo:arena_size`) and the island's linked
+  `EXECUTOR_BACKING` agree, measured before and after.

--- a/docs/issues/1256-contract-qos-carries-depth-only.md
+++ b/docs/issues/1256-contract-qos-carries-depth-only.md
@@ -1,0 +1,74 @@
+---
+id: 1256
+title: "Contract QoS reaches the build as DEPTH only -- reliability, history
+  and durability are declared, delivered, and dropped"
+status: open
+type: enhancement
+area: orchestration, build
+severity: low
+related: [issue-1227, issue-1255]
+---
+
+## What is true today
+
+The launch contract already carries the whole profile. `QosDecl` in the pinned
+`ros-launch-manifest` (`v0.1.31`, `types/src/types.rs:432`) has
+`reliability`, `durability`, `depth`, `history` and `lifespan`, and play_launch's
+`effective_qos` resolves them per endpoint into the SystemModel.
+
+nano-ros reads one field of it. The entity inventory's `depth_of`
+(`entity_inventory.rs:872`) takes `sub_endpoints[*].qos.depth` and nothing
+else, and the declaration grammar it emits is documented as "leaving room for
+`@reliability=`, `@history=` and `@durability=` without another grammar
+change" (`entity_inventory.rs:350`). The room was left; nothing moved into it.
+
+So a contract that says
+
+```yaml
+sub:
+  control_cmd: { qos: { depth: 1, reliability: best_effort } }
+```
+
+sizes the arena from `depth: 1` and silently ignores `best_effort`.
+
+## Why the other three matter for memory, not just for correctness
+
+- **history.** `KEEP_ALL` has no depth bound at all. Today it is priced as
+  whatever `depth` says (or the ROS default 10), which under-sizes a
+  KEEP_ALL subscription rather than refusing it. The build should refuse or
+  demand an explicit cap, on the same "absence is not zero" rule issue 1227
+  applied to depth.
+- **reliability.** On XRCE a reliable stream needs history buffers the
+  best-effort one does not, and on Cyclone a RELIABLE writer keeps a history
+  cache sized from depth. Neither is priced from the contract.
+- **durability.** `TRANSIENT_LOCAL` publishers keep the last `depth` samples
+  for late joiners. That is publisher-side memory, and publishers are exactly
+  the endpoints issue 1227 left undeclared ("sizes no receive buffer, so
+  nothing reads it yet").
+
+## Also: code vs contract agreement covers depth only
+
+`nros_declared_qos_generated.h` and the boot-time `check_declared_depth`
+(phase-403) catch a node whose code passes a depth the contract does not state
+(`DECLARED_DEPTH_MISMATCH`). A code/contract disagreement on reliability or
+durability is not checked at all, and that disagreement is an interop failure
+(an incompatible-QoS match never delivers) rather than a sizing one.
+
+## Where the ROS defaults live
+
+When the contract is silent the build uses ROS 2's defaults, and those are
+still literals in code: `PUBSUB_QOS_DEPTH = 10` (`nros-node/build.rs:27`), the
+`qos_profiles!` table (phase-428 W10, `58612b5b4`), and copies in
+`nros-c/src/qos.rs` and the cffi layer, held equal by gates against
+`docs/reference/rmw-qos-profiles.txt`. The Zephyr Kconfig
+`CONFIG_NROS_PUBSUB_QOS_DEPTH` (`7ff68c777`) is the only config-side copy. A
+fix that adds three more defaulted fields should move the defaults to one
+config source first, rather than adding three more literals.
+
+## Acceptance
+
+- The inventory carries all four fields per endpoint; an unknown value is an
+  error, never a skip.
+- KEEP_ALL without a stated cap refuses at build time, naming the endpoint.
+- The declared-QoS header and boot check cover reliability and durability.
+- ROS default values are read from one config source, not from code literals.


### PR DESCRIPTION
Files three open issues found while integrating nano-ros into Autoware Safety Island. Docs only; no code changes.

- #1254: `scripts/zephyr/setup.sh` installs the Zephyr SDK with `--prefix $SCRIPT_DIR/sdk`, inside the checkout, so RFC-0095 D2's store tree is not what the tree does. A downstream 4.4 workspace's `env.sh` bound itself to a sibling clone's SDK. Lists the seven readers of the checkout path. Measured: `nros setup --tool zephyr-sdk-1-0-1` without `--prefix` already lands in the store.
- #1255: the derived arena prices every declared subscription slot at one image-wide type bound (880 B on the reference island). The declared-depth triple carries the type and `subs_arena()` drops it. phase-392 W3c deferred this to phase-403 step 3, which landed without it, so nothing owns it. Also records the stale "NOT WIRED YET" comment at `build.rs:335`.
- #1256: the contract's `QosDecl` carries reliability, durability, history and lifespan; the entity inventory reads depth only. KEEP_ALL is priced as if bounded, the declared-QoS boot check covers depth only, and ROS default values are still code literals.

Ids reserved with `just issue-new`. `issue-index`, `prose-issue-refs`, `doc-commit-citations`, `doc-recipe-refs` and `archived-issue-status` pass.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKY5TGsRzN9SVs1e4c8BoH
