### PR TITLE
phase-441 W4+W5 — the live-peer lane's runner, and the phrase that overclaims

### DIFF
--- a/.github/workflows/live-peer.yml
+++ b/.github/workflows/live-peer.yml
@@ -33,8 +33,72 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # phase-441 W4 — WHICH RECORDED ROWS NEED WHICH RUNNER.
+  #
+  # Membership follows from the ledger; the RUNNER does not, and the ledger is
+  # the wrong place to teach it. A cell on a board needs that board's SDK, its
+  # cross toolchain and — off native_sim — an emulator, and the container the
+  # host rows run in has none of them. That is already stated by each cell's
+  # PLATFORM coordinate in `interop::CELLS`, so the split is computed from it
+  # (`--runner host|board`) rather than recorded a second time.
+  #
+  # This job exists so the expensive half can be SKIPPED, not merely fast: with
+  # no board cell in the ledger, `board` never starts and nobody pays for a
+  # Zephyr SDK, a west update and a fixture build to run zero cells. A job-level
+  # `if:` needs an output, and an output needs a job.
+  #
+  # `regression` deliberately does NOT depend on it: the host rows must keep
+  # running when the board mapping is broken. Verification not being hostage to
+  # everything else being green is why this whole lane exists.
+  membership:
+    name: which recorded rows need which runner
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/newslabntu/nano-ros-ci:humble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      host_cells: ${{ steps.split.outputs.host_cells }}
+      board_cells: ${{ steps.split.outputs.board_cells }}
+      has_board: ${{ steps.split.outputs.has_board }}
+      setup_scopes: ${{ steps.split.outputs.setup_scopes }}
+      build_scopes: ${{ steps.split.outputs.build_scopes }}
+      narrowing: ${{ steps.split.outputs.narrowing }}
+    steps:
+      - uses: actions/checkout@v4
+      # In the container for its `python3-tomli`: the tool reads the ledger with
+      # `tomllib`, which ubuntu-22.04's system python (3.10) does not have.
+      - name: Split the recorded rows by the runner their board needs
+        id: split
+        run: |
+          tool=scripts/check-interop-verdicts.py
+          host="$(python3 "$tool" --list-passing --runner host | tr '\n' ' ')"
+          board="$(python3 "$tool" --list-passing --runner board | tr '\n' ' ')"
+          setup="$(python3 "$tool" --list-passing --runner board --scopes setup | tr '\n' ' ')"
+          build="$(python3 "$tool" --list-passing --runner board --scopes build | tr '\n' ' ')"
+          narrowing="$(python3 "$tool" --list-passing --runner board --narrowing | tr '\n' ' ')"
+          has_board=false
+          [ -n "$(echo $board)" ] && has_board=true
+          printf 'this runner:  %s\n' "$host"
+          printf 'a board:      %s\n' "$board"
+          printf 'setup scopes: %s\n' "$setup"
+          printf 'build scopes: %s\n' "$build"
+          printf 'narrowing:    %s\n' "$narrowing"
+          {
+              printf 'host_cells=%s\n' "$host"
+              printf 'board_cells=%s\n' "$board"
+              printf 'has_board=%s\n' "$has_board"
+              printf 'setup_scopes=%s\n' "$setup"
+              printf 'build_scopes=%s\n' "$build"
+              printf 'narrowing=%s\n' "$narrowing"
+          } >> "$GITHUB_OUTPUT"
+
   regression:
-    name: cells with a recorded live PASS
+    name: rows whose board IS this runner
     runs-on: ubuntu-22.04
     # The distro comes from the image, which is why grepping this file for
     # `ros-humble` finds nothing (that reading cost issue 1127 a wrong revision).
@@ -104,6 +168,22 @@ jobs:
         run: |
           git submodule update --init --recursive third-party/dds/cyclonedds
 
+      # THE PEER — phase-441 W4. Neither CI image bakes
+      # `ros-humble-rmw-zenoh-cpp` (ci-base's own header says the ROS package
+      # set is provisioned per run, "the way a user does"), and without it
+      # `require_ros2()` answers with a `skip!` for every zenoh cell. Until this
+      # branch that was invisible: the junit rewrite turned the skip into
+      # `<skipped>`, `_test-focused` exited 0, and the lane reported that cells
+      # with a recorded PASS still pass. The recipe now refuses to call a
+      # skipped membership a verdict, so the absence has to be supplied rather
+      # than absorbed — and this is the sanctioned spelling for it, installing
+      # what `nros-sdk-index.toml` declares instead of restating it here.
+      - name: Provision the declared system closure (phase-413 W3)
+        id: system
+        run: |
+          source ./activate.sh
+          nros setup --system --sudo
+
       # NOT "the fixtures those CELLS resolve", which is what this said until
       # 2026-09-09. `lane-stage.py` classifies a step by keyword, `cells` is the
       # marker for the runtime stage, and the classifier takes the most specific
@@ -123,11 +203,27 @@ jobs:
           bash scripts/build/fixtures-build.sh linux rust zenoh
           bash scripts/build/fixtures-build.sh linux rust cyclonedds
 
+      # `host`, not everything — phase-441 W4. A board cell's image is built by
+      # an SDK this container does not carry, so running one here resolves no
+      # fixture and `skip!`s; `_rewrite-skipped-junit` then turns that into a
+      # `<skipped>` and the lane reports a cell it never ran as still passing.
+      # That is not hypothetical: `zephyr-qos-rust-zenoh` has been in this
+      # lane's membership since the ledger's first entry.
+      #
+      # The exit code carries the one thing a step outcome cannot — whether the
+      # cells produced RESULTS. 2 is the recipe's "this lane could not run".
       - name: Run the cells with a recorded PASS
         id: cells
         run: |
           source ./activate.sh
-          just native test-live-peer-regression
+          set +e
+          just native test-live-peer-regression host
+          rc=$?
+          set -e
+          ran=false
+          [ "$rc" -le 1 ] && ran=true
+          printf 'cells_ran=%s\n' "$ran" >> "$GITHUB_OUTPUT"
+          exit $rc
 
       - name: Ledger after the run
         if: always()
@@ -148,9 +244,212 @@ jobs:
             [{"name": "Build the nros CLI", "conclusion": "${{ steps.cli.outcome }}"},
              {"name": "Report what the ledger claims, before running anything", "conclusion": "${{ steps.ledger.outcome }}"},
              {"name": "Check out the submodules the fixtures vendor", "conclusion": "${{ steps.submodules.outcome }}"},
+             {"name": "Provision the declared system closure (phase-413 W3)", "conclusion": "${{ steps.system.outcome }}"},
              {"name": "Build the fixtures those rows resolve", "conclusion": "${{ steps.fixtures.outcome }}"},
              {"name": "Run the cells with a recorded PASS", "conclusion": "${{ steps.cells.outcome }}"}]
-        run: python3 scripts/ci/lane-stage.py --report --lane "live-peer regression"
+          # The fourth axis (phase-441 W4): the cells step FAILED tells you the
+          # step failed, never whether the cells produced results. Empty when the
+          # step never ran, which reads as "nobody said" and changes nothing.
+          NROS_LANE_CELLS_RAN: ${{ steps.cells.outputs.cells_ran }}
+        run: python3 scripts/ci/lane-stage.py --report --lane "live-peer regression (host)"
+
+  # phase-441 W4 — THE SIBLING LANE, FOR THE ROWS WHOSE BOARD IS NOT THE RUNNER.
+  #
+  # A split, not "provision an emulator in `regression`", and the reason is the
+  # comment at the top of this file: the host rows must not be hostage to
+  # anything they do not need. Provisioning a Zephyr SDK, a west workspace and
+  # an emulator in the one job would put nineteen host cells behind a toolchain
+  # they never touch — and it would pay for that toolchain on every run,
+  # including the runs where the ledger records no board cell at all.
+  #
+  # The cost of a split is a second lane to keep green and a second place to
+  # notice a red. Both are paid down here rather than accepted: this job is one
+  # `if:` away from not existing when there is nothing for it to run, and it
+  # reports through the SAME stage reporter as its sibling, so the run list
+  # shows "could not run the board rows" and "the board rows regressed" as
+  # different sentences.
+  #
+  # `nano-ros-zephyr-ci`, not `nano-ros-ci`, because the SDK is the expensive
+  # half and that image bakes it (nightly's zephyr line runs on it daily). What
+  # neither image bakes is the ROS side of the peer — `ros-humble-rmw-zenoh-cpp`
+  # is provisioned per run, from what `nros-sdk-index.toml` declares.
+  #
+  # The image is a Zephyr one and the scope list below is derived, so those two
+  # can disagree: a FreeRTOS cell entering the ledger asks for a scope this
+  # image cannot provision. That is checked, loudly, rather than run — see the
+  # `setup` step.
+  board:
+    name: rows whose board is NOT this runner
+    needs: [membership]
+    if: needs.membership.outputs.has_board == 'true'
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/newslabntu/nano-ros-zephyr-ci:humble-sdk0.17.4-r4
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      stage_label: ${{ steps.stage.outputs.label }}
+      reached_cells: ${{ steps.stage.outputs.reached_cells }}
+    env:
+      # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to
+      # create on a host it does not own. A CI container IS owned; the image
+      # ships `uv` for exactly this. Ignored by the 3.7 line, which is the
+      # default and what the recorded board cell was measured on.
+      NROS_ZEPHYR_CREATE_VENV: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the nros CLI
+        id: cli
+        run: |
+          git submodule update --init --depth 1 packages/cli/third-party/play_launch
+          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
+          "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
+
+      # The image registered the SDK CMake package as root; the container runs
+      # with HOME=/github/home → re-register for this HOME.
+      - name: Register the baked Zephyr SDK for this HOME
+        id: sdk
+        run: /opt/zephyr-sdk/setup.sh -c
+
+      # Issue 0078 — container host-disk headroom before the west update + pip.
+      # Mirrors nightly's zephyr line, which measured cells tipping over at 78 MB
+      # free. The baked SDK stays; the build needs it.
+      - name: Reclaim disk before the SDK setup
+        id: disk
+        run: |
+          echo "before:"; df -h / | tail -1
+          apt-get clean 2>/dev/null || true
+          rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /usr/share/locale 2>/dev/null || true
+          rm -rf "$HOME/.cache/pip" 2>/dev/null || true
+          echo "after:";  df -h / | tail -1
+
+      # The image bakes bin/cargo-clippy from a non-rustup-owner layer, so
+      # `rustup target add` (which `just setup` reaches) trips on the
+      # clippy-preview conflict. Same fix as nightly's zephyr line.
+      - name: Unblock the rustup clippy-preview conflict
+        id: rustup
+        run: |
+          rustup_home="$(rustup show home 2>/dev/null || echo "$HOME/.rustup")"
+          find "$rustup_home/toolchains" -maxdepth 3 -type f \
+              \( -name cargo-clippy -o -name clippy-driver \) -delete 2>/dev/null || true
+          rustup toolchain list 2>/dev/null | awk '{print $1}' | while read -r tc; do
+              [ -z "$tc" ] && continue
+              rustup component add clippy --toolchain "$tc" \
+                  || echo "  (clippy add failed for $tc — non-fatal)"
+          done
+
+      # The PEER. Neither CI image bakes `ros-humble-rmw-zenoh-cpp`, and without
+      # it every zenoh cell answers `require_ros2()` with a skip — which the
+      # junit rewrite turns into a green. `nros-sdk-index.toml` declares the
+      # package; this installs what it declares rather than restating it as an
+      # `apt-get install` line (phase-413 W3's rule).
+      - name: Provision the declared system closure (phase-413 W3)
+        id: system
+        run: |
+          source ./activate.sh
+          nros setup --system --sudo
+
+      # The scopes come from the ROWS, via their platform coordinate — no list
+      # here to keep in step. `--skip-sdk` for zephyr because this image bakes
+      # it; the assertion above the loop is what keeps a scope this image cannot
+      # provision from being run as if it could.
+      - name: just setup the scopes those rows need
+        id: setup
+        env:
+          SCOPES: ${{ needs.membership.outputs.setup_scopes }}
+        run: |
+          source ./activate.sh
+          for s in $SCOPES; do
+              case "$s" in
+                  zephyr|qemu) ;;
+                  *)
+                      echo "This lane runs in a Zephyr image and can provision" >&2
+                      echo "  zephyr and qemu. A row with a recorded PASS needs" >&2
+                      echo "  '$s', which it cannot — so this run would report a" >&2
+                      echo "  green over cells it never built." >&2
+                      echo "Give that board its own job (or its own image) and" >&2
+                      echo "  add it to LANES in scripts/ci/lane-stage.py." >&2
+                      exit 1
+                      ;;
+              esac
+          done
+          for s in $SCOPES; do
+              extra=""
+              [ "$s" = "zephyr" ] && extra="--skip-sdk"
+              echo "=== just setup $s $extra ==="
+              just setup "$s" $extra
+          done
+
+      # zephyr-sys' build.rs runs bindgen over Zephyr headers — needs libclang.so
+      # and clang's resource-dir headers.
+      - name: Install clang + libclang for bindgen
+        id: clang
+        run: |
+          apt-get update -q
+          apt-get install -y --no-install-recommends \
+            $(python3 scripts/sdk/prereq-packages.py --manager apt clang libclang-dev)
+
+      # NARROWED to the leaves these rows resolve. `just build zephyr` is the
+      # whole west lane, and the tree already says what that is worth — on this
+      # very cell: "running the whole west lane to reach one cell is not
+      # something anyone would type" (just/zephyr-dev.just). The narrowing comes
+      # from the same tool that chose the rows.
+      - name: Build the fixtures those rows resolve
+        id: fixtures
+        env:
+          SCOPES: ${{ needs.membership.outputs.build_scopes }}
+          NARROWING: ${{ needs.membership.outputs.narrowing }}
+        run: |
+          source ./activate.sh
+          for kv in $NARROWING; do
+              echo "narrowing: $kv"
+              export "$kv"
+          done
+          for s in $SCOPES; do
+              echo "=== just build $s ==="
+              just build "$s"
+          done
+
+      - name: Run the board cells with a recorded PASS
+        id: cells
+        run: |
+          source ./activate.sh
+          set +e
+          just native test-live-peer-regression board
+          rc=$?
+          set -e
+          ran=false
+          [ "$rc" -le 1 ] && ran=true
+          printf 'cells_ran=%s\n' "$ran" >> "$GITHUB_OUTPUT"
+          exit $rc
+
+      - name: Ledger after the run
+        if: always()
+        run: |
+          source ./activate.sh
+          just interop-verdicts || true
+
+      - name: Which stage did this lane reach?
+        id: stage
+        if: always()
+        env:
+          NROS_LANE_STEPS: >-
+            [{"name": "Build the nros CLI", "conclusion": "${{ steps.cli.outcome }}"},
+             {"name": "Register the baked Zephyr SDK for this HOME", "conclusion": "${{ steps.sdk.outcome }}"},
+             {"name": "Reclaim disk before the SDK setup", "conclusion": "${{ steps.disk.outcome }}"},
+             {"name": "Unblock the rustup clippy-preview conflict", "conclusion": "${{ steps.rustup.outcome }}"},
+             {"name": "Provision the declared system closure (phase-413 W3)", "conclusion": "${{ steps.system.outcome }}"},
+             {"name": "just setup the scopes those rows need", "conclusion": "${{ steps.setup.outcome }}"},
+             {"name": "Install clang + libclang for bindgen", "conclusion": "${{ steps.clang.outcome }}"},
+             {"name": "Build the fixtures those rows resolve", "conclusion": "${{ steps.fixtures.outcome }}"},
+             {"name": "Run the board cells with a recorded PASS", "conclusion": "${{ steps.cells.outcome }}"}]
+          NROS_LANE_CELLS_RAN: ${{ steps.cells.outputs.cells_ran }}
+        run: python3 scripts/ci/lane-stage.py --report --lane "live-peer regression (board)"
 
   # The job NAME carries the stage, for the same reason `run-matrix.yml`'s
   # `coverage` job does: a check-run name is the last piece of a run that is
@@ -162,7 +461,7 @@ jobs:
   # `|| 'DID NOT START'` covers the run where `regression` produces no outputs
   # at all, which is neither a verdict nor a lane failure.
   stage:
-    name: "live-peer — ${{ needs.regression.outputs.stage_label || 'DID NOT START' }}"
+    name: "live-peer host — ${{ needs.regression.outputs.stage_label || 'DID NOT START' }}"
     needs: [regression]
     if: always()
     runs-on: ubuntu-22.04
@@ -177,11 +476,55 @@ jobs:
         run: |
           label="$LABEL"
           reached="$REACHED"
-          echo "live-peer regression: $label"
+          echo "live-peer regression (host): $label"
           if [ "$reached" != "true" ]; then
               echo ""
               echo "The cells did not run, so this run says NOTHING about whether"
               echo "a recorded-passing cell still passes. It is a verdict about"
               echo "the lane, not about the code. Do not read a green ledger as"
               echo "guarded until a run reaches its cells."
+          fi
+
+  # The board half's own name, for the same reason — and with the two answers
+  # this job has that its sibling does not.
+  #
+  # `board` is SKIPPED when the ledger records no cell on a board, which is a
+  # legitimate state and not a failure. But a skipped job is a grey tick, and a
+  # grey tick reads as "fine" — so the fallback chain says WHICH of the three
+  # non-verdicts happened: the split could not be computed, there was nothing to
+  # run, or the job was to run and never started.
+  stage-board:
+    name: "live-peer board — ${{ needs.board.outputs.stage_label || (needs.membership.result != 'success' && 'NO VERDICT: could not split the ledger by runner') || (needs.membership.outputs.has_board == 'true' && 'DID NOT START') || 'no cell on a board has a recorded PASS' }}"
+    needs: [membership, board]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Say in the run list what the log would have to be opened for
+        env:
+          LABEL: ${{ needs.board.outputs.stage_label }}
+          REACHED: ${{ needs.board.outputs.reached_cells }}
+          HAS_BOARD: ${{ needs.membership.outputs.has_board }}
+          CELLS: ${{ needs.membership.outputs.board_cells }}
+          SPLIT: ${{ needs.membership.result }}
+        run: |
+          label="$LABEL"
+          reached="$REACHED"
+          if [ "$SPLIT" != "success" ]; then
+              echo "The ledger could not be split by runner, so this run does not"
+              echo "know whether it OWED anything. Not a verdict about the code."
+              exit 0
+          fi
+          if [ "$HAS_BOARD" != "true" ]; then
+              echo "No cell on a board has a recorded PASS, so there is nothing"
+              echo "for this lane to guard yet. That is the honest state of the"
+              echo "coverage, not a green: see phase-441 W1-W3."
+              exit 0
+          fi
+          echo "live-peer regression (board): ${label:-DID NOT START}"
+          echo "  rows: $CELLS"
+          if [ "$reached" != "true" ]; then
+              echo ""
+              echo "The board cells did not run, so this run says NOTHING about"
+              echo "whether they still pass. It is a verdict about the lane —"
+              echo "most likely its toolchain, its image or its fixtures."
           fi

--- a/docs/roadmap/phase-433-rmw-live-verification.md
+++ b/docs/roadmap/phase-433-rmw-live-verification.md
@@ -185,9 +185,11 @@ the same build — the shape of a defect only a peer can show.
   W3 (PR #587)**. C/cyclone is what runs; Rust/cyclone is carved. What remains
   after the correction: C++ has exactly one cell (`cpp_multi_node_entry`) and
   it has no focused runner.
-* **Platform.** One on-target cell exists (`zephyr-qos-rust-zenoh`) and no
-  recipe runs it. FreeRTOS, NuttX, ThreadX and esp32 have **zero** live-peer
-  cells. Every claim that an RTOS image interoperates rests on host testing plus
+* **Platform.** One non-Linux cell exists (`zephyr-qos-rust-zenoh`) and no
+  recipe runs it. (This line read "one on-target cell" until phase-441 W5:
+  that cell is `native_sim/native/64`, whose sockets are the host's, so it is
+  not a witness for a device — see phase-441.) FreeRTOS, NuttX, ThreadX and
+  esp32 have **zero** live-peer cells. Every claim that an RTOS image interoperates rests on host testing plus
   the wire being the same, which is an argument, not a measurement.
 * **Direction, for cyclone services.** zenoh has both `nano_server` and
   `ros2_server`; cyclone has only `nano_server`. A nano-ros *client* against a

--- a/docs/roadmap/phase-441-rmw-on-target-verification.md
+++ b/docs/roadmap/phase-441-rmw-on-target-verification.md
@@ -155,6 +155,74 @@ into a sibling lane that does — with the split visible in the stage reporter
 added for issue 1158, so "this lane could not run the on-target cells" and "the
 on-target cells regressed" stay distinguishable.
 
+**LANDED 2026-09-10 — SPLIT, and the split is DERIVED.**
+
+*Which option, and why.* A sibling job (`board`) in the same workflow, gated on
+the ledger actually containing a row that needs one. Provisioning the toolchain
+in `regression` was rejected on this lane's own stated reason: it exists
+separately from `just ci tier1` because "verification must not be hostage to
+everything else being green", and putting a Zephyr SDK, a west update and an
+emulator in front of nineteen host cells that touch none of them re-creates
+exactly that hostage relationship — every provisioning flake would cost the
+whole lane its verdict. The other half of the trade is the cost of a split, and
+both halves of it are paid down rather than accepted: the second lane does not
+exist when there is nothing for it to run (`if: needs.membership.outputs
+.has_board == 'true'`), and it reports through the SAME stage reporter, so the
+run list carries two named answers instead of one job with two meanings.
+
+*The split is computed, never recorded.* A cell's runner follows from its
+PLATFORM coordinate, which `interop::CELLS` already states — so the ledger gains
+no `needs_qemu` field (a second source that drifts the moment a cell moves
+board). `check-interop-cell-runners.py` now parses the platform beside the tier;
+`check-interop-verdicts.py --runner host|board` narrows any listing by it, and
+`--scopes setup|build` / `--narrowing` derive what the board job must provision
+and which fixture leaves it must build. Two authored maps back that, and both
+fail CLOSED: an unmapped board is an error naming the platform, an unmapped cell
+is an error naming the cell, and every scope token is checked against
+`scripts/build/scope.sh` while every narrowing value is checked against
+`examples/fixtures.toml`.
+
+*The lane runs `just native test-live-peer-regression host|board`.* Three things
+that were wrong there had to be fixed for the acceptance to be satisfiable at
+all:
+
+* **The board row was already in the host lane.** `zephyr-qos-rust-zenoh` has
+  had a recorded PASS since the ledger's first entry, and the host container
+  builds no Zephyr image — so that cell resolved no fixture, skipped, and was
+  counted green. Not a future hazard: today's state.
+* **A regression could not be reported as one.** The loop classified `100` as
+  "tests ran and failed", but it calls `_test-focused`, which swallows nextest's
+  100 and answers 1 — so every real failure would have been reported as a
+  harness fault. It now reads the junit (`_count-real-failures`) rather than the
+  exit code alone.
+* **A skipped membership read as a pass.** `--assert-ran` checks that every
+  in-scope cell with a recorded PASS produced a NON-SKIP result, over the junits
+  of the whole run; a membership that only skipped is exit 2, "this lane could
+  not run". Because that exposure is only useful if the absence can be supplied,
+  both jobs now provision the declared system closure — neither CI image bakes
+  `ros-humble-rmw-zenoh-cpp`, so without it every zenoh cell skips.
+
+*The "could not run" case is named, three ways.* `lane-stage.py` gained the
+fourth axis it needed: a cells STEP failing does not say whether the cells
+produced results, so the workflow forwards the recipe's own answer
+(`NROS_LANE_CELLS_RAN`) and the reporter says `NO VERDICT: the cells could not
+run` instead of `VERDICT: cells ran and FAILED`. `stage-board`'s job NAME
+distinguishes the three non-verdicts a skipped board job can mean — the ledger
+could not be split, there was nothing to run, or the job never started — so a
+grey tick never reads as "fine". Both jobs are in `LANES`, and `--selftest`
+cross-checks each against the YAML in both directions.
+
+*Left deliberately.* The board job runs on a GitHub-hosted runner in
+`nano-ros-zephyr-ci` (the image nightly's Zephyr line uses daily) rather than on
+the self-hosted `nros-qemu, nros-sdk-zephyr` fleet: the fleet has the toolchains
+but its ROS story is unverified, and `NROS_SELF_HOSTED_READY` gating would make
+this lane's verdict depend on a fleet variable. When W1's Cortex-M cell lands,
+its `qemu` scope is already derived and provisioned; whether the SDK's own QEMU
+suffices there is W1's measurement, not an assumption made here. A board cell on
+a NON-Zephyr kernel (W3) will ask for a scope this image cannot provision, and
+the setup step FAILS naming it rather than running a green over cells it never
+built.
+
 ### W5 — retire the phrase, or earn it
 
 Whatever W1–W3 land, correct the places that currently call the native_sim cell

--- a/docs/roadmap/phase-441-rmw-on-target-verification.md
+++ b/docs/roadmap/phase-441-rmw-on-target-verification.md
@@ -232,6 +232,53 @@ QoS interop ──`; phase-433's coverage map inherits the same reading.
 **Acceptance.** Every surviving use of "on-target" names a coordinate whose
 sockets are not the host's, or says which board it means.
 
+**LANDED 2026-09-10 — 169 uses examined, 20 changed.**
+
+The sweep covered every non-archived `on-target` / `on target` / `on_target` in
+the tree (243 including `archived/`, which is a record and was left alone). The
+uses split into four kinds, and only one of them is the overclaim:
+
+1. **Not the phrase.** `non-target`, `json-target-spec`, `corrosion-target`,
+   "depends on target" — the CMake and cargo senses, which is most of the
+   non-hyphenated half. Untouched.
+2. **A real target.** `emulator.rs`'s baremetal MPS2 cells, RFC-0074's cadence
+   "taken from an on-target guest clock" on the FreeRTOS mps2-an385 QEMU lane,
+   phase-372's "on-target smoke when hardware is available". These name a
+   coordinate whose sockets are not the host's. Left.
+3. **A feature, not a coordinate.** RFC-0052's `on-target contract monitors` —
+   `nros-diagnostics`, `executor/monitor.rs`, the parity ledger's `why` text,
+   the generated messages' `STAMP_OFFSET` comments, phase-296 W3b. The phrase
+   there is the RFC's own vocabulary for "checked in the image rather than by an
+   external monitor node subscribing to `/statistics`", it is true on every
+   board the executor runs on, and it makes no claim about a test's reach.
+   24 of the 64 non-phase-441 hyphenated hits, left — rewriting an RFC's
+   vocabulary is the mass rewrite this item was told not to do.
+4. **The overclaim: `native_sim` called on-target.** 20 lines, all in the
+   phase-276 Zephyr entry family and its interop sibling. Fixed.
+
+The replacement word was already in the tree: `entry_e2e.rs` says **in-image**
+three lines from where it said on-target, and that is exactly the distinction
+those sentences are drawing (the nano-ros application vs the test harness and
+the ROS peer). So the fix is one word, not a rephrasing:
+
+| where | was |
+| --- | --- |
+| `interop::CELLS` section header | `── Zephyr on-target QoS interop ──` → `native_sim`, plus why |
+| `entry_e2e.rs` (8) | on-target seeding / endpoints / store / listener → in-image |
+| `qos_zephyr_ros2_interop_e2e.rs`, `interop_e2e.rs`, `zephyr.rs` | "both nodes on-target" → in-image; "the on-target zephyr-image QoS interop" → "the zephyr native_sim image" |
+| `examples/fixtures.toml` (2), the qos + safety entry crates (3) | the on-target pair / safe_listener → in-image |
+| `just/zephyr-dev.just` | "a publisher ON TARGET" → "in a Zephyr NATIVE_SIM image" |
+| `executor/spin.rs` | "Measured on-target" → "Measured on that native_sim image" (the same comment already said native_sim two lines up) |
+| phase-433's coverage map | "One on-target cell exists" → "One non-Linux cell exists", with the correction noted in place |
+
+Left deliberately, beyond kinds 1–3: `spin.rs`'s "a growing count is the
+on-target signal that a tier is not keeping up" (the signal available inside any
+image, contrasted with an external observer differencing timestamps);
+phase-433's W7 heading, which describes the cell this phase is about to build
+and is quoted verbatim above; `docs/issues/README.md`, which is generated.
+W4's own new code uses the phrase twice, both times to say why it is not the
+vocabulary of the runner split.
+
 ## What this phase does NOT promise
 
 **Not real hardware.** Everything above is QEMU. A QEMU MPS2-AN385 is a genuine

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -4726,7 +4726,7 @@ skip_probe = true
 # (examples/workspaces/features/src/zephyr_rust_qos_entry): the
 # qos-on-embedded coverage cell. The QoS profiles are declared per-entity in
 # node code (RFC-0041, reliable + transient_local on /qos_chatter); the
-# on-target QoS-matched pair republishes its receive count on /qos_ok.
+# in-image QoS-matched pair republishes its receive count on /qos_ok.
 # Distinct zenohd port (7460). Consumed by tests/entry_e2e.rs
 # (zephyr_rust_qos cell).
 [[workspace_fixture]]
@@ -4748,7 +4748,7 @@ skip_probe = true
 # (examples/workspaces/safety/src/zephyr_rust_safety_entry): the
 # safety-on-embedded coverage cell. The system declares [system].features =
 # ["safety"] → the zenoh backend attaches the E2E CRC + sequence number on
-# publish and validates on receive; the on-target safe_listener republishes
+# publish and validates on receive; the in-image safe_listener republishes
 # its CRC-VALIDATED count on /safe_ok. Distinct zenohd port (7490). Consumed
 # by tests/entry_e2e.rs (zephyr_rust_safety cell).
 [[workspace_fixture]]

--- a/examples/workspaces/features/src/zephyr_rust_qos_entry/Cargo.toml
+++ b/examples/workspaces/features/src/zephyr_rust_qos_entry/Cargo.toml
@@ -7,7 +7,7 @@
 # The QoS override lives in NODE CODE (declarative per-entity profiles via
 # `create_subscription_for_topic_with_qos` — reliable + transient_local on
 # `/qos_chatter`), so no capability emit is needed: this rides the plain
-# register+spin Zephyr path proven by the base entry. The on-target QoS-matched
+# register+spin Zephyr path proven by the base entry. The in-image QoS-matched
 # pair republishes its receive count on `/qos_ok` for cross-process observers.
 #
 # Shape mirrors `examples/workspaces/rust/src/zephyr_rust_qos_entry` (phase-225.P): RMW

--- a/examples/workspaces/features/src/zephyr_rust_qos_entry/src/lib.rs
+++ b/examples/workspaces/features/src/zephyr_rust_qos_entry/src/lib.rs
@@ -12,7 +12,7 @@
 //!      `/qos_chatter` with a NON-DEFAULT profile (reliable + transient_local)
 //!      and the listener subscribes with the byte-identical profile,
 //!   4. exports `rust_main` that gates on the network, opens an `Executor`,
-//!      registers, and spins forever — the on-target QoS-matched pair
+//!      registers, and spins forever — the in-image QoS-matched pair
 //!      republishes its receive count on `/qos_ok` for cross-process observers.
 //!
 //! There is NO Rust `fn main` (Zephyr emits the C `main`).

--- a/examples/workspaces/safety/src/zephyr_rust_safety_entry/Cargo.toml
+++ b/examples/workspaces/safety/src/zephyr_rust_safety_entry/Cargo.toml
@@ -8,7 +8,7 @@
 # lowers to the `safety-e2e` backend feature — the zenoh backend attaches the
 # E2E CRC + sequence number on publish and validates on receive, and
 # `rust_safety_listener_pkg` reads the per-message `CallbackCtx::integrity()`. Both
-# nodes run on-target; the listener republishes its CRC-VALIDATED receive
+# nodes run in-image; the listener republishes its CRC-VALIDATED receive
 # count on `/safe_ok` for cross-process observers (Track D).
 #
 # Shape mirrors `ws-qos-rust/src/zephyr_rust_safety_entry` (phase-276 W5): RMW flows

--- a/just/native.just
+++ b/just/native.just
@@ -1141,20 +1141,54 @@ zenohd:
 #
 # Needs ROS 2 and a live bus: run it in the `ros2` distrobox on the box tree
 # (issue 0759), or on a runner whose image carries the distro.
+#
+# phase-441 W4 — THE RUNNER IS NOT IN THE LEDGER, AND MUST NOT BE.
+#
+# Membership follows from a recorded verdict; what it takes to RUN a cell does
+# not. A cell on a board needs that board's SDK, its cross toolchain and — off
+# native_sim — an emulator, none of which the host lane's container carries.
+# `runner=` narrows to the cells whose board IS this machine (`host`) or is not
+# (`board`); the split is computed from each cell's platform coordinate in
+# `interop::CELLS`, so nothing has to be kept in step by hand. `all` is the
+# hand-run default: a developer with everything provisioned wants everything.
+#
+# The two failure modes this recipe keeps apart are the point of it:
+#
+#   exit 1  a cell with a RECORDED PASS produced a real failure. A verdict.
+#   exit 2  the cells did not produce results at all — a fixture that would not
+#           build, a peer that is not installed, a filter that named nothing.
+#           NOT a verdict, and reporting it as a regression is the mislabel
+#           this whole phase kept tripping over.
 [group("debug")]
-test-live-peer-regression verbose="":
+test-live-peer-regression runner="all" verbose="":
     #!/usr/bin/env bash
     set -euo pipefail
-    cells=$(python3 scripts/check-interop-verdicts.py --list-passing)
+    runner="{{runner}}"
+    case "$runner" in
+        host|board|all) ;;
+        *)
+            echo "test-live-peer-regression: runner='$runner' is not one of" >&2
+            echo "  host | board | all. host = the cells whose board is this" >&2
+            echo "  machine; board = the cells that need a board toolchain." >&2
+            exit 2
+            ;;
+    esac
+    cells=$(python3 scripts/check-interop-verdicts.py --list-passing --runner "$runner")
     if [ -z "$cells" ]; then
-        echo "test-live-peer-regression: the ledger records no passing cell, so"
-        echo "  there is nothing whose regression this lane could detect."
-        echo "  Run a cell live and record it: see \`just interop-verdicts\`."
+        echo "test-live-peer-regression: the ledger records no passing cell on the"
+        echo "  '$runner' runner, so there is nothing whose regression this lane"
+        echo "  could detect. Run a cell live and record it: \`just interop-verdicts\`."
         exit 0
     fi
-    echo "== live-peer regression lane — cells with a recorded PASS =="
+    echo "== live-peer regression lane ($runner runner) — cells with a recorded PASS =="
     echo "$cells" | sed 's/^/  /'
-    bins=$(python3 scripts/check-interop-verdicts.py --list-passing --by-binary)
+    bins=$(python3 scripts/check-interop-verdicts.py --list-passing --runner "$runner" --by-binary)
+    # Each binary's junit, kept: `_test-focused` resets the one nextest writes
+    # on every call, so the skipped-membership check below needs its own copies.
+    junit_dir="tmp/live-peer-junit/$runner"
+    rm -rf "$junit_dir"
+    mkdir -p "$junit_dir"
+    source scripts/test/nextest-profile.sh
     failed=0
     broken=0
     for b in $bins; do
@@ -1163,29 +1197,57 @@ test-live-peer-regression verbose="":
         just _test-focused "binary(=$b)" {{verbose}}
         rc=$?
         set -e
-        # A run that could not START is not a verdict. `just` answers 1 for a
-        # missing recipe and nextest answers 1 for a filter it cannot parse
-        # (issue 0743), and calling either "a regression" is the mislabel this
-        # whole phase kept tripping over — a `[SKIPPED] fixture not built`
-        # rendered as FAIL, a `ros2` usage error rendered as a discovery
-        # timeout. 100 is nextest's "tests ran and some failed".
-        case "$rc" in
-            0)   ;;
-            100) failed=1 ;;
-            *)   broken=1; echo "  (exit $rc — the RUN did not happen; not a verdict)" ;;
-        esac
+        junit="$(nros_nextest_junit_path)"
+        real=0
+        if [ -f "$junit" ]; then
+            cp "$junit" "$junit_dir/$b.xml"
+            real="$(just _count-real-failures "$junit")"
+        fi
+        # Classified by what the junit HOLDS, not by the exit code alone.
+        # `_test-focused` answers 1 for a real failure AND 1 for "the filter
+        # named nothing" AND 1 for a build that never produced a junit — it
+        # swallows nextest's own 100, so the `100) failed=1` arm this recipe
+        # used to carry could never fire and every regression would have been
+        # reported as a harness fault.
+        if [ "$rc" -eq 0 ]; then
+            :
+        elif [ "$real" -gt 0 ]; then
+            failed=1
+        else
+            broken=1
+            echo "  (exit $rc with no real failure in the junit — the RUN did not"
+            echo "   happen; not a verdict)"
+        fi
     done
-    if [ "$broken" -ne 0 ]; then
-        echo ""
-        echo "This lane could not run. That is a harness fault, NOT a regression"
-        echo "verdict — fix the invocation and re-run before believing anything"
-        echo "about the cells."
-        exit 2
+    # A SKIP IS NOT A VERDICT, and this lane's own membership is the place that
+    # costs the most: `_rewrite-skipped-junit` turns a missing peer or fixture
+    # into `<skipped>`, `_test-focused` exits 0, and the lane reports that cells
+    # with a recorded PASS still pass — over a run that measured nothing.
+    set +e
+    python3 scripts/check-interop-verdicts.py --assert-ran "$junit_dir" --runner "$runner"
+    ran_rc=$?
+    set -e
+    if [ "$ran_rc" -ne 0 ]; then
+        broken=1
     fi
+    # Precedence: a REAL failure outranks "could not run". A red that is real
+    # must never be relabelled as infrastructure — the other direction (issue
+    # 0445's absorbing verdict) is what the guard above is for, and both are
+    # printed either way.
     if [ "$failed" -ne 0 ]; then
         echo ""
         echo "A cell with a RECORDED PASS did not pass. That is a regression, not"
         echo "a new finding: this lane's membership is exactly what a human has"
         echo "already measured working against a live peer."
+        if [ "$broken" -ne 0 ]; then
+            echo "(Some other cells in this run produced no result at all — see above.)"
+        fi
         exit 1
+    fi
+    if [ "$broken" -ne 0 ]; then
+        echo ""
+        echo "This lane could not run. That is a harness fault, NOT a regression"
+        echo "verdict — fix what the lines above name and re-run before believing"
+        echo "anything about the cells."
+        exit 2
     fi

--- a/just/zephyr-dev.just
+++ b/just/zephyr-dev.just
@@ -406,7 +406,8 @@ test-xrce verbose="":
     fi
     cargo nextest run "${cargo_nextest_args[@]}" "${args[@]}"
 
-# An nros zenoh-pico publisher ON TARGET reaches a stock `ros2 topic echo`
+# An nros zenoh-pico publisher in a Zephyr NATIVE_SIM image reaches a stock
+# `ros2 topic echo`
 # subscriber (issue #141) — the only `interop::CELLS` cell built through the
 # west leaves rather than native fixtures, so it has TWO build channels and
 # skips on either (phase-433 / issue 1127).

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -9703,7 +9703,8 @@ fn check_deadline_miss(
 // credited each spin the REQUESTED timeout — spin.rs `delta_us` fallback —
 // so shared-session wakes made low-rate timers fire early (a 100 ms timer
 // at ~67 ms on Zephyr native_sim) and tick rounding made fast tiers fire
-// late. Measured on-target; mechanism documented at the fallback site.)
+// late. Measured on that native_sim image; mechanism documented at the
+// fallback site.)
 //
 // Every platform port exports `nros_platform_clock_ns` through the same
 // linkage contract the wake primitives rely on (`nros_platform_export_clock!`

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -308,7 +308,13 @@ pub const CELLS: &[InteropCell] = &[
        c(Linux, Rust, Zenoh, Lifecycle, Interop, Runtime),
        NativeFixtures, RosEdition(Zenoh), BiDir, "interop_e2e"),
 
-    // ── Zephyr on-target QoS interop ────────────────────────────────────
+    // ── Zephyr native_sim QoS interop ───────────────────────────────────
+    // phase-441 W5 — this header read "Zephyr on-target QoS interop", which
+    // claimed what the coordinate does not support: `ZephyrNativeSim` is
+    // `native_sim/native/64`, where the sockets are OFFLOADED to the host and
+    // the pointer width is the host's, so no RTOS network stack is in the path.
+    // The cell is real coverage (it caught issue #141) and it is not a witness
+    // for a device. `ZephyrQemuCortexM` is the coordinate that would be.
     // Issue 0341 — the ONLY runtime test of this shape
     // (qos_zephyr_ros2_interop_e2e.rs) boots the RUST `ws-qos-rust` zephyr entry
     // over zenoh-pico → rmw_zenoh_cpp. The matrix used to declare Cpp/Cyclonedds,

--- a/packages/testing/nros-tests/tests/entry_e2e.rs
+++ b/packages/testing/nros-tests/tests/entry_e2e.rs
@@ -22,8 +22,8 @@
 //!   LIVE-reads its launch-baked `publish_period_ms` initial (250) in the
 //!   node callback and publishes it — the `int32-sink` must see
 //!   `Received: 250`, proving bake → store seed (`apply_param_services`) →
-//!   on-target live read.
-//! - **Qos** (phase-276 W5): the on-target reliable+transient_local pair
+//!   in-image live read.
+//! - **Qos** (phase-276 W5): the in-image reliable+transient_local pair
 //!   matches + delivers in-image (`Z_FEATURE_LOCAL_SUBSCRIBER`); the
 //!   listener's republished count on `/qos_ok` reaches an external sink.
 //! - **Lifecycle** (phase-276 W3 / #128): `apply_lifecycle` autostart drives
@@ -281,7 +281,7 @@ fn exec_for(platform: MP, lang: ML, workload: MW) -> Exec {
                    fold puts the file after the inline `<param>`, so the file wins (rlm phase-54, \
                    issue 0307). 120 is the node-specific block beating the same file's `/**: 999`, \
                    so this value proves the whole chain at once — file projection, specificity \
-                   ranking, on-target seeding and the live re-read. The launch-inline path is what \
+                   ranking, in-image seeding and the live re-read. The launch-inline path is what \
                    the C and C++ params cells assert (they carry no overlay, and still see 250)",
         },
         (MP::ZephyrNativeSim, ML::Rust, MW::Qos) => Exec {
@@ -290,7 +290,7 @@ fn exec_for(platform: MP, lang: ML, workload: MW) -> Exec {
             boot: Boot::ZephyrNativeSim,
             proof: Proof::SinkCount { topic: "/qos_ok" },
             note: "phase-276 W5 (RFC-0041): per-entity reliable+transient_local declared IN NODE \
-                   CODE on both on-target endpoints; in-image delivery rides \
+                   CODE on both in-image endpoints; in-image delivery rides \
                    Z_FEATURE_LOCAL_SUBSCRIBER. The baked qos port is shared with qos_zephyr_ros2_interop_e2e \
                    (issue #141 — the zephyr-qos-port nextest group serializes them)",
         },
@@ -300,7 +300,7 @@ fn exec_for(platform: MP, lang: ML, workload: MW) -> Exec {
             boot: Boot::ZephyrNativeSim,
             proof: Proof::LifecycleActive,
             note: "phase-276 W3 / #128: apply_lifecycle installs the five REP-2002 services and \
-                   drives the boot autostart (Configure→Activate) on-target — no manual set",
+                   drives the boot autostart (Configure→Activate) in-image — no manual set",
         },
         (MP::ZephyrNativeSim, ML::Rust, MW::Safety) => Exec {
             resolver: build_zephyr_workspace_rust_safety_entry,
@@ -309,7 +309,7 @@ fn exec_for(platform: MP, lang: ML, workload: MW) -> Exec {
             proof: Proof::SinkCount { topic: "/safe_ok" },
             note: "phase-276 W4 (RFC-0028): [system].features = [\"safety\"] lowers to the \
                    safety-e2e backend feature — CRC+seq attached per publish, validated on \
-                   receive, CallbackCtx::integrity() read on-target",
+                   receive, CallbackCtx::integrity() read in-image",
         },
         (p, l, w) => panic!(
             "entry_e2e: no execution mapping for matrix cell {p:?}/{l:?}/{w:?} — add an \
@@ -812,7 +812,7 @@ fn run_cell(pcell: &MCell) {
 
             // The published value IS the live param read: ≥3 exact
             // `Received: <value>` lines prove the launch <param> was
-            // compile-baked, seeded into the on-target store, and live-read
+            // compile-baked, seeded into the in-image store, and live-read
             // by the node's callback.
             let line = nros_tests::output::int32_listener_line(value);
             let out = obs
@@ -843,7 +843,7 @@ fn run_cell(pcell: &MCell) {
             let mut obs = spawn_int32_sink(topic, &observer_locator);
             let mut guest = boot_guest(&cell, &entry);
 
-            // `topic` carries the on-target listener's running receive
+            // `topic` carries the in-image listener's running receive
             // count — samples there mean the in-image pair matched,
             // delivered, and the republish reached the wire.
             let _ = obs

--- a/packages/testing/nros-tests/tests/interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/interop_e2e.rs
@@ -37,7 +37,7 @@
 //!
 //! Bespoke interop lanes kept OUT of this consumer (their own binaries):
 //! `xrce_ros2_interop.rs` (XRCE Agent lifecycle specifics) and
-//! `qos_zephyr_ros2_interop_e2e.rs` (the on-target zephyr-image QoS interop,
+//! `qos_zephyr_ros2_interop_e2e.rs` (the zephyr native_sim image QoS interop,
 //! `zephyr-qos-port` nextest group). See the phase-295 W6.c doc for the
 //! introspection/benchmark lanes retired in the reduction.
 //!

--- a/packages/testing/nros-tests/tests/qos_zephyr_ros2_interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/qos_zephyr_ros2_interop_e2e.rs
@@ -11,7 +11,7 @@
 //! (`<domain>/<topic>/<type>/TypeHashNotSupported` both sides) and the
 //! direction works — this test pins it so a real regression can't hide again.
 //!
-//! Reuses the phase-276 W5 `ws-qos-rust` Zephyr image (both nodes on-target;
+//! Reuses the phase-276 W5 `ws-qos-rust` Zephyr image (both nodes in-image;
 //! `/qos_ok` republished at 1 Hz) and its baked router port — the
 //! `zephyr-qos-port` nextest group serializes this with
 //! the `entry_e2e` zephyr_rust_qos cell so the routers never collide.

--- a/packages/testing/nros-tests/tests/zephyr.rs
+++ b/packages/testing/nros-tests/tests/zephyr.rs
@@ -298,7 +298,7 @@ fn start_image(bin: &Path, locator: &Option<String>, what: &str) -> ZephyrProces
 // The parametrized matrix consumer — 27 (rmw × lang × workload) cells
 // =============================================================================
 
-/// One Zephyr native_sim example cell: boot the on-target pair against the
+/// One Zephyr native_sim example cell: boot the in-image pair against the
 /// cell's isolation resource and prove the workload contract. Case names
 /// carry `<rmw>_<lang>_<workload>_e2e` so the `.config/nextest.toml` groups
 /// can slice by family (e.g. `test(xrce)`, `test(zenoh_cpp_service_e2e)`).

--- a/scripts/check-interop-cell-runners.py
+++ b/scripts/check-interop-cell-runners.py
@@ -256,7 +256,15 @@ def parse_cells(src: str) -> list[dict]:
 
 
 def _parse_cell(arg: str, line: int) -> dict:
-    """The tier out of the row's `c(platform, lang, rmw, workload, kind, tier)`."""
+    """The platform and tier out of `c(platform, lang, rmw, workload, kind, tier)`.
+
+    The PLATFORM is here for phase-441 W4: which runner a cell needs is a
+    property of its coordinate and of nothing else. `.config/interop-verdicts.
+    toml` records that a cell passed, not what it takes to run one, and giving
+    it a `needs_qemu = true` field would be a second source for a fact the
+    coordinate already states -- the shape `row_coord()` exists to prevent.
+    Read it here, once, like the tier.
+    """
     arg = arg.strip()
     if not arg.startswith("c("):
         raise ParseError(
@@ -277,7 +285,12 @@ def _parse_cell(arg: str, line: int) -> dict:
             f"this gate -- an unrecognised tier would silently read as "
             f"not-Runtime and drop its cells out of the check."
         )
-    return {"tier": tier}
+    platform = re.split(r"[\s(]", inner[0].strip(), maxsplit=1)[0]
+    if not platform:
+        raise ParseError(
+            f"{INTEROP_RS.name}:{line}: `c(...)` has an empty platform token"
+        )
+    return {"platform": platform, "tier": tier}
 
 
 def _parse_test(arg: str, line: int) -> dict:
@@ -588,6 +601,11 @@ def self_test(verbose: bool = False) -> None:
     cells = parse_cells(_MINI_RS)
     assert [c["id"] for c in cells] == ["cell-alpha", "cell-beta", "cell-carved"], cells
     assert [c["tier"] for c in cells] == ["Runtime", "Runtime", "CarveOut"], cells
+    # phase-441 W4 -- the platform, which is what says whether a cell's runner
+    # is this host or a board. Asserted here so a `c(...)` shape change that
+    # drops it fails where the parse lives, not in the lane that reads it.
+    assert [c["platform"] for c in cells] == [
+        "Linux", "Linux", "ZephyrNativeSim"], cells
     assert cells[2]["test"] is None, "selftest: NO_TEST was not recognised"
     assert cells[0]["test"] == "alpha_e2e", cells[0]
 

--- a/scripts/check-interop-verdicts.py
+++ b/scripts/check-interop-verdicts.py
@@ -158,6 +158,186 @@ def test_sources(cells: list[dict]) -> dict[str, str | None]:
     return out
 
 
+# --- which RUNNER a cell needs (phase-441 W4) ----------------------------
+#
+# `live-peer.yml` derives its membership from this ledger, so a cell joins the
+# lane the moment a verdict is recorded. What does NOT follow is the RUNNER: a
+# cell on a board needs that board's SDK, its cross toolchain and — off
+# native_sim — an emulator, and the container the host cells run in has none of
+# them.
+#
+# The ledger is the wrong place to say so. It records that a cell PASSED; what
+# it takes to run one is a property of the cell's COORDINATE, which
+# `interop::CELLS` already states. A `needs_qemu = true` field beside the
+# verdict would be a second source for that fact, drifting the moment a cell
+# moves board — the shape `row_coord()` exists to prevent. So the split is
+# computed from the platform token, here, once.
+#
+# Two classes, and the vocabulary is deliberately NOT "on-target" (phase-441
+# W5): `ZephyrNativeSim` is `native_sim/native/64`, whose sockets are the
+# host's, and calling its lane on-target claims what the artifact does not
+# support. The question this split actually asks is whether the cell's BOARD is
+# the runner itself.
+HOST_PLATFORM = "Linux"
+RUNNERS = ("host", "board", "all")
+
+# platform -> the `just setup <scope>` tokens that provision it, or None for a
+# platform no lane can provision today.
+#
+# AUTHORED, because it is a judgement and not a lookup: `ZephyrQemuCortexM`
+# needs the Zephyr SDK *and* an emulator, which no single existing table says.
+# Two things keep it from drifting quietly — every token is checked against
+# `scripts/build/scope.sh`'s own platform list (a renamed scope fails here), and
+# a platform missing from this map is an ERROR rather than an empty scope set,
+# so recording a verdict for a board nothing provisions tells the next person
+# what to add instead of silently running nothing.
+# Two roles, because they are two different questions and a board can answer
+# them differently: `setup` provisions (the SDK, the cross toolchain, the
+# emulator), `build` owns the fixtures the cells resolve. `ZephyrQemuCortexM`
+# is provisioned by `zephyr` AND `qemu` and its fixtures are `zephyr`'s;
+# collapsing the two would make the lane build QEMU's own baremetal fixtures to
+# run a Zephyr cell.
+BOARD_SCOPES: "dict[str, dict[str, tuple[str, ...]] | None]" = {
+    "ZephyrNativeSim": {"setup": ("zephyr",), "build": ("zephyr",)},
+    "ZephyrQemuCortexM": {"setup": ("zephyr", "qemu"), "build": ("zephyr",)},
+    "FreertosMps2": {"setup": ("freertos", "qemu"), "build": ("freertos",)},
+    "FreertosPosix": {"setup": ("freertos",), "build": ("freertos",)},
+    "NuttxArm": {"setup": ("nuttx", "qemu"), "build": ("nuttx",)},
+    "NuttxRiscv": {"setup": ("nuttx", "qemu"), "build": ("nuttx",)},
+    "ThreadxLinux": {"setup": ("threadx_linux",), "build": ("threadx_linux",)},
+    "ThreadxRiscv64": {
+        "setup": ("threadx_riscv64", "qemu"), "build": ("threadx_riscv64",),
+    },
+    "Esp32Qemu": {"setup": ("esp32",), "build": ("esp32",)},
+    "QemuBaremetal": {"setup": ("qemu",), "build": ("qemu",)},
+    # Neither has a CI story in this tree (phase-441 "What this phase does NOT
+    # promise"): the FVP is x86_64-only and maintainer-run, PX4-SITL is built by
+    # no runner. `None` is not "no provisioning needed" — it is "decide, and
+    # write the decision here".
+    "Fvp": None,
+    "Px4": None,
+}
+
+# cell id -> the (env var, value) that narrows a scope's fixture build to the
+# leaf THAT cell resolves.
+#
+# Needed because `just build zephyr` is the whole west lane, and the tree
+# already says why that is not the answer (`just/zephyr-dev.just`, on this very
+# cell: "running the whole west lane to reach one cell is not something anyone
+# would type"). Nightly builds ONE zephyr example per job for the same reason.
+#
+# Keyed by CELL, because the leaf is a property of the cell and not of its
+# board. A recorded board cell missing from here is an ERROR — the alternative
+# is a lane that builds everything or builds nothing, and both were tried.
+# The value is cross-checked against `examples/fixtures.toml`, so a renamed
+# west build name fails here instead of silently narrowing to nothing.
+BOARD_FIXTURE_NARROWING: "dict[str, tuple[str, str]]" = {
+    "zephyr-qos-rust-zenoh": (
+        "NROS_ZEPHYR_FIXTURE_FILTER", "build-ws-rs-qos-entry-zenoh",
+    ),
+}
+
+FIXTURES_TOML = ROOT / "examples" / "fixtures.toml"
+
+SCOPE_SH = ROOT / "scripts" / "build" / "scope.sh"
+
+
+def known_scopes() -> set[str]:
+    """The scope tokens `just setup <scope>` accepts, read from their source."""
+    m = re.search(
+        r'^_NROS_SCOPE_PLATFORMS="([^"]*)"',
+        SCOPE_SH.read_text(encoding="utf-8"),
+        re.M,
+    )
+    if not m:
+        raise LedgerError(
+            f"{_rel(SCOPE_SH)}: no `_NROS_SCOPE_PLATFORMS=\"...\"` line — the "
+            f"scope vocabulary moved, and this tool validates BOARD_SCOPES "
+            f"against it"
+        )
+    return set(m.group(1).split())
+
+
+def runner_of(platform: str) -> str:
+    """`host` if the cell runs on the runner itself, else `board`."""
+    return "host" if platform == HOST_PLATFORM else "board"
+
+
+def scopes_for(platforms, role: str = "setup") -> list[str]:
+    """The `just <role> <scope>` tokens these platforms need, sorted.
+
+    Raises `LedgerError` naming the platform when the map has no answer — a
+    lane that provisions nothing must say so, not run nothing.
+    """
+    known = known_scopes()
+    out: set[str] = set()
+    for plat in sorted(set(platforms)):
+        if plat == HOST_PLATFORM:
+            continue
+        if BOARD_SCOPES.get(plat) is None:
+            raise LedgerError(
+                f"a cell on `{plat}` has a recorded PASS, and BOARD_SCOPES in "
+                f"scripts/check-interop-verdicts.py does not say what provisions "
+                f"it. Add the `just setup <scope>` tokens for that board (and "
+                f"give the lane a runner that can) — an empty scope set would "
+                f"run nothing and report green."
+            )
+        for tok in BOARD_SCOPES[plat][role]:
+            if tok not in known:
+                raise LedgerError(
+                    f"BOARD_SCOPES maps `{plat}` to scope `{tok}`, which is not a "
+                    f"scope token in {_rel(SCOPE_SH)} ({' '.join(sorted(known))})"
+                )
+            out.add(tok)
+    return sorted(out)
+
+
+def narrowing_for(ids) -> list[str]:
+    """`KEY=value` lines narrowing a fixture build to these cells' leaves.
+
+    Several cells sharing a key are joined with `|`: the one narrowing hook in
+    the tree (`NROS_ZEPHYR_FIXTURE_FILTER`) is a REGEX, so an alternation is its
+    union. A future key whose union is not an alternation must say so here
+    rather than inherit this one's meaning.
+    """
+    fixtures = FIXTURES_TOML.read_text(encoding="utf-8")
+    merged: dict[str, list[str]] = {}
+    for cid in sorted(set(ids)):
+        if cid not in BOARD_FIXTURE_NARROWING:
+            raise LedgerError(
+                f"`{cid}` has a recorded PASS on a board runner and "
+                f"BOARD_FIXTURE_NARROWING in scripts/check-interop-verdicts.py "
+                f"does not say which fixture leaf it resolves. Add it — the lane "
+                f"would otherwise build every leaf of that scope (hours) or none "
+                f"of them (a green over nothing)."
+            )
+        key, value = BOARD_FIXTURE_NARROWING[cid]
+        if value not in fixtures:
+            raise LedgerError(
+                f"BOARD_FIXTURE_NARROWING[{cid}] narrows to `{value}`, which "
+                f"appears nowhere in {_rel(FIXTURES_TOML)} — a renamed leaf "
+                f"would narrow the build to nothing and read as done"
+            )
+        merged.setdefault(key, []).append(value)
+    return [f"{k}={'|'.join(sorted(set(v)))}" for k, v in sorted(merged.items())]
+
+
+def in_runner(cells: list[dict], ids, runner: str) -> list[str]:
+    """The subset of `ids` whose cell runs on `runner` (`all` keeps every id).
+
+    An id the cell table no longer names is dropped, for the reason
+    `--list-passing` already gives: that is the ledger gate's problem, and
+    crashing the regression lane over it helps nobody.
+    """
+    by_id = {c["id"]: c for c in cells}
+    if runner == "all":
+        return [c for c in ids if c in by_id]
+    return [
+        c for c in ids
+        if c in by_id and runner_of(by_id[c]["platform"]) == runner
+    ]
+
+
 # --- which cases can be EVIDENCE ----------------------------------------
 
 
@@ -813,6 +993,66 @@ def after_run(junit: Path, cells: list[dict], sources, owners, entries) -> list[
     return out
 
 
+def assert_ran(
+    junit_dir: Path,
+    passing: list[str],
+    cells: list[dict],
+    sources,
+    owners,
+    runner: str,
+) -> int:
+    """Did every cell with a recorded PASS actually produce a result? — W4.
+
+    The regression lane's failure mode is not a red. It is a GREEN over a run
+    in which every case hit `skip!` for want of the peer or the fixture:
+    `_rewrite-skipped-junit` turns those into `<skipped>`, `_test-focused` exits
+    0 and prints that it did, and the lane reports that cells with a recorded
+    PASS still pass. That is issue 0445's absorbing verdict in the one place it
+    costs the most — the lane whose entire subject is "does what worked still
+    work".
+
+    So a skipped membership is NOT a verdict. Exit 3, which the recipe maps to
+    "this lane could not run" rather than to a regression.
+    """
+    xmls = sorted(junit_dir.glob("*.xml")) if junit_dir.is_dir() else []
+    ran: set[str] = set()
+    skipped: dict[str, list[str]] = {}
+    for x in xmls:
+        seen, _ = observed(x, cells, sources, owners)
+        for cid, row in seen.items():
+            if row["verdict"]:
+                ran.add(cid)
+            for name in row["skipped"]:
+                skipped.setdefault(cid, []).append(name)
+    missing = [c for c in passing if c not in ran]
+    scope = "" if runner == "all" else f" ({runner} runner)"
+    if not missing:
+        print(
+            f"Every cell with a recorded PASS{scope} produced a result in this "
+            f"run ({len(passing)} of {len(passing)}) — the pass/fail below IS "
+            f"about the code."
+        )
+        return 0
+    print(
+        f"{len(missing)} of {len(passing)} cell(s) with a recorded PASS{scope} "
+        f"produced NO result in this run:"
+    )
+    for cid in missing:
+        why = skipped.get(cid)
+        detail = (
+            f"skipped: {', '.join(sorted(why)[:3])}" if why
+            else "no case of its binary reached this junit"
+        )
+        print(f"  {cid} — {detail}")
+    if not xmls:
+        print(f"  (no junit at all under {_rel(junit_dir)})")
+    print("")
+    print("A skip is not evidence about the code, so this run is NOT a")
+    print("regression verdict — it is a verdict about the lane. Fix what the")
+    print("[SKIPPED] lines above name (the peer, or the fixture) and re-run.")
+    return 3
+
+
 # --- writing an entry ----------------------------------------------------
 
 
@@ -1135,8 +1375,105 @@ def self_test(verbose: bool = False, tmp: Path | None = None) -> None:
     # leaked directory per test run is a slow mess nobody would attribute here.
     with tempfile.TemporaryDirectory(prefix="nros-interop-verdicts-") as td:
         _self_test_junit(Path(td) if tmp is None else tmp, cells, src, owners)
+    with tempfile.TemporaryDirectory(prefix="nros-interop-runner-") as td:
+        _self_test_runner_split(Path(td), cells, src, owners)
     if verbose:
         print("check-interop-verdicts: self-test OK")
+
+
+def _self_test_runner_split(
+    tmp: Path, cells: list[dict], src: dict[str, str | None], owners: list[dict]
+) -> None:
+    """phase-441 W4 — the runner split and the skipped-membership guard."""
+    assert runner_of(HOST_PLATFORM) == "host", "selftest: the host board is not host"
+    assert runner_of("ZephyrNativeSim") == "board", (
+        "selftest: native_sim classified as the host runner. Its SOCKETS are "
+        "the host's, but its image is built by the Zephyr SDK, which the host "
+        "lane's container does not carry — that is what the split is about."
+    )
+
+    # Every scope this map names must be a scope `just setup` accepts. This is
+    # the arm that catches a RENAMED scope, which an authored map cannot.
+    for plat, roles in BOARD_SCOPES.items():
+        if roles is None:
+            continue
+        for role, toks in roles.items():
+            assert scopes_for([plat], role) == sorted(set(toks)), (
+                f"selftest: BOARD_SCOPES[{plat}][{role}] does not survive scopes_for"
+            )
+    assert scopes_for(["ZephyrQemuCortexM", "ZephyrNativeSim"]) == ["qemu", "zephyr"], (
+        "selftest: two boards' scopes did not merge"
+    )
+    assert scopes_for(["ZephyrQemuCortexM"], "build") == ["zephyr"], (
+        "selftest: the emulator scope leaked into the BUILD role — that lane "
+        "would build QEMU's own baremetal fixtures to run a Zephyr cell"
+    )
+    assert scopes_for([HOST_PLATFORM]) == [], "selftest: the host board asked for a scope"
+
+    # The narrowing map: present, and pointing at something that exists.
+    assert narrowing_for(["zephyr-qos-rust-zenoh"]) == [
+        "NROS_ZEPHYR_FIXTURE_FILTER=build-ws-rs-qos-entry-zenoh"
+    ], narrowing_for(["zephyr-qos-rust-zenoh"])
+    try:
+        narrowing_for(["a-board-cell-nobody-mapped"])
+    except LedgerError as e:
+        assert "a-board-cell-nobody-mapped" in str(e), e
+    else:
+        raise AssertionError(
+            "selftest: an unmapped board cell was given no fixture narrowing, "
+            "which builds every leaf of its scope or none of them"
+        )
+    for plat, why in (
+        ("Fvp", "a platform mapped to None"),
+        ("Bicycle", "a platform the map has never heard of"),
+    ):
+        try:
+            scopes_for([plat])
+        except LedgerError as e:
+            assert plat in str(e), f"selftest: the error does not name {plat}: {e}"
+        else:
+            raise AssertionError(f"selftest: {why} was given an empty scope set")
+
+    synth = [
+        {"id": "h", "platform": "Linux", "test": "alpha_e2e", "tier": "Runtime"},
+        {"id": "b", "platform": "ZephyrNativeSim", "test": "zed_e2e", "tier": "Runtime"},
+    ]
+    assert in_runner(synth, ["h", "b"], "host") == ["h"], "selftest: host filter"
+    assert in_runner(synth, ["h", "b"], "board") == ["b"], "selftest: board filter"
+    assert in_runner(synth, ["h", "b"], "all") == ["h", "b"], "selftest: all filter"
+    assert in_runner(synth, ["h", "gone"], "all") == ["h"], (
+        "selftest: an id no longer in CELLS crashed the lane instead of being "
+        "dropped"
+    )
+
+    # The guard: a run in which the membership only SKIPPED is not a verdict.
+    (tmp / "skips.xml").write_text(
+        _junit([("alpha_e2e", "meets_a_peer", "skip"),
+                ("alpha_e2e", "cases_bound_to_interop_cells", "pass")])
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = assert_ran(tmp, ["cell-alpha"], cells, src, owners, "host")
+    assert rc == 3, "selftest: a wholly-skipped membership reported a verdict"
+    assert "cell-alpha" in buf.getvalue(), buf.getvalue()
+
+    (tmp / "real.xml").write_text(
+        _junit([("alpha_e2e", "meets_a_peer", "pass")])
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = assert_ran(tmp, ["cell-alpha"], cells, src, owners, "host")
+    assert rc == 0, (
+        f"selftest: a cell that DID produce a result was called a skip: "
+        f"{buf.getvalue()}"
+    )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = assert_ran(tmp / "nowhere", ["cell-alpha"], cells, src, owners, "board")
+    assert rc == 3 and "no junit at all" in buf.getvalue(), (
+        f"selftest: an absent junit dir passed the guard: {buf.getvalue()}"
+    )
 
 
 def _self_test_case_map(
@@ -1380,6 +1717,36 @@ def main(argv: list[str]) -> int:
         help="with --list-passing, emit the distinct TEST BINARIES those cells "
         "live in instead of the cell ids (several cells share one binary)",
     )
+    ap.add_argument(
+        "--runner",
+        choices=RUNNERS,
+        default="all",
+        help="phase-441 W4 — narrow to the cells whose BOARD is the runner "
+        "itself (`host`) or is not (`board`). Derived from the cell's platform "
+        "coordinate, never from the ledger",
+    )
+    ap.add_argument(
+        "--scopes",
+        choices=("setup", "build"),
+        help="with --list-passing --runner board, emit the scope tokens those "
+        "cells need for that verb (`just setup <scope>` / `just build <scope>`) "
+        "instead of the cell ids",
+    )
+    ap.add_argument(
+        "--narrowing",
+        action="store_true",
+        help="with --list-passing --runner board, emit the `KEY=value` env "
+        "assignments that narrow the fixture build to the leaves those cells "
+        "resolve",
+    )
+    ap.add_argument(
+        "--assert-ran",
+        metavar="DIR",
+        help="phase-441 W4 — every junit in DIR, together: exit 3 naming the "
+        "cells with a recorded PASS (in --runner scope) that produced no "
+        "non-skip result. A skip is not a verdict, so a lane that skips its "
+        "membership has not guarded it",
+    )
     args = ap.parse_args(argv)
 
     if args.self_test:
@@ -1424,7 +1791,7 @@ def main(argv: list[str]) -> int:
             print(line)
         return 0
 
-    if args.list_passing:
+    if args.list_passing or args.assert_ran:
         try:
             entries = load_ledger(text)
         except LedgerError as e:
@@ -1433,13 +1800,71 @@ def main(argv: list[str]) -> int:
         passing = sorted(
             e["cell"] for e in entries if e.get("verdict") == "pass"
         )
-        if args.by_binary:
-            by_id = {c["id"]: c for c in cells}
+        try:
+            passing = in_runner(cells, passing, args.runner)
+        except LedgerError as e:
+            print(f"check-interop-verdicts: {e}", file=sys.stderr)
+            return 1
+
+    if args.assert_ran:
+        return assert_ran(
+            Path(args.assert_ran), passing, cells, sources, owners, args.runner
+        )
+
+    if args.list_passing:
+        by_id = {c["id"]: c for c in cells}
+        if args.scopes or args.narrowing:
+            try:
+                if args.scopes:
+                    print("\n".join(
+                        scopes_for(
+                            (by_id[c]["platform"] for c in passing), args.scopes
+                        )
+                    ))
+                if args.narrowing:
+                    print("\n".join(narrowing_for(passing)))
+            except LedgerError as e:
+                print(f"check-interop-verdicts: {e}", file=sys.stderr)
+                return 1
+        elif args.by_binary:
             # A cell whose id is no longer in CELLS is the ledger gate's problem,
             # not this lane's — skip it here rather than crash the run that is
-            # supposed to detect regressions.
+            # supposed to detect regressions. (`in_runner` has already dropped
+            # those, so this reads only the cells that survived it.)
+            #
+            # A binary hosting cells of BOTH runners cannot be narrowed by
+            # binary at all — `binary(=x)` runs every case in it — so it is a
+            # hard error rather than a silent mis-assignment. Nothing in the
+            # tree is shaped that way today; a future cell that shares a binary
+            # across boards needs a case-level filter, and this says so at the
+            # moment it is written.
+            mixed = sorted(
+                {
+                    by_id[c]["test"]
+                    for c in passing
+                    if by_id[c].get("test")
+                }
+                & {
+                    by_id[c]["test"]
+                    for c in in_runner(
+                        cells,
+                        [e["cell"] for e in entries if e.get("verdict") == "pass"],
+                        "board" if args.runner == "host" else "host",
+                    )
+                    if by_id[c].get("test")
+                }
+            )
+            if args.runner != "all" and mixed:
+                print(
+                    f"check-interop-verdicts: {', '.join(mixed)} host(s) passing "
+                    f"cells on BOTH runners; `binary(=…)` cannot express that "
+                    f"split. Give the board cell its own test binary, or filter "
+                    f"by case.",
+                    file=sys.stderr,
+                )
+                return 1
             bins = sorted(
-                {by_id[c]["test"] for c in passing if c in by_id and by_id[c].get("test")}
+                {by_id[c]["test"] for c in passing if by_id[c].get("test")}
             )
             print("\n".join(bins))
         else:

--- a/scripts/ci/lane-stage.py
+++ b/scripts/ci/lane-stage.py
@@ -126,6 +126,13 @@ LABELS = {
     "verdict-fail": "VERDICT: cells ran and FAILED",
     "no-verdict-provisioning": "NO VERDICT: stopped in provisioning",
     "no-verdict-build": "NO VERDICT: stopped in the build",
+    # phase-441 W4. The cells STEP ran and failed, and the runner it invoked
+    # said the cells themselves did not produce results — a fixture that would
+    # not build, a peer that is not installed, a membership that only skipped.
+    # Without this, a step outcome is the whole story and every such run reads
+    # as "a recorded-passing cell regressed", which is the one thing the
+    # live-peer lane exists to say.
+    "no-verdict-cells": "NO VERDICT: the cells could not run",
     "no-verdict-none": "NO VERDICT: died before any stage",
     "cancelled": "NO VERDICT: cancelled",
     "running": "still running",
@@ -149,13 +156,21 @@ Result = collections.namedtuple(
     "Result", "kind stage label failing_step reached_cells")
 
 
-def classify(steps, job_conclusion=None):
+def classify(steps, job_conclusion=None, cells_ran=None):
     """Classify one job's ordered steps.
 
     `steps` is [{"name": str, "conclusion": str}] — the shape `gh run view
     --json jobs` returns AND the shape the workflow reports from
     `steps.<id>.outcome`. `job_conclusion` is optional and only used to tell a
     job that died with no failing step from one that never ran.
+
+    `cells_ran` is the FOURTH axis, and only the in-workflow half can supply it
+    (phase-441 W4): a step outcome says the cells step failed, never whether the
+    cells produced results. `just native test-live-peer-regression` already
+    knows — it answers 2 for "this lane could not run" and 1 for a real
+    regression — and the workflow forwards that as `NROS_LANE_CELLS_RAN`.
+    `None` means nobody said, which is what `--history` has for every past run,
+    so the classification there is unchanged.
 
     Returns a Result whose `kind` is one of:
         verdict-pass  verdict-fail  no-verdict  cancelled  running
@@ -176,6 +191,9 @@ def classify(steps, job_conclusion=None):
     if cells == "success":
         return Result("verdict-pass", CELLS, LABELS["verdict-pass"], "", True)
     if cells == "failure":
+        if cells_ran is False:
+            return Result("no-verdict", CELLS, LABELS["no-verdict-cells"],
+                          first_failing, False)
         return Result("verdict-fail", CELLS, LABELS["verdict-fail"],
                       first_failing, True)
 
@@ -215,7 +233,12 @@ def report(lane, steps_json):
     # A step that never ran reports an empty outcome, not `skipped`.
     steps = [{"name": s.get("name", "?"), "conclusion": s.get("conclusion") or "skipped"}
              for s in steps]
-    res = classify(steps)
+    # An UNSET variable is `None`, not False: "nobody said" and "the runner said
+    # the cells did not run" are different answers, and only the second may turn
+    # a red into a no-verdict.
+    said = os.environ.get("NROS_LANE_CELLS_RAN", "").strip().lower()
+    cells_ran = {"true": True, "false": False}.get(said)
+    res = classify(steps, cells_ran=cells_ran)
 
     out = [f"{lane}: {res.label}"]
     if res.failing_step:
@@ -467,8 +490,26 @@ LANES = (
         "Build the nros CLI": BUILD,
         "Report what the ledger claims, before running anything": PROVISIONING,
         "Check out the submodules the fixtures vendor": PROVISIONING,
+        "Provision the declared system closure (phase-413 W3)": PROVISIONING,
         "Build the fixtures those rows resolve": BUILD,
         "Run the cells with a recorded PASS": CELLS,
+    }),
+    # phase-441 W4 — the same lane's board half, split out because these rows
+    # need a board SDK and an emulator the host container does not carry. It is
+    # a SEPARATE LaneSpec rather than more steps in `regression` for the reason
+    # the split exists at all: "the board rows could not be built" and "the
+    # board rows regressed" have to be different sentences, and a stage label
+    # is per JOB.
+    LaneSpec("live-peer.yml", "board", "stage-board", {
+        "Build the nros CLI": BUILD,
+        "Register the baked Zephyr SDK for this HOME": PROVISIONING,
+        "Reclaim disk before the SDK setup": PROVISIONING,
+        "Unblock the rustup clippy-preview conflict": PROVISIONING,
+        "Provision the declared system closure (phase-413 W3)": PROVISIONING,
+        "just setup the scopes those rows need": PROVISIONING,
+        "Install clang + libclang for bindgen": PROVISIONING,
+        "Build the fixtures those rows resolve": BUILD,
+        "Run the board cells with a recorded PASS": CELLS,
     }),
 )
 
@@ -508,7 +549,16 @@ def _one_lane_consistency(chk, lane, doc):
     job = doc["jobs"][lane.job]
     steps = job["steps"]
     names = [s.get("name", "") for s in steps]
-    reporter = [s for s in steps if "lane-stage.py" in str(s.get("run", ""))]
+    # `--report` as well as the filename: a step that merely NAMES this script
+    # is not this script's reporter, and one does — the board lane's setup step
+    # tells the reader to add a scope here. Matching on the filename alone found
+    # it, called the job's reporter ambiguous, and then died on the env of the
+    # wrong step.
+    reporter = [
+        s for s in steps
+        if "lane-stage.py" in str(s.get("run", ""))
+        and "--report" in str(s.get("run", ""))
+    ]
 
     chk(f"{w} has exactly one lane-stage reporter", len(reporter) == 1)
     if not reporter:
@@ -663,6 +713,29 @@ def selftest(verbose=False):
             ("Build the fixtures those rows resolve", "success"),
             ("Run the cells with a recorded PASS", "failure")),
             "failure").kind == "verdict-fail")
+
+    # 8c. phase-441 W4 — the fourth axis. The cells STEP failing is the same
+    #     word for "a recorded-passing cell regressed" and for "the cells never
+    #     produced a result": a fixture that would not build, a peer that is not
+    #     installed, a membership that only skipped. The recipe already knows
+    #     (exit 2 vs 1) and the workflow forwards it.
+    cells_failed = _steps(
+        ("Build the nros CLI", "success"),
+        ("Build the fixtures those rows resolve", "success"),
+        ("Run the board cells with a recorded PASS", "failure"))
+    chk("a cells-step failure with NOTHING said is still a verdict",
+        classify(cells_failed, "failure").kind == "verdict-fail")
+    said_no = classify(cells_failed, "failure", cells_ran=False)
+    chk("...and the SAME steps are a no-verdict when the runner says the cells "
+        "did not run",
+        said_no.kind == "no-verdict" and said_no.stage == CELLS)
+    chk("...which does not claim to have reached the cells",
+        said_no.reached_cells is False)
+    chk("...and says so in its label",
+        said_no.label == LABELS["no-verdict-cells"])
+    chk("cells_ran=True changes nothing about a passing lane",
+        classify(_steps(("Run the board cells with a recorded PASS", "success")),
+                 "success", cells_ran=True).kind == "verdict-pass")
 
     # 9. THE MAP IS AUTHORED, SO IT DRIFTS. `--report` is handed step names by
     #    the workflow, and those names are a copy of the workflow's own `- name:`


### PR DESCRIPTION
Phase-441 **W4** (the lane's runner) and **W5** (the phrase that overclaims). Two commits, in that order.

## W4 — split, and derive the split

`live-peer.yml` gets its membership from `.config/interop-verdicts.toml`, so a cell joins the lane the moment a verdict is recorded. The **runner** does not follow: a cell on a board needs that board's SDK, its cross toolchain and — off native_sim — an emulator, and the container the host cells run in has none of them.

**Chosen: a sibling job (`board`), gated on the ledger actually containing a row that needs one.** Provisioning the toolchain inside `regression` was rejected on this lane's own stated reason — it exists separately from `just ci tier1` because *verification must not be hostage to everything else being green*, and putting a Zephyr SDK, a west update and an emulator in front of nineteen host cells that touch none of them re-creates exactly that. The cost of a split (a second thing to keep green, a second place to notice a red) is paid down rather than accepted: the board job **does not exist** when there is nothing for it to run, and it reports through the **same stage reporter**, so the run list carries two named answers instead of one job with two meanings.

**The split is computed, never recorded.** `interop::CELLS` already states each cell's platform, so the ledger gains no `needs_qemu` field — a second source for one fact that drifts the moment a cell moves board. `check-interop-cell-runners.py` parses the platform beside the tier (one parser, the `row_coord()` rule); `check-interop-verdicts.py --runner host|board` narrows any listing by it, and `--scopes setup|build` / `--narrowing` derive what the board job provisions and which fixture leaves it builds. Both authored maps fail closed and are cross-checked — scope tokens against `scripts/build/scope.sh`, narrowing values against `examples/fixtures.toml`.

Three things had to be fixed for the acceptance to be satisfiable at all:

* **The board row was already in the host lane.** `zephyr-qos-rust-zenoh` has had a recorded PASS since the ledger's first entry, and the host container builds no Zephyr image — so it resolved no fixture, skipped, and counted green. Today's state, not a future hazard.
* **A regression could not be reported as one.** The cell loop treated exit `100` as "tests ran and failed", but it calls `_test-focused`, which swallows nextest's 100 and answers 1 — so every real failure would have read as a harness fault. It reads the junit now.
* **A skipped membership read as a pass.** `--assert-ran` requires every in-scope recorded-passing cell to produce a **non-skip** result; a run that only skipped is exit 2, "this lane could not run". Because exposing that is only useful if the absence can be supplied, both jobs now provision the declared system closure — neither CI image bakes `ros-humble-rmw-zenoh-cpp`, so without it every zenoh cell skips.

**"Could not run" is named, three ways.** `lane-stage.py` gains the axis it needed: a cells *step* failing does not say whether the cells produced results, so the workflow forwards the recipe's own answer (`NROS_LANE_CELLS_RAN`) and the reporter says `NO VERDICT: the cells could not run` rather than `VERDICT: cells ran and FAILED`. `stage-board`'s job **name** distinguishes the three non-verdicts a skipped board job can mean (the split failed / nothing to run / never started). Both jobs are in `LANES`, cross-checked against the YAML in both directions by `--selftest`.

The lane stays `schedule` + `workflow_dispatch`; no job name was added to any required set.

## W5 — retire the phrase where it overclaims

`ZephyrNativeSim` is `native_sim/native/64`: sockets offloaded to the host, host pointer width, no RTOS network stack in the path. **169 non-archived uses examined** (243 including `archived/`, which is a record), **20 changed**. Four kinds; only one is the overclaim:

1. not the phrase (`non-target`, `json-target-spec`, `corrosion-target`, "depends on target") — untouched;
2. a real target (baremetal MPS2 cells, RFC-0074's guest clock on the FreeRTOS mps2-an385 QEMU lane, phase-372's hardware smoke) — left;
3. a **feature**, not a coordinate — RFC-0052's `on-target contract monitors` (24 hits), true on every board the executor runs on and making no claim about a test's reach — left;
4. `native_sim` called on-target — 20 lines, fixed.

The replacement word was already in the tree: `entry_e2e.rs` says **in-image** three lines from where it said on-target, and that is exactly the distinction those sentences draw. Plus the `interop::CELLS` section header (now `── Zephyr native_sim QoS interop ──`, with the reason) and phase-433's coverage map, corrected in place.

## Testing

* `just check fast` — 288/290; the two reds are `capability-conditionals` and `xrce-vendored-versions`, both "submodule not checked out" in a fresh agent worktree.
* `just check lane-stage-reporting` — 82 checks green, including the new board lane in both directions.
* `check-interop-verdicts.py --self-test` / `check-interop-cell-runners.py --self-test` — green, with new negative controls for the runner split, the scope/narrowing maps and the skipped-membership guard.
* `cargo +nightly fmt --check` on the two edited crates.

Tier: this is CI plumbing, gates and comments — no compile-tier code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
