### PR TITLE
feat(phase-441 W3): a SECOND KERNEL's live-peer cell — FreeRTOS/MPS2-AN385 over lwIP

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -463,6 +463,31 @@ slow-timeout = { period = "180s", terminate-after = 3 }
 [[profile.default.overrides]]
 filter = "binary(zephyr_cortex_m_qemu) or binary(pubsub_zephyr_cortex_m_ros2_interop_e2e)"
 test-group = "zephyr-cortex-m-baked-port"
+
+# phase-441 W3 — the SECOND-KERNEL live-peer cell
+# (`freertos-mps2-pubsub-c-zenoh-n2r`). It boots the SAME `workspace-c-freertos`
+# image as `entry_e2e`'s freertos_c cell, so it starts a router on the same baked
+# port (`port_of(FreertosMps2, C, EntryPubsub)`) and the two must not run at
+# once — the issue #141 shape, one kernel over.
+#
+# THIS OVERRIDE MUST STAY HERE, ahead of the `binary(~freertos)` one far below.
+# nextest applies the FIRST matching override per setting, and `~freertos` is a
+# SUBSTRING match that also matches `pubsub_freertos_ros2_interop_e2e` — so
+# writing this rule down there instead would leave it in `qemu-emulated` while
+# `entry_e2e` sits in `matrix-consumers-serial`, and DIFFERENT GROUPS DO NOT
+# SERIALIZE AGAINST EACH OTHER. That is exactly the defect phase-373 W1 found in
+# the zephyr sibling directly above, where the protection had been off for two
+# phases while the config parsed cleanly. Verify with `cargo nextest show-config
+# test-groups`, which prints resolved membership; the filter parsing is not
+# evidence that the group applies.
+#
+# 180s x 3 for the same reason the sibling has it: an emulated Cortex-M3 pays a
+# cold boot, an lwIP bring-up and a zenoh-pico session handshake before it
+# publishes, and the group is max-threads=1, so the window cannot be spent
+# contending with the partner it now waits for.
+[[profile.default.overrides]]
+filter = "binary(pubsub_freertos_ros2_interop_e2e)"
+test-group = "matrix-consumers-serial"
 slow-timeout = { period = "180s", terminate-after = 3 }
 
 # Issue #34 — host-integration "compile-shape" tests shell out to cargo / nros

--- a/docs/roadmap/phase-441-rmw-on-target-verification.md
+++ b/docs/roadmap/phase-441-rmw-on-target-verification.md
@@ -410,13 +410,87 @@ it was one.
 
 ### W3 — a second RTOS, not a second Zephyr board
 
-FreeRTOS on MPS2-AN385 (lwIP) is the strongest candidate: it is a different
-kernel, a different IP stack, and it already has QEMU networking. NuttX and
-ThreadX are the alternatives.
+**Status: the cell is LANDED and has NEVER MET A PEER. Kernel taken: FreeRTOS on
+MPS2-AN385.** The declaration, the tripwire, the test and the runner exist; the
+verdict does not, and `.config/interop-verdicts.toml` carries no entry for it —
+which is what "never run" is supposed to look like here, not an oversight.
 
-Pick ONE. The value of this phase is a second *kernel* witness, and picking one
-and finishing it beats three half-configured lanes — the shape phase-433 W2 hit
-when it ran cells before their fixtures could build.
+FreeRTOS on MPS2-AN385 (lwIP) was the strongest candidate: it is a different
+kernel, a different IP stack, and it already has QEMU networking. NuttX and
+ThreadX were the alternatives; nothing was found that argued against the first
+choice, so no switch was made.
+
+The cell is `freertos-mps2-pubsub-c-zenoh-n2r` — `(FreertosMps2, C, Zenoh,
+EntryPubsub, Interop, Runtime)`, peer `RosEdition(Zenoh)`, direction
+`NanoToRos`, test `pubsub_freertos_ros2_interop_e2e`, build channel
+`FreertosMps2Fixtures` (`just freertos build-fixtures`), runner
+`just freertos test-ros2`. It reuses `entry_e2e`'s `workspace-c-freertos` image
+and therefore its baked port, so `.config/nextest.toml` puts it in
+`matrix-consumers-serial` — placed ABOVE the `binary(~freertos)` →
+`qemu-emulated` override, because that substring match would otherwise claim it
+first and two different groups do not serialize against each other (the
+phase-373 W1 defect, one binary over).
+
+Five axes move at once, and the C is not an accident: the existing on-target row
+runs the Rust API, so this one exercises the C ABI, the half of the surface an
+RTOS consumer is most likely to be using.
+
+| axis | `zephyr-qos-rust-zenoh` | this cell |
+| --- | --- | --- |
+| kernel | Zephyr | FreeRTOS |
+| IP stack | host (NSOS offload) | lwIP over emulated LAN9118 |
+| pointers | 64-bit host | 32-bit thumbv7m |
+| libc | host glibc | newlib-nano |
+| API | Rust | C |
+
+**Measured while landing it, on a host with no ROS.**
+
+*The mechanism half is alive.* An MPS2-AN385 FreeRTOS image boots under
+`qemu-system-arm`, brings up lwIP over the emulated LAN9118, opens a zenoh-pico
+session over **slirp** to a router on the host's gateway address, and publishes
+— 23 samples in 45 s, with `[INFO] Publishing: 'Hello World: N'` climbing and no
+kernel fault. So the kernel, the IP stack, the cross toolchain and the emulator
+are not the open question; only the peer is. (Caveat, stated because RFC-0075
+exists: the router in that measurement was the SDK store's upstream `zenohd`
+1.7.2, **not** ROS's `rmw_zenohd`, so it says nothing whatever about
+`rmw_zenoh_cpp` pairing. It answers "does a FreeRTOS guest reach a host router
+through slirp", and only that.)
+
+*The cell needs a ROS host for BOTH halves, not just the peer — and that is
+new information.* The fixture the cell resolves cannot be BUILT here at all:
+
+```
+$ bash scripts/build/workspace-fixtures-build.sh freertos c
+  -> workspace-c-freertos (c) examples/workspaces/c
+     nros build demo_bringup:freertos …
+Error: 2 <depend> name(s) resolve to nothing:
+  example_interfaces — declared by …/service_server_pkg/package.xml, …
+  std_msgs           — declared by …/talker_pkg/package.xml, …
+```
+
+Neither name is a package in that workspace, neither is in
+`packages/interfaces/` (which carries only `diagnostic-msgs`,
+`lifecycle-msgs`, `rcl-interfaces`, `rosgraph-msgs`), and neither is a
+`[prereq.*]` with `role = "package"` in `nros-sdk-index.toml`. They resolve
+through ament or not at all. That is a property of the workspace-fixture lane
+generally, not of this board — it is why `live-peer.yml` builds its fixtures on
+a ROS runner — but it sharpens W4 below from a scheduling question into a
+provisioning one.
+
+*Defects exposed by the second-kernel crossing so far: **zero**, and the number
+is not yet meaningful.* W1 states the falsifiable prediction (phase-337 W2 found
+five defects moving a workload across a comparable boundary). It cannot be
+evaluated from this side of a peer: nothing in this cell has been run against
+`rmw_zenoh_cpp`, so "no defects" here means "no observations", not "no bugs".
+Do not read the green `check-interop-*` gates as evidence — every one of them is
+a statement about the declaration, which is exactly the class
+`check-interop-verdicts` exists to separate from a result.
+
+**What is left, and it is one thing:** run
+`just freertos test-ros2` on a host with ROS 2 + `rmw_zenoh_cpp`,
+`arm-none-eabi-gcc`, `qemu-system-arm` and the FreeRTOS + lwIP submodules, then
+`check-interop-verdicts.py --record freertos-mps2-pubsub-c-zenoh-n2r --junit …`.
+Until that happens the cell is honestly unproven and says so.
 
 ### W4 — say what the lane covers, in the lane
 
@@ -496,6 +570,14 @@ suffices there is W1's measurement, not an assumption made here. A board cell on
 a NON-Zephyr kernel (W3) will ask for a scope this image cannot provision, and
 the setup step FAILS naming it rather than running a green over cells it never
 built.
+
+*What W3 adds to this.* The FreeRTOS/MPS2 cell is exactly the non-Zephyr case in the
+last paragraph: it needs `arm-none-eabi-gcc`, `qemu-system-arm` and the FreeRTOS + lwIP
+submodules, none of which `nano-ros-zephyr-ci` provisions. Written before this split
+landed, W3 had recorded the consequence under the OLD lane — the cell would be selected,
+skip, and read as green. The split and `--assert-ran` retire that: until a scope provides
+those four, the board job fails naming the scope, a NO VERDICT and never a pass. Providing
+them is the one item W3 leaves open here.
 
 ### W5 — retire the phrase, or earn it
 

--- a/just/freertos.just
+++ b/just/freertos.just
@@ -380,6 +380,30 @@ test-all verbose="":
     fi
     cargo nextest run "${cargo_nextest_args[@]}" "${e2e_args[@]}"
 
+# phase-441 W3 — an nros publisher on a SECOND KERNEL reaches a stock
+# `ros2 topic echo` subscriber. The FreeRTOS/MPS2-AN385 C workspace entry boots
+# under QEMU, brings up lwIP over the emulated LAN9118, dials the host router
+# through the slirp gateway 192.0.3.1 and publishes `/chatter`; a stock
+# `rmw_zenoh_cpp` peer on the same router must see it.
+#
+# This is the only `interop::CELLS` cell that is not Zephyr or Linux, and that
+# is its whole point: every other on-target row runs on native_sim, whose
+# sockets, pointer width and libc are the HOST's.
+#
+# Deliberately NOT sequenced after `build-fixtures` the way `just freertos test`
+# is — the same call the zephyr sibling makes (`just zephyr test-ros2-qos`):
+# this is an aimable unit, and running the whole ARM lane to reach one cell is
+# not something anyone would type. Build the fixture
+# (`just freertos build-fixtures`), then aim.
+#
+# Its baked router port is shared with `entry_e2e`'s freertos_c cell, so nextest
+# serializes the two in `matrix-consumers-serial`.
+# Needs ROS 2 + `rmw_zenoh_cpp`, `arm-none-eabi-gcc`, `qemu-system-arm`, the
+# FreeRTOS + lwIP trees and that fixture; skips on each.
+[group("debug")]
+test-ros2 verbose="":
+    @just _test-focused 'binary(=pubsub_freertos_ros2_interop_e2e)' {{verbose}}
+
 # Phase 121.6 — build the FreeRTOS Posix-port smoke test for
 # nros-platform-freertos. Uses the in-tree FreeRTOS-Kernel + a
 # minimal FreeRTOSConfig.h. Excludes net.c (no lwIP in this harness).

--- a/packages/testing/nros-tests/src/ci_lane.rs
+++ b/packages/testing/nros-tests/src/ci_lane.rs
@@ -890,7 +890,7 @@ _tier-build:
         let documented = [
             (CiLane::Tier1, 19, 12),
             (CiLane::Tier2, 12, 12),
-            (CiLane::Tier2Nightly, 36, 35),
+            (CiLane::Tier2Nightly, 37, 35),
         ];
         for (lane, want_cells, want_coords) in documented {
             assert_eq!(

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -41,6 +41,13 @@ pub enum BuildChannel {
     /// `PlatformId::ZephyrNativeSim` and `PlatformId::ZephyrQemuCortexM` are
     /// producible here (phase-441 W1) — the board is a row field, not a channel.
     ZephyrWestLeaves,
+    /// FreeRTOS workspace entry cross-built for MPS2-AN385 (Cortex-M3) by
+    /// `just freertos build-fixtures` — `scripts/build/workspace-fixtures-build.sh
+    /// freertos <lang>`, driven off the `platform = "freertos"` rows of
+    /// `examples/fixtures.toml`. The artifact is an ELF QEMU boots; the guest's
+    /// lwIP stack dials the baked `tcp/192.0.3.1:<port>` locator through the
+    /// slirp gateway (phase-441 W3).
+    FreertosMps2Fixtures,
 }
 
 impl BuildChannel {
@@ -51,6 +58,7 @@ impl BuildChannel {
         match self {
             BuildChannel::NativeFixtures => "just native build-fixtures",
             BuildChannel::ZephyrWestLeaves => "just zephyr build-fixtures",
+            BuildChannel::FreertosMps2Fixtures => "just freertos build-fixtures",
         }
     }
 
@@ -59,6 +67,7 @@ impl BuildChannel {
         match self {
             BuildChannel::NativeFixtures => "native",
             BuildChannel::ZephyrWestLeaves => "zephyr",
+            BuildChannel::FreertosMps2Fixtures => "freertos",
         }
     }
 
@@ -71,6 +80,7 @@ impl BuildChannel {
                 p,
                 PlatformId::ZephyrNativeSim | PlatformId::ZephyrQemuCortexM
             ),
+            BuildChannel::FreertosMps2Fixtures => matches!(p, PlatformId::FreertosMps2),
         }
     }
 }
@@ -368,6 +378,40 @@ pub const CELLS: &[InteropCell] = &[
        c(ZephyrQemuCortexM, C, Zenoh, Pubsub, Interop, Runtime),
        ZephyrWestLeaves, RosEdition(Zenoh), NanoToRos,
        "pubsub_zephyr_cortex_m_ros2_interop_e2e"),
+
+    // ── phase-441 W3 — the SECOND KERNEL's live peer ────────────────────
+    // tests/pubsub_freertos_ros2_interop_e2e.rs. Every other on-target row in
+    // this list is Zephyr native_sim, whose sockets, pointer width and libc are
+    // the HOST's (`matrix.rs`: "Zephyr native_sim (NSOS host sockets)"). So
+    // before this row the live-peer coverage of the RTOS ports was one kernel,
+    // one board, and a network stack that is not an RTOS network stack.
+    //
+    // This one is a different kernel (FreeRTOS), a different IP stack (lwIP
+    // over the emulated LAN9118), a 32-bit target (thumbv7m), a different libc
+    // (newlib-nano) and a real emulator — and it reaches the host over QEMU
+    // SLIRP, unicast only, which is what makes it affordable: CLAUDE.md forbids
+    // `sudo`, TAP needs `ip tuntap add`, and zenoh-pico's baked
+    // `tcp/192.0.3.1:<port>` locator needs no multicast at all. (Cyclone's SPDP
+    // does; that is issue 1251 and phase-441 W2's measurement, deliberately not
+    // this cell's problem.)
+    //
+    // C rather than Rust, and that is a second axis moved for free: the
+    // existing on-target row runs the Rust API, this one runs the C ABI
+    // (`nros_cpp_publisher_create` out of `examples/workspaces/c`) — the half
+    // of the surface an RTOS consumer is most likely to be using.
+    //
+    // It reuses `entry_e2e`'s freertos_c image and therefore its baked router
+    // port (`port_of(FreertosMps2, C, EntryPubsub)`), exactly as the zephyr QoS
+    // interop cell reuses the `ws-qos-rust` image and port. Two binaries on one
+    // port must not run at once, so `.config/nextest.toml` puts this one in
+    // `matrix-consumers-serial` with `entry_e2e` — and the override has to sit
+    // ABOVE `binary(~freertos)`, or `qemu-emulated` claims it first and the
+    // serialization silently does not happen (the phase-373 W1 defect, one
+    // binary over).
+    ic("freertos-mps2-pubsub-c-zenoh-n2r",
+       c(FreertosMps2, C, Zenoh, EntryPubsub, Interop, Runtime),
+       FreertosMps2Fixtures, RosEdition(Zenoh), NanoToRos,
+       "pubsub_freertos_ros2_interop_e2e"),
 
     // ── Declarative cross-RMW bridges ───────────────────────────────────
     // The nano bridge is a `ws-bridge-*-rust` native_entry; a ROS 2 peer sits on

--- a/packages/testing/nros-tests/tests/pubsub_freertos_ros2_interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/pubsub_freertos_ros2_interop_e2e.rs
@@ -1,0 +1,204 @@
+//! phase-441 W3 — a SECOND KERNEL meets a live ROS 2 peer.
+//!
+//! The tree's only other on-target live-peer cell is
+//! `qos_zephyr_ros2_interop_e2e`, and phase-441's own analysis is why this file
+//! exists: that cell runs on `native_sim/native/64`, where the sockets are the
+//! HOST's (NSOS), the pointer width is the host's and the libc is the host's.
+//! It proves our zenoh-pico code talks to `rmw_zenoh_cpp`; it does not prove it
+//! does so from anything shaped like a device.
+//!
+//! This one moves five axes at once and keeps the crossing mechanism identical:
+//!
+//! | axis | zephyr cell | here |
+//! | --- | --- | --- |
+//! | kernel | Zephyr | **FreeRTOS** |
+//! | IP stack | host (NSOS offload) | **lwIP over emulated LAN9118** |
+//! | pointers | 64-bit host | **32-bit thumbv7m** |
+//! | libc | host glibc | **newlib-nano** |
+//! | API | Rust | **C** (`nros_cpp_publisher_create`) |
+//!
+//! ## How the guest reaches the peer, and why it is affordable
+//!
+//! `scripts/qemu/launch-mps2-an385.sh` offers slirp and TAP. TAP needs
+//! `ip tuntap add` — root — and CLAUDE.md forbids `sudo` outright, so slirp is
+//! the only path an agent or a CI runner can take. Slirp is **unicast only**:
+//! the guest sits on 192.0.3.x and the gateway 192.0.3.1 forwards to the host
+//! machine (`QemuProcess::start_mps2_an385_freertos_slirp` passes
+//! `net=192.0.3.0/24,host=192.0.3.1` precisely so the board's static lwIP
+//! config and QEMU's virtual net agree).
+//!
+//! Unicast-only is exactly what zenoh-pico client mode already does: the image
+//! carries a COMPILE-TIME `NROS_ENTRY_LOCATOR` of `tcp/192.0.3.1:<port>` (baked
+//! by the `workspace-c-freertos` row of `examples/fixtures.toml`) and dials it.
+//! Nothing about this cell needs a multicast crossing — which is what makes it
+//! the RMW to do first. Cyclone's SPDP would need a configured unicast peer
+//! list plus a QEMU `hostfwd` this tree does not emit; that is issue 1251 and
+//! phase-441 W2's measurement, deliberately not this cell's problem.
+//!
+//! The router is ROS's own `rmw_zenohd` (RFC-0075 — we ship none), started on
+//! `0.0.0.0` so the slirp gateway can forward to it, while the ROS 2 peer dials
+//! `tcp/127.0.0.1:<port>`. One router, two sides, no multicast anywhere.
+//!
+//! ## What it asserts
+//!
+//! The image's `demo_bringup` talker publishes a CDR `std_msgs/msg/Int32`
+//! counter on `/chatter` at 1 Hz. A stock `ros2 topic echo` (rmw_zenoh_cpp,
+//! multicast scouting off via the session config `ros2_env_setup_with_locator`
+//! writes) must receive one. That is the nano-pub → ros2-sub direction, the same
+//! direction issue #141 found dead against a healthy publisher on Zephyr.
+//!
+//! ## Preconditions, all of which SKIP
+//!
+//! ROS 2 + `rmw_zenoh_cpp`, the FreeRTOS kernel + lwIP trees, `arm-none-eabi-gcc`,
+//! `qemu-system-arm`, and the `workspace-c-freertos` fixture
+//! (`just freertos build-fixtures`). A host with no ROS skips — that is the
+//! correct outcome, not a failure, and a bare `cargo nextest` renders the
+//! `skip!` panic as FAILED (only `just test-all`'s junit rewrite converts it).
+//!
+//! Its baked router port is shared with `entry_e2e`'s freertos_c cell, so
+//! `.config/nextest.toml` puts this binary in `matrix-consumers-serial` —
+//! ABOVE the `binary(~freertos)` → `qemu-emulated` override, or that one claims
+//! it first and the serialization silently does not happen (phase-373 W1's
+//! defect, one binary over).
+//!
+//! Run with:
+//! `just freertos test-ros2` (or
+//! `cargo nextest run -p nros-tests --test pubsub_freertos_ros2_interop_e2e`)
+
+use nros_tests::{
+    alloc::port_of,
+    fixtures::{
+        QemuProcess, ZenohRouter, build_freertos_workspace_c_entry, freertos, is_qemu_available,
+    },
+    matrix::{Lang, PlatformId, Workload},
+    ros2::{DEFAULT_ROS_DISTRO, require_ros2, ros2_env_setup_with_locator},
+    skip,
+};
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
+
+/// The router port baked into the FreeRTOS C workspace entry — the allocator's
+/// `(freertos-mps2, c, entry-pubsub)` number, the SAME formula the fixture
+/// baker uses for that row's `NROS_ENTRY_LOCATOR` cmake def. Never a literal:
+/// the image and the router can then not disagree by hand.
+const FREERTOS_C_ENTRY_PORT: u16 =
+    port_of(PlatformId::FreertosMps2, Lang::C, Workload::EntryPubsub);
+
+/// How long to keep asking `ros2 topic echo` for a sample. The guest is an
+/// emulated Cortex-M3 doing a cold boot, an lwIP DHCP-less bring-up and a
+/// zenoh-pico session handshake before it publishes anything, and each attempt
+/// pays multi-second ros2 CLI startup on top; `entry_e2e`'s QEMU cells budget
+/// 60–90 s for the same boot with a native observer.
+const DELIVERY_WINDOW: Duration = Duration::from_secs(150);
+
+#[test]
+fn nros_freertos_mps2_publisher_reaches_ros2_topic_echo() {
+    if !require_ros2() {
+        skip!(
+            "ROS 2 / rmw_zenoh_cpp not available — install it from apt \
+             (`ros-$ROS_DISTRO-rmw-zenoh-cpp`, declared in nros-sdk-index.toml)."
+        );
+    }
+    if !freertos::is_freertos_available() {
+        skip!("FREERTOS_DIR not set or invalid — `just setup freertos`");
+    }
+    if !freertos::is_lwip_available() {
+        skip!("LWIP_DIR not set or invalid — `just setup freertos`");
+    }
+    if !freertos::is_arm_gcc_available() {
+        skip!("arm-none-eabi-gcc not found — `nros setup --tool arm-none-eabi-gcc`");
+    }
+    if !is_qemu_available() {
+        skip!("qemu-system-arm not found");
+    }
+
+    let entry = build_freertos_workspace_c_entry()
+        .unwrap_or_else(|e| skip!("freertos C workspace entry not built: {e}"));
+
+    // 0.0.0.0, not 127.0.0.1: the guest reaches this router through the slirp
+    // gateway 192.0.3.1, which is a DIFFERENT host address than loopback. The
+    // ROS 2 peer below dials loopback for the same one router.
+    let _router = ZenohRouter::start_on("0.0.0.0", FREERTOS_C_ENTRY_PORT)
+        .unwrap_or_else(|e| skip!("zenohd failed to start on {FREERTOS_C_ENTRY_PORT}: {e}"));
+    let peer_locator = format!("tcp/127.0.0.1:{FREERTOS_C_ENTRY_PORT}");
+
+    let mut guest = QemuProcess::start_mps2_an385_freertos_slirp(&entry)
+        .unwrap_or_else(|e| panic!("boot freertos QEMU (mps2-an385): {e}"));
+
+    // Poll `ros2 topic echo --once` until a sample lands. Each attempt pays
+    // multi-second ros2 CLI startup, so bail on the first success.
+    let (env, _config_guard) = ros2_env_setup_with_locator(DEFAULT_ROS_DISTRO, &peer_locator);
+    let deadline = Instant::now() + DELIVERY_WINDOW;
+    let mut last = String::new();
+    let mut delivered = false;
+    while Instant::now() < deadline {
+        let script = format!(
+            "{env} && timeout 12 ros2 topic echo --once /chatter std_msgs/msg/Int32 \
+             --no-daemon --spin-time 2 2>&1"
+        );
+        let out = Command::new("bash")
+            .args(["-c", &script])
+            .output()
+            .expect("failed to spawn bash for ros2 invocation");
+        last = String::from_utf8_lossy(&out.stdout).into_owned();
+        if last.contains("data:") {
+            delivered = true;
+            break;
+        }
+    }
+
+    // The guest's own console is the only diagnosis available when this fails:
+    // a board that never got a lwIP address, never opened the TCP session or
+    // died in the kernel all look identical from the ROS side — an empty
+    // `ros2 topic echo`. issue 0667's shape in particular, an undersized task
+    // stack, lands as `*** MALLOC FAILED ***` rather than as a stack-overflow
+    // message, because heap_4 hands out the stack. Collected only on the
+    // failure path, and as a DRAIN rather than a wait: `collect_until` returns
+    // whatever was printed whether or not its pattern appears, and renders a
+    // harness fault INTO the text instead of dropping it. Defaulting away a
+    // `wait_for_*` error does the opposite — it reports an empty console for a
+    // guest that had plenty to say, which is issue 0670 and what
+    // `check-wait-evidence-discarded` refuses. The sentinel is a string the
+    // image cannot emit, so the call always runs its whole window and hands
+    // back the entire console.
+    const DRAIN_SENTINEL: &str = "\u{1}nros-drain-sentinel";
+    let guest_console = if delivered {
+        String::new()
+    } else {
+        let log = guest.collect_until(DRAIN_SENTINEL, Duration::from_secs(2));
+        let note = nros_tests::output::runtime_silence_note(&log)
+            .map(|n| format!("\n  {n}"))
+            .unwrap_or_default();
+        format!("{note}\n  --- guest output ---\n{log}\n  --- end guest output ---")
+    };
+    guest.kill();
+
+    assert!(
+        delivered,
+        "`ros2 topic echo` (rmw_zenoh_cpp) never received the FreeRTOS/MPS2-AN385 \
+         entry's 1 Hz `/chatter` publish within {}s — the nano-pub → ros2-sub \
+         direction does not cross a second kernel (phase-441 W3).\n\
+         router: tcp/0.0.0.0:{FREERTOS_C_ENTRY_PORT} (guest dials \
+         tcp/192.0.3.1:{FREERTOS_C_ENTRY_PORT} through slirp; peer dials \
+         {peer_locator})\n\
+         last ros2 output:\n{last}\n\
+         guest console:\n{guest_console}",
+        DELIVERY_WINDOW.as_secs()
+    );
+}
+
+// Issue 0352 / phase-324 — bind this test to `interop::CELLS`. The coordinates
+// below must equal what the list declares for `pubsub_freertos_ros2_interop_e2e`;
+// adding/retiring an interop cell for this test, or drifting a cell's coordinate
+// (issue 0341 defect 2), turns this RED. Needs no fixtures — runs in tier 1.
+#[test]
+fn cases_bound_to_interop_cells() {
+    #[allow(unused_imports)]
+    use nros_tests::matrix::{Lang::*, PlatformId::*, Rmw::*, Workload::*};
+    nros_tests::interop::assert_test_bound(
+        "pubsub_freertos_ros2_interop_e2e",
+        &[(FreertosMps2, C, Zenoh, EntryPubsub)],
+    );
+}


### PR DESCRIPTION
## phase-441 W3 — a second KERNEL, not a second Zephyr board

Every on-target row in `interop::CELLS` was Zephyr `native_sim`, whose sockets,
pointer width and libc are the **host's**. So the one cell we called on-target
verification never put an RTOS network stack in the path. This adds the second
kernel.

**Kernel taken: FreeRTOS on MPS2-AN385**, as the phase doc proposed. NuttX and
ThreadX were the alternatives; nothing was found that argued against the first
choice, so no switch was made.

| axis | `zephyr-qos-rust-zenoh` | `freertos-mps2-pubsub-c-zenoh-n2r` |
| --- | --- | --- |
| kernel | Zephyr | **FreeRTOS** |
| IP stack | host (NSOS offload) | **lwIP over emulated LAN9118** |
| pointers | 64-bit host | **32-bit thumbv7m** |
| libc | host glibc | **newlib-nano** |
| API | Rust | **C** |

C rather than Rust moves a second axis for free: the existing on-target row runs
the Rust API, this one runs the C ABI — the half of the surface an RTOS consumer
is most likely to be using.

Zenoh, not Cyclone. The image dials a baked `tcp/192.0.3.1:<port>` locator, and
QEMU **slirp** is unicast-only because TAP needs `ip tuntap add` and CLAUDE.md
forbids `sudo`. Cyclone's SPDP would need the four settings and the `hostfwd`
flag issue 1251 measured — that is W2's problem, deliberately not this one.

### What lands

* `interop::BuildChannel::FreertosMps2Fixtures` — the third channel, `just
  freertos build-fixtures`, producing `PlatformId::FreertosMps2`.
* The cell: `Tier::Runtime`, peer `RosEdition(Zenoh)`, direction `NanoToRos`.
* `tests/pubsub_freertos_ros2_interop_e2e.rs`, carrying the
  `interop::assert_test_bound` coordinate tripwire, and `skip!`ping on each of
  its five preconditions rather than passing vacuously.
* `just freertos test-ros2`, so `check-interop-cell-runners` has something to
  find. Same shape as `just zephyr test-ros2-qos`, and **not** sequenced after
  `build-fixtures`: an aimable unit should not drag the whole ARM lane.
* A `.config/nextest.toml` override putting the binary in
  `matrix-consumers-serial` beside `entry_e2e`, whose `workspace-c-freertos`
  image and baked port it reuses. It sits **above** `binary(~freertos)` on
  purpose — that substring match would otherwise route it to `qemu-emulated`,
  and two different groups do not serialize against each other. That is the
  phase-373 W1 defect, one binary over.

### Measured, on a host with no ROS

**The mechanism half is alive.** An MPS2-AN385 FreeRTOS image boots under
`qemu-system-arm`, brings up lwIP over the emulated LAN9118, opens a zenoh-pico
session over slirp to a host router and publishes — 23 samples in 45 s, no
kernel fault. The kernel, the IP stack, the cross toolchain and the emulator are
not the open question; only the peer is.

Caveat stated because RFC-0075 exists: that router was the SDK store's upstream
`zenohd` 1.7.2, **not** ROS's `rmw_zenohd`, so it says nothing whatever about
`rmw_zenoh_cpp` pairing. It answers "does a FreeRTOS guest reach a host router
through slirp", and only that.

**The cell needs a ROS host for BOTH halves, not just the peer.** New
information, written into the phase doc: the fixture cannot be *built* here
either.

```
nros build demo_bringup:freertos …
Error: 2 <depend> name(s) resolve to nothing:
  example_interfaces — declared by …/service_server_pkg/package.xml, …
  std_msgs           — declared by …/talker_pkg/package.xml, …
```

Neither is a package in that workspace, neither is in `packages/interfaces/`
(which carries only `diagnostic-msgs`, `lifecycle-msgs`, `rcl-interfaces`,
`rosgraph-msgs`), and neither is a `[prereq.*]` with `role = "package"`. They
resolve through ament or not at all. That is a property of the workspace-fixture
lane generally — it is why `live-peer.yml` builds its fixtures on a ROS runner —
but it turns W4 from a scheduling question into a concrete provisioning list.

**Defects exposed by the crossing: zero, and the number is not yet meaningful.**
W1 states the falsifiable prediction (phase-337 W2 found five defects moving a
workload across a comparable boundary). It cannot be evaluated from this side of
a peer: nothing here has met `rmw_zenoh_cpp`, so "none found" means "none
observed". `.config/interop-verdicts.toml` therefore gains **no** entry — a new
cell starts life unproven, and the six green `check-interop-*` gates are
statements about the *declaration*, which is exactly the class
`check-interop-verdicts` exists to keep separate from a result.

### Also sharpened: W4

`live-peer.yml` checks out only `third-party/dds/cyclonedds`, builds only native
+ linux rows, and runs `just native test-live-peer-regression`, whose binary set
comes from the ledger. So the moment this cell records a PASS, that lane selects
`pubsub_freertos_ros2_interop_e2e` on a runner with **no `arm-none-eabi-gcc`, no
`qemu-system-arm`, and no FreeRTOS or lwIP submodule** — and it will not go red:
`_test-focused` rewrites the `skip!` and reports "All failures were [SKIPPED]
preconditions — treating as pass". A green lane over a cell that never booted is
the absorbing verdict this phase is about, one level out. The phase doc now
records those four preconditions as W4's provisioning list.

### Verification

`just check fast` — **288/290 green, 2 skipped** (`ivc-fsp`: `NV_SPE_FSP_DIR`
unset; `repr-memory-agreement`: `arm-none-eabi-nm` off `PATH`). The `pre-push`
hook's own fast tier is green.

Two reds seen on the first run were **provisioning in a fresh agent worktree,
and confirmed as such by fixing them**: `xrce-vendored-versions` (no vendored
XRCE tree → `git submodule update --init packages/rmw/xrce/xrce-sys/{micro-cdr,
micro-xrce-dds-client}`) and `leaf-lockfiles` (the `nros-nuttx-{,riscv-}ffi`
leaves patch `third-party/nuttx/libc`, uninitialised → `git submodule update
--init third-party/nuttx/libc`). Neither is touched by this branch and both went
green on init.

Also run green: `matrix_fixture_coverage` G1–G5 (10/10), `interop::tests::*`
(6/6), `check-interop-cell-runners` (23/23 Runtime cells have a runner, ledger
still empty), `check-interop-verdicts` (20 pass / 0 fail / 3 never-run),
`check-nextest-binary-filters`, `check-wait-evidence-discarded`,
`cargo +nightly fmt -p nros-tests --check`.

Tier run: **`just check fast`** plus the targeted nros-tests binaries above. Not
tier 1 — its fixture build is the ROS-gated one this PR just measured as
unavailable on this host.

### What needs a ROS host

One thing, and it is the whole remaining item for W3:

```
just freertos build-fixtures          # needs ROS for std_msgs/example_interfaces
just freertos test-ros2
python3 scripts/check-interop-verdicts.py --record freertos-mps2-pubsub-c-zenoh-n2r \
        --junit target/nextest/default/junit.xml --where '<host>'
```

plus `arm-none-eabi-gcc`, `qemu-system-arm`, and the FreeRTOS + lwIP submodules.
Until that runs, the cell is honestly unproven and every artifact here says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
