### PR TITLE
ci(host-tests): upload the fixture and tier logs the lane already writes

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -432,3 +432,21 @@ jobs:
           path: target/nextest/default/junit.xml
           if-no-files-found: ignore
           retention-days: 7
+
+      # The fixture and tier logs. Every build step above sends its output to
+      # `build/ci-logs/<step>.log` and echoes a 120-line tail only on FAILURE,
+      # which keeps the job log readable — and left this lane's largest step
+      # with no record at all. "Build workspace fixtures" is 54 of the job's
+      # ~102 minutes (run 34432822434) and wrote 42,882 lines that existed only
+      # on a runner that is then reclaimed: no per-workspace timing, and no way
+      # to tell one slow group serialising the jobserver from fifteen evenly
+      # loaded ones, which call for different fixes. `always()` because these
+      # are most wanted when a LATER step is the one that failed.
+      - name: Upload fixture and tier logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: host-integration-ci-logs
+          path: build/ci-logs/
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
The tier-1 integration job's largest step produces its log to a file that is never uploaded. This uploads it.

## Why

Every build step in `nros-tests integration (host)` redirects to `build/ci-logs/<step>.log` and echoes a 120-line tail only on failure. Readable job log — and no record of the lane's biggest cost:

| step | time (run 34432822434) | share |
|---|---|---|
| Build workspace fixtures | 53.8 min | 52.6 % |
| `just ci tier1` | 31.8 min | 31.1 % |
| Build rust core fixtures | 10.2 min | 10.0 % |

That first step wrote **42,882 lines** that existed only on a reclaimed runner. No per-workspace timing, so no way to tell which of two shapes explains the 54 minutes:

- **one slow group serialising the jobserver** while the other fourteen finish early — fix: split that group (`features` has 24 rows);
- **fifteen evenly loaded groups** — fix: more parallelism.

Different fixes. Without the log, choosing between them is a guess.

## What changes

One step, beside the existing JUnit upload and on the same terms: `if: always()` (the logs matter most when a *later* step failed) and `retention-days: 7`. The steps still redirect and the job log still shows only a tail.

## Verified

Workflow parses. `just check fast` 289/290 — the red is `xrce-vendored-versions`, which refuses in a fresh worktree for want of `nros setup --source` trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
