### PR TITLE
docs(#1258, #1259): file two frictions from moving a downstream to the nros store

### DIFF
--- a/docs/issues/1258-zephyr-store-workspace-is-bound-to-one-checkout.md
+++ b/docs/issues/1258-zephyr-store-workspace-is-bound-to-one-checkout.md
@@ -1,0 +1,79 @@
+---
+id: 1258
+title: "A Zephyr workspace in the store is bound to the ONE checkout that
+  provisioned it -- every later project builds that checkout's Zephyr module"
+status: open
+type: bug
+area: zephyr, tooling
+severity: medium
+related: [issue-1254, issue-1259]
+---
+
+## Symptom
+
+`scripts/zephyr/setup.sh` ("Initialize Workspace") makes the workspace's west
+manifest project a symlink to the checkout that ran it:
+
+```
+west init -l --mf "$MANIFEST" "$WORKSPACE_DIR/$NANO_ROS_NAME"
+rm -rf "$WORKSPACE_DIR/$NANO_ROS_NAME"
+ln -sf "$NANO_ROS_ROOT" "$WORKSPACE_DIR/$NANO_ROS_NAME"
+```
+
+with `.west/config` reading `[manifest] path = nano-ros`. West's project list
+is what Zephyr's module discovery reads, so the `nros` Zephyr module of EVERY
+build in that workspace comes from the symlink target. Measured on a
+downstream (Autoware Safety Island) board build, `build/zephyr_modules.txt`:
+
+```
+"nros":"<workspace>/nano-ros":"/home/aeon/repos/simple-autoware-safety-island/third-party/nano-ros/zephyr"
+```
+
+That was harmless while a workspace sat beside ONE checkout. Since phase-440
+W4 the default install target is `$NROS_STORE/workspaces/zephyr/<version>`,
+and RFC-0095 D2's point is that "one Zephyr workspace must be shared by every
+project that wants that version". The first project to provision a line now
+binds every later project on the host to its nano-ros tree. A second project
+pinning a different nano-ros builds the first one's `zephyr/` CMake and
+Kconfig with its own `find_package(nano_ros)` runtime, and nothing reports the
+mix. The two trees on this host already disagree:
+
+| workspace | `nano-ros ->` |
+| --- | --- |
+| `~/repos/nano-ros/zephyr-workspace` (3.7) | `/home/aeon/repos/nano-ros` |
+| `~/.nros/workspaces/zephyr/4.4` (provisioned by the island) | `.../simple-autoware-safety-island/third-party/nano-ros` |
+
+It is also RFC-0095 D1 inverted: the provisioned tree does not live inside a
+checkout, but it reaches INTO one, so deleting or moving that checkout breaks
+every project's Zephyr build.
+
+## Fix shape
+
+The store workspace should carry no checkout. `setup.sh` already copies the
+manifest file before replacing it with the symlink (west init follows
+symlinks); keep the COPY as a manifest-only project, and let each build name
+its own nano-ros Zephyr module, e.g. through `ZEPHYR_EXTRA_MODULES` from
+`find_package(nano_ros)`, which every consumer already calls. Then the
+workspace is keyed by Zephyr version alone, which is what its path claims.
+
+## Also: provisioning re-fetches a line that is already on disk
+
+A fresh `NROS_ZEPHYR_VERSION=4.4 just zephyr setup` into the store fetched
+Zephyr at ~250 KB/s (165 MB in ~20 min, ~4.6 GB to go) on a host that already
+held the same line at `~/repos/nano-ros-workspace-4.4`. West can seed from it:
+`update.path-cache` makes `west update` clone each project from a local repo
+with a plain `git clone` (`west/app/project.py`, "cloning from {cache_dir}";
+no `--shared`/`--reference`), so the new tree carries no `objects/info/alternates`
+and does not depend on the old one. Measured: the Zephyr repo arrived as an
+891 MB pack in a few minutes, against 165 MB in twenty over the network. It is
+a COPY, not hardlinks (link count 1, a repacked pack name), so it costs its
+full size on disk. Passing it through a `WEST_CONFIG_GLOBAL` file reached
+`setup.sh`'s plain `west update` unchanged.
+`setup.sh` could accept a cache path, or offer the legacy checkout-relative
+tree of the same line as one.
+
+## Acceptance
+
+- A store workspace's west project list contains no path into a checkout.
+- Two projects pinning two nano-ros revisions build against one store
+  workspace, each with its own `zephyr/` module (`zephyr_modules.txt`).

--- a/docs/issues/1259-nros-setup-tool-leaves-zephyr-sdk-without-toolchains.md
+++ b/docs/issues/1259-nros-setup-tool-leaves-zephyr-sdk-without-toolchains.md
@@ -1,0 +1,90 @@
+---
+id: 1259
+title: "`nros setup --tool zephyr-sdk-1-0-1` reports success and leaves an SDK
+  with no toolchains -- the index pins the _minimal bundle and has no
+  post-install step"
+status: open
+type: bug
+area: tooling, zephyr
+severity: medium
+related: [issue-1254, issue-1258]
+---
+
+## Symptom
+
+```
+$ nros setup --tool zephyr-sdk-1-0-1
+nros setup --tool zephyr-sdk-1-0-1: prebuilt 1.0.1 (dist linux-x86_64) -> ~/.nros/sdk/zephyr-sdk-1-0-1/1.0.1
+```
+
+exits 0 and leaves 68 MB:
+
+```
+zephyr-sdk-1.0.1/{cmake,hosttools,sdk_gnu_toolchains,sdk_version,setup.sh}
+```
+
+No `gnu/arm-zephyr-eabi`, no `gnu/x86_64-zephyr-elf`. The first `west build`
+for any Cortex-M board fails inside `FindZephyr-sdk.cmake`, naming neither the
+missing toolchain nor the step that should have fetched it.
+
+## Cause
+
+`[tool.zephyr-sdk-1-0-1]` pins sdk-ng's `_minimal` tarball. A minimal bundle
+is DESIGNED to be completed by its own installer, `./setup.sh -t <target> -h
+-c`, which downloads the toolchains, installs the host tools and registers the
+CMake package. The index has no post-install concept (no such key in
+`nros-sdk-index.toml`, nothing in `cmd/setup.rs`), so `nros setup` stops at
+unpack.
+
+nano-ros's own `scripts/zephyr/setup.sh` hides this by running the installer
+itself (`install_sdk`) -- but only on the path that installs the SDK with
+`--prefix` INSIDE the checkout (issue 1254). The store path, which RFC-0095
+makes the default, is the one that never completes.
+
+`[board.zephyr]` lists `packages = ["zephyr-sdk"]`, the 0.16.8 entry, which
+pins the FULL bundle, so `nros setup zephyr` on the 3.7 line ships toolchains;
+the installer's host-tools and registration steps are still skipped there.
+
+Measured on this host: after running the installer by hand in the store entry,
+2.2 GB with `gnu/{arm-zephyr-eabi,x86_64-zephyr-elf}`, and the SDK accepted by
+a Zephyr 4.4 board build.
+
+## Also found on the same path
+
+- **The per-user CMake package registry accumulates SDKs from every clone.**
+  The installer's `-c` writes `~/.cmake/packages/Zephyr-sdk/<hash>`. On the
+  host this was measured on it lists five SDKs from four trees: three
+  separate nano-ros clones, each with its own `scripts/zephyr/sdk/`, and the
+  store. A configure without `ZEPHYR_SDK_INSTALL_DIR` gets whichever
+  `find_package(Zephyr-sdk)` picks, which is a silent version substitution of
+  the kind `nros sdk-path` exists to prevent (issue 0625).
+- **`nros sdk-path` answers the store PREFIX, not the SDK root.** The tarball
+  has a top-level `zephyr-sdk-<ver>/` and is unpacked without
+  `--strip-components`, so `ZEPHYR_SDK_INSTALL_DIR` must be
+  `<prefix>/zephyr-sdk-<ver>`. Every consumer has to know the tarball layout.
+- **There is no local source for a dist.** `nros setup --tool` fetches the
+  index URL or nothing (`NROS_OFFLINE` only drops the system provider). Moving
+  a host to the store therefore re-downloads an SDK it already holds: the full
+  0.16.8 tarball arrived at ~400 KB/s (121 MB in the first ~5 minutes) with an
+  installed 0.16.8 one directory away. A `file://` dist override, verified
+  against the same sha256, would make that a copy.
+- **The SDK entries are not named by one rule** (`zephyr-sdk` is 0.16.8,
+  `zephyr-sdk-1-0-1` is 1.0.1). A consumer that starts from the version a
+  Zephyr tree states in `zephyr/SDK_VERSION` has to search the index by
+  version rather than compose a name.
+
+## Fix shape
+
+- The index can state a post-install command for a tool (the installer and its
+  `-t` targets), and `nros setup` runs it, recorded in `.nros-provenance`, so a
+  re-run is a no-op.
+- Registration (`-c`) is dropped in favour of consumers exporting
+  `ZEPHYR_SDK_INSTALL_DIR` from `nros sdk-path`.
+- `sdk-path` returns the SDK ROOT (the index records the subdirectory), and
+  the Zephyr line -> SDK entry mapping has one resolver.
+
+## Acceptance
+
+- `nros setup zephyr` alone produces an SDK a 4.4 `west build` accepts.
+- A second `nros setup` is a no-op, and `nros store gc` reclaims the whole
+  entry.


### PR DESCRIPTION
Files two issues found while moving Autoware Safety Island's Zephyr toolchains from sibling-checkout paths into the nros store (RFC-0095), the way a user would. Docs only; no code changes.

- #1258: `scripts/zephyr/setup.sh` symlinks the workspace's west manifest project to the checkout that ran it. Since phase-440 W4 that workspace is the shared store entry, so every later project on the host builds the first project's `zephyr/` module. Measured in a downstream `zephyr_modules.txt`. Also records that provisioning re-fetches a Zephyr line already on disk, and that west's `update.path-cache` turns it into a local copy with no alternates.
- #1259: `nros setup --tool zephyr-sdk-1-0-1` exits 0 with the 68 MB `_minimal` bundle and no toolchains; the index has no post-install step, and nano-ros's own `setup.sh` completes the SDK only on its in-checkout `--prefix` path. Also: the per-user CMake registry holds SDKs from every clone, `sdk-path` answers the prefix rather than the SDK root, the SDK entries follow no naming rule, and there is no local source for a dist.

Rebased onto main after #832 merged, so #1259's citation of #1254 now resolves and no baseline row is needed.

Local checks: `issue-index`, `prose-issue-refs`, `doc-commit-citations`, `doc-recipe-refs`, `archived-issue-status` and `string-conventions` pass. The full fast tier was run from a worktree and 288 of 290 pass. The two that fail need sources a bare worktree does not have and say so: `capability-conditionals` (zenoh-pico submodule not initialised) and `xrce-vendored-versions` ("no vendored tree checked out -- nothing verified"). The push used the hook's documented `NROS_SKIP_PREPUSH_CHECKS=1` for that reason only; the issue-id, pin and reachability checks still ran, and CI runs the fast tier in full.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKY5TGsRzN9SVs1e4c8BoH
