### PR TITLE
fix(check): a stale image is reported, never judged — and a lane that built one fails

### DIFF
--- a/.config/gate-selftest-baseline.txt
+++ b/.config/gate-selftest-baseline.txt
@@ -1,11 +1,12 @@
-#
-# (remove its line) or disappears (delete its line) — so the debt
 # Gate scripts that do NOT yet run their own selftest on the normal
-# Regenerate: python3 scripts/check-gate-selftests.py --write-baseline
+# path. A RATCHET, not an allowlist: this file may only shrink.
+#
 # `check-gate-selftests` fails when a script here gains a selftest
+# (remove its line) or disappears (delete its line) — so the debt
 # cannot silently grow and cannot silently go stale, which is the
 # issue-0743 class.
-# path. A RATCHET, not an allowlist: this file may only shrink.
+#
+# Regenerate: python3 scripts/check-gate-selftests.py --write-baseline
 scripts/check-activate-shells.sh
 scripts/check-archive-lang-items.sh
 scripts/check-artifact-identity-budget.sh
@@ -88,7 +89,6 @@ scripts/check-submodule-pinned-locks.py
 scripts/check-sysdep-remedies.sh
 scripts/check-test-domain-assignment.sh
 scripts/check-tier-preconditions.sh
-scripts/check-tier-priority-plan-image.py
 scripts/check-tier-priority-plan.py
 scripts/check-version-lockstep.sh
 scripts/check-wait-evidence-discarded.py

--- a/scripts/check-tier-priority-plan-image.py
+++ b/scripts/check-tier-priority-plan-image.py
@@ -13,9 +13,20 @@ Two things it must not do, both of which would defeat the point:
   * Treat "the priority is never applied in this image" as a pass. If the
     Kconfig gates are off, the transport INHERITS its creator and there IS no
     band — that is the NuttX pre-0736 state, and it is reported as such.
+  * Judge an image the tree has moved past. A `.config` configured before a
+    nano-ros default changed resolves the OLD band, and a verdict on it is a
+    verdict about a museum. In discovery mode it is reported `[STALE]` and
+    never judged — and a workspace where nothing was judged and something is
+    stale FAILS, because "checked nothing current" must not read as "checked".
+    In `--images-from` mode the caller BUILT it, so a stale one FAILS. The
+    rule and its measurements live beside `stale_band_reasons` in
+    `scripts/lib/priority_plan.py`.
 
 Usage:
     python3 scripts/check-tier-priority-plan-image.py <path/to/zephyr/.config> [tier_key]
+    python3 scripts/check-tier-priority-plan-image.py --images-from <list> [tier_key]
+    python3 scripts/check-tier-priority-plan-image.py            # discovery
+    python3 scripts/check-tier-priority-plan-image.py --selftest
 """
 
 import os
@@ -24,7 +35,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
-from priority_plan import load_plans, scan_pins, resolve_zephyr_plan
+from priority_plan import (BAND_DEFAULTED, kconfig_default, load_plans,
+                           resolve_zephyr_plan, scan_pins, stale_band_reasons)
 
 RESOLVERS = {"zephyr": resolve_zephyr_plan}
 
@@ -53,16 +65,22 @@ def discover():
 
 def check_one(dotconfig, tier_key, plans):
     plan = plans.get(tier_key)
+    reasons = stale_band_reasons(dotconfig)
+    if reasons:
+        print(f"  [STALE]   {dotconfig.parent.parent.name}: not evidence about this tree")
+        for r in reasons:
+            print(f"        {r}")
+        return 0, 0, "stale"
     resolved = RESOLVERS[plan["derived"]](dotconfig)
     if "error" in resolved:
         print(f"  cannot resolve {dotconfig}: {resolved['error']}")
-        return 2, 0
+        return 2, 0, "error"
     if "unapplied" in resolved:
         # Not a pass and not a failure: the image applies no band at all, so
         # there is nothing for a pin to collide with. Reported so it cannot be
         # mistaken for a checked image (issue 0766).
         print(f"  [NO BAND] {dotconfig.parent.parent.name}: {resolved['unapplied']}")
-        return 0, 0
+        return 0, 0, "noband"
     lo, hi = resolved["reserved"]["transport"]
     plo, phi = resolved["pool"]["app"]
     errs, ok = [], 0
@@ -84,9 +102,9 @@ def check_one(dotconfig, tier_key, plans):
         print(f"  [FAIL] {name}: transport [{lo}, {hi}], pool [{plo}, {phi}]")
         for e in errs:
             print(f"        {e}")
-        return 1, ok
+        return 1, ok, "judged"
     print(f"  [ok]   {name}: transport [{lo}, {hi}], pool [{plo}, {phi}] — {ok} pin(s)")
-    return 0, ok
+    return 0, ok, "judged"
 
 
 def images_from(listing):
@@ -115,22 +133,52 @@ def images_from(listing):
     return configs, missing
 
 
-def check_many(configs, tier_key, plans, origin):
+def check_many(configs, tier_key, plans, origin, listed):
+    """Judge `configs`; `listed` says whether the caller BUILT them.
+
+    A STALE image means different things in the two modes. Discovered, it is
+    residue the workspace happens to hold: reported, never judged. Listed, the
+    caller just built it, so a `.config` still carrying an old default means the
+    build did not re-run configure after the default moved — a missing edge,
+    and a failure, not residue.
+    """
     plan = plans.get(tier_key)
     if plan is None or not plan.get("derived"):
         print(f"{tier_key!r} has no DERIVED plan")
         return 2
+    if not selftest():
+        return 1
     rc, total, failed = 0, 0, []
+    states = {"judged": 0, "stale": 0, "noband": 0, "error": 0}
     print(f"check-tier-priority-plan-image: {len(configs)} image(s) ({origin})")
     for c in configs:
-        r, n = check_one(c, tier_key, plans)
+        r, n, state = check_one(c, tier_key, plans)
+        if state == "stale" and listed:
+            r = 1
         if r:
             failed.append(c.parent.parent.name)
         rc = max(rc, r)
         total += n
+        states[state] += 1
+    if states["stale"] and listed:
+        print(f"\n  {states['stale']} image(s) this run BUILT still carry an old "
+              f"default: the build did not re-run configure after it moved. "
+              f"`cmake <build-dir>` re-runs it in place.")
+    elif states["stale"] and not states["judged"]:
+        # issue 0599's rule one step on: "checked nothing" must not read as
+        # "checked". Nothing here was judged, and the images that COULD
+        # carry a band are the stale ones — the rest apply none — so
+        # rebuilding them is what would produce evidence. A precondition,
+        # and unmet preconditions fail.
+        print(f"\n  no image was judged: the {states['stale']} that could carry "
+              f"a band are STALE, and the other {states['noband']} apply none. "
+              f"Rebuild the stale ones (`just zephyr build-fixtures`), or "
+              f"`cmake <build-dir>` to re-run configure in place.")
+        rc = max(rc, 1)
     verdict = "FAILED" if rc else "OK"
     print(f"\ntier-priority-plan-image: {verdict} "
-          f"({total} pin-check(s) over {len(configs)} image(s))")
+          f"({total} pin-check(s) over {states['judged']} current image(s); "
+          f"{states['stale']} STALE, {states['noband']} NO BAND)")
     if failed:
         # Named in the LAST lines on purpose: a failing lane prints the tail of
         # this output, and the per-image [FAIL] blocks are above it. The tier-2
@@ -141,6 +189,8 @@ def check_many(configs, tier_key, plans, origin):
 
 
 def main(argv):
+    if len(argv) > 1 and argv[1] == "--selftest":
+        return 0 if selftest() else 1
     plans = load_plans()
     tier_key = "zephyr"
     if len(argv) >= 3 and argv[1] == "--images-from":
@@ -156,7 +206,8 @@ def main(argv):
             print(f"check-tier-priority-plan-image: {argv[2]} names no image — "
                   "the caller built nothing, so there is nothing to check")
             return 2
-        return check_many(configs, tier_key, plans, f"listed in {argv[2]}")
+        return check_many(configs, tier_key, plans, f"listed in {argv[2]}",
+                          listed=True)
     if len(argv) < 2:
         # Discovery mode (the operator's `just check tier-priority-plan-image`):
         # every image the workspace holds. A tree with no Zephyr workspace
@@ -170,7 +221,8 @@ def main(argv):
             print("  The DEFERRED pins reported by check-tier-priority-plan stay "
                   "unchecked on this host.")
             return 0
-        return check_many(configs, tier_key, plans, "every image in the workspace")
+        return check_many(configs, tier_key, plans, "every image in the workspace",
+                          listed=False)
     dotconfig = Path(argv[1])
     tier_key = argv[2] if len(argv) > 2 else "zephyr"
     if not dotconfig.is_file():
@@ -183,6 +235,15 @@ def main(argv):
         print(f"{tier_key!r} has no DERIVED plan — use check-tier-priority-plan")
         return 2
 
+    reasons = stale_band_reasons(dotconfig)
+    if reasons:
+        print(f"tier-priority-plan-image ({tier_key}): STALE image — cannot judge "
+              f"it against this tree")
+        for r in reasons:
+            print(f"  {r}")
+        print(f"  `cmake {dotconfig.parent.parent}` re-runs configure from the "
+              f"cached settings and regenerates the .config in place.")
+        return 2
     resolved = RESOLVERS[plan["derived"]](dotconfig)
     if "error" in resolved:
         print(f"cannot resolve: {resolved['error']}")
@@ -231,6 +292,88 @@ def main(argv):
     print(f"\ntier-priority-plan-image ({tier_key}): OK ({ok} pin(s) "
           f"checked against this image)")
     return 0
+
+
+def selftest():
+    """The staleness rule's own negative control, run on the normal path.
+
+    This rule fails SILENT if it breaks: `kconfig_default` returning None turns
+    every comparison off and every image back into a judged one. So the REAL
+    zephyr/Kconfig must yield an integer for both band inputs, and the synthetic
+    cases must come out the way they are written — including the three
+    "cannot tell" cases that must answer "not stale".
+    """
+    import tempfile
+    fails = []
+
+    def expect(name, got, want):
+        if got != want:
+            fails.append(f"{name}: got {got!r}, want {want!r}")
+
+    for key in BAND_DEFAULTED:
+        v = kconfig_default(key)
+        if not isinstance(v, int):
+            fails.append(f"real zephyr/Kconfig: no integer default for {key} "
+                         f"(got {v!r}) — the stale check would be silently OFF")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        kc = d / "Kconfig"
+        kc.write_text(
+            "config NROS_ZENOH_READ_PRIORITY\n"
+            "    int \"read\"\n"
+            "    default 200\n"
+            "    help\n"
+            "      default 999 is help text, not an attribute.\n"
+            "\n"
+            "config NROS_ZENOH_LEASE_PRIORITY\n"
+            "    int \"lease\"\n"
+            "    default 100 if SOMETHING\n"
+            "    default 200\n")
+        expect("a plain default",
+               kconfig_default("CONFIG_NROS_ZENOH_READ_PRIORITY", kc), 200)
+        expect("a conditional default is not one fact",
+               kconfig_default("CONFIG_NROS_ZENOH_LEASE_PRIORITY", kc), None)
+
+        def image(name, dotconfig, confs, cache=True):
+            b = d / name
+            (b / "zephyr").mkdir(parents=True)
+            (b / "zephyr" / ".config").write_text(dotconfig)
+            app = d / f"{name}-app"
+            app.mkdir()
+            for fn, body in confs.items():
+                (app / fn).write_text(body)
+            if cache:
+                (b / "CMakeCache.txt").write_text(
+                    f"APPLICATION_SOURCE_DIR:PATH={app}\n"
+                    f"CONF_FILE:STRING={';'.join(confs)}\n")
+            return b / "zephyr" / ".config"
+
+        READ16 = "CONFIG_NROS_ZENOH_READ_PRIORITY=16\n"
+        expect("a value equal to the default is current",
+               stale_band_reasons(image("cur", "CONFIG_NROS_ZENOH_READ_PRIORITY=200\n",
+                                        {"prj.conf": ""}), kc), [])
+        expect("an old default that no conf sets is STALE",
+               len(stale_band_reasons(image("old", READ16,
+                                            {"prj.conf": "CONFIG_FOO=y\n"}), kc)), 1)
+        expect("a conf that sets it is an OVERRIDE, not staleness",
+               stale_band_reasons(image("ovr", READ16, {"prj.conf": READ16}), kc), [])
+        expect("no CMakeCache is UNKNOWN, never stale",
+               stale_band_reasons(image("unk", READ16, {"prj.conf": ""}, cache=False), kc), [])
+        expect("an absent symbol has nothing to compare",
+               stale_band_reasons(image("abs", "CONFIG_FOO=y\n", {"prj.conf": ""}), kc), [])
+        expect("no single default means no comparison",
+               stale_band_reasons(image("cond", "CONFIG_NROS_ZENOH_LEASE_PRIORITY=16\n",
+                                        {"prj.conf": ""}), kc), [])
+
+    if fails:
+        print("check-tier-priority-plan-image --selftest: FAILED")
+        for f in fails:
+            print(f"  {f}")
+        return False
+    print("check-tier-priority-plan-image --selftest: OK "
+          "(real zephyr/Kconfig parses; 8 synthetic cases)")
+    return True
 
 
 if __name__ == "__main__":

--- a/scripts/lib/priority_plan.py
+++ b/scripts/lib/priority_plan.py
@@ -226,6 +226,152 @@ def _dotconfig_ints(path):
     return out
 
 
+
+# ---------------------------------------------------------------------------
+# Is an image's band EVIDENCE about this tree?  (tier 2, 2026-09-10)
+# ---------------------------------------------------------------------------
+#
+# A `.config` records what Kconfig resolved WHEN THE IMAGE WAS CONFIGURED. If a
+# nano-ros default has moved since, the band it resolves is the old tree's, and
+# judging it is judging a museum. Measured: tier 2 failed nine runs running on
+# six `build-c-*-zenoh` dirs configured 2026-08-27/29 — before issue 0852 moved
+# `NROS_ZENOH_{READ,LEASE}_PRIORITY`'s default from 16 (the 0-31 band) to 200
+# (the 0-255 band). 16 on the new band is k_thread 14, the least urgent
+# preemptive priority, so `pool.app` resolved to [15, 14] — EMPTY — and the
+# gate's own remedy ("move it into pool.app") had no answer. The pins were
+# never wrong; the images were.
+#
+# CONTENT, not mtime, and that choice is measured too. Kconfiglib rewrites
+# `.config` only when its content changes, so an image rebuilt after a default
+# change that does not touch it keeps its OLD mtime, and an mtime test would
+# call it stale forever. A commit-time test on `zephyr/Kconfig` is coarser
+# still: it stales every image on ANY edit to that file, and its last commit
+# (phase-412 W3b) added an unrelated QoS-depth symbol.
+#
+# The rule: a band input nano-ros AUTHORS a default for, whose `.config` value
+# differs from the CURRENT default, and which no conf the image was configured
+# with sets, can only have come from an older default.
+
+KCONFIG = ROOT / "zephyr" / "Kconfig"
+
+# The band inputs nano-ros authors a default for. `CONFIG_NUM_PREEMPT_PRIORITIES`
+# and the two scheduling gates belong to Zephyr and the board, not to us.
+BAND_DEFAULTED = ("CONFIG_NROS_ZENOH_READ_PRIORITY",
+                  "CONFIG_NROS_ZENOH_LEASE_PRIORITY")
+
+_KCONFIG_ENTRY = re.compile(
+    r"^(config|menuconfig|choice|endchoice|menu|endmenu|if|endif|"
+    r"source|rsource|osource|orsource|comment|mainmenu)\b")
+_KCONFIG_DEFAULT = re.compile(r"^\s+default\s+(\S+)(\s+if\s+.+)?\s*$")
+_KCONFIG_HELP = re.compile(r"^\s+(help|---help---)\s*$")
+
+
+def kconfig_default(symbol, kconfig=None):
+    """The unconditional integer default Kconfig gives `symbol`, or None.
+
+    `symbol` as the .config spells it (`CONFIG_` prefix). None when the entry is
+    absent, has a CONDITIONAL default (`default X if Y`), has more than one, or
+    has a non-integer one — the cases where "the default" is not a single fact,
+    so no caller may compare a value against it. Help text is not parsed for
+    attributes, which is Kconfig's own rule: `help` ends the attribute list.
+    """
+    name = symbol[len("CONFIG_"):] if symbol.startswith("CONFIG_") else symbol
+    try:
+        lines = Path(kconfig or KCONFIG).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    inside = in_help = False
+    defaults = []
+    for line in lines:
+        if _KCONFIG_ENTRY.match(line):
+            if inside:
+                break
+            inside = re.match(rf"^config\s+{re.escape(name)}\s*$", line) is not None
+            in_help = False
+            continue
+        if not inside or in_help:
+            continue
+        if _KCONFIG_HELP.match(line):
+            in_help = True
+            continue
+        m = _KCONFIG_DEFAULT.match(line)
+        if m:
+            defaults.append((m.group(1), m.group(2)))
+    if len(defaults) != 1 or defaults[0][1]:
+        return None
+    value = defaults[0][0]
+    return int(value) if value.lstrip("-").isdigit() else None
+
+
+def _image_confs(dotconfig):
+    """The conf files the image at `<build>/zephyr/.config` was configured with.
+
+    From the build's `CMakeCache.txt` — `CONF_FILE`, `EXTRA_CONF_FILE`,
+    `OVERLAY_CONFIG`, relative entries against `APPLICATION_SOURCE_DIR` — plus
+    the app's `boards/*.conf`, which may or may not merge and are counted as
+    possibly-setting so they can only SUPPRESS a stale verdict, never cause one.
+    None when there is no cache: "unknown", which no caller may read as "no conf
+    sets it".
+    """
+    cache = Path(dotconfig).parent.parent / "CMakeCache.txt"
+    try:
+        text = cache.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    vals = {}
+    for line in text.splitlines():
+        m = re.match(r"^([A-Za-z_]+):[A-Z]+=(.*)$", line)
+        if m:
+            vals[m.group(1)] = m.group(2)
+    base = Path(vals.get("APPLICATION_SOURCE_DIR", ""))
+    out = []
+    for key in ("CONF_FILE", "EXTRA_CONF_FILE", "OVERLAY_CONFIG"):
+        for part in re.split(r"[;\s]+", vals.get(key, "")):
+            if part:
+                p = Path(part)
+                out.append(p if p.is_absolute() else base / p)
+    if base.is_dir():
+        out += sorted((base / "boards").glob("*.conf"))
+    return out
+
+
+def _conf_sets(conf, key):
+    try:
+        text = Path(conf).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return re.search(rf"^\s*{re.escape(key)}=", text, re.M) is not None
+
+
+def stale_band_reasons(dotconfig, kconfig=None):
+    """Why this image's band is NOT evidence about the current tree; [] if it is.
+
+    Conservative in exactly one direction: every "cannot tell" — no single
+    default, no cache to read — answers "not stale" and leaves the image to be
+    judged as before. It can suppress a verdict only with a positive reason.
+    """
+    cfg = _dotconfig_ints(dotconfig)
+    confs = None
+    reasons = []
+    for key in BAND_DEFAULTED:
+        have = cfg.get(key)
+        if have is None:
+            continue
+        want = kconfig_default(key, kconfig)
+        if want is None or have == want:
+            continue
+        if confs is None:
+            confs = _image_confs(dotconfig)
+            if confs is None:
+                return []
+        if any(_conf_sets(c, key) for c in confs):
+            continue
+        reasons.append(
+            f"{key}={have}, but zephyr/Kconfig now defaults it to {want} and no "
+            f"conf this image was configured with sets it — the image predates "
+            f"the default change")
+    return reasons
+
 NROS_PLATFORM_PRIORITY_MAX = 255
 
 
@@ -288,8 +434,16 @@ def resolve_zephyr_plan(dotconfig):
     bands = {}
     for name, key in (("read", "CONFIG_NROS_ZENOH_READ_PRIORITY"),
                       ("lease", "CONFIG_NROS_ZENOH_LEASE_PRIORITY")):
-        # issue 0852 — Kconfig's default on the 0-255 band, not the old 0-31 16.
-        band = cfg.get(key, 200)
+        # Absent from the .config means the default applies. Read it from the
+        # one place it is written: this was a literal `200` restating
+        # zephyr/Kconfig, updated BY HAND from 16 when issue 0852 moved the
+        # default — a second copy of the fact whose first copy going stale is
+        # what tier 2 tripped over.
+        band = cfg.get(key)
+        if band is None:
+            band = kconfig_default(key)
+            if band is None:
+                return {"error": f"cannot read {key}'s default from zephyr/Kconfig"}
         posix = zpico_band_to_posix(band, num_preempt)
         bands[name] = {"band": band, "posix": posix,
                        "kthread": posix_rr_to_kthread(posix, num_preempt)}


### PR DESCRIPTION
Follow-up to #1253 (`3f4dc5c93`), which fixed the **lane** half of tier 2's red: the lane now checks the images it built (`--images-from`) rather than every image a workspace holds. This PR fixes what was still open: how the checker treats an image configured before a nano-ros default moved.

## The pins were never wrong. Measured on a real image

- The failing images (`build-c-*-zenoh`) are the **only** ones setting `CONFIG_NROS_ZENOH_{READ,LEASE}_PRIORITY`, to `16`. No tracked `.conf` sets it. `16` is the **old** default: the images were configured 08-27/29, and `a67d8668f` (issue 0852, 09-04) moved the default to `200`. On the 0–255 band, `16` is k_thread 14, so `pool.app` became `[15, 14]`, which is **empty**.
- If you correct **only** those two values to `200` on a copy of the same `.config`, every pin passes:

  ```
  reserved.transport = [4, 4]   pool.app = [5, 14]
  OK (8 pin(s) checked against this image)
  ```

## The rule: content, not time

A band input has a nano-ros default. If an image's `.config` holds a different value, and none of the confs the image was configured with sets it, the value can only come from an older default. That image is stale.

- **Not mtime.** Kconfiglib rewrites `.config` only when its content changes.
- **Not `zephyr/Kconfig`'s commit time.** Any edit to that file would make every image stale.
- The conf list comes from `CMakeCache.txt`, so an image that *sets* the value counts as an override, not as stale.
- When the checker cannot tell, it answers **not stale** and judges the image as before.

## What a stale image means depends on who named it

| mode | stale image | why |
|---|---|---|
| discovery (`just check tier-priority-plan-image`) | `[STALE]`, not judged; nothing judged + stale → **fail** | residue the workspace holds |
| `--images-from` (the lane) | **fail** | the lane just built it, so configure did not re-run after the default moved: a missing edge |
| single `.config` | exit 2 + `cmake <build-dir>` remedy | |

## Also

- `resolve_zephyr_plan` had the default hand-copied as a literal `200`. It now reads `zephyr/Kconfig`, and a parse failure is an error.
- A **selftest** runs on both multi-image paths, because a parser that silently returns None turns the whole rule off.
- The header of `.config/gate-selftest-baseline.txt` was scrambled by a `sort -u`, the same class as issue 1241. I regenerated it; the rows are unchanged except for the one removed line.

## Verified

Local runs on 67 real images plus a corrected copy of one. Exit codes:

- `--images-from`, stale image: **1**
- `--images-from`, corrected copy: **0** (8 pins)
- discovery: **1** (6 STALE, 61 NO BAND; before this PR all 6 were `[FAIL]`)
- single stale image: **2**
- Also passing: `--selftest`, `check-tier-priority-plan` (30 pins), `check-gate-selftests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
