### PR TITLE
docs(issues): vacate ids 0417 and 1080 — every citation now names the commit that did the work

### DIFF
--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -20,16 +20,7 @@
 #         control while explaining why this header is worth a gate. `archived/`
 #         is not scanned, so only 1092's citation needs a row.
 #
-#   0417  RESERVED, NEVER WRITTEN. `refs/issue-ids/0417` exists on origin, so
-#   1080  the id was claimed with `just issue-new` and no file was ever
-#         committed — issue 0999's shape ("the id was reserved, the fix
-#         landed, the file never got written"). The citations are honest and
-#         point at nothing, and the fix is to write the file, which needs
-#         whoever claimed the id. Not deleted: a reference removed is a
-#         record lost, and the id is not free either.
-#
-#   1110  DELIBERATELY WITHDRAWN — the same end state as 0417/1080, reached
-#         from the opposite direction. The file DID exist, on the phase-431
+#   1110  DELIBERATELY WITHDRAWN. The file DID exist, on the phase-431
 #         branch only: W6 filed it while the rustdoc lane was red, and
 #         phase-431 deletes it because the lane is green and an OPEN issue
 #         against a green lane is a false claim in the series whose job is to
@@ -40,9 +31,6 @@
 #
 docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
 docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
-docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md:1080
-docs/issues/1186-executor-backing-latch-test-races-siblings.md:0417
 docs/roadmap/archived/phase-431-ship-the-nros-binary.md:1110
-docs/roadmap/phase-432-codegen-one-producer-many-packs.md:1080
 just/check/docs.just:1110
 scripts/build/rustdoc-set.sh:1110

--- a/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
+++ b/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
@@ -5,7 +5,7 @@ status: open
 type: bug
 area: ci, c
 severity: high
-related: [1040, 1059, 1080, 1102, 1162, 0417, RFC-0061]
+related: [1040, 1059, 1102, 1162, RFC-0061]
 found: 2026-09-06
 ---
 
@@ -57,7 +57,7 @@ feature shape the lanes compile). This issue is the CI gate.
   since phase-396 — it needs artifacts no merge-gating job builds.
 - `test-unit` on `merge_group` compiles the workspace under default features;
   same blind spot one lane later.
-- Issue 1080 / #1102 closed the `--no-default-features` half of this class on
+- `b9450327d` + `92849933d` / #1102 closed the `--no-default-features` half of this class on
   the batch lane for `nros-node`. This is the other direction — a crate whose
   default (`panic-platform`) compiles almost nothing of its surface, and
   whose shipped shape is a specific positive feature set that every consumer

--- a/docs/issues/1185-backing-latch-test-order-dependent.md
+++ b/docs/issues/1185-backing-latch-test-order-dependent.md
@@ -5,7 +5,7 @@ title: "`the_static_is_handed_out_once_and_only_once` fails IN SUITE and passes
 status: open
 type: bug
 area: [core, testing]
-related: [0417, 1171, phase-392]
+related: [1171, phase-392]
 ---
 
 ## What

--- a/docs/issues/1186-executor-backing-latch-test-races-siblings.md
+++ b/docs/issues/1186-executor-backing-latch-test-races-siblings.md
@@ -6,7 +6,7 @@ type: bug
 area: core, testing
 severity: medium
 found: 2026-09-07
-related: [0417, 1145]
+related: [1145]
 ---
 
 ## What
@@ -37,7 +37,7 @@ second test would observe an already-consumed latch and assert nothing") and
 guards against SPLITTING the test, which is not the same as guarding against a
 sibling.
 
-Issue 0417's class exactly, one module over: process-global statics shared by
+`b206e02e5`'s class exactly, one module over: process-global statics shared by
 tests in one binary, where the verdict depends on nextest/libtest scheduling.
 
 ## Measured

--- a/docs/issues/archived/1082-zephyr-kconfig-default-never-reaches-a-reused-build-dir.md
+++ b/docs/issues/archived/1082-zephyr-kconfig-default-never-reaches-a-reused-build-dir.md
@@ -6,7 +6,7 @@ type: bug
 area: build
 severity: high
 found: 2026-09-05
-related: [0852, 0623, 0196, 1075, 1080]
+related: [0852, 0623, 0196, 1075]
 ---
 
 # Kconfig keeps what it has; a new `default` is not a new value
@@ -75,7 +75,7 @@ changed it.
 The gate that reports it needs BUILT Zephyr images, and it says so — the static
 `check-tier-priority-plan` passes and DEFERS these 8 pins to
 `check-tier-priority-plan-image`. No Zephyr image could be built on this host at
-all until issues **1075** (link) and **1080** (compile) were fixed hours earlier.
+all until issue **1075** (link) and `b9450327d` (compile) were fixed hours earlier.
 Fixing those two is what let this check run for the first time.
 
 Three failures stacked in one lane, each hiding the next.

--- a/docs/issues/archived/1162-fqn-c-symbol-defined-twice.md
+++ b/docs/issues/archived/1162-fqn-c-symbol-defined-twice.md
@@ -6,7 +6,7 @@ type: bug
 area: api, build
 severity: high
 found: 2026-09-06
-related: [0417]
+related: []
 ---
 
 # Two PRs shipped the same capability, and the collision was invisible

--- a/docs/issues/archived/1170-fqn-dedup-left-three-stale-callers.md
+++ b/docs/issues/archived/1170-fqn-dedup-left-three-stale-callers.md
@@ -7,7 +7,7 @@ area: api, build
 severity: high
 found: 2026-09-06
 resolved: 2026-09-06
-related: [1162, 1169, 0417, 0196]
+related: [1162, 1169, 0196]
 ---
 
 > **DUPLICATE of issue 1169 — retracted 2026-09-07.** I diagnosed and fixed this

--- a/docs/issues/archived/1174-backing-latch-test-needs-its-own-process.md
+++ b/docs/issues/archived/1174-backing-latch-test-needs-its-own-process.md
@@ -7,7 +7,7 @@ area: testing, core
 severity: medium
 found: 2026-09-06
 resolved: 2026-09-06
-related: [0417, 1036, 1168, 1183, 1186]
+related: [1036, 1168, 1183, 1186]
 ---
 
 > **DUPLICATE of issues 1183/1186 — retracted 2026-09-07.** I diagnosed and
@@ -53,7 +53,7 @@ whoever gets there second.
 ## Why the crate's existing fix does not apply
 
 `nros-node` already has this class twice, and both are fixed with a `Mutex`
-guard: `SimTimeGuard`, and `TypedProbeGuard` from issue 0417's
+guard: `SimTimeGuard`, and `TypedProbeGuard` from `b206e02e5`'s
 *"the two typed-probe tests share four process-global statics and race"*.
 
 A lock is the right tool there and the wrong one here. Those statics are

--- a/docs/issues/archived/1175-nros-c-calls-alloc-gated-lifecycle-ungated.md
+++ b/docs/issues/archived/1175-nros-c-calls-alloc-gated-lifecycle-ungated.md
@@ -7,7 +7,7 @@ area: api, core, build
 severity: high
 found: 2026-09-06
 resolved: 2026-09-06
-related: [0417, 1162, 1163, 1170, 1177, 0952]
+related: [1162, 1163, 1170, 1177, 0952]
 ---
 
 > **DUPLICATE of issue 1177 — retracted 2026-09-07.** Diagnosed and fixed

--- a/docs/issues/archived/1188-api-parity-ours-c-drops-rclc-aliases.md
+++ b/docs/issues/archived/1188-api-parity-ours-c-drops-rclc-aliases.md
@@ -7,7 +7,7 @@ area: api, tooling, ci
 severity: medium
 found: 2026-09-07
 resolved: 2026-09-07
-related: [1040, 1042, 1091, 0417]
+related: [1040, 1042, 1091]
 ---
 
 # 14 symbols whose names match upstream character for character, reported as gaps

--- a/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
+++ b/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
@@ -56,7 +56,7 @@ Do not re-do these; they are the evidence the rest is worth doing.
 - The tier table is STRUCTURED (`Vec<TierView>` of values, not C initialiser
   strings), and escaping is the `c_str` FILTER rather than an IR field.
 - `just check workspace-all` runs on `merge_group`, so a no-alloc break cannot
-  reach main again the way issue 1080's did.
+  reach main again the way the alloc-gated stack probe did (`b9450327d`).
 
 ## Track 1 — drop `TargetProfile` (independent, do first)
 

--- a/scripts/check-prose-issue-refs.py
+++ b/scripts/check-prose-issue-refs.py
@@ -206,8 +206,8 @@ def check_baseline_shape(lines):
     That content is the file's entire value. Its rows are `<path>:<id>` and say
     nothing about WHY; the header is where an IN-FLIGHT citation is told apart
     from a deliberate NEGATION (issue 9999, whose control issue 1092 would be
-    destroyed by filing it) and from an id reserved but never written (0417,
-    1080). Without it the next reader cannot tell which lines are debt.
+    destroyed by filing it) and from an id reserved but never
+    written. Without it the next reader cannot tell which lines are debt.
 
     The rule is the weakest one that catches a sort: comments come first. It
     permits any header a person writes and refuses the shape no person writes.


### PR DESCRIPTION
This PR removes issue ids **0417** and **1080**. Both came from earlier mistakes, and neither will ever get an issue file.

| id | what happened | what the citations now name |
|---|---|---|
| 0417 | Filed (`159ad573d`) and dropped the same minute (`3925c56f8`) as a duplicate of #414. Later docs still cited "issue 0417", meaning the typed-probe race. | `b206e02e5`, the typed-probe race fix. Its `fix(#417)` doesn't point here either: GitHub #417 is an unrelated colcon PR. |
| 1080 | Filed on PR #489, which was closed as superseded. The issue file never reached main. | `b9450327d` + `92849933d`, where the fix actually landed |

- **Prose baseline:** three rows and the "RESERVED, NEVER WRITTEN" header block removed. The ratchet only shrinks.
- **`related:` lists:** the dead id is dropped from 6 archived issues. The checker's docstring no longer uses these ids as its example.
- **Origin refs:** `refs/issue-ids/0417` and `refs/issue-ids/1080` are deleted. The reservation script always allocates above the highest id, so neither number can be handed out again.
- **Left as is:** archived issue 1241. It quotes the old header as evidence, and was true when written.

**Verified:** `check-prose-issue-refs` and its `--selftest`, the issue-index frontmatter parse, and `just check fast` (288 of 290 pass). The 2 that fail need zenoh-pico/XRCE sources a fresh worktree lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
