### PR TITLE
fix(executor): arena exhaustion names the QoS-depth knob, the budgeted depth, and the entity

### DIFF
--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -636,7 +636,17 @@ pub(crate) fn maybe_report_arena_headroom(used: usize, capacity: usize) {
 /// `NodeError::BufferTooSmall` is the same code a dozen other paths return, so
 /// on a target where a return code is all you get, exhaustion here is
 /// indistinguishable from a message that did not fit a receive buffer. This
-/// names the two knobs that actually govern it and the numbers involved.
+/// names the entity that failed, the numbers involved, and the knobs that
+/// actually govern it.
+///
+/// `NROS_PUBSUB_QOS_DEPTH` comes FIRST, with the depth this image was budgeted
+/// for. Since phase-412 W3b the derived arena prices every subscription at that
+/// depth, so a subscription created deeper than it is the ordinary way a
+/// derived arena runs out — and raising the depth re-derives the arena, where a
+/// hand-set `NROS_EXECUTOR_ARENA_SIZE` goes stale the next time any other term
+/// moves (the rationale #775 gave for the depth knob). The line named only the
+/// size and the action-client count until then, i.e. not the knob the likeliest
+/// failure needs.
 ///
 /// The counterpart to [`report_arena_headroom`], and the reason lowering
 /// `NROS_EXECUTOR_ACTION_CLIENTS` is safe to suggest: too small fails at
@@ -645,18 +655,77 @@ pub(crate) fn maybe_report_arena_headroom(used: usize, capacity: usize) {
 /// One-shot for the same reason the advisory is — the numbers do not change
 /// between registrations, and a per-registration line on an RTOS target is a
 /// flood (issue 0371's shape). `nros_log`, never stdio (issue 0589), and inside
-/// the 256-byte format budget that truncated the first advisory.
+/// the 256-byte format budget that truncated the first advisory — at the widest
+/// realistic values too (10-digit counts, a 32-byte entity, a 5-digit depth),
+/// which
+/// `executor::tests::an_exhausted_arena_decodes_to_the_knob_an_operator_must_set`
+/// derives from the real line and holds under the buffer.
 #[cold]
-pub(crate) fn report_arena_exhausted(want: usize, used: usize, capacity: usize) {
+pub(crate) fn report_arena_exhausted(
+    entity: &'static str,
+    want: usize,
+    used: usize,
+    capacity: usize,
+) {
     if ARENA_EXHAUSTED_REPORTED.swap(true, portable_atomic::Ordering::Relaxed) {
         return;
     }
+    let entity = entity_label(entity);
+    let depth = crate::config::arena_model::BUDGETED_QOS_DEPTH;
     nros_log::log_error!(
         nros_log::get_logger("nros"),
-        "arena exhausted: {want} more bytes needed, {used}/{capacity} in use. \
-         Raise NROS_EXECUTOR_ARENA_SIZE, or NROS_EXECUTOR_ACTION_CLIENTS if \
-         this image registers action clients. issue 0900"
+        "arena exhausted at {entity}: {want} B short, {used}/{capacity} used. \
+         Raise NROS_PUBSUB_QOS_DEPTH (budgeted {depth}) if a sub is deeper, \
+         else NROS_EXECUTOR_ARENA_SIZE or NROS_EXECUTOR_ACTION_CLIENTS \
+         (Zephyr: CONFIG_*)."
     );
+}
+
+/// The registering entity, short enough for the log budget.
+///
+/// From `core::any::type_name`, whose full spelling carries every generic
+/// argument and runs past 150 bytes. The generics go, and so does all but the
+/// last TWO path segments: most arena entries are a module's `Entry`, so the
+/// last segment alone would name nothing (`sub_buffered::Entry`, not `Entry`).
+/// Capped at 32 bytes; type names are ASCII, so the cut is on a char boundary.
+pub(crate) fn entity_label(full: &'static str) -> &'static str {
+    let path = full.split('<').next().unwrap_or(full);
+    let label = match path.rmatch_indices("::").nth(1) {
+        Some((i, _)) => &path[i + 2..],
+        None => path,
+    };
+    let cut = label.len().min(32);
+    label.get(..cut).unwrap_or(label)
+}
+
+#[cfg(test)]
+mod entity_label_tests {
+    use super::entity_label;
+
+    mod sub_buffered {
+        pub struct Entry<T>(pub T);
+    }
+
+    /// The shape nearly every arena entry has: a module's `Entry`, generic.
+    /// The last segment alone is `Entry` for all of them, which names nothing.
+    #[test]
+    fn a_module_entry_keeps_its_module_and_drops_its_generics() {
+        let full = core::any::type_name::<sub_buffered::Entry<[u8; 1024]>>();
+        assert!(full.contains('<'), "precondition: a generic name: {full}");
+        assert_eq!(entity_label(full), "sub_buffered::Entry");
+    }
+
+    #[test]
+    fn a_primitive_is_itself() {
+        assert_eq!(entity_label(core::any::type_name::<u8>()), "u8");
+    }
+
+    #[test]
+    fn a_long_label_is_capped_for_the_log_budget() {
+        let label = entity_label("a::a_module_name_well_past_the_cap::AnEntryTypeName<X>");
+        assert_eq!(label.len(), 32, "{label}");
+        assert!(label.starts_with("a_module_name_well_past_the_cap"));
+    }
 }
 
 /// One-shot latch for [`report_arena_exhausted`]. A static for the reason

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -4115,6 +4115,7 @@ impl<'s> Executor<'s> {
             // so on a target where a return code is all you get, arena
             // exhaustion is indistinguishable from a message that did not fit.
             super::arena::report_arena_exhausted(
+                core::any::type_name::<T>(),
                 new_used - self.arena.len(),
                 self.arena_used,
                 self.arena.len(),
@@ -4149,6 +4150,7 @@ impl<'s> Executor<'s> {
             // the half carrying buffered subscriptions and action entries,
             // which is what an island image actually allocates.
             super::arena::report_arena_exhausted(
+                core::any::type_name::<T>(),
                 new_used - self.arena.len(),
                 self.arena_used,
                 self.arena.len(),

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -3222,6 +3222,44 @@ fn an_exhausted_arena_decodes_to_the_knob_an_operator_must_set() {
         "the exhaustion line overflowed nros_log's format buffer and was \
          truncated, so its actionable half never reached the sink: {exhausted}"
     );
+    // The #775 residue. The derived arena prices every subscription at the
+    // budgeted QoS depth (phase-412 W3b), so a subscription deeper than it is
+    // the ordinary way a derived arena runs out, and the line named neither the
+    // knob nor the depth to compare against -- nor which entity ran out.
+    let depth = crate::config::arena_model::BUDGETED_QOS_DEPTH;
+    let budgeted = alloc::format!("NROS_PUBSUB_QOS_DEPTH (budgeted {depth})");
+    assert!(
+        exhausted.contains(&budgeted),
+        "the exhaustion line must name the depth knob AND the depth this image \
+         budgeted (`{budgeted}`): {exhausted}"
+    );
+    assert!(
+        exhausted.contains("arena exhausted at u8:"),
+        "the exhaustion line must name the entity that ran out (`u8` here, the \
+         type this test allocated): {exhausted}"
+    );
+    // The WIDEST line, derived from this one rather than from a second copy of
+    // the format string: every value swapped for its widest realistic width
+    // (10-digit counts, a 5-digit depth, a 32-byte entity -- `entity_label`'s
+    // cap). A line that fits here with room to spare can still truncate on a
+    // board whose numbers are wider, which is how the first advisory was cut.
+    let width = |n: u64| alloc::string::ToString::to_string(&n).len();
+    // The `want` the line printed is the shortfall the record took.
+    let shortfall = u64::from(crate::boot_report::snapshot().failed_alloc_shortfall);
+    let widest = exhausted.len() - "u8".len() + 32
+        - width(shortfall)
+        - width(executor.arena_used() as u64)
+        - width(capacity as u64)
+        - width(u64::from(depth))
+        + 3 * 10
+        + 5;
+    assert!(
+        widest <= nros_log::format_buffer_capacity(),
+        "at its widest the exhaustion line is {widest} bytes, past nros_log's \
+         {}-byte format buffer; it would truncate on a board with larger \
+         numbers: {exhausted}",
+        nros_log::format_buffer_capacity()
+    );
 
     // ---- channel 2: the record, read as BYTES and decoded by the script ---
     let snap = crate::boot_report::snapshot();

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -280,6 +280,13 @@ def report(rec: dict[str, int]) -> int:
             f"  set NROS_EXECUTOR_ARENA_SIZE >= {cap + rec['failed_alloc_shortfall']}\n"
             "  (Zephyr: CONFIG_NROS_EXECUTOR_ARENA_SIZE)\n"
             "\n"
+            "  or, if a subscription was created deeper than the QoS depth the\n"
+            "  arena was budgeted for, raise NROS_PUBSUB_QOS_DEPTH instead\n"
+            "  (Zephyr: CONFIG_NROS_PUBSUB_QOS_DEPTH). The arena is re-derived\n"
+            "  from the depth, so it cannot go stale the way a hand-set size does.\n"
+            "  The console line (`arena exhausted at ...`) names the entity and\n"
+            "  the depth the image budgeted.\n"
+            "\n"
             "That is the FIRST failure, which is the one that explains the boot;\n"
             "later allocations may also have failed as a consequence."
         )


### PR DESCRIPTION
Fixes the diagnostic residue #775 left behind. Since phase-412 W3b, the derived arena prices every subscription at the resolved `NROS_PUBSUB_QOS_DEPTH`. So the usual way a derived arena runs out is a subscription created deeper than that depth. Until now, the runtime line reporting the failure named neither that knob nor the depth to compare against.

## Before → after

```
arena exhausted: 9 more bytes needed, 0/74240 in use. Raise NROS_EXECUTOR_ARENA_SIZE,
or NROS_EXECUTOR_ACTION_CLIENTS if this image registers action clients. issue 0900
```
```
arena exhausted at u8: 9 B short, 0/74240 used. Raise NROS_PUBSUB_QOS_DEPTH (budgeted 10)
if a sub is deeper, else NROS_EXECUTOR_ARENA_SIZE or NROS_EXECUTOR_ACTION_CLIENTS (Zephyr: CONFIG_*).
```

- **Entity:** both allocators pass `type_name::<T>()`. `entity_label` shortens it to the last two path segments, drops the generics, and caps it at 32 bytes. Most entries are a module's `Entry`, so the last segment alone would name nothing.
- **Depth:** the line prints `arena_model::BUDGETED_QOS_DEPTH`, the value this build was sized for.
- **Decoder (`read-boot-report.py`):** keeps the exact `NROS_EXECUTOR_ARENA_SIZE >= N` advice and adds the depth alternative with its Zephyr spelling. This is a text change only; the boot record layout is untouched.

These are the only two runtime report sites. C and C++ register through the same Rust allocators.

## The 256-byte log buffer, measured

`nros_log` truncates at 256 bytes. I estimated the widest line at 232 bytes; the new assertion measured **263**, so the first draft would have been cut off on a board with wider numbers. I cut 16 bytes from the line. The decode test now works out the widest line **from the real line**, swapping each value for its widest realistic width, and asserts it fits `nros_log::format_buffer_capacity()`. There is no second copy of the format string to drift, and the test's first run (red at 263) served as its negative control.

## Verified

- `just check node-std-tests`: green (407 lib tests plus the isolated decode cell).
- `cargo +nightly fmt --check`: clean.
- clippy `-D warnings` on nros-node, with and without `std`: clean.
- `just check fast`: 288/290. The two red gates, `capability-conditionals` and `xrce-vendored-versions`, need zenoh-pico and XRCE sources that a fresh worktree doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
