### PR TITLE
fix(check): a baseline's header is the part no gate reads — now one does, for all of them

### DIFF
--- a/.config/gate-selftest-baseline.txt
+++ b/.config/gate-selftest-baseline.txt
@@ -1,11 +1,12 @@
-#
-# (remove its line) or disappears (delete its line) — so the debt
 # Gate scripts that do NOT yet run their own selftest on the normal
-# Regenerate: python3 scripts/check-gate-selftests.py --write-baseline
+# path. A RATCHET, not an allowlist: this file may only shrink.
+#
 # `check-gate-selftests` fails when a script here gains a selftest
+# (remove its line) or disappears (delete its line) — so the debt
 # cannot silently grow and cannot silently go stale, which is the
 # issue-0743 class.
-# path. A RATCHET, not an allowlist: this file may only shrink.
+#
+# Regenerate: python3 scripts/check-gate-selftests.py --write-baseline
 scripts/check-activate-shells.sh
 scripts/check-archive-lang-items.sh
 scripts/check-artifact-identity-budget.sh

--- a/just/check/gates.just
+++ b/just/check/gates.just
@@ -49,6 +49,15 @@ gate-lists:
 gate-selftests:
     @python3 scripts/check-gate-selftests.py
 
+# Issue 1241's class, for EVERY ratchet baseline. A baseline's header is the
+# part no gate reads, so a `sort` that scrambles it leaves every lane green —
+# it did, twice (prose-issue-ref, then gate-selftest). Sorted comment blocks
+# fail everywhere; a baseline whose writer declares `BASELINE_HEADER` must
+# carry exactly that header. Buildless, milliseconds, self-testing.
+[group("hygiene")]
+baseline-shape:
+    @python3 scripts/check-baseline-shape.py
+
 # A gate must exercise its own failure path EVERY time it runs, not once behind
 # a flag on the day it was written. A baseline ratchet: the debt may only
 # shrink, and a script that gains a selftest must leave the baseline.

--- a/scripts/check-baseline-shape.py
+++ b/scripts/check-baseline-shape.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Every ratchet baseline keeps the header a person wrote. Issue 1241's class.
+
+A baseline's comments are the part no gate reads, so a `sort` that scrambles
+them leaves every lane green. 1241 found it in the prose-issue-ref baseline
+and fixed that one file; the gate-selftest baseline then sat on main with its
+header in byte order and a spacer lost to `sort -u`. The rules and their
+measurements are in `scripts/lib/baseline_shape.py`.
+
+Scope:
+  * every tracked `.config/*.txt`, against rules 1 and 2 (sorted comments);
+  * every baseline a script declares as `BASELINE` beside a module-level
+    `BASELINE_HEADER`, against rule 3 as well — the file's header must be the
+    one its writer emits. The writer is IMPORTED, not parsed, so the header is
+    compared with the very string `--write-baseline` writes.
+
+A writer with a fixed header should declare `BASELINE_HEADER` and write it;
+that is what opts its baseline into rule 3. Finding NO such writer fails —
+it means discovery broke, and rule 3 would silently check nothing.
+
+Usage:
+    check-baseline-shape.py              # the gate (runs its selftest first)
+    check-baseline-shape.py --selftest   # the selftest alone
+"""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+import baseline_shape
+from tracked import tracked  # issue 0721: index lookup, not a walk
+
+DECLARES_HEADER = re.compile(r"^BASELINE_HEADER\s*=", re.MULTILINE)
+
+
+def writers():
+    """{baseline Path: (writer script Path, header)} for rule 3."""
+    out = {}
+    for i, script in enumerate(tracked("scripts", suffix=".py")):
+        if not DECLARES_HEADER.search(script.read_text(encoding="utf-8")):
+            continue
+        spec = importlib.util.spec_from_file_location(f"_baseline_writer_{i}", script)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        base = Path(mod.BASELINE)
+        if not base.is_absolute():
+            base = ROOT / base
+        out[base.resolve()] = (script, mod.BASELINE_HEADER)
+    return out
+
+
+def main(argv):
+    fails = baseline_shape.selftest()
+    if fails:
+        print("check-baseline-shape --selftest: FAILED", file=sys.stderr)
+        for f in fails:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+    if "--selftest" in argv:
+        print("check-baseline-shape --selftest: OK")
+        return 0
+
+    ws = writers()
+    if not ws:
+        print("check-baseline-shape: no script declares BASELINE_HEADER — "
+              "discovery is broken, and rule 3 would check nothing.", file=sys.stderr)
+        return 1
+    files = set(tracked(".config", suffix=".txt")) | set(ws)
+    errs = []
+    for f in sorted(files):
+        rel = f.relative_to(ROOT)
+        script, header = ws.get(f, (None, None))
+        if not f.is_file():
+            errs.append(f"{rel}: declared as BASELINE by "
+                        f"{script.relative_to(ROOT)} and not on disk")
+            continue
+        found = baseline_shape.problems(f.read_text(encoding="utf-8"), header)
+        if not found:
+            continue
+        if script:
+            fix = (f"`python3 {script.relative_to(ROOT)} --write-baseline` "
+                   f"rewrites it — read the row diff too")
+        else:
+            fix = (f"restore the header from history (`git log -p -- {rel}`); "
+                   f"it has no writer to regenerate it")
+        errs.append(f"{rel}:\n    " + "\n    ".join(found) + f"\n    fix: {fix}. "
+                    f"Never `sort` a baseline: the rows are a set, the header "
+                    f"is prose.")
+    if errs:
+        print(f"check-baseline-shape: {len(errs)} baseline(s) lost their header's "
+              f"shape:\n", file=sys.stderr)
+        for e in errs:
+            print(f"  {e}\n", file=sys.stderr)
+        return 1
+    print(f"check-baseline-shape OK — {len(files)} baseline(s); "
+          f"{len(ws)} checked against their writer's header")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-board-name-reach.py
+++ b/scripts/check-board-name-reach.py
@@ -79,6 +79,14 @@ import sys
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OVERLAY_DIR = os.path.join(ROOT, "cmake", "board")
 BASELINE = os.path.join(ROOT, ".config", "board-name-reach-baseline.txt")
+# Module-level so `check-baseline-shape` can hold the file to it.
+BASELINE_HEADER = (
+    "# phase-437 W1 — board names that do not yet state their reach\n"
+    "# (RFC-0093). A RATCHET: it may only SHRINK. W4-W6 empty it.\n"
+    "#\n"
+    "# Regenerate ONLY to record a rename that removed one:\n"
+    "#     python3 scripts/check-board-name-reach.py --write-baseline\n"
+)
 
 # An ISA or CPU family. Naming one is a claim about every machine that has it.
 ARCH = {
@@ -336,13 +344,7 @@ def main():
 
     if "--write-baseline" in sys.argv:
         with open(BASELINE, "w", encoding="utf8") as fh:
-            fh.write(
-                "# phase-437 W1 — board names that do not yet state their reach\n"
-                "# (RFC-0093). A RATCHET: it may only SHRINK. W4-W6 empty it.\n"
-                "#\n"
-                "# Regenerate ONLY to record a rename that removed one:\n"
-                "#     python3 scripts/check-board-name-reach.py --write-baseline\n"
-            )
+            fh.write(BASELINE_HEADER)
             for b in sorted(violations):
                 fh.write(f"{b}\n")
         print(f"wrote baseline: {len(violations)} known violation(s)")

--- a/scripts/check-codegen-version-surface.py
+++ b/scripts/check-codegen-version-surface.py
@@ -700,7 +700,7 @@ def read_versions(path=None, errors=None):
     return cur, low
 
 
-HEADER = """\
+BASELINE_HEADER = """\
 # phase-429 W3 — the version-surface stamp for `NROS_CODEGEN_VERSION`.
 #
 # EVIDENCE, NOT THE TOKEN. Nothing compiles this file, nothing compares these
@@ -720,7 +720,7 @@ HEADER = """\
 
 def write_baseline(surface, version, path=None):
     path = path or BASELINE
-    lines = [HEADER, f"version {version}\n"]
+    lines = [BASELINE_HEADER, f"version {version}\n"]
     for key in sorted(surface):
         lines.append(f"{digest(surface[key])} {key}\n")
     with open(path, "w", encoding="utf8") as fh:

--- a/scripts/check-doc-recipe-refs.py
+++ b/scripts/check-doc-recipe-refs.py
@@ -67,6 +67,35 @@ from tracked import tracked  # issue 0721: index lookup, not a walk
 
 REPO = Path(__file__).resolve().parent.parent
 BASELINE = REPO / ".config" / "doc-recipe-refs-baseline.txt"
+# Module-level so `check-baseline-shape` can hold the file to it.
+BASELINE_HEADER = "\n".join([
+    "# `just <recipe>` references in documents that name no recipe.",
+    "#",
+    "# A RATCHET, not an allowlist: this file may only SHRINK. The gate",
+    "# fails when a new dead reference appears AND when a line here stops",
+    "# offending — so the debt cannot grow and cannot go stale.",
+    "#",
+    "# NOT every entry is a defect, and this is the part to read before",
+    "# 'fixing' one. Three classes name a non-existent recipe CORRECTLY,",
+    "# and rewriting them would replace a true sentence with a wrong",
+    "# command:",
+    "#",
+    "#   NEGATION      AGENTS.md: 'there is no supported ... `just",
+    "#                 install-local` flow'. The point IS that it does",
+    "#                 not exist.",
+    "#   PROPOSAL      docs/research/sdk-ux/: '`just monitor <board>`",
+    "#                 that decodes panics' — a UX being argued for, not",
+    "#                 an instruction.",
+    "#   RELEASE NOTE  migration-install-local-removal.md names the",
+    "#                 recipe it documents the REMOVAL of.",
+    "#",
+    "# The rest are stale instructions: a reader copies them and gets",
+    "# `Justfile does not contain recipe`. Those are worth fixing, and",
+    "# each needs the recipe that replaced it — `just --list`, or the",
+    "# module's own list via `just <mod>`.",
+    "#",
+    "# Regenerate deliberately with --write-baseline and read the diff.",
+]) + "\n"
 
 # `just --help`. A flag that takes a value swallows the token after it, which
 # would otherwise read as the recipe name.
@@ -400,35 +429,8 @@ def main() -> int:
     found = set(offenders())
 
     if args.write_baseline:
-        lines = [
-            "# `just <recipe>` references in documents that name no recipe.",
-            "#",
-            "# A RATCHET, not an allowlist: this file may only SHRINK. The gate",
-            "# fails when a new dead reference appears AND when a line here stops",
-            "# offending — so the debt cannot grow and cannot go stale.",
-            "#",
-            "# NOT every entry is a defect, and this is the part to read before",
-            "# 'fixing' one. Three classes name a non-existent recipe CORRECTLY,",
-            "# and rewriting them would replace a true sentence with a wrong",
-            "# command:",
-            "#",
-            "#   NEGATION      AGENTS.md: 'there is no supported ... `just",
-            "#                 install-local` flow'. The point IS that it does",
-            "#                 not exist.",
-            "#   PROPOSAL      docs/research/sdk-ux/: '`just monitor <board>`",
-            "#                 that decodes panics' — a UX being argued for, not",
-            "#                 an instruction.",
-            "#   RELEASE NOTE  migration-install-local-removal.md names the",
-            "#                 recipe it documents the REMOVAL of.",
-            "#",
-            "# The rest are stale instructions: a reader copies them and gets",
-            "# `Justfile does not contain recipe`. Those are worth fixing, and",
-            "# each needs the recipe that replaced it — `just --list`, or the",
-            "# module's own list via `just <mod>`.",
-            "#",
-            "# Regenerate deliberately with --write-baseline and read the diff.",
-            "",
-        ]
+        # The header's trailing newline splits to the blank separator line.
+        lines = BASELINE_HEADER.split("\n")
         lines += [f"{p}\t{r}" for p, r in sorted(found)]
         BASELINE.write_text("\n".join(lines) + "\n")
         print(f"check-doc-recipe-refs: wrote {len(found)} baseline entr(ies)")

--- a/scripts/check-gate-selftests.py
+++ b/scripts/check-gate-selftests.py
@@ -48,6 +48,18 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASELINE = os.path.join(ROOT, ".config", "gate-selftest-baseline.txt")
+# Module-level so `check-baseline-shape` can hold the file to it.
+BASELINE_HEADER = (
+    "# Gate scripts that do NOT yet run their own selftest on the normal\n"
+    "# path. A RATCHET, not an allowlist: this file may only shrink.\n"
+    "#\n"
+    "# `check-gate-selftests` fails when a script here gains a selftest\n"
+    "# (remove its line) or disappears (delete its line) — so the debt\n"
+    "# cannot silently grow and cannot silently go stale, which is the\n"
+    "# issue-0743 class.\n"
+    "#\n"
+    "# Regenerate: python3 scripts/check-gate-selftests.py --write-baseline\n"
+)
 
 # A call to a selftest routine. Definitions and flag-dispatch lines are excluded
 # by the caller, not here, so both halves are visible at the use site.
@@ -201,17 +213,7 @@ def load_baseline():
 def write_baseline(states):
     debt = sorted(r for r, (s, _) in states.items() if s != "auto")
     with open(BASELINE, "w", encoding="utf8") as fh:
-        fh.write(
-            "# Gate scripts that do NOT yet run their own selftest on the normal\n"
-            "# path. A RATCHET, not an allowlist: this file may only shrink.\n"
-            "#\n"
-            "# `check-gate-selftests` fails when a script here gains a selftest\n"
-            "# (remove its line) or disappears (delete its line) — so the debt\n"
-            "# cannot silently grow and cannot silently go stale, which is the\n"
-            "# issue-0743 class.\n"
-            "#\n"
-            "# Regenerate: python3 scripts/check-gate-selftests.py --write-baseline\n"
-        )
+        fh.write(BASELINE_HEADER)
         for r in debt:
             fh.write(r + "\n")
     print(f"wrote {BASELINE} — {len(debt)} script(s) of {len(states)} still owe a selftest")

--- a/scripts/check-prose-issue-refs.py
+++ b/scripts/check-prose-issue-refs.py
@@ -65,6 +65,9 @@ import subprocess
 import re
 import sys
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from baseline_shape import late_comment_lines
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASELINE = os.path.join(ROOT, ".config", "prose-issue-ref-baseline.txt")
 
@@ -211,15 +214,15 @@ def check_baseline_shape(lines):
 
     The rule is the weakest one that catches a sort: comments come first. It
     permits any header a person writes and refuses the shape no person writes.
+    It is THIS file's convention, not every baseline's, so it stays here; the
+    rules that hold for all of them are `check-baseline-shape`'s, and the
+    finder is shared (`scripts/lib/baseline_shape.py`).
     """
-    first_row = next((i for i, l in enumerate(lines)
-                      if l.strip() and not l.startswith("#")), None)
-    if first_row is None:
-        return None
-    late = [i for i, l in enumerate(lines[first_row:], first_row)
-            if l.startswith("#")]
+    late = late_comment_lines(lines)
     if not late:
         return None
+    first_row = next(i for i, l in enumerate(lines)
+                     if l.strip() and not l.startswith("#"))
     return (
         "check-prose-issue-refs: the baseline's comments are INTERLEAVED with its "
         "rows.\n"

--- a/scripts/check-roadmap-boxes.py
+++ b/scripts/check-roadmap-boxes.py
@@ -68,6 +68,13 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASELINE = os.path.join(ROOT, ".config", "roadmap-boxes-baseline.txt")
+# Module-level so `check-baseline-shape` can hold the file to it.
+BASELINE_HEADER = (
+    "# Phase sections whose declared `**Files:**` all exist while boxes\n"
+    "# stay open (issue 1103). A ratchet: entries may only be REMOVED.\n"
+    "# An entry here is a claim that the section is genuinely unfinished\n"
+    "# despite its files landing — say why beside it.\n"
+)
 
 SECTION = re.compile(r"^### ")
 OPEN_BOX = re.compile(r"^- \[ \]")
@@ -211,12 +218,7 @@ def main(argv):
     if "--write-baseline" in argv:
         os.makedirs(os.path.dirname(BASELINE), exist_ok=True)
         with open(BASELINE, "w", encoding="utf8") as fh:
-            fh.write(
-                "# Phase sections whose declared `**Files:**` all exist while boxes\n"
-                "# stay open (issue 1103). A ratchet: entries may only be REMOVED.\n"
-                "# An entry here is a claim that the section is genuinely unfinished\n"
-                "# despite its files landing — say why beside it.\n"
-            )
+            fh.write(BASELINE_HEADER)
             for d, h, _, _ in flagged:
                 fh.write(f"{key(d, h)}\n")
         print(f"check-roadmap-boxes: baseline written ({len(flagged)} section(s))")

--- a/scripts/check-roadmap-claims.py
+++ b/scripts/check-roadmap-claims.py
@@ -66,6 +66,13 @@ import tempfile
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ROADMAP = os.path.join("docs", "roadmap")
 BASELINE = os.path.join(".config", "roadmap-claims-baseline.txt")
+# Module-level so `check-baseline-shape` can hold the file to it.
+BASELINE_HEADER = (
+    "# phase-419 W2 — roadmap phases whose claims contradict their own\n"
+    "# body. RATCHET: this list may only SHRINK. Each line is a finding\n"
+    "# for a person to work, not debt to hide; fix the phase and delete\n"
+    "# the line.\n"
+)
 
 # A status line in any of the shapes `check-roadmap-status.sh` accepts. Kept in
 # step with that gate deliberately: two different ideas of where a status lives
@@ -337,12 +344,7 @@ def main(argv):
     if len(argv) > 1 and argv[1] == "--write-baseline":
         path = os.path.join(ROOT, BASELINE)
         with open(path, "w", encoding="utf-8") as fh:
-            fh.write(
-                "# phase-419 W2 — roadmap phases whose claims contradict their own\n"
-                "# body. RATCHET: this list may only SHRINK. Each line is a finding\n"
-                "# for a person to work, not debt to hide; fix the phase and delete\n"
-                "# the line.\n"
-            )
+            fh.write(BASELINE_HEADER)
             for k in sorted(keys):
                 fh.write(k + "\n")
         print(f"wrote {BASELINE} — {len(keys)} entr(ies)")

--- a/scripts/check/check-gate-lists.py
+++ b/scripts/check/check-gate-lists.py
@@ -70,6 +70,17 @@ EXEMPT_FILE = REPO / ".config" / "gate-lane-exempt.txt"
 # derived fast+build set, so inverting where membership is WRITTEN did not
 # move what the ratchet reads.
 BASELINE = REPO / ".config" / "gate-registry-baseline.txt"
+# Module-level so `check-baseline-shape` can hold the file to it.
+BASELINE_HEADER = (
+    "# The gate names `just/check.just`'s registries have carried.\n"
+    "# May only GROW. A name here and not in a registry fails\n"
+    "# `check-gate-lists` (issue 1071 -- a PR deleted four gates and every\n"
+    "# gate stayed green, because sorted-and-one-per-line is a property a\n"
+    "# deletion satisfies).\n"
+    "#\n"
+    "# Regenerate ONLY for a deliberate retirement, and say which gate went:\n"
+    "#   python3 scripts/check/check-gate-lists.py --write-baseline\n"
+)
 
 # The one lane whose membership is still authored. A build gate is the
 # EXCEPTION — it cannot run without something compiled — so it is listed, and
@@ -341,15 +352,7 @@ def load_baseline() -> set[str] | None:
 def write_baseline(names: set[str]) -> None:
     BASELINE.parent.mkdir(parents=True, exist_ok=True)
     BASELINE.write_text(
-        "# The gate names `just/check.just`'s registries have carried.\n"
-        "# May only GROW. A name here and not in a registry fails\n"
-        "# `check-gate-lists` (issue 1071 -- a PR deleted four gates and every\n"
-        "# gate stayed green, because sorted-and-one-per-line is a property a\n"
-        "# deletion satisfies).\n"
-        "#\n"
-        "# Regenerate ONLY for a deliberate retirement, and say which gate went:\n"
-        "#   python3 scripts/check/check-gate-lists.py --write-baseline\n"
-        + "".join(f"{n}\n" for n in sorted(names)),
+        BASELINE_HEADER + "".join(f"{n}\n" for n in sorted(names)),
         encoding="utf-8",
     )
 

--- a/scripts/lib/baseline_shape.py
+++ b/scripts/lib/baseline_shape.py
@@ -1,0 +1,207 @@
+"""The shape of a ratchet baseline — the half of the file no gate reads.
+
+A ratchet baseline is rows a gate compares against plus a comment header a
+person reads, and every loader in this tree skips `#` lines. So nothing about a
+gate's verdict depends on the header, which is exactly why it can be destroyed
+with every lane green. It has been, twice:
+
+  * `.config/prose-issue-ref-baseline.txt` (issue 1241) went through `sort` in
+    a conflict resolution; its CLASSIFIED block — which rows are debt and which
+    are deliberate — ended up interleaved among the rows it classifies.
+  * `.config/gate-selftest-baseline.txt` went through `sort -u`: its header
+    came back in byte order with one of its two `#` spacers deduplicated away,
+    and sat on main that way.
+
+1241 added a check for the first shape to one file. This module is the class,
+for every baseline, in one spelling (`scripts/check-baseline-shape.py` runs it):
+
+  RULE 1 — no comment block is in sorted order. Prose is never written sorted;
+  a block of MIN_SORTED_TEXT or more text lines that IS sorted — in byte order
+  (`LC_ALL=C sort`) or in a locale-style fold (`sort` under en_US ignores
+  punctuation and case) — came out of a sort. The threshold is measured, not a
+  taste: four authored lines fall in order by chance 1 time in 24 per ordering,
+  and a 3-line block of `doc-commit-citations-baseline.txt` does today.
+
+  RULE 2 — the whole file is not sorted. A locale `sort` interleaves comments
+  with rows that share a first letter, leaving no block long enough for rule 1.
+  That is the 1241 shape.
+
+  RULE 3 — where the WRITER emits a fixed header (`BASELINE_HEADER` in its
+  script), the file's leading comment block IS that header, line for line. The
+  strongest check, and available only where there is a source of truth to
+  compare with, which is why rules 1 and 2 exist for the files that have none.
+
+"Comments first" is NOT a rule here: `doc-commit-citations-baseline.txt`
+groups its hashes under per-document explanations on purpose. The one file
+whose convention it is enforces it with `late_comment_lines`.
+"""
+
+import re
+
+MIN_SORTED_TEXT = 5
+
+
+def _loose(line):
+    """A locale-style collation key: case folded, punctuation dropped."""
+    return re.sub(r"[^a-z0-9 ]", "", line.lower()).strip()
+
+
+ORDERINGS = (("byte order", lambda l: l), ("locale order", _loose))
+
+
+def _text_lines(lines):
+    return [l for l in lines if l.startswith("#") and l.strip("# \t")]
+
+
+def comment_blocks(lines):
+    """(0-based start, lines) for each run of consecutive `#` lines."""
+    blocks, start, cur = [], None, []
+    for i, line in enumerate(lines):
+        if line.startswith("#"):
+            if not cur:
+                start = i
+            cur.append(line)
+        elif cur:
+            blocks.append((start, cur))
+            cur = []
+    if cur:
+        blocks.append((start, cur))
+    return blocks
+
+
+def _sorted_by(seq):
+    for name, key in ORDERINGS:
+        keys = [key(l) for l in seq]
+        if keys == sorted(keys):
+            return name
+    return None
+
+
+def sorted_blocks(lines):
+    """[(0-based start, block length, ordering)] for rule 1."""
+    hits = []
+    for start, block in comment_blocks(lines):
+        if len(_text_lines(block)) < MIN_SORTED_TEXT:
+            continue
+        order = _sorted_by(block)
+        if order:
+            hits.append((start, len(block), order))
+    return hits
+
+
+def whole_file_sorted(lines):
+    """The ordering the whole file is in, for rule 2, or None."""
+    body = [l for l in lines if l.strip()]
+    if len(_text_lines(body)) < MIN_SORTED_TEXT:
+        return None
+    return _sorted_by(body)
+
+
+def leading_header(text):
+    """The comment block before the first row, trailing blank lines dropped."""
+    head = []
+    for line in text.split("\n"):
+        if line.startswith("#") or not line.strip():
+            head.append(line)
+        else:
+            break
+    while head and not head[-1].strip():
+        head.pop()
+    return head
+
+
+def header_diff(text, expected):
+    """(1-based line, file's line, writer's line) at the first difference, or None."""
+    got, want = leading_header(text), leading_header(expected)
+    for i in range(max(len(got), len(want))):
+        g = got[i] if i < len(got) else "<end of header>"
+        w = want[i] if i < len(want) else "<end of header>"
+        if g != w:
+            return i + 1, g, w
+    return None
+
+
+def late_comment_lines(lines):
+    """0-based indices of `#` lines after the first row (for a comments-first file)."""
+    first_row = next((i for i, l in enumerate(lines)
+                      if l.strip() and not l.startswith("#")), None)
+    if first_row is None:
+        return []
+    return [i for i, l in enumerate(lines[first_row:], first_row) if l.startswith("#")]
+
+
+def problems(text, expected_header=None):
+    """Every shape problem in one baseline's text, as messages without a path."""
+    lines = text.split("\n")
+    out = []
+    hits = sorted_blocks(lines)
+    for start, n, order in hits:
+        out.append(
+            f"line {start + 1}: its {n}-line comment block is in {order} — the "
+            f"shape a `sort` leaves behind; nobody writes prose sorted")
+    if not hits:
+        order = whole_file_sorted(lines)
+        if order:
+            out.append(
+                f"the whole file is in {order}, comments among the rows — the "
+                f"shape a locale `sort` leaves behind (issue 1241)")
+    if expected_header is not None:
+        d = header_diff(text, expected_header)
+        if d:
+            n, got, want = d
+            out.append(
+                f"line {n}: the header differs from the one its writer emits\n"
+                f"      file:   {got}\n"
+                f"      writer: {want}")
+    return out
+
+
+def selftest():
+    """Failures of this module's own negative controls, [] when they all hold."""
+    fails = []
+
+    def expect(name, got, want):
+        if got != want:
+            fails.append(f"{name}: got {got!r}, want {want!r}")
+
+    header = (
+        "# Gate scripts that do NOT yet run their own selftest on the normal\n"
+        "# path. A RATCHET, not an allowlist: this file may only shrink.\n"
+        "#\n"
+        "# `check-gate-selftests` fails when a script here gains a selftest\n"
+        "# (remove its line) or disappears (delete its line) — so the debt\n"
+        "# cannot silently grow and cannot silently go stale, which is the\n"
+        "# issue-0743 class.\n"
+        "#\n"
+        "# Regenerate: python3 scripts/check-gate-selftests.py --write-baseline\n")
+    authored = header + "scripts/a.sh\nscripts/b.sh\n"
+    # What `LC_ALL=C sort -u` makes of it — the gate-selftest baseline on main.
+    sort_u = "\n".join(sorted({l for l in authored.split("\n") if l})) + "\n"
+
+    expect("an authored header passes", problems(authored), [])
+    expect("... and matches its writer", problems(authored, header), [])
+    expect("`sort -u` trips rule 1", len(problems(sort_u)), 1)
+    expect("... and rule 3", len(problems(sort_u, header)), 2)
+    expect("`sort -u` dropped a spacer",
+           len(leading_header(sort_u)), len(leading_header(header)) - 1)
+
+    # A locale sort interleaves: `# cannot`, `cannot/x`, `# Gate`, `gate/y` ...
+    rows = "cannot/x\ngate/y\nissue/z\npath/w\nremove/v\n"
+    loc = "\n".join(sorted((l for l in (header + rows).split("\n") if l),
+                           key=_loose)) + "\n"
+    expect("a locale sort trips rule 2",
+           [p.split(",")[0] for p in problems(loc)],
+           ["the whole file is in locale order"])
+
+    four = "# alpha\n# beta\n# delta\n# gamma\nrow\n"
+    expect("four lines in order by chance are not a sort", problems(four), [])
+
+    sections = header + "aaa\n\n# per-document note, deliberately\n# after rows\nbbb\n"
+    expect("comments after rows are legitimate here", problems(sections, header), [])
+    expect("late_comment_lines still sees them",
+           len(late_comment_lines(sections.split("\n"))), 2)
+
+    spacer_lost = header.replace("#\n# Regenerate", "# Regenerate") + "row\n"
+    expect("a lost spacer is a rule 3 difference at its line",
+           header_diff(spacer_lost, header)[0], 8)
+    return fails


### PR DESCRIPTION
Issue 1241 fixed a `sort`-scrambled header in **one** baseline. Then `.config/gate-selftest-baseline.txt` sat on main scrambled by a `sort -u`: header in byte order, one `#` spacer lost. No lane noticed, because every baseline loader skips `#` lines. This PR makes that class a gate, for every baseline.

## `check-baseline-shape` (fast lane)

One helper, `scripts/lib/baseline_shape.py`, with three rules:

1. **No sorted comment block.** A block of 5+ text lines in byte or locale order came out of a sort. The threshold is measured: a 3-line block in `doc-commit-citations-baseline.txt` is in order by chance today.
2. **The whole file is not sorted.** This catches a locale `sort` that interleaves comments with rows (the 1241 shape), where no block is long enough for rule 1.
3. **The header matches the writer's.** Seven writers now declare a module-level `BASELINE_HEADER` instead of a string literal buried in `--write-baseline`. The gate *imports* each writer, so it compares against the exact string the writer emits.

Scope: every tracked `.config/*.txt` for rules 1–2, and every baseline whose writer declares `BASELINE_HEADER` for rule 3 (16 baselines, 7 of them with a writer). The gate fails if it discovers no writer at all, so a discovery bug can't make rule 3 silently check nothing.

"Comments first" is not a general rule, because `doc-commit-citations` puts explanations between its rows on purpose. prose-issue-refs keeps that rule for itself, now through the shared helper.

## Negative controls (real baselines, restored after each)

| scramble | caught by |
|---|---|
| `LC_ALL=C sort -u` doc-commit-citations (no writer) | rule 1 (58-line block, byte order); fix names `git log -p` |
| main's current gate-selftest file | rule 1 + rule 3; fix names `--write-baseline` |
| locale `sort` of prose-issue-ref | rule 1 on two interleaved blocks |
| `sort` of roadmap-boxes (4-line header, under the threshold) | rule 3 alone |

## Also

- `.config/gate-selftest-baseline.txt` is regenerated: header restored, rows unchanged. It's byte-identical to #840's copy, so the two PRs merge cleanly in either order.
- Moving each header into a constant changed no output: re-running every writer's `--write-baseline` reproduces its tracked file.

## Verified

- `check-baseline-shape` passes, including its selftest.
- All eight touched checkers pass, plus `check-gate-selftests` and `check-gate-visibility`.
- `just check fast`: 289/291. The two reds are `capability-conditionals` and `xrce-vendored-versions`, which need zenoh-pico and XRCE sources that a fresh worktree doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
