### PR TITLE
fix(params): tier 1 cannot reach its cyclone cells — three declares drop a #[must_use] answer

### DIFF
--- a/packages/api/nros/src/node_runtime.rs
+++ b/packages/api/nros/src/node_runtime.rs
@@ -1239,9 +1239,17 @@ impl ::nros_platform::NodeDispatchRuntime for ExecutorNodeRuntime {
         self.executor
             .register_parameter_services()
             .map_err(|e| capability_reason(&e))?;
+        // Nothing is declared before this seeding runs, so every `false` here is
+        // a refusal — a full table, or a value its descriptor rejects — and a
+        // launch `<param>` the program would otherwise believe it has.
         for (name, raw) in params {
-            self.executor
-                .declare_parameter(name, infer_param_value(raw));
+            if !self
+                .executor
+                .declare_parameter(name, infer_param_value(raw))
+            {
+                return Err("a launch <param> was refused by the parameter store \
+                            (table full, or a value its descriptor rejects)");
+            }
         }
         Ok(())
     }
@@ -1669,9 +1677,17 @@ impl NodeRuntime for ExecutorSink<'_> {
                             .register_parameter_services()
                             .map_err(decl_err_from_node)?;
                     }
+                    let name = metadata.source_name.as_str();
                     let value = param_default_to_value(metadata.parameter_default.as_ref());
-                    self.executor
-                        .declare_parameter(metadata.source_name.as_str(), value);
+                    // `apply_param_services` seeds launch `<param>` values BEFORE
+                    // this runs, and the launch value must win — so a name that is
+                    // already declared is the expected `false`, not a refusal. Only
+                    // a name that is still absent afterwards was refused.
+                    if !self.executor.declare_parameter(name, value)
+                        && self.executor.get_parameter(name).is_none()
+                    {
+                        return Err(NodeDeclError::Runtime);
+                    }
                 }
                 Ok(())
             }

--- a/packages/testing/nros-tests/bins/param-chatter-talker/src/main.rs
+++ b/packages/testing/nros-tests/bins/param-chatter-talker/src/main.rs
@@ -29,7 +29,10 @@ fn main() {
     executor
         .register_parameter_services()
         .expect("Failed to register parameter services");
-    executor.declare_parameter("start_value", ParameterValue::Integer(0));
+    assert!(
+        executor.declare_parameter("start_value", ParameterValue::Integer(0)),
+        "declare_parameter(start_value) was refused"
+    );
     info!("Parameter services registered for /talker");
 
     let publisher = {

--- a/packages/testing/nros-tests/bins/sim-clock-listener/src/main.rs
+++ b/packages/testing/nros-tests/bins/sim-clock-listener/src/main.rs
@@ -52,7 +52,10 @@ fn main() {
     // parameter is the whole request, exactly as in ROS 2 — the runtime
     // reconciles it on the next spin, once a node exists to hang the
     // subscription on.
-    executor.declare_parameter("use_sim_time", nros::ParameterValue::Bool(true));
+    assert!(
+        executor.declare_parameter("use_sim_time", nros::ParameterValue::Bool(true)),
+        "declare_parameter(use_sim_time) was refused"
+    );
 
     let _nid = executor
         .node_builder("sim_listener")


### PR DESCRIPTION
Tier 1 (`host-tests`) failed its last two runs in **Build workspace fixtures**, before any test ran. The build broke on two `declare_parameter` calls that ignore a `#[must_use]` result:

```
error: unused return value of `Executor::<'s>::declare_parameter` that must be used
    --> packages/api/nros/src/node_runtime.rs:1243:13
    --> packages/api/nros/src/node_runtime.rs:1673:21
make: *** [...linux-rust-all-...mk:94: fixture-0028] Error 101
```

(runs 34461154151 @ `e13ad23f7`, 34463489409 @ `719ed1bc9`)

## Why it matters now

`bde0a7e94` fixed the two tier-1 cyclone cells, `ros2_pubsub_e2e` and `ros2_srv_e2e`. Both had failed on every run because the CI image had no `rmw_cyclonedds_cpp`: `librmw_cyclonedds_cpp.so: cannot open shared object file`, in runs 34432822434 and 34316087289. No host-tests run has reached those cells since that fix, because this compile break stops the job first.

## Why only the fixture build saw it

phase-428 W6 made the declare family `#[must_use]`. The callers in `node_runtime.rs` sit behind `param-services`, which no unit lane enables for `nros`; the unit lane tests it with `env,std`. So the fixture build, which uses `-D warnings`, was the first build to compile them.

## Each site answers the refusal its own way (none use `let _ =`)

| site | a `false` means | handling |
|---|---|---|
| `apply_param_services` (seeds launch `<param>` values into an empty store) | always a refusal: table full, or the descriptor rejects the value | `Err(&'static str)`, the function's existing error type |
| `EntityKind::Parameter` arm (runs **after** the seeding; the launch value must win) | usually just "already declared", which is correct | error only if the name is **still absent** afterwards → `NodeDeclError::Runtime` |
| `sim-clock-listener`, `param-chatter-talker` (test fixtures) | the fixture's one declaration was refused | `assert!`, so the fixture fails instead of passing without testing anything |

The sweep found only these three sites that drop the result; `param-two-node-talker` already asserts.

## Verified

- With `RUSTFLAGS="-D warnings"`: `nros` compiles with `param-services,sim-time`, and so does `sim-clock-listener`.
- `cargo test -p nros --lib`: 84/84 with the lane's `env,std`, 85/85 with `+param-services`, and 85/85 with `+sim-time`.
- `nros-node` lib tests (`std,sim-time,param-services`): 404 pass.
- `just check fast`: 289/290. The one red is `xrce-vendored-versions`, which fails because a fresh worktree has no XRCE sources.
- The cyclone cells themselves, run solo with main's scripts on a host that has the RMW: pubsub A.1 and A.2 **PASS**, services B.1 and B.2 **PASS**.

**Not verified:** `param-chatter-talker` was not compiled here, because it needs `nros sync` for `generated/std_msgs`. Its change is the same `assert!` as the listener's. CI has not yet shown the cyclone cells passing on the new image; the next host-tests run on main after this PR merges will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
