### PR TITLE
fix(esp32): the heap was sized to hold the executor arena, and the arena moved to .bss

### DIFF
--- a/packages/boards/nros-board-esp32-qemu/src/node.rs
+++ b/packages/boards/nros-board-esp32-qemu/src/node.rs
@@ -258,17 +258,33 @@ pub fn init_hardware(config: &Config) {
     //   (mepc=0x9ae65930), the pre-#190 0xffffffff config-pointer fault.
     //   None of them were allocator or zenoh-pico bugs.
     //
-    // 48 KB fits the executor arena AND leaves a ~67 KB stack; both esp32
-    // pair-delivery directions run green on it. Check `.stack` in
-    // `readelf -S` after changing ANY large static — there is no runtime
-    // stack-overflow guard on this target.
+    // 48 KB fitted the executor arena AND left a ~67 KB stack — while the
+    // arena was a HEAP allocation. It is not any more: phase-392 W6 moved the
+    // executor backing into a named `.bss` static
+    // (`nros_node::executor::backing::EXECUTOR_BACKING`, RFC-0002 § 4.4b), and
+    // that is a MOVE, not a saving — the bytes left this heap and became
+    // linker-visible `.bss`. This heap was never reduced to match, so the
+    // backing was paid for twice, and on this board `.bss` is paid for out of
+    // the stack. Measured on `esp32_entry` (the workspace fixture) with the
+    // heap at 48 KB: `EXECUTOR_BACKING` 29,400 B in `.bss`, stack 19,312 B
+    // against the 32,768 B `check-stack-floor` minimum — the nightly `esp32`
+    // lane's red.
+    //
+    // So the TOO-SMALL arm above no longer binds: the 17,032 B allocation that
+    // killed 16 KB at open is now the static. 16 KB it is again, and the
+    // subtraction is the whole 32 KB. The executor only falls back to this heap
+    // when its backing does not fit the reservation (a second executor, or an
+    // entry sized past the default) — and that fails LOUDLY at open ("memory
+    // allocation of N bytes failed"), never as a silent overflow. Check
+    // `.stack` in `readelf -S` after changing ANY large static — there is no
+    // runtime stack-overflow guard on this target.
     // For DDS builds the example crate enables `nros-platform/global-allocator`,
     // which registers a 256 KB static `FreeListHeap` instead — calling
     // `esp_alloc::heap_allocator!` on top of that produces the
     // "the `#[global_allocator]` in nros_platform conflicts with
     // global allocator in: esp_alloc" link error (Phase 101.7).
     #[cfg(not(feature = "dds-heap"))]
-    esp_alloc::heap_allocator!(size: 48 * 1024);
+    esp_alloc::heap_allocator!(size: 16 * 1024);
 
     // Step 3: Register the monotonic clock with the shared busy-wait sleep
     // loop in `nros-baremetal-common`. Without this, `sleep_ms` silently


### PR DESCRIPTION
## The nightly red
`esp32` has failed every night since 09-06: `check-stack-floor: [FAIL] esp32_entry: stack 19,312 B is BELOW the esp32 floor of 32,768 B.` On esp32-c3 `.stack` is the linker leftover after `.bss`, with no runtime overflow guard (issues 0190, 1052).

## Root cause
The 09-07 fix (`ZPICO_MAX_SUBSCRIBERS = 1`) DID take effect — `SMALL_PAYLOADS` is 4,096 B — but its "~47,116 B" was computed, not measured.

`init_hardware`'s `esp_alloc` heap was 48 KB, and its own comment said why: *"48 KB fits the executor arena AND leaves a ~67 KB stack"*. Phase-392 W6 (09-06) moved the executor backing into the `.bss` static `EXECUTOR_BACKING`. Per CLAUDE.md that is a MOVE, not a saving — and this heap was never reduced, so the backing was paid twice, out of the stack. Measured with the heap at 48 KB: heap 49,152 B + `EXECUTOR_BACKING` 29,400 B in `.bss`, stack 19,312 B.

## Fix
Heap back to 16 KB — the value whose only failure was the 17,032 B arena allocation that is now the static. A backing that does not fit the reservation falls back to the heap and fails LOUDLY at open, never silently. Comment rewritten to say so.

## Verified
| image | stack before | after (floor 32,768) |
|---|---|---|
| `esp32_entry` | 19,312 B | **52,080 B** |
| `esp32_qemu_talker` | — | 94,440 B |
| `esp32_qemu_listener` | — | 64,176 B |
| `logging-smoke-esp32-qemu` | — | 271,660 B |

`just esp32 test` on the rebuilt images (local `qemu-system-riscv32 -M esp32c3`, `rmw_zenohd`): **5/5 PASS** incl. `test_esp32_workspace_entry_e2e` (the nightly cell), `test_esp32_to_native`, `test_native_to_esp32` — so no esp32 image takes the heap arm; had one, it would have died at open.

Part of phase-413 W2 (nightly lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK