### PR TITLE
docs(phase-443 W6): the build ends at an artifact, and the templates stop teaching a checkout

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -62,6 +62,7 @@
 - [Logging](./user-guide/logging.md)
 - [Simulated Time](./user-guide/simulated-time.md)
 - [Build Profiles](./user-guide/build-profiles.md)
+- [What `nros build` Produces](./user-guide/build-artifacts.md)
 - [Profiling Your Build](./user-guide/build-profiling.md)
 - [Deployment Workflow](./user-guide/deployment.md)
 - [Cross-backend Bridges](./user-guide/cross-backend-bridges.md)

--- a/book/src/getting-started/workspace-bringup.md
+++ b/book/src/getting-started/workspace-bringup.md
@@ -292,13 +292,26 @@ this guide. Copy the whole directory out and rename the packages, then:
 
 ```bash
 nros setup native
+nros sync            # once per workspace — the generated message bindings
 nros build native
 ```
 
 `nros build` walks the packages, resolves the image, checks the toolchain,
 generates the root manifest and the entry, and hands off to cargo. The older
-`nros sync` / `nros codegen-system` / `nros check` sequence still works; it is
-just no longer something you have to type.
+`nros codegen-system` / `nros check` steps still work; they are just no longer
+something you have to type.
+
+`nros sync` is the one that is still yours to run. A workspace that has never
+been synced has no generated message crates, so `nros build` refuses at
+preflight and names it:
+
+```text
+Error: missing prerequisites for this build:
+  - generated message bindings (this workspace has never been synced)
+      run: nros sync
+```
+
+Once per workspace is enough; after that, re-run it when you edit a `.msg`.
 
 The workspace README at `examples/workspaces/rust/README.md`
 documents the exact CLI commands that are verified green today.

--- a/book/src/getting-started/workspace-cpp.md
+++ b/book/src/getting-started/workspace-cpp.md
@@ -342,9 +342,13 @@ nros build native
 ./build/posix-zenoh-native/cmake/native_entry
 ```
 
-`nros build` runs `nros sync` for you (it resolves the SystemModel via the
-pinned `nros-launch-resolve` helper whenever the launch XML or `system.toml`
-is newer), writes the root, configures, and builds. The coordinate directory
+`nros build` resolves the SystemModel for you (via the pinned
+`nros-launch-resolve` helper, whenever the launch XML or `system.toml` is
+newer), writes the root, configures, and builds. It does **not** run `nros
+sync`: a workspace that has never been synced has no generated message
+bindings, and `nros build` refuses at preflight naming `nros sync` as the
+remedy. Sync once per workspace; after that only a `.msg` edit needs it
+again. The coordinate directory
 names what it contains: platform, RMW, board. Driving `cmake` yourself against
 the generated root still works.
 

--- a/book/src/user-guide/build-artifacts.md
+++ b/book/src/user-guide/build-artifacts.md
@@ -1,0 +1,182 @@
+# What `nros build` Produces
+
+`nros build` ends at an **artifact** and stops. It discovers your packages,
+resolves the image, checks the toolchain, generates the root build file and the
+entry, and then hands off to the native tool — `cargo`, `cmake`, `west` or
+`idf.py`. The last stage is an `exec`, so the artifact is exactly the one that
+tool would have produced had you run it yourself.
+
+This page answers the question the build does not: **what are you holding, and
+where is it?**
+
+## There is no `nros run` and no `nros flash`
+
+That is a decision, not a gap. How an image is flashed or started is a property
+of the board and of your bench — a probe, a bootloader, a QEMU command line, a
+CI fixture — and nano-ros cannot know it without inventing a device inventory
+nobody asked for. So nano-ros delivers binaries, and the board's own tooling
+takes them from there.
+
+The commands quoted below are **that tooling's**, reproduced here as a
+reference. They are not nano-ros wrappers and nano-ros does not run them for
+you.
+
+There is also no install step: `nros build` never runs `cmake --install`, writes
+no `install/` prefix and stages nothing. Whatever the native tool wrote in its
+own build tree is the deliverable.
+
+## Where it lands
+
+Which tool builds an image is decided by its platform and by whether the
+workspace crosses languages:
+
+| platform / shape | driver | the artifact |
+| --- | --- | --- |
+| Rust-only, any non-Zephyr non-ESP32 board | `cargo` | `<ws>/target/[<triple>/]<profile>/<image>_entry` |
+| any workspace containing C or C++ | `cmake` | `<ws>/build/<coordinate>/cmake/<image>_entry` |
+| a `zephyr` board | `west` | `<ws>/build/zephyr/zephyr.{elf,bin,exe}` |
+| an `esp32` board | `idf.py` | ESP-IDF's own `build/` in the project directory |
+
+The **coordinate** is the platform and the RMW — `posix-zenoh`,
+`freertos-cyclonedds` — plus, for CMake, the board, because CMake pins one
+compiler per configure and two boards on one platform would otherwise share a
+cache: `posix-zenoh-native`, `freertos-zenoh-mps2-an385-freertos`.
+
+One path the build *does* print is easy to mistake for the binary:
+
+```text
+nros build:   entry → …/build/posix-zenoh/native_entry
+```
+
+That is the generated **entry package** — source that nano-ros wrote for you,
+under `build/` because it is build output. The compiled program is elsewhere;
+see below.
+
+## Native host (cargo)
+
+`nros build` runs `cargo build -p <image>_entry` from the workspace root and
+passes no `--target-dir`, so cargo's own default applies:
+
+```text
+<ws>/target/<profile-dir>/<image>_entry
+```
+
+`<profile-dir>` is `debug` unless the image declares
+`[image.<id>] profile = …`, in which case it is that profile's directory
+(`nros profile dir <name>` prints it). A board that pins a cross triple adds a
+level — `target/<triple>/<profile-dir>/<image>_entry` — because `nros build`
+passes `--target` for it.
+
+**Next step:** run it. It is an ordinary host executable.
+
+```bash
+./target/debug/native_entry
+```
+
+A multi-process zenoh example also needs a router; that is ROS's `rmw_zenohd`,
+not something nano-ros ships — see
+[Deployment Workflow](deployment.md) and
+[Install](../getting-started/installation.md#do-i-need-ros-2-installed).
+
+## C, C++ and mixed workspaces (cmake)
+
+CMake is chosen whenever the package graph contains anything that is not Rust,
+on the host and when cross-compiling alike. The generated root is `<ws>/build/<coordinate>/CMakeLists.txt`,
+it is configured into `<ws>/build/<coordinate>/cmake/`, and each image's
+executable lands at the top of that directory:
+
+```text
+<ws>/build/<coordinate>/cmake/<image>_entry
+```
+
+For example, `examples/workspaces/c` builds `[image.native]` to
+`build/posix-zenoh-native/cmake/native_entry` and its FreeRTOS image to
+`build/freertos-zenoh-mps2-an385-freertos/cmake/freertos_entry`. (Node packages
+also build their own executables, under `cmake/pkg/<pkg>/<pkg>`; the *image* is
+the one at the top level.)
+
+The file has no extension in either case. On the host it is a host executable;
+for a cross board it is a statically linked ELF for that architecture — the
+FreeRTOS one above is `ELF 32-bit LSB executable, ARM, EABI5, statically
+linked`.
+
+**Next step:**
+
+* **host** — run it directly.
+* **QEMU** — the ELF is what `-kernel` takes, with the machine and CPU your
+  board's guide names.
+* **hardware** — hand the ELF to your flasher (`probe-rs`, OpenOCD, a
+  vendor tool). nano-ros has no opinion about which.
+
+## Zephyr (west)
+
+`nros build` resolves your application and its overlays and runs `west build`
+from the workspace root, passing no `-d`, so west's default build directory
+applies. Zephyr writes its image under `zephyr/` inside it:
+
+```text
+<ws>/build/zephyr/zephyr.elf      # always
+<ws>/build/zephyr/zephyr.exe      # native_sim — a host executable
+<ws>/build/zephyr/zephyr.bin      # cross targets — the raw image
+<ws>/build/zephyr/zephyr.map      # the link map
+```
+
+Which of `.exe` and `.bin` appears is Zephyr's choice, not nano-ros's: a
+`native_sim` build produces `zephyr.exe`, a Cortex-M build produces
+`zephyr.bin`.
+
+**Next step — Zephyr's own verbs:**
+
+```bash
+./build/zephyr/zephyr.exe     # native_sim: just run it
+west build -t run             # emulated boards: Zephyr's runner
+west flash                    # hardware: the runner declared by the board
+```
+
+`west flash` picks its runner from the board's own `board.cmake`; nano-ros adds
+nothing to it. Note that these are run against the west build directory, so
+they work from wherever you would normally run `west`.
+
+## ESP32
+
+Two different shapes, because there are two ways to build for an ESP32:
+
+**ESP-IDF component** (`idf.py` driver) — `nros build` runs `idf.py build` in
+the project directory, and the artifact is whatever ESP-IDF writes under that
+project's `build/`. The next step is Espressif's:
+
+```bash
+idf.py -p /dev/ttyUSB0 flash monitor
+```
+
+See [ESP32 (ESP-IDF component)](../getting-started/integration-esp-idf.md).
+
+**Rust bare-metal (esp-hal)** — these are standalone cargo leaves rather than
+`nros build` images, so the artifact is an ordinary cargo one: the ELF at
+`target/<triple>/<profile-dir>/<name>`. `espflash` turns it into a flash image
+or writes it to a board:
+
+```bash
+espflash flash --monitor target/riscv32imc-unknown-none-elf/release/talker
+espflash save-image --chip esp32c3 --flash-size 4mb --merge \
+    target/riscv32imc-unknown-none-elf/release/talker talker.bin
+```
+
+See [ESP32 (esp-hal)](../getting-started/esp32.md).
+
+## Finding it yourself
+
+When in doubt, ask the build what it is about to do. `--dry-run` prints the
+stages and the exact command, and performs no I/O:
+
+```bash
+nros build <image> --dry-run
+```
+
+The tool named in that command owns the output location, and its own
+documentation is the authority — which is the whole point of handing off rather
+than wrapping.
+
+For the generation side of this — which root file is written, why the entry is
+derived rather than hand-written, and what the coordinate directory holds — see
+[Images](../getting-started/workspace-entry-pkg.md#what-nros-build-generates).

--- a/book/src/user-guide/deployment.md
+++ b/book/src/user-guide/deployment.md
@@ -61,10 +61,18 @@ cmake -B build && cmake --build build   # C / C++ leaves
 For real hardware, deployment step becomes flash/load/monitor. For QEMU,
 deployment is launching simulator with correct network setup.
 
-There is no `nros deploy` / `nros build` / `nros run` verb — Phase 222
-removed those wrappers. `nros` is provisioner + codegen + metadata only;
-deployment runs on the **vendor's native tools**. The embedded deploy
-contract is a documented three-step sequence (per
+There is no `nros run`, no `nros flash` and no `nros deploy` verb, and none is
+planned: `nros build` ends at an artifact, and how that artifact is flashed or
+started is a property of the board and of your bench. Deployment runs on the
+**vendor's native tools**. See
+[What `nros build` Produces](build-artifacts.md) for where each target family's
+artifact lands and which of the vendor's commands takes it from there.
+
+(`nros build` itself *does* exist — RFC-0065 introduced it after Phase 222 had
+removed an earlier set of wrappers. It generates the root build file and the
+entry and hands off; it does not wrap running or flashing.)
+
+The embedded deploy contract is a documented three-step sequence (per
 [RFC-0003 §4](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0003-rtos-integration-pattern.md)):
 
 1. **Bake** — `nros codegen-system --bringup <pkg>` reads

--- a/book/src/user-guide/troubleshooting.md
+++ b/book/src/user-guide/troubleshooting.md
@@ -256,9 +256,19 @@ cargo build
 zenoh-pico submodule not found at /path/to/zenoh-pico. Run: git submodule update --init
 ```
 
-**Solution**:
+**Solution**: init that one submodule, scoped — **not** `--recursive`. The
+transitive closure is large and mostly irrelevant to any one task, and the
+launch toolchain's third-level runtime submodules are never built by nano-ros.
+
 ```bash
-git submodule update --init --recursive
+git submodule update --init packages/rmw/zenoh/zpico-sys/zenoh-pico
+```
+
+Better still, let provisioning do it — this is what `nros setup` is for, and it
+fetches shallow rather than deepening to reach the pin:
+
+```bash
+nros setup <board> --rmw zenoh      # or: nros setup --source zenoh-pico
 ```
 
 ### CMake Cache Stale

--- a/docs/development/ros2-on-non-ubuntu.md
+++ b/docs/development/ros2-on-non-ubuntu.md
@@ -92,11 +92,20 @@ The box is an ordinary Linux that happens to have ROS. Treat it as one:
 
 ```bash
 distrobox enter ros2
-git clone --recurse-submodules https://github.com/NEWSLabNTU/nano-ros
+git clone https://github.com/NEWSLabNTU/nano-ros      # NOT --recurse-submodules
 cd nano-ros
 . scripts/dev/ros2-box-env.sh      # gives this toolchain its own store
 just setup-cli && just ci gate
 ```
+
+**Never `--recurse-submodules`, here or anywhere** (RFC-0097 D10). The
+submodules are large and most are irrelevant to any one task, and a recursive
+clone also drags in `play_launch`'s layer-3 runtime submodules, which nano-ros
+never builds. `scripts/bootstrap.sh` initialises the one submodule the CLI build
+needs (`packages/cli/third-party/play_launch`), scoped — run it once if you use
+`just setup-cli`, which builds but does not init. Everything else comes from
+`nros setup --source <name>`, which fetches shallow (`--depth 1`) rather than
+deepening to reach a pin.
 
 **Never build on the host and run in the box**, and never mirror one tree into
 the other. Host and box differ in compiler and libc, nothing checks that shared

--- a/examples/templates/zephyr-byo/README.md
+++ b/examples/templates/zephyr-byo/README.md
@@ -29,23 +29,28 @@ siblings — Zephyr's standard layout.
 west init -m https://github.com/NEWSLabNTU/nano-ros-zephyr-example my-ws
 cd my-ws && west update              # clones Zephyr + nano-ros (NOT submodules)
 
-# 2. nano-ros CLI + provisioning (RMW host daemon + transport submodules)
-#    The `nros` CLI ships in-tree at `packages/cli/` (Phase 218); build it once.
-( cd modules/nano-ros && git submodule update --init packages/cli && just setup-cli )
-. modules/nano-ros/activate.sh                              # puts nros on PATH
+# 2. The `nros` CLI — INSTALL it, do not build it out of `modules/nano-ros`.
+#    This is your workspace, not a nano-ros checkout: `nros` is a tool you
+#    install once per machine, like `west` itself. See the book's Install page.
+curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh
+export PATH="${NROS_HOME:-$HOME/.nros}/bin:$PATH"           # if it says to
+
+# 3. Provisioning (RMW host daemon + transport sources). Run these from the
+#    nano-ros module: `nros setup` reads its index and scripts from the
+#    nano-ros source tree, which `west update` has already placed there.
 ( cd modules/nano-ros && nros setup zephyr --rmw zenoh )   # zenohd + zenoh-pico + mbedtls
 ( cd modules/nano-ros && nros setup --source px4-rs )      # workspace cargo-load dep
 
-# 3. Zephyr SDK — nros setup does NOT provide it; install the SDK the standard
+# 4. Zephyr SDK — nros setup does NOT provide it; install the SDK the standard
 #    Zephyr way and point ZEPHYR_SDK_INSTALL_DIR at it (or register it):
 export ZEPHYR_SDK_INSTALL_DIR=/path/to/zephyr-sdk-0.16.8
 
-# 4. Patches into YOUR workspace (Zephyr 4.x: `west patch apply` instead)
+# 5. Patches into YOUR workspace (Zephyr 4.x: `west patch apply` instead)
 for p in nsos-recvmsg-patch native-sim-ipproto-ip-patch nsos-adapt-ipproto-ip-patch; do
     bash modules/nano-ros/scripts/zephyr/$p.sh "$PWD"
 done
 
-# 5. Build + run. The C codegen resolves std_msgs's .msg via NROS_STD_MSGS_DIR
+# 6. Build + run. The C codegen resolves std_msgs's .msg via NROS_STD_MSGS_DIR
 #    (a ROS install, or any dir with std_msgs/msg/*.msg). The app lives at
 #    nano-ros-app/app (the manifest repo's self.path), NOT ./app.
 export NROS_STD_MSGS_DIR=/opt/ros/humble/share/std_msgs
@@ -57,7 +62,17 @@ ZENOH_CONFIG_OVERRIDE='listen/endpoints=["tcp/127.0.0.1:7456"];scouting/multicas
 
 `nros` on PATH is auto-resolved as the codegen tool. A real board (e.g.
 `qemu_cortex_a9`) swaps `-b`, the SDK target, and drops the native_sim overlay;
-see the book. **This exact flow is e2e-verified** (build → `Published: 1`).
+see the book.
+
+> **No nano-ros release has been cut yet**, so `install.sh` will tell you so and
+> point you at the book's
+> [Install](https://github.com/NEWSLabNTU/nano-ros/blob/main/book/src/getting-started/installation.md)
+> page. Until one exists, the way to obtain `nros` is a *separate* nano-ros
+> checkout with `./scripts/bootstrap.sh` — separate on purpose: a nano-ros
+> checkout's own build is only correct against that checkout (RFC-0090), and
+> `modules/nano-ros` is a west module of *your* workspace, not a development
+> tree. Building the CLI out of it is a contributor's workflow in a user's
+> project, and this template used to say to do exactly that.
 
 ## Notes
 

--- a/examples/workspaces/c/README.md
+++ b/examples/workspaces/c/README.md
@@ -18,6 +18,7 @@ From the repository root:
 source ./activate.sh
 cd examples/workspaces/c
 nros setup native
+nros sync            # once per workspace: generated message bindings
 nros build native
 ```
 
@@ -25,5 +26,7 @@ nros build native
 toolchain, generates what the build system needs, and hands off to
 cargo/cmake/west — so compiler errors are the compiler's, unchanged
 (RFC-0065). `nros build` with no image lists what this workspace
-declares. The old `nros sync` / `codegen-system` / `check` sequence
-still works; it is just no longer something you have to type.
+declares. The old `codegen-system` / `check` steps still work; they are
+just no longer something you have to type — but `nros sync` still is.
+A workspace that has never been synced has no generated message crates,
+so `nros build` refuses at preflight and names `nros sync` as the remedy.

--- a/examples/workspaces/cpp/README.md
+++ b/examples/workspaces/cpp/README.md
@@ -18,6 +18,7 @@ From the repository root:
 source ./activate.sh
 cd examples/workspaces/cpp
 nros setup native
+nros sync            # once per workspace: generated message bindings
 nros build native
 ```
 
@@ -25,5 +26,7 @@ nros build native
 toolchain, generates what the build system needs, and hands off to
 cargo/cmake/west — so compiler errors are the compiler's, unchanged
 (RFC-0065). `nros build` with no image lists what this workspace
-declares. The old `nros sync` / `codegen-system` / `check` sequence
-still works; it is just no longer something you have to type.
+declares. The old `codegen-system` / `check` steps still work; they are
+just no longer something you have to type — but `nros sync` still is.
+A workspace that has never been synced has no generated message crates,
+so `nros build` refuses at preflight and names `nros sync` as the remedy.

--- a/examples/workspaces/mixed/README.md
+++ b/examples/workspaces/mixed/README.md
@@ -20,6 +20,7 @@ From the repository root:
 source ./activate.sh
 cd examples/workspaces/mixed
 nros setup native
+nros sync            # once per workspace: generated message bindings
 nros build native
 ```
 
@@ -27,5 +28,7 @@ nros build native
 toolchain, generates what the build system needs, and hands off to
 cargo/cmake/west — so compiler errors are the compiler's, unchanged
 (RFC-0065). `nros build` with no image lists what this workspace
-declares. The old `nros sync` / `codegen-system` / `check` sequence
-still works; it is just no longer something you have to type.
+declares. The old `codegen-system` / `check` steps still work; they are
+just no longer something you have to type — but `nros sync` still is.
+A workspace that has never been synced has no generated message crates,
+so `nros build` refuses at preflight and names `nros sync` as the remedy.

--- a/examples/workspaces/rust/README.md
+++ b/examples/workspaces/rust/README.md
@@ -21,6 +21,7 @@ From the repository root:
 source ./activate.sh
 cd examples/workspaces/rust
 nros setup native
+nros sync            # once per workspace: generated message bindings
 nros build native
 ```
 
@@ -28,8 +29,10 @@ nros build native
 toolchain, generates what the build system needs, and hands off to
 cargo/cmake/west — so compiler errors are the compiler's, unchanged
 (RFC-0065). `nros build` with no image lists what this workspace
-declares. The old `nros sync` / `codegen-system` / `check` sequence
-still works; it is just no longer something you have to type.
+declares. The old `codegen-system` / `check` steps still work; they are
+just no longer something you have to type — but `nros sync` still is.
+A workspace that has never been synced has no generated message crates,
+so `nros build` refuses at preflight and names `nros sync` as the remedy.
 
 Run the native entry with a Zenoh router available:
 

--- a/packages/api/nros-c/docs/troubleshooting.md
+++ b/packages/api/nros-c/docs/troubleshooting.md
@@ -35,12 +35,17 @@ zenoh-pico and zenohd must be the same version. Symptoms:
 `z_publisher_put failed: -100` (`_Z_ERR_TRANSPORT_TX_FAILED`) followed
 by `-73` (`_Z_ERR_SESSION_CLOSED`).
 
-Build zenohd from the pinned submodule (`just build-zenohd`) or install
-the matching version.
+The router is the one ROS ships: `ros2 run rmw_zenoh_cpp rmw_zenohd`.
+nano-ros vendors none (RFC-0075), and the old `just build-zenohd` recipe
+was retired with the vendored copy.
 
 ## Build Issues
 
-- **Submodule not found** — run `git submodule update --init --recursive`
+- **Submodule not found** — init that ONE submodule, scoped:
+  `git submodule update --init packages/rmw/zenoh/zpico-sys/zenoh-pico`.
+  Never `--recursive` on nano-ros — the transitive closure is large and
+  mostly irrelevant to any one task. `nros setup <board> --rmw zenoh`
+  provisions it for you, shallow, and is the preferred route.
 - **CMake cache stale** (changed env vars not taking effect) — delete
   `CMakeCache.txt` and rebuild. For Cargo-based builds, run
   `cargo clean -p zpico-sys` then rebuild.

--- a/packages/api/nros-cpp/docs/troubleshooting.md
+++ b/packages/api/nros-cpp/docs/troubleshooting.md
@@ -32,12 +32,17 @@ zenoh-pico and zenohd must be the same version. Symptoms:
 `z_publisher_put failed: -100` (`_Z_ERR_TRANSPORT_TX_FAILED`) followed
 by `-73` (`_Z_ERR_SESSION_CLOSED`).
 
-Build zenohd from the pinned submodule (`just build-zenohd`) or install
-the matching version.
+The router is the one ROS ships: `ros2 run rmw_zenoh_cpp rmw_zenohd`.
+nano-ros vendors none (RFC-0075), and the old `just build-zenohd` recipe
+was retired with the vendored copy.
 
 ## Build Issues
 
-- **Submodule not found** — run `git submodule update --init --recursive`
+- **Submodule not found** — init that ONE submodule, scoped:
+  `git submodule update --init packages/rmw/zenoh/zpico-sys/zenoh-pico`.
+  Never `--recursive` on nano-ros — the transitive closure is large and
+  mostly irrelevant to any one task. `nros setup <board> --rmw zenoh`
+  provisions it for you, shallow, and is the preferred route.
 - **CMake cache stale** — delete `CMakeCache.txt` and rebuild. For
   Cargo-based builds, run `cargo clean -p zpico-sys` then rebuild.
 - **`NROS_PUBLISHER_SIZE` undefined** — the build did not run the

--- a/packages/api/nros/src/guide/troubleshooting.rs
+++ b/packages/api/nros/src/guide/troubleshooting.rs
@@ -27,12 +27,17 @@
 //! `z_publisher_put failed: -100` (`_Z_ERR_TRANSPORT_TX_FAILED`) followed
 //! by `-73` (`_Z_ERR_SESSION_CLOSED`).
 //!
-//! Build zenohd from the pinned submodule (`just build-zenohd`) or install
-//! the matching version.
+//! The router is the one ROS ships: `ros2 run rmw_zenoh_cpp rmw_zenohd`.
+//! nano-ros vendors none (RFC-0075), and the old `just build-zenohd` recipe
+//! was retired with the vendored copy.
 //!
 //! ## Build issues
 //!
-//! - **Submodule not found** — run `git submodule update --init --recursive`
+//! - **Submodule not found** — init that ONE submodule, scoped:
+//!   `git submodule update --init packages/rmw/zenoh/zpico-sys/zenoh-pico`.
+//!   Never `--recursive` on nano-ros — the transitive closure is large and
+//!   mostly irrelevant to any one task. `nros setup <board> --rmw zenoh`
+//!   provisions it for you, shallow, and is the preferred route.
 //! - **CMake cache stale** (changed env vars not taking effect) — run
 //!   `cargo clean -p zpico-sys` then rebuild
 //!

--- a/packages/cli/cargo-nano-ros/README.md
+++ b/packages/cli/cargo-nano-ros/README.md
@@ -3,8 +3,11 @@
 Shared codegen library for [nano-ros](https://github.com/NEWSLabNTU/nano-ros) message generation. The canonical user CLI is `nros`, built from the `nros-cli` crate in this repo.
 
 > **Not published.** This crate is `publish = false`; there is no
-> `cargo install`. Build the CLI from a nano-ros checkout with `just setup-cli`,
-> then `source activate.sh` to put `nros` on `PATH`.
+> `cargo install`. To *use* nano-ros, install an `nros` release
+> (`scripts/install.sh`); to *develop* nano-ros, build the CLI from the checkout
+> with `./scripts/bootstrap.sh`, then `source activate.sh` to put `nros` on
+> `PATH`. See [`nros-cli/README.md`](../nros-cli/README.md) for why the two
+> paths are not interchangeable.
 
 ```bash
 nros generate-rust --force

--- a/packages/cli/nros-cli-core/README.md
+++ b/packages/cli/nros-cli-core/README.md
@@ -1,9 +1,11 @@
 # nros-cli-core
 
-Library backing the canonical [`nros` CLI](../nros-cli/). Contains the subcommand dispatch, project scaffolder, config inspector, build / run / doctor wrappers, codegen commands, and shell-completion generator.
+Library backing the canonical [`nros` CLI](../nros-cli/). Contains the subcommand dispatch, project scaffolder, config inspector, the `build` driver and the `doctor` health check, codegen commands, and shell-completion generator. (There is no `run` verb: `nros build` ends at an artifact — see [What `nros build` Produces](../../../book/src/user-guide/build-artifacts.md).)
 
 > **Not published.** This crate is `publish = false` and is not on crates.io.
-> Build the CLI from a nano-ros checkout with `just setup-cli`.
+> To *use* nano-ros, install an `nros` release (`scripts/install.sh`); to
+> *develop* nano-ros, build the CLI from the checkout with
+> `./scripts/bootstrap.sh`. See [`nros-cli/README.md`](../nros-cli/README.md).
 
 ## License
 

--- a/packages/cli/nros-cli/README.md
+++ b/packages/cli/nros-cli/README.md
@@ -3,15 +3,27 @@
 The `nros` command-line tool — the user-facing entry point to [nano-ros](https://github.com/NEWSLabNTU/nano-ros).
 
 > **Not published.** This crate is `publish = false`; there is no
-> `cargo install nros-cli` and no crates.io release. Build it from a nano-ros
-> checkout — `just setup-cli` produces `packages/cli/target/release/nros`, and
-> `source activate.sh` puts it on `PATH`. A *globally* installed `nros` shadowing
-> the tree's own binary is a known footgun; see
+> `cargo install nros-cli` and no crates.io release. How you get `nros` depends
+> on which side of it you are on:
+>
+> | you are… | you get `nros` by… |
+> | --- | --- |
+> | **using** nano-ros to build your own project | installing a release: `curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh \| sh` |
+> | **developing** nano-ros itself | building it from the checkout: `./scripts/bootstrap.sh` (`just setup-cli` is the internal alias, and does not init the CLI submodule) |
+>
+> That is not a preference: inside a checkout the tree's own build is the only
+> correct binary, because a released `nros` emits code that this tree's runtime
+> would have to compile
+> ([RFC-0090](../../../docs/design/0090-codegen-version-is-the-compatibility-token.md)).
+> No release has been cut yet, so today everyone takes the second row —
+> `install.sh` says so if you run it early. A *globally* installed `nros`
+> shadowing the tree's own binary is a known footgun; see
 > [`book/src/internals/cli-in-monorepo.md`](../../../book/src/internals/cli-in-monorepo.md).
 
 ```bash
+# Contributor path (the one that works today):
 git clone https://github.com/NEWSLabNTU/nano-ros && cd nano-ros
-just setup-cli && source activate.sh
+./scripts/bootstrap.sh && source activate.sh
 
 nros new my-project --platform freertos --rmw zenoh --lang c talker
 nros generate rust


### PR DESCRIPTION
phase-443 W6 — RFC-0097 **D8** (the product is binaries; running them is the user's, and is documented) and **D10** (never `--recurse-submodules`, for contributors either).

*Note on numbering:* the task named these D11/D12; on `work/rfc-0097-release-composition` as fetched, the decisions with that content are **D8**, **D9** and **D10** (D11/D12 there are the CI-pin and `setup --check` decisions). Implemented against the content, not the number.

## 1. What `nros build` produces (D8)

`nros build` ends at an artifact and stops — no `nros run`, no `nros flash`, and none should be added. What was missing was the documentation: a user finishing a build had nothing telling them what they were holding.

New page **`book/src/user-guide/build-artifacts.md`** (nav entry beside *Build Profiles*), per target family, **measured** rather than derived:

| driver | artifact | how it was verified |
| --- | --- | --- |
| cargo | `<ws>/target/[<triple>/]<profile>/<image>_entry` | `nros build` passes no `--target-dir` (read from `cmd/build.rs`), so cargo's default applies; `nros profile dir dev` → `debug` |
| cmake | `<ws>/build/<coordinate>/cmake/<image>_entry` | real build trees in `examples/workspaces/c` — `posix-zenoh-native/cmake/native_entry`, `freertos-zenoh-mps2-an385-freertos/cmake/freertos_entry` (`file` → `ELF 32-bit LSB, ARM, statically linked`) |
| west | `<ws>/build/zephyr/zephyr.{elf,exe,bin,map}` | 91 in-tree west build dirs — `.exe` on native_sim, `.bin` on cortex-m |
| idf.py | ESP-IDF's own `build/`, then `idf.py -p <port> flash monitor` | the in-tree ESP-IDF page; **not** measured here (no in-tree `idf.py` build), and the page does not assert filenames |

Each family's next step is quoted as **the board's own tooling** (`west flash`, `west build -t run`, `espflash`, run it directly), never as something nano-ros wraps.

`deployment.md` claimed *"there is no `nros deploy` / `nros build` / `nros run` verb — Phase 222 removed those wrappers."* RFC-0065 reintroduced `nros build`, so that line was false; corrected and cross-linked.

## 2. Templates that teach the checkout model (D10)

* **`examples/templates/zephyr-byo/README.md`** — the named offender. Said `git submodule update --init packages/cli && just setup-cli` inside a *user's own west workspace*. Now installs `nros` via `scripts/install.sh`, and says why `modules/nano-ros` is not a place to build a CLI (RFC-0090). The page's *"this exact flow is e2e-verified"* claim is **withdrawn for the step that changed** rather than left standing over edited text.
* **Three CLI crate READMEs** (`nros-cli`, `cargo-nano-ros`, `nros-cli-core`) routed users through `just setup-cli` with no release path; they carry the user/contributor split now, as `packages/cli/README.md` already did.
* **Four copies of one recursive-init defect** — `book/src/user-guide/troubleshooting.md`, `packages/api/nros-c/docs/troubleshooting.md`, `packages/api/nros-cpp/docs/troubleshooting.md`, and the rustdoc twin `packages/api/nros/src/guide/troubleshooting.rs` — all said `git submodule update --init --recursive` on nano-ros. Scoped now, to the one submodule the symptom names; zpico-sys's own panic already spells it that way. The same three also still said `just build-zenohd`, retired with the vendored router (RFC-0075). `docs/development/ros2-on-non-ubuntu.md` was the contributor half of the same rule (`git clone --recurse-submodules`).

## 3. The `nros sync` sequencing is the OPPOSITE of stale — measured

The task's premise was that "run `nros sync`, then `nros build`" is stale because sync is merged into build. **It is not, on this tree.** Measured on a fresh copy of `examples/templates/multi-node-workspace` with `generated/` and `build/` removed:

```
$ nros build --dry-run
Error: missing prerequisites for this build:
  - generated message bindings (this workspace has never been synced)
      run: nros sync
```

`builder::preflight::check` raises it at stage 3, and no build path calls `cmd::ws::run_sync`. So the **false** claims were the ones saying sync is subsumed — `workspace-cpp.md` ("`nros build` runs `nros sync` for you"), `workspace-bringup.md`, and the four `examples/workspaces/*/README.md` ("no longer something you have to type"). Those are corrected to name `nros sync` as a once-per-workspace step. **RFC-0097 D9 remains a decision, not a landed fact** — no doc here claims otherwise.

## Verification

* `just book` — **builds green**; the new page and both cross-page anchors (`#what-nros-build-generates`, `#do-i-need-ros-2-installed`) confirmed present in `book/book/`.
* `just check fast` — **288/288**, 2 skipped for unprovisioned trees (`ivc-fsp`, two nuttx-ffi leaves), both unrelated.
* `cargo +nightly fmt --check -p nros` clean (the one `.rs` file touched is doc-comment only).

Sweep command for the class: `git grep -n -- '--recursive\|--recurse-submodules'` and `git grep -n 'setup-cli'` over `examples/`, `book/src/`, `packages/**/*.md`.

Does **not** touch `docs/roadmap/phase-443-release-composition.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
