### PR TITLE
feat(phase-443 W1+W5, RFC-0097): the index leaves the binary, and `setup --check` covers the build stage

### DIFF
--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -1318,6 +1318,20 @@ packages = ["arm-none-eabi-gcc", "qemu", "freertos-kernel", "lwip"]
 # third-party/ros/rosidl/rosidl_adapter/scripts as its last ladder rung
 # (env override and /opt/ros still win). Python deps ride [python.*]:
 # catkin-pkg, empy (PINNED 3.3.4 — empy 4 breaks rosidl templates), lark.
+#
+# RFC-0097 D12 — `build_stage = true`: a TARGET BUILD pulls this in, not a
+# board. `nros setup <board>` resolves the board's packages plus the chosen
+# rmw's, and the rmw DEFAULTS to zenoh, so a plain board setup never reaches
+# `[rmw.cyclonedds]` and never provisions this. A host with no ROS therefore
+# met it as a BUILD FAILURE, mid-compile. `nros setup --check` reports it now.
+#
+# `check` is the OTHER rung of msg_to_cyclone_idl.py's ladder: a host with ROS
+# sourced (or an explicit override) needs nothing provisioned, and reporting it
+# MISSING there would exit `--check` nonzero on a correctly configured host.
+# `python_import`, not `runs`: `runs` splits on whitespace and spawns directly,
+# so `python3 -c 'import rosidl_adapter'` cannot be written as one. And not a
+# `path` probe either — the directory existing is a PROXY, being importable is
+# the property, which is the distinction the script itself refuses on.
 version = "humble-5621b26"
 git = "https://github.com/ros2/rosidl"
 ref = "5621b26eff54596a356ad8abd72c06e7650d21f7"
@@ -1332,6 +1346,8 @@ ref = "5621b26eff54596a356ad8abd72c06e7650d21f7"
 # derived, and leaving an authored one would be a second spelling of a location
 # the store already knows.
 location = "store"
+build_stage = true
+check = { python_import = "rosidl_adapter", env = "NROS_ROSIDL_ADAPTER_BIN_DIR" }
 
 # --- OS packages (phase-327 W1, RFC-0062) -----------------------------------
 #

--- a/packages/cli/nros-cli-core/src/cmd/doctor.rs
+++ b/packages/cli/nros-cli-core/src/cmd/doctor.rs
@@ -95,6 +95,169 @@ fn report_legacy_unversioned_installs() {
     }
 }
 
+/// RFC-0097 D12 — with no workspace to scope it to, `nros doctor` verifies the
+/// INSTALL: **launcher, store, pin resolution**.
+///
+/// Before this, a `doctor` that could not auto-detect a nano-ros workspace
+/// simply failed — so the one user who most needs a health check, the one who
+/// has just run `install.sh` and has nothing to point it at, was the one user
+/// it refused to answer. "Where is my store, did the launcher land, and does
+/// the pin in this directory resolve" is a question that needs no workspace at
+/// all.
+///
+/// Every input is a PARAMETER, so this is testable against a constructed store
+/// without a test mutating `$NROS_HOME`/`$NROS_STORE` (which in this crate is a
+/// cross-thread race — `tests/store_reclaim.rs`).
+///
+/// Exactly ONE thing here counts as a problem: **a pin naming a nano-ros this
+/// store cannot produce**, which is a project that cannot be built. An absent
+/// store, an unfronted launcher and a binary that is not a store toolchain are
+/// all legitimate states — a contributor running the tree's own build has all
+/// three — and a doctor that fails on a working setup is a doctor people learn
+/// to ignore.
+fn install_report(store: &Path, exe: &Path, cwd: &Path) -> (Vec<String>, usize) {
+    use crate::orchestration::{dispatch, pin, store as store_mod};
+
+    let mut lines = Vec::new();
+    let mut problems = 0usize;
+
+    // --- the store ---------------------------------------------------------
+    if store.is_dir() {
+        let entries = store_mod::scan(store);
+        let bytes: u64 = entries.iter().map(|e| e.size_bytes).sum();
+        lines.push(format!(
+            "  [OK] store      {} ({}, {} entr{})",
+            store.display(),
+            store_mod::format_size(bytes),
+            entries.len(),
+            if entries.len() == 1 { "y" } else { "ies" }
+        ));
+    } else {
+        // Not a problem: a contributor building in the checkout has no store,
+        // and telling them to make one would be wrong.
+        lines.push(format!(
+            "  [--] store      {} does not exist yet — nothing has been provisioned here",
+            store.display()
+        ));
+    }
+
+    // --- the launcher ------------------------------------------------------
+    //
+    // `<store>/bin/nros` is what `install.sh` fronts and what a user's PATH
+    // points at. Reported separately from "am I a store toolchain", because
+    // those come apart in both directions: a contributor's in-tree build is not
+    // a store toolchain and needs no front, while a front pointing at nothing
+    // is an install that half happened.
+    let front = store.join("bin").join("nros");
+    if front.exists() {
+        lines.push(format!("  [OK] launcher   {}", front.display()));
+    } else {
+        lines.push(format!(
+            "  [--] launcher   no {} — install with `curl -fsSL <install.sh> | sh`, \
+             or use a checkout's own build",
+            front.display()
+        ));
+    }
+    match pin::running_version(exe) {
+        Some((v, origin)) => lines.push(format!(
+            "  [OK] running    nano-ros {v} (from the {})",
+            origin.label()
+        )),
+        None => lines.push(format!(
+            "  [--] running    {} is not a store toolchain (a checkout build, or an \
+             unpacked prefix) — it will never dispatch",
+            exe.display()
+        )),
+    }
+
+    // --- pin resolution ----------------------------------------------------
+    //
+    // Asked DIRECTLY, not via `dispatch::decide`. An earlier draft read the
+    // launcher's verdict and counted `Decision::Missing` as the problem, and
+    // an end-to-end run showed that arm is unreachable: if this binary IS a
+    // store toolchain, `redispatch()` has already met the missing version in
+    // `main` and failed before `doctor` parsed anything; and if it is NOT one,
+    // `decide` returns `Proceed("not a launcher")` at rung 4 without ever
+    // looking at the pin. So the verdict a doctor could reuse is exactly the
+    // one it can never see — and the CHECKOUT BUILD case, which is most of
+    // them, learned nothing about whether its project's pin is satisfiable.
+    match pin::find_and_load(cwd) {
+        Err(e) => {
+            problems += 1;
+            lines.push(format!(
+                "  [!!] pin        present but unreadable: {e:#}\n\
+                 \x20              a pin that cannot be parsed is not a floating project, \
+                 it is an unreadable one"
+            ));
+        }
+        Ok(None) => lines.push(
+            "  [--] pin        this project names no toolchain — the build floats \
+             (`nros build` writes one on its first run)"
+                .to_string(),
+        ),
+        Ok(Some(p)) => {
+            let running = pin::running_version(exe).map(|(v, _)| v);
+            if let Some(bin) = pin::installed_bin(store, &p.version) {
+                lines.push(format!(
+                    "  [OK] pin        {} names nano-ros {} → {}",
+                    p.path.display(),
+                    p.version,
+                    bin.display()
+                ));
+            } else if running.as_deref() == Some(p.version.as_str()) {
+                lines.push(format!(
+                    "  [OK] pin        {} names nano-ros {}, which is what is running here",
+                    p.path.display(),
+                    p.version
+                ));
+            } else {
+                problems += 1;
+                lines.push(format!(
+                    "  [!!] pin        {} names nano-ros {}, which is not in this store\n\
+                     \x20              looked in: {}\n\
+                     \x20              install it:  curl -fsSL <install.sh> | sh -s -- --version {}",
+                    p.path.display(),
+                    p.version,
+                    pin::candidate_bins(store, &p.version)
+                        .iter()
+                        .map(|b| b.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    p.version
+                ));
+            }
+        }
+    }
+
+    // --- what the launcher would do ----------------------------------------
+    //
+    // Informational, never a problem: it is `dispatch::decide` itself, so this
+    // line cannot disagree with the launcher about what will happen next — the
+    // rung above says whether the pin CAN be satisfied, this one says whether
+    // this process will hand over.
+    match dispatch::decide(&dispatch::Context {
+        exe: exe.to_path_buf(),
+        cwd: cwd.to_path_buf(),
+        store: store.to_path_buf(),
+        dispatched: std::env::var(dispatch::DISPATCHED_ENV).ok(),
+        skip: std::env::var_os(dispatch::SKIP_ENV).is_some(),
+    }) {
+        Ok(dispatch::Decision::Proceed(why)) => {
+            lines.push(format!("  [--] dispatch   stays in this process — {why}"));
+        }
+        Ok(dispatch::Decision::Exec { version, bin }) => lines.push(format!(
+            "  [OK] dispatch   would exec nano-ros {version} at {}",
+            bin.display()
+        )),
+        Ok(dispatch::Decision::Missing { version, .. }) => lines.push(format!(
+            "  [--] dispatch   would install nano-ros {version} first"
+        )),
+        Err(e) => lines.push(format!("  [--] dispatch   undecidable: {e:#}")),
+    }
+
+    (lines, problems)
+}
+
 pub fn run(args: Args) -> Result<()> {
     report_legacy_unversioned_installs();
 
@@ -130,22 +293,44 @@ pub fn run(args: Args) -> Result<()> {
                 );
                 None
             }
-            Err(e) => {
-                return Err(e).wrap_err(
-                    "could not auto-detect the nano-ros workspace root; \
-                     pass --workspace <path> explicitly",
-                );
-            }
+            // RFC-0097 D12 — no workspace is not a failure, it is a different
+            // QUESTION. A user who has just run `install.sh` has no workspace
+            // to point this at, and refusing them was refusing the only person
+            // who needed the answer.
+            Err(_) => None,
         },
     };
 
-    if let Some(root) = root {
-        run_just_doctor(&root, args.platform.as_deref())?;
-    }
+    let install_problems = match &root {
+        Some(root) => {
+            run_just_doctor(root, args.platform.as_deref())?;
+            0
+        }
+        None => {
+            eprintln!("nros doctor: no nano-ros workspace here — checking the INSTALL instead");
+            let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("nros"));
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            let store = crate::orchestration::store::root();
+            eprintln!(
+                "nros doctor: store root {} (from {})",
+                store.display(),
+                crate::orchestration::store::root_origin()
+            );
+            let (lines, problems) = install_report(&store, &exe, &cwd);
+            for line in lines {
+                eprintln!("{line}");
+            }
+            eprintln!(
+                "  (point it at a workspace with `--workspace <path>` for the \
+                 per-platform checks)"
+            );
+            problems
+        }
+    };
 
-    let problems = deploy_problems.unwrap_or(0) + gate_problems;
+    let problems = deploy_problems.unwrap_or(0) + gate_problems + install_problems;
     if problems > 0 {
-        bail!("nros doctor: {problems} problem(s) (images + license gates)");
+        bail!("nros doctor: {problems} problem(s) (images + license gates + install)");
     }
     Ok(())
 }
@@ -496,6 +681,155 @@ fn is_executable(path: &Path) -> bool {
 #[cfg(not(unix))]
 fn is_executable(path: &Path) -> bool {
     path.is_file()
+}
+
+#[cfg(test)]
+mod install_report_tests {
+    use super::*;
+    use crate::orchestration::{dispatch, pin};
+
+    /// A store entry shaped like one `scripts/install.sh` writes.
+    fn install_toolchain(store: &Path, version: &str) -> PathBuf {
+        let bin = store.join("sdk").join("nros").join(version).join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let exe = bin.join("nros");
+        std::fs::write(&exe, b"#!/bin/sh\nexit 0\n").unwrap();
+        exe
+    }
+
+    /// A user's project directory — deliberately NOT inside a checkout, which
+    /// a tempdir root guarantees (`dispatch::decide` proceeds unconditionally
+    /// inside one, so a checkout would make every pin assertion vacuous).
+    fn project(dir: &Path, rel: &str, pin_version: Option<&str>) -> PathBuf {
+        let p = dir.join(rel);
+        std::fs::create_dir_all(&p).unwrap();
+        if let Some(v) = pin_version {
+            pin::write(&p, v).unwrap();
+        }
+        p
+    }
+
+    /// `install_report` asks `dispatch::decide`, which reads these two names
+    /// off the process env. Neither is ever set in a test run; assert it rather
+    /// than let a stray export make the pin assertions vacuous.
+    fn assert_dispatch_env_clean() {
+        for v in [dispatch::DISPATCHED_ENV, dispatch::SKIP_ENV] {
+            assert!(
+                std::env::var_os(v).is_none(),
+                "${v} is set — it would short-circuit the launcher decision \
+                 this test is about"
+            );
+        }
+    }
+
+    /// The D12 acceptance: `nros doctor` with NO workspace answers about the
+    /// INSTALL — launcher, store, pin resolution.
+    ///
+    /// Measured before this landed, from an empty directory:
+    /// `Error: could not auto-detect the nano-ros workspace root; pass
+    /// --workspace <path> explicitly`. A user who has just run `install.sh` has
+    /// no workspace to pass, so the one person who needed the answer was the
+    /// one person refused it.
+    #[test]
+    fn with_no_workspace_the_report_covers_launcher_store_and_pin() {
+        assert_dispatch_env_clean();
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let exe = install_toolchain(&store, "0.7.9");
+        std::fs::create_dir_all(store.join("bin")).unwrap();
+        std::fs::write(store.join("bin").join("nros"), b"#!/bin/sh\n").unwrap();
+        let cwd = project(tmp.path(), "proj", None);
+
+        let (lines, problems) = install_report(&store, &exe, &cwd);
+        assert_eq!(problems, 0, "a healthy install has no problems:\n{lines:#?}");
+        let text = lines.join("\n");
+        for needle in ["store", "launcher", "running", "pin"] {
+            assert!(
+                text.contains(needle),
+                "the install report must cover `{needle}`:\n{text}"
+            );
+        }
+        assert!(
+            text.contains(&store.display().to_string()),
+            "the report must name the store it looked at:\n{text}"
+        );
+        assert!(
+            text.contains("0.7.9"),
+            "the report must name the version that is running:\n{text}"
+        );
+    }
+
+    /// The one PROBLEM this report counts: a project pins a nano-ros the store
+    /// cannot produce. That is a project which cannot be built, and it is
+    /// exactly what a fresh user hits after cloning someone else's repo.
+    #[test]
+    fn a_pin_naming_an_uninstalled_toolchain_is_the_problem_it_counts() {
+        assert_dispatch_env_clean();
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let exe = install_toolchain(&store, "0.7.9");
+        let cwd = project(tmp.path(), "proj", Some("0.9.9"));
+
+        let (lines, problems) = install_report(&store, &exe, &cwd);
+        assert_eq!(problems, 1, "the unresolvable pin must count:\n{lines:#?}");
+        let text = lines.join("\n");
+        assert!(text.contains("0.9.9"), "name the version wanted:\n{text}");
+        assert!(
+            text.contains(&cwd.join(pin::FILE_NAME).display().to_string()),
+            "name the pin file that asked for it:\n{text}"
+        );
+        assert!(
+            text.contains("install"),
+            "a problem must carry a remedy:\n{text}"
+        );
+    }
+
+    /// A pin the store CAN satisfy is not a problem, and the report says which
+    /// binary would run. The verdict comes from `dispatch::decide`, so this
+    /// also pins that the doctor and the launcher cannot disagree.
+    #[test]
+    fn a_resolvable_pin_names_the_binary_the_launcher_would_exec() {
+        assert_dispatch_env_clean();
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let exe = install_toolchain(&store, "0.7.9");
+        let other = install_toolchain(&store, "0.9.9");
+        let cwd = project(tmp.path(), "proj", Some("0.9.9"));
+
+        let (lines, problems) = install_report(&store, &exe, &cwd);
+        assert_eq!(problems, 0, "{lines:#?}");
+        assert!(
+            lines.join("\n").contains(&other.display().to_string()),
+            "the report must name the binary the pin resolves to:\n{}",
+            lines.join("\n")
+        );
+    }
+
+    /// An empty store is a legitimate state — a contributor building the
+    /// tree's own CLI has neither store nor front — so it is REPORTED and not
+    /// counted. A doctor that fails on a working setup gets ignored.
+    #[test]
+    fn an_absent_store_is_reported_and_is_not_a_problem() {
+        assert_dispatch_env_clean();
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("no-store-here");
+        let exe = tmp.path().join("checkout").join("target/release/nros");
+        std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        let cwd = project(tmp.path(), "proj", None);
+
+        let (lines, problems) = install_report(&store, &exe, &cwd);
+        assert_eq!(problems, 0, "{lines:#?}");
+        let text = lines.join("\n");
+        assert!(
+            text.contains("does not exist yet"),
+            "an absent store must be SAID, not silently skipped:\n{text}"
+        );
+        assert!(
+            text.contains("not a store toolchain"),
+            "a checkout build must be named as such:\n{text}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/cli/nros-cli-core/src/cmd/doctor.rs
+++ b/packages/cli/nros-cli-core/src/cmd/doctor.rs
@@ -741,7 +741,10 @@ mod install_report_tests {
         let cwd = project(tmp.path(), "proj", None);
 
         let (lines, problems) = install_report(&store, &exe, &cwd);
-        assert_eq!(problems, 0, "a healthy install has no problems:\n{lines:#?}");
+        assert_eq!(
+            problems, 0,
+            "a healthy install has no problems:\n{lines:#?}"
+        );
         let text = lines.join("\n");
         for needle in ["store", "launcher", "running", "pin"] {
             assert!(

--- a/packages/cli/nros-cli-core/src/cmd/sdk_front.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sdk_front.rs
@@ -45,7 +45,7 @@ pub struct Args {
 
 pub fn run(args: Args) -> Result<()> {
     let front = if args.front.is_empty() {
-        let index = SdkIndex::load(&crate::cmd::setup::resolve_index(&args.index))?;
+        let index = SdkIndex::load(&crate::cmd::setup::resolve_index(&args.index)?)?;
         let Some(tool) = index.tool.get(&args.tool) else {
             let known: Vec<&str> = index.tool.keys().map(String::as_str).collect();
             bail!(

--- a/packages/cli/nros-cli-core/src/cmd/sdk_path.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sdk_path.rs
@@ -58,7 +58,7 @@ pub struct Args {
 }
 
 pub fn run(args: Args) -> Result<()> {
-    let index = SdkIndex::load(&crate::cmd::setup::resolve_index(&args.index))?;
+    let index = SdkIndex::load(&crate::cmd::setup::resolve_index(&args.index)?)?;
 
     if args.source {
         return run_source(&index, &args);

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -213,7 +213,7 @@ pub fn run(args: Args) -> Result<()> {
         };
     }
 
-    let index_path = resolve_index(&args.index);
+    let index_path = resolve_index(&args.index)?;
     let index = SdkIndex::load(&index_path)?;
     let host = host_key();
 
@@ -286,7 +286,7 @@ pub fn run(args: Args) -> Result<()> {
         if let Some(notice) = check_board_argument(&index, args.board.as_deref())? {
             eprintln!("{notice}");
         }
-        return run_check_all(&index);
+        return run_check_all(&index, &index_workspace(&index_path));
     }
 
     if let Some(tool) = args.tool.as_deref() {
@@ -947,6 +947,56 @@ pub(crate) fn source_dir_of(
     }
 }
 
+/// RFC-0097 D12 — what a TARGET BUILD will need that no board provisions.
+///
+/// `nros setup <board>` resolves a board's `[tool.*]`/`[source.*]` slice and
+/// the chosen RMW's. `rosidl` rides `[rmw.cyclonedds]`, and the rmw defaults to
+/// zenoh, so a plain board setup never reaches it — which is why a host with no
+/// ROS first learned about it from a cyclone msg→IDL step failing mid-build.
+/// The failure text there names the remedy correctly; the TIMING is what D12
+/// fixes, by asking the question at `--check` time instead.
+///
+/// Presence is an OR over TWO rungs, and both are needed:
+///
+/// * the provisioned copy is populated — the answer `nros setup --source
+///   <name>` produces, and the only one that holds on a host with no ROS. WHERE
+///   that is comes from `source_dir_of`, never from `dest` directly: phase-440
+///   moved `rosidl` to `location = "store"` and removed its `dest`, so a probe
+///   that read the authored path would report the one build-stage source we
+///   have as permanently MISSING;
+/// * the entry's own `check` probe answers Present — a host that has the thing
+///   from somewhere else entirely (ROS sourced, an explicit override). Without
+///   this rung, `--check` would report MISSING and EXIT NONZERO on a correctly
+///   configured host, which is worse than not reporting at all.
+///
+/// Returned rather than printed so the selection is unit-testable — the same
+/// split `source_build_names` uses for issue 0374's reason.
+fn build_stage_report(
+    index: &SdkIndex,
+    workspace: &Path,
+) -> Vec<(String, ProbeResult, String)> {
+    index
+        .source
+        .iter()
+        .filter(|(_, src)| src.build_stage)
+        .map(|(name, src)| {
+            let present =
+                source_present(name, src, workspace)
+                    || run_probe(src.check.as_ref()) == ProbeResult::Present;
+            let state = if present {
+                ProbeResult::Present
+            } else {
+                ProbeResult::Missing
+            };
+            (
+                name.clone(),
+                state,
+                format!("nros setup --source {name}"),
+            )
+        })
+        .collect()
+}
+
 /// #0390 — provision (or with `check`, VERIFY) the repo build stage's source
 /// UNION (the index's top-level `build_sources`). `just test` links every RMW's
 /// `-sys` and `build-test-fixtures` resolves graphs path-depping platform
@@ -1128,29 +1178,228 @@ pub fn activate_store_path(dirs: &[PathBuf]) {
 }
 
 /// Locate the SDK index for auto-setup: cwd, then the passed workspace, then
-/// `$NROS_WORKSPACE`, then the copy SHIPPED BESIDE THE BINARY. `None` ⇒
-/// auto-setup is a no-op (not every build runs near a nano-ros workspace).
-/// Shared with `nros doctor`'s license-gate check (187.7).
+/// `$NROS_WORKSPACE`, then the STORE's cached copy, then the copy SHIPPED
+/// BESIDE THE BINARY. `None` ⇒ auto-setup is a no-op (not every build runs near
+/// a nano-ros workspace). Shared with `nros doctor`'s license-gate check
+/// (187.7).
+///
+/// RFC-0097 D5 — this rung reads the cache and **never fetches**, where
+/// [`resolve_index`] does. The two surfaces ask different questions: `nros
+/// setup` is the verb whose job is provisioning, so reaching the network there
+/// is what the user asked for; a BUILD reaching it is a surprise, and on an
+/// offline host it would be a connect timeout on every single invocation. So a
+/// build sees whatever `nros setup` already warmed, and the shipped copy
+/// otherwise.
 pub(crate) fn locate_index(workspace: Option<&Path>) -> Option<PathBuf> {
-    let cwd = PathBuf::from("nros-sdk-index.toml");
+    let cwd = PathBuf::from(INDEX_FILE);
     if cwd.is_file() {
         return Some(cwd);
     }
     let ws = workspace
         .map(Path::to_path_buf)
         .or_else(|| std::env::var_os("NROS_WORKSPACE").map(PathBuf::from));
-    ws.map(|w| w.join("nros-sdk-index.toml"))
+    ws.map(|w| w.join(INDEX_FILE))
         .filter(|p| p.is_file())
-        .or_else(shipped_index)
+        .or_else(|| store_index(/* fetch */ false).ok().map(|(p, _)| p))
+}
+
+/// The one spelling of the index's file name.
+pub(crate) const INDEX_FILE: &str = "nros-sdk-index.toml";
+
+/// RFC-0097 D5 — where a `nros` with no checkout FETCHES the index from.
+///
+/// The index is a MANIFEST OF POINTERS into `nano-ros-sdk`'s per-tool releases.
+/// It has no ABI, so a newer index is usable by an older CLI — which is the
+/// whole point: 70 index commits per 60 days were each forcing a CLI release
+/// purely because [`shipped_index`] read the copy baked into the release asset.
+///
+/// It tracks the branch rather than a release tag on purpose. A pin here would
+/// re-create the coupling this removes — the index would move only when
+/// something published it — and every artifact the index points at carries its
+/// own `sha256`, which is the integrity that matters. The one thing a moving
+/// index can do to an older CLI is add a SECTION it cannot parse
+/// (`deny_unknown_fields`), and [`fetch_index`] refuses to cache anything this
+/// binary cannot load, so that lands as "kept the copy I already had" rather
+/// than as a broken install.
+///
+/// Override with `$NROS_INDEX_URL` — a mirror, an air-gapped copy, a test
+/// server. Sibling of `scripts/install.sh`'s `NROS_INSTALL_URL`, and it relaxes
+/// the same thing for the same reason: the scheme restriction below holds for
+/// the URL we chose and not for one the operator typed.
+pub(crate) const DEFAULT_INDEX_URL: &str =
+    "https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/nros-sdk-index.toml";
+
+/// The store's copy of the index — `<store>/fetch/nros-sdk-index.toml`.
+///
+/// `fetch/` is RFC-0095 D2's download cache (`store::Category::Fetch`), which
+/// is exactly what this is: a file pulled off the network and kept so the next
+/// run need not pull it again. Derived from the store ROOT the caller passes —
+/// never `~/.nros` and never a literal — because the root answers to
+/// `$NROS_STORE`/`$NROS_HOME` and a second spelling here is how the two come to
+/// disagree.
+pub(crate) fn index_cache_path(store: &Path) -> PathBuf {
+    store.join("fetch").join(INDEX_FILE)
+}
+
+/// Which rung answered [`index_from_store`] — so a caller can say so, and so a
+/// test can tell "used the cache" from "fetched it again".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IndexOrigin {
+    /// The store already held it.
+    Cached,
+    /// Downloaded from `url` on this call.
+    Fetched,
+    /// The copy inside the release asset (`<prefix>/share/nros/`).
+    Shipped,
+}
+
+/// RFC-0097 D5 — the index, from the store, fetching it if that is allowed.
+///
+/// Every input is a PARAMETER: the store root, the URL, whether the network may
+/// be touched, whether a warm cache should be replaced, and where the shipped
+/// fallback is. [`store_index`] is the thin wrapper that reads those from the
+/// environment. That split is what makes this testable without a test mutating
+/// process env — which in this crate is a cross-thread race, not a nuisance
+/// (`tests/store_reclaim.rs`: "No test here touches `$NROS_HOME`,
+/// `$NROS_STORE`").
+///
+/// Order, and why each rung is where it is:
+///
+/// 1. **the warm cache**, unless `refresh` — nothing is cheaper and nothing is
+///    more predictable.
+/// 2. **the network**, unless `offline` — the D5 behaviour: this CLI resolves
+///    an index it did not ship with.
+/// 3. **the warm cache again**, when a `refresh` fetch failed. A refresh that
+///    cannot reach the network must not DELETE what the store already had.
+/// 4. **the shipped copy** — the first-run-with-no-network case. A binary
+///    installed on an air-gapped host still provisions from the table it was
+///    released with.
+/// 5. **an error that names the way out**, because at this point nothing on
+///    this host can answer and a bare "no such file" would send the reader
+///    looking for a file they were never going to have.
+pub(crate) fn index_from_store(
+    store: &Path,
+    url: &str,
+    offline: bool,
+    refresh: bool,
+    shipped: Option<&Path>,
+) -> Result<(PathBuf, IndexOrigin)> {
+    let cache = index_cache_path(store);
+    if cache.is_file() && !refresh {
+        return Ok((cache, IndexOrigin::Cached));
+    }
+    let why: String = if offline {
+        format!("the network was not consulted ($NROS_OFFLINE, or a build rather than `nros setup`), so {url} was not contacted")
+    } else {
+        match fetch_index(&cache, url) {
+            Ok(()) => return Ok((cache, IndexOrigin::Fetched)),
+            Err(e) => format!("{e:#}"),
+        }
+    };
+    if cache.is_file() {
+        return Ok((cache, IndexOrigin::Cached));
+    }
+    if let Some(s) = shipped {
+        return Ok((s.to_path_buf(), IndexOrigin::Shipped));
+    }
+    bail!(
+        "no SDK index: none in the cwd or workspace, none cached at {}, \
+         and none shipped beside this binary.\n  \
+         {}\n  \
+         Fix any one of:\n    \
+         nros setup --index <path>          a copy you already have\n    \
+         NROS_INDEX_URL=<url>              fetch it from a mirror\n    \
+         unset NROS_OFFLINE                allow the default fetch ({url})",
+        cache.display(),
+        why,
+    )
+}
+
+/// Download `url` into the store's cache, atomically, and only if this binary
+/// can actually READ what came back.
+///
+/// The validation is the load-bearing half. A captive portal answers 200 with
+/// HTML; a mirror can serve a truncated file; and an index from a NEWER tree
+/// may carry a section this build's `deny_unknown_fields` rejects. Any of those
+/// written straight to the cache would poison every later run, including the
+/// ones that would otherwise have been fine — so the download lands beside the
+/// cache under a pid-unique name, is parsed AND validated there, and only then
+/// takes the cache's place.
+fn fetch_index(cache: &Path, url: &str) -> Result<()> {
+    let dir = cache
+        .parent()
+        .ok_or_else(|| eyre::eyre!("index cache path {} has no parent", cache.display()))?;
+    std::fs::create_dir_all(dir).wrap_err_with(|| format!("create {}", dir.display()))?;
+    let tmp = dir.join(format!("{INDEX_FILE}.download-{}", std::process::id()));
+    let tmp_str = tmp.to_string_lossy().into_owned();
+    let mut cmd = vec![
+        "curl",
+        "-L",
+        "--fail",
+        "--silent",
+        "--show-error",
+        // An offline host must fail in seconds, not hang: this runs on the way
+        // to a provisioning step, not as the step itself.
+        "--connect-timeout",
+        "10",
+        "--max-time",
+        "60",
+    ];
+    // Same rule as `scripts/install.sh`: the DEFAULT is a URL we chose, so it
+    // holds the https line; a URL the operator typed is one they picked, and
+    // refusing their `file://` mirror only pushes them to `curl` by hand.
+    if url == DEFAULT_INDEX_URL {
+        cmd.extend(["--proto", "=https", "--tlsv1.2"]);
+    }
+    cmd.extend(["-o", &tmp_str, url]);
+    let out = Command::new(cmd[0])
+        .args(&cmd[1..])
+        .output()
+        .wrap_err_with(|| format!("could not run curl to fetch {url}"))?;
+    if !out.status.success() {
+        let _ = std::fs::remove_file(&tmp);
+        bail!(
+            "could not fetch the SDK index from {url}: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    if let Err(e) = SdkIndex::load(&tmp) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).wrap_err_with(|| {
+            format!("{url} did not answer with an index this `nros` can read (cache left alone)")
+        });
+    }
+    std::fs::rename(&tmp, cache)
+        .wrap_err_with(|| format!("install the fetched index at {}", cache.display()))?;
+    Ok(())
+}
+
+/// [`index_from_store`] with the environment read for it, once, here.
+///
+/// `fetch` is the CALLER's decision (see [`locate_index`]); `$NROS_OFFLINE`
+/// vetoes it either way, which is the same escape-hatch shape the rest of this
+/// module uses.
+fn store_index(fetch: bool) -> Result<(PathBuf, IndexOrigin)> {
+    let store = crate::orchestration::store::root();
+    let url = std::env::var("NROS_INDEX_URL").unwrap_or_else(|_| DEFAULT_INDEX_URL.to_string());
+    let offline = !fetch || std::env::var_os("NROS_OFFLINE").is_some();
+    let refresh = std::env::var_os("NROS_INDEX_REFRESH").is_some();
+    let shipped = shipped_index();
+    let got = index_from_store(&store, &url, offline, refresh, shipped.as_deref())?;
+    if got.1 == IndexOrigin::Fetched {
+        eprintln!("nros: fetched the SDK index → {}", got.0.display());
+    }
+    Ok(got)
 }
 
 /// The index shipped inside the release, at `<prefix>/share/nros/` — phase-431
 /// W5.
 ///
-/// Without this a released `nros` cannot run `nros setup <board>` AT ALL: the
-/// index was only ever looked for in the cwd or a workspace, both of which
-/// assume a checkout, and the whole point of shipping a binary is that there
-/// is no checkout. The release asset carries it; this is where it is found.
+/// RFC-0097 D5 demoted this from the answer to the LAST RESORT: it is what a
+/// first run with no network and no cache falls back to, so an air-gapped host
+/// still provisions from the table the binary was released with. Everything
+/// else prefers [`index_from_store`], because a copy inside the asset can only
+/// ever be as new as the asset.
 ///
 /// Resolved from the running executable rather than from `$NROS_HOME`, so a
 /// binary and the index it was released with stay together — two versions in
@@ -1159,7 +1408,7 @@ pub(crate) fn locate_index(workspace: Option<&Path>) -> Option<PathBuf> {
 pub(crate) fn shipped_index() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let prefix = exe.parent()?.parent()?; // <prefix>/bin/nros -> <prefix>
-    let candidate = prefix.join("share/nros/nros-sdk-index.toml");
+    let candidate = prefix.join("share/nros").join(INDEX_FILE);
     candidate.is_file().then_some(candidate)
 }
 
@@ -1167,13 +1416,20 @@ pub(crate) fn shipped_index() -> Option<PathBuf> {
 ///
 /// `--index` defaults to the bare name `nros-sdk-index.toml`, which resolves
 /// against the cwd — right inside a checkout, and unusable for a released
-/// binary. So a DEFAULT that does not resolve falls back to the shipped copy;
-/// a path the user actually typed is never second-guessed.
-pub fn resolve_index(explicit: &Path) -> PathBuf {
-    if explicit != Path::new("nros-sdk-index.toml") || explicit.is_file() {
-        return explicit.to_path_buf();
+/// binary. So a DEFAULT that does not resolve goes to the store (fetching it
+/// if the store has none — RFC-0097 D5), and only then to the shipped copy; a
+/// path the user actually typed is never second-guessed.
+///
+/// Fallible since D5: when no rung answers, the error names the ways out
+/// (`--index`, `$NROS_INDEX_URL`, `$NROS_OFFLINE`). It used to hand back the
+/// bare default name and let `SdkIndex::load` report "no such file
+/// nros-sdk-index.toml", which sends the reader looking in the cwd for a file
+/// that was never going to be there.
+pub fn resolve_index(explicit: &Path) -> Result<PathBuf> {
+    if explicit != Path::new(INDEX_FILE) || explicit.is_file() {
+        return Ok(explicit.to_path_buf());
     }
-    shipped_index().unwrap_or_else(|| explicit.to_path_buf())
+    store_index(/* fetch */ true).map(|(p, _)| p)
 }
 
 /// The workspace root a `[source.*]` `dest` is resolved against: the directory
@@ -1815,6 +2071,32 @@ fn run_probe_in(
             answered_missing = true;
         }
     }
+    // RFC-0097 D12 — "can the build's interpreter import it", the question
+    // `scripts/cyclonedds/msg_to_cyclone_idl.py` asks before choosing a rung.
+    // A host with no `python3` cannot answer it, and "cannot ask" is not
+    // "absent" — same discipline as `pkg_config` above.
+    if let Some(module) = &check.python_import {
+        if let Ok(st) = std::process::Command::new("python3")
+            .args(["-c", &format!("import {module}")])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+        {
+            if st.success() {
+                return ProbeResult::Present;
+            }
+            answered_missing = true;
+        }
+    }
+    // RFC-0097 D12 — an explicit override the build honours. Set-but-nowhere is
+    // NOT satisfaction: that is a misconfiguration, and reporting it as present
+    // is how the build failure lands with no clue attached.
+    if let Some(var) = &check.env {
+        match std::env::var_os(var) {
+            Some(v) if std::path::Path::new(&v).is_dir() => return ProbeResult::Present,
+            _ => answered_missing = true,
+        }
+    }
     if answered_missing {
         ProbeResult::Missing
     } else {
@@ -2255,7 +2537,7 @@ fn run_check_tool(index: &SdkIndex, name: &str) -> Result<()> {
 
 /// phase-327 W3 — the generic walker: probe every declared class and print a
 /// remedy COMPUTED from the entry. Exit 1 when anything is missing.
-fn run_check_all(index: &SdkIndex) -> Result<()> {
+fn run_check_all(index: &SdkIndex, workspace: &Path) -> Result<()> {
     let mut missing = 0usize;
     // Separate from `missing` only because the `report` closure below captures
     // that one mutably; both are summed at the end.
@@ -2327,6 +2609,16 @@ fn run_check_all(index: &SdkIndex) -> Result<()> {
             ProbeResult::Missing
         };
         report("tool", &label, ok, format!("nros setup --tool {name}"));
+    }
+
+    // RFC-0097 D12 — the BUILD stage. Every class above is something a BOARD
+    // pulls in, which is why `nros setup <board>` could pre-empt all of them
+    // and none of them was the one that bit: `rosidl` rides
+    // `[rmw.cyclonedds]`, the rmw defaults to zenoh, and a host with no ROS met
+    // it as a build failure deep inside the cyclone msg→IDL step. A setup check
+    // must report what a BUILD will need, not only what a board will.
+    for (name, ok, remedy) in build_stage_report(index, workspace) {
+        report("build", &name, ok, remedy);
     }
 
     // [rust.toolchain.*] — `rustup toolchain list` + per-component listing.
@@ -2509,7 +2801,7 @@ mod tests {
     #[test]
     fn an_explicit_index_is_never_replaced_by_the_shipped_one() {
         let typed = Path::new("some/other/index.toml");
-        assert_eq!(resolve_index(typed), typed.to_path_buf());
+        assert_eq!(resolve_index(typed).unwrap(), typed.to_path_buf());
 
         // The default, when it resolves in the cwd, is also left alone: inside
         // a checkout the tree's own index must win over any shipped copy.
@@ -2517,8 +2809,422 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let here = dir.join("nros-sdk-index.toml");
         std::fs::write(&here, "").unwrap();
-        assert_eq!(resolve_index(&here), here);
+        assert_eq!(resolve_index(&here).unwrap(), here);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ---- RFC-0097 D5: the index is fetched into the store, not read out of
+    // the release asset -------------------------------------------------------
+    //
+    // Every test below drives `index_from_store` with EXPLICIT parameters and a
+    // `file://` URL. No process environment is touched (these run as threads —
+    // `tests/store_reclaim.rs`: "No test here touches `$NROS_HOME`,
+    // `$NROS_STORE`"), and no test reaches the network: `curl` speaks `file://`,
+    // so the fetch under test is the REAL fetch, not a mock of one.
+
+    /// A parseable index, distinguishable by the tool name it declares.
+    fn index_text(tool: &str) -> String {
+        format!("[tool.{tool}]\nversion = \"1.0\"\n")
+    }
+
+    /// `file://` URL for a path — what stands in for the network here.
+    fn file_url(p: &Path) -> String {
+        format!("file://{}", p.display())
+    }
+
+    /// D5's headline: **a CLI resolves an index it did not ship with.**
+    ///
+    /// The shipped copy is present and readable, and it still loses — that is
+    /// the whole decision. Before this, `shipped_index()` was the answer, so
+    /// every one of the 70 index commits per 60 days needed a CLI release to
+    /// reach anyone.
+    #[test]
+    fn a_fetched_index_beats_the_copy_shipped_in_the_asset() {
+        let dir = crate::test_support::scratch_dir("d5_fetch_beats_shipped");
+        let store = dir.join("store");
+        let upstream = dir.join("upstream-index.toml");
+        std::fs::write(&upstream, index_text("only-upstream-has-me")).unwrap();
+        let shipped = dir.join("shipped-index.toml");
+        std::fs::write(&shipped, index_text("shipped-and-old")).unwrap();
+
+        let (got, origin) = index_from_store(
+            &store,
+            &file_url(&upstream),
+            /* offline */ false,
+            /* refresh */ false,
+            Some(&shipped),
+        )
+        .expect("a reachable URL resolves");
+
+        assert_eq!(origin, IndexOrigin::Fetched);
+        assert_eq!(got, index_cache_path(&store));
+        let idx = SdkIndex::load(&got).expect("the cached copy parses");
+        assert!(
+            idx.tool.contains_key("only-upstream-has-me"),
+            "the resolved index must be the FETCHED one, not the shipped one: {:?}",
+            idx.tool.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// The cache lives under the STORE ROOT it was given — never `~/.nros` and
+    /// never any other literal. Two different roots must never share a file.
+    #[test]
+    fn the_cache_is_derived_from_the_store_root_it_was_given() {
+        let dir = crate::test_support::scratch_dir("d5_cache_under_store");
+        let a = dir.join("store-a");
+        let b = dir.join("store-b");
+        assert!(index_cache_path(&a).starts_with(&a));
+        assert_ne!(index_cache_path(&a), index_cache_path(&b));
+
+        let upstream = dir.join("up.toml");
+        std::fs::write(&upstream, index_text("t")).unwrap();
+        let (got, _) =
+            index_from_store(&a, &file_url(&upstream), false, false, None).expect("fetch");
+        // The path it FETCHED to is the path the helper derives — asserting a
+        // prefix instead would let the two drift apart while both still sit
+        // somewhere under the store.
+        assert_eq!(got, index_cache_path(&a), "fetched somewhere the helper does not name");
+        assert!(
+            got.starts_with(&a),
+            "the cache landed at {} — outside the store root {}",
+            got.display(),
+            a.display()
+        );
+        // `starts_with` alone does NOT say this: `<store>/sdk/fetch/...` has the
+        // store as a prefix too, and `<store>/sdk` is exactly where this landed
+        // once already (phase-440 — `sdk_store::store_root()` IS `<store>/sdk`).
+        // The index cache is a store-level artifact and a PEER of the SDK tree,
+        // never a child of it: it describes which SDK to install, so it cannot
+        // live inside the thing it describes.
+        let sdk_root = a.join("sdk");
+        assert!(
+            !got.starts_with(&sdk_root),
+            "the cache landed at {} — inside the SDK tree {}, not beside it",
+            got.display(),
+            sdk_root.display()
+        );
+        assert!(!index_cache_path(&b).exists(), "the other store was written");
+    }
+
+    /// A warm cache answers without a fetch. Proven by pointing the URL at a
+    /// file that does not exist: if anything reached for it, this fails.
+    #[test]
+    fn a_warm_cache_answers_without_fetching() {
+        let dir = crate::test_support::scratch_dir("d5_warm_cache");
+        let store = dir.join("store");
+        let cache = index_cache_path(&store);
+        std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+        std::fs::write(&cache, index_text("cached")).unwrap();
+
+        let (got, origin) = index_from_store(
+            &store,
+            &file_url(&dir.join("there-is-no-such-file.toml")),
+            /* offline */ false,
+            /* refresh */ false,
+            None,
+        )
+        .expect("the cache alone is enough");
+        assert_eq!(origin, IndexOrigin::Cached);
+        assert_eq!(got, cache);
+    }
+
+    /// `nros setup --check` with a warm cache works with NO network: the
+    /// offline arm never contacts the URL and still resolves. This is also the
+    /// rung `locate_index` uses for every build (it passes `fetch = false`).
+    #[test]
+    fn offline_with_a_warm_cache_resolves_and_never_contacts_the_url() {
+        let dir = crate::test_support::scratch_dir("d5_offline_warm");
+        let store = dir.join("store");
+        let cache = index_cache_path(&store);
+        std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+        std::fs::write(&cache, index_text("cached")).unwrap();
+
+        // A URL that WOULD resolve, to prove the offline arm is what answered.
+        let upstream = dir.join("up.toml");
+        std::fs::write(&upstream, index_text("upstream")).unwrap();
+
+        let (got, origin) =
+            index_from_store(&store, &file_url(&upstream), true, false, None).expect("warm cache");
+        assert_eq!(origin, IndexOrigin::Cached);
+        assert_eq!(got, cache);
+        let idx = SdkIndex::load(&got).unwrap();
+        assert!(
+            idx.tool.contains_key("cached"),
+            "offline resolved the upstream copy — it must not have looked"
+        );
+    }
+
+    /// The acceptance the shipped copy still exists for: a FIRST run, no cache,
+    /// no network. It must still work.
+    #[test]
+    fn a_first_run_with_no_network_and_no_cache_falls_back_to_the_shipped_copy() {
+        let dir = crate::test_support::scratch_dir("d5_first_run_offline");
+        let store = dir.join("store");
+        let shipped = dir.join("shipped.toml");
+        std::fs::write(&shipped, index_text("shipped")).unwrap();
+
+        // Both shapes of "no network": refused (offline) and attempted-and-failed.
+        for (offline, url) in [
+            (true, file_url(&dir.join("unreachable.toml"))),
+            (false, file_url(&dir.join("unreachable.toml"))),
+        ] {
+            let (got, origin) = index_from_store(&store, &url, offline, false, Some(&shipped))
+                .expect("the shipped copy is the fallback");
+            assert_eq!(origin, IndexOrigin::Shipped, "offline={offline}");
+            assert_eq!(got, shipped, "offline={offline}");
+            assert!(
+                !index_cache_path(&store).exists(),
+                "a failed fetch must leave no cache behind (offline={offline})"
+            );
+        }
+    }
+
+    /// With nothing left to try, the error names the way out — `--index`,
+    /// `$NROS_INDEX_URL`, `$NROS_OFFLINE` — and the cache path it looked at.
+    ///
+    /// The old behaviour handed back the bare name `nros-sdk-index.toml` and
+    /// let `SdkIndex::load` say "no such file", which sends the reader hunting
+    /// in their cwd for a file that was never going to be there.
+    #[test]
+    fn with_nothing_to_fall_back_on_the_error_names_the_offline_path() {
+        let dir = crate::test_support::scratch_dir("d5_no_rung_left");
+        let store = dir.join("store");
+        let err = index_from_store(
+            &store,
+            &file_url(&dir.join("unreachable.toml")),
+            /* offline */ true,
+            false,
+            None,
+        )
+        .expect_err("no cwd index, no cache, no shipped copy — nothing can answer");
+        let msg = format!("{err:#}");
+        for needle in [
+            "NROS_INDEX_URL",
+            "NROS_OFFLINE",
+            "--index",
+            &index_cache_path(&store).display().to_string(),
+        ] {
+            assert!(
+                msg.contains(needle),
+                "the failure text must name `{needle}`:\n{msg}"
+            );
+        }
+    }
+
+    /// A response this binary cannot READ must not become the cache.
+    ///
+    /// Three real shapes collapse into this one: a captive portal answering 200
+    /// with HTML, a truncated mirror, and an index from a newer tree carrying a
+    /// section `deny_unknown_fields` rejects. Any of them written to the cache
+    /// would poison every later run — including the runs that would otherwise
+    /// have been fine, because rung 1 never re-fetches.
+    #[test]
+    fn a_response_this_binary_cannot_parse_never_becomes_the_cache() {
+        let dir = crate::test_support::scratch_dir("d5_garbage_response");
+        let store = dir.join("store");
+        let garbage = dir.join("portal.html");
+        std::fs::write(&garbage, "<html><body>Sign in to the WiFi</body></html>").unwrap();
+        let shipped = dir.join("shipped.toml");
+        std::fs::write(&shipped, index_text("shipped")).unwrap();
+
+        let (got, origin) = index_from_store(
+            &store,
+            &file_url(&garbage),
+            false,
+            false,
+            Some(shipped.as_path()),
+        )
+        .expect("an unreadable answer falls through to the shipped copy");
+        assert_eq!(origin, IndexOrigin::Shipped);
+        assert_eq!(got, shipped);
+        assert!(
+            !index_cache_path(&store).exists(),
+            "the unparseable download was installed as the cache"
+        );
+    }
+
+    /// `$NROS_INDEX_REFRESH` replaces a warm cache — and a refresh that CANNOT
+    /// reach the network keeps what the store already had rather than deleting
+    /// it. A refresh must never leave a host worse off than not asking.
+    #[test]
+    fn a_refresh_replaces_the_cache_but_a_failed_one_keeps_it() {
+        let dir = crate::test_support::scratch_dir("d5_refresh");
+        let store = dir.join("store");
+        let cache = index_cache_path(&store);
+        std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+        std::fs::write(&cache, index_text("old")).unwrap();
+
+        let upstream = dir.join("new.toml");
+        std::fs::write(&upstream, index_text("new")).unwrap();
+        let (got, origin) =
+            index_from_store(&store, &file_url(&upstream), false, true, None).expect("refetch");
+        assert_eq!(origin, IndexOrigin::Fetched);
+        assert!(
+            SdkIndex::load(&got).unwrap().tool.contains_key("new"),
+            "the refresh did not replace the cache"
+        );
+
+        let (got, origin) = index_from_store(
+            &store,
+            &file_url(&dir.join("gone.toml")),
+            false,
+            /* refresh */ true,
+            None,
+        )
+        .expect("a failed refresh still resolves");
+        assert_eq!(origin, IndexOrigin::Cached);
+        assert!(
+            SdkIndex::load(&got).unwrap().tool.contains_key("new"),
+            "a failed refresh destroyed the cache it could not replace"
+        );
+    }
+
+    // ---- RFC-0097 D12: `setup --check` covers the BUILD stage ---------------
+
+    /// An index declaring one build-stage source with a probe that cannot be
+    /// satisfied on any host. `dest` is relative to the workspace the report
+    /// resolves against.
+    fn build_stage_index(dest: &str) -> SdkIndex {
+        SdkIndex::parse(&format!(
+            "[source.rosidl]\nversion = \"humble\"\n\
+             git = \"https://example/rosidl\"\nref = \"deadbeef\"\n\
+             dest = \"{dest}\"\nbuild_stage = true\n\
+             check = {{ python_import = \"nros_no_such_module_exists\" }}\n"
+        ))
+        .expect("the build-stage schema parses")
+    }
+
+    /// The D12 acceptance: on a host that has neither the vendored copy nor the
+    /// thing itself, `--check` REPORTS it, by name, with the remedy.
+    ///
+    /// The state before this: `run_check_all` walked `[prereq.*]`, `[tool.*]`,
+    /// `[rust.*]` and `[python.*]` and no `[source.*]` at all, so a full
+    /// `nros setup --check` on this tree printed 101 lines and mentioned
+    /// `rosidl` zero times. The first mention a no-ROS host got was a cyclone
+    /// msg→IDL step failing mid-build.
+    #[test]
+    fn a_build_stage_source_neither_vendored_nor_present_is_reported_with_its_remedy() {
+        let ws = crate::test_support::scratch_dir("d12_missing");
+        let index = build_stage_index("third-party/ros/rosidl");
+
+        let got = build_stage_report(&index, &ws);
+        assert_eq!(got.len(), 1, "one build-stage source was declared");
+        let (name, state, remedy) = &got[0];
+        assert_eq!(name, "rosidl");
+        assert_eq!(*state, ProbeResult::Missing);
+        assert_eq!(remedy, "nros setup --source rosidl");
+    }
+
+    /// The vendored copy, once provisioned, satisfies it — the answer the
+    /// remedy actually produces, and the only rung a host with no ROS has.
+    #[test]
+    fn a_provisioned_vendored_copy_satisfies_the_build_stage_check() {
+        let ws = crate::test_support::scratch_dir("d12_vendored");
+        let dest = "third-party/ros/rosidl";
+        std::fs::create_dir_all(ws.join(dest)).unwrap();
+        std::fs::write(ws.join(dest).join("README.md"), "x").unwrap();
+
+        let got = build_stage_report(&build_stage_index(dest), &ws);
+        assert_eq!(got[0].1, ProbeResult::Present);
+    }
+
+    /// The OTHER rung: a host that has the thing from somewhere else needs
+    /// nothing provisioned, and reporting it MISSING there would exit `--check`
+    /// nonzero on a correctly configured host. `sys` stands in for
+    /// `rosidl_adapter` — importable on every host that has python3 at all.
+    #[test]
+    fn a_host_that_already_has_it_is_not_told_to_provision_a_vendored_copy() {
+        let ws = crate::test_support::scratch_dir("d12_probe_rung");
+        let index = SdkIndex::parse(
+            "[source.rosidl]\nversion = \"humble\"\n\
+             git = \"https://example/rosidl\"\nref = \"deadbeef\"\n\
+             dest = \"third-party/ros/rosidl\"\nbuild_stage = true\n\
+             check = { python_import = \"sys\" }\n",
+        )
+        .unwrap();
+        assert!(
+            !ws.join("third-party/ros/rosidl").exists(),
+            "nothing is vendored — the probe must be what answers"
+        );
+        assert_eq!(build_stage_report(&index, &ws)[0].1, ProbeResult::Present);
+    }
+
+    /// A source that is NOT `build_stage` stays off this report. Every
+    /// `[source.*]` in the tree would otherwise be reported — the cross-only
+    /// kernels a native-only user never builds included — and `--check` would
+    /// fail on a host with nothing wrong with it.
+    #[test]
+    fn an_ordinary_source_is_not_a_build_stage_row() {
+        let ws = crate::test_support::scratch_dir("d12_not_build_stage");
+        let index = SdkIndex::parse(
+            "[source.freertos-kernel]\nversion = \"11\"\n\
+             git = \"https://example/f\"\nref = \"v11\"\ndest = \"third-party/f\"\n",
+        )
+        .unwrap();
+        assert!(build_stage_report(&index, &ws).is_empty());
+    }
+
+    /// The DATA half of D12, asserted against the tree's own index — a code
+    /// path with no `build_stage = true` anywhere reports nothing and passes
+    /// every test above.
+    #[test]
+    fn the_shipped_index_declares_rosidl_as_a_build_stage_source() {
+        let index_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../..")
+            .join(INDEX_FILE);
+        let index = SdkIndex::load(&index_path)
+            .unwrap_or_else(|e| panic!("load {}: {e:#}", index_path.display()));
+        let rosidl = index
+            .source
+            .get("rosidl")
+            .expect("[source.rosidl] is in this tree's index");
+        assert!(
+            rosidl.build_stage,
+            "rosidl rides [rmw.cyclonedds], which `nros setup <board>` never \
+             resolves (rmw defaults to zenoh) — it must be on the --check report"
+        );
+        let check = rosidl
+            .check
+            .as_ref()
+            .expect("without a probe, every ROS host reports MISSING and --check exits nonzero");
+        assert_eq!(check.python_import.as_deref(), Some("rosidl_adapter"));
+        assert_eq!(check.env.as_deref(), Some("NROS_ROSIDL_ADAPTER_BIN_DIR"));
+    }
+
+    /// A `build_stage` entry that nothing can LOCATE is refused at LOAD: the
+    /// report asks whether its provisioned directory is populated, so such an
+    /// entry would be reported MISSING forever with a remedy that provisions
+    /// nothing visible.
+    #[test]
+    fn a_build_stage_source_nothing_can_locate_is_refused() {
+        let err = SdkIndex::parse("[source.x]\nversion = \"1\"\nbuild_stage = true\n")
+            .unwrap()
+            .validate()
+            .expect_err("nothing names where it lives");
+        assert!(
+            format!("{err:#}").contains("build_stage"),
+            "the refusal must name the field: {err:#}"
+        );
+    }
+
+    /// The other half of that rule, and the case the FIRST version of it got
+    /// wrong: a store source has no `dest` ON PURPOSE (RFC-0095 D1/D2 — the path
+    /// is derived from name + version so nobody can spell it twice), and
+    /// `rosidl` is simultaneously the only build-stage source we have. A rule
+    /// spelled `build_stage && dest.is_none()` therefore refused the SHIPPED
+    /// index, which is every `nros` failing to read its own manifest.
+    ///
+    /// `the_shipped_index_declares_rosidl_as_a_build_stage_source` loads the
+    /// real file and would have caught it too; this pins the rule directly, so
+    /// the reason survives even if the shipped entry changes shape again.
+    #[test]
+    fn a_build_stage_source_in_the_store_needs_no_dest() {
+        SdkIndex::parse(
+            "[source.x]\nversion = \"1\"\nbuild_stage = true\nlocation = \"store\"\n",
+        )
+        .unwrap()
+        .validate()
+        .expect("a store source derives its path; requiring `dest` here refuses the real index");
     }
 
     /// issue 0603 — a `header` probe answers about the `-dev` package, where
@@ -2803,6 +3509,78 @@ mod probe_kind_tests {
 
     fn probe(c: CheckProbe, base: Option<&std::path::Path>) -> ProbeResult {
         run_probe_in(Some(&c), base)
+    }
+
+    /// RFC-0097 D12 — `python_import` asks the INTERPRETER, not the filesystem.
+    ///
+    /// The distinction it exists for: `scripts/cyclonedds/msg_to_cyclone_idl.py`
+    /// refuses a `rosidl_adapter` whose scripts EXIST but cannot import, because
+    /// "the directory existing is a PROXY; being importable is the property".
+    /// A `path` probe cannot express that, and `runs` cannot express `python3
+    /// -c "import x"` at all — it splits on whitespace and spawns directly, so
+    /// `-c` would receive `'import`.
+    #[test]
+    fn python_import_answers_the_interpreter_not_the_filesystem() {
+        if !command_exists("python3") {
+            // The probe abstains where it cannot ask, and so does this test.
+            return;
+        }
+        assert_eq!(
+            probe(
+                CheckProbe {
+                    python_import: Some("sys".into()),
+                    ..Default::default()
+                },
+                None
+            ),
+            ProbeResult::Present,
+            "a stdlib module must read Present, or the probe is always-missing"
+        );
+        assert_eq!(
+            probe(
+                CheckProbe {
+                    python_import: Some("nros_definitely_not_installed".into()),
+                    ..Default::default()
+                },
+                None
+            ),
+            ProbeResult::Missing
+        );
+    }
+
+    /// RFC-0097 D12 — `env` is present only when the variable names an existing
+    /// DIRECTORY. Set-but-nowhere is a misconfiguration, and calling it present
+    /// is how the build failure lands with no clue attached.
+    #[test]
+    fn env_probe_needs_the_variable_to_name_a_real_directory() {
+        // A test-only name, so no concurrent test can be reading it (the idiom
+        // `doctor.rs`'s gate tests use — this crate has no env lock).
+        const VAR: &str = "NROS_TEST_PROBE_ENV_DIR";
+        let c = || CheckProbe {
+            env: Some(VAR.into()),
+            ..Default::default()
+        };
+        let saved = std::env::var_os(VAR);
+        // SAFETY: a uniquely-named variable this process alone reads; restored
+        // before returning.
+        unsafe { std::env::remove_var(VAR) };
+        assert_eq!(probe(c(), None), ProbeResult::Missing, "unset");
+
+        let dir = crate::test_support::scratch_dir("probe_env_dir");
+        unsafe { std::env::set_var(VAR, &dir) };
+        assert_eq!(probe(c(), None), ProbeResult::Present, "names a directory");
+
+        unsafe { std::env::set_var(VAR, dir.join("no-such-child")) };
+        assert_eq!(
+            probe(c(), None),
+            ProbeResult::Missing,
+            "set to a path that is not there is a misconfiguration, not presence"
+        );
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var(VAR, v) },
+            None => unsafe { std::env::remove_var(VAR) },
+        }
     }
 
     /// `runs` distinguishes three states, and the third is the point: a tool

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -971,10 +971,7 @@ pub(crate) fn source_dir_of(
 ///
 /// Returned rather than printed so the selection is unit-testable — the same
 /// split `source_build_names` uses for issue 0374's reason.
-fn build_stage_report(
-    index: &SdkIndex,
-    workspace: &Path,
-) -> Vec<(String, ProbeResult, String)> {
+fn build_stage_report(index: &SdkIndex, workspace: &Path) -> Vec<(String, ProbeResult, String)> {
     index
         .source
         .iter()
@@ -988,11 +985,7 @@ fn build_stage_report(
             } else {
                 ProbeResult::Missing
             };
-            (
-                name.clone(),
-                state,
-                format!("nros setup --source {name}"),
-            )
+            (name.clone(), state, format!("nros setup --source {name}"))
         })
         .collect()
 }
@@ -1289,7 +1282,9 @@ pub(crate) fn index_from_store(
         return Ok((cache, IndexOrigin::Cached));
     }
     let why: String = if offline {
-        format!("the network was not consulted ($NROS_OFFLINE, or a build rather than `nros setup`), so {url} was not contacted")
+        format!(
+            "the network was not consulted ($NROS_OFFLINE, or a build rather than `nros setup`), so {url} was not contacted"
+        )
     } else {
         match fetch_index(&cache, url) {
             Ok(()) => return Ok((cache, IndexOrigin::Fetched)),
@@ -1369,8 +1364,18 @@ fn fetch_index(cache: &Path, url: &str) -> Result<()> {
             format!("{url} did not answer with an index this `nros` can read (cache left alone)")
         });
     }
-    std::fs::rename(&tmp, cache)
-        .wrap_err_with(|| format!("install the fetched index at {}", cache.display()))?;
+    // The ONE write discipline (issues 0498/0562, gate `check-atomic-sync-writes`).
+    // A hand-rolled rename here would be atomic and nothing else; this is also
+    // write-if-changed, so a refresh that fetches byte-identical content leaves
+    // the cache's mtime alone instead of re-staling everything keyed on it.
+    // The download still lands in `tmp` first, because the parse below must
+    // happen before anything is published — a response this binary cannot read
+    // must never become the cache.
+    let bytes = std::fs::read(&tmp).wrap_err_with(|| format!("read {}", tmp.display()))?;
+    let published = crate::atomic_file::atomic_write_bytes(cache, &bytes)
+        .wrap_err_with(|| format!("install the fetched index at {}", cache.display()));
+    let _ = std::fs::remove_file(&tmp);
+    published?;
     Ok(())
 }
 
@@ -2883,7 +2888,11 @@ mod tests {
         // The path it FETCHED to is the path the helper derives — asserting a
         // prefix instead would let the two drift apart while both still sit
         // somewhere under the store.
-        assert_eq!(got, index_cache_path(&a), "fetched somewhere the helper does not name");
+        assert_eq!(
+            got,
+            index_cache_path(&a),
+            "fetched somewhere the helper does not name"
+        );
         assert!(
             got.starts_with(&a),
             "the cache landed at {} — outside the store root {}",
@@ -2903,7 +2912,10 @@ mod tests {
             got.display(),
             sdk_root.display()
         );
-        assert!(!index_cache_path(&b).exists(), "the other store was written");
+        assert!(
+            !index_cache_path(&b).exists(),
+            "the other store was written"
+        );
     }
 
     /// A warm cache answers without a fetch. Proven by pointing the URL at a

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -977,9 +977,8 @@ fn build_stage_report(index: &SdkIndex, workspace: &Path) -> Vec<(String, ProbeR
         .iter()
         .filter(|(_, src)| src.build_stage)
         .map(|(name, src)| {
-            let present =
-                source_present(name, src, workspace)
-                    || run_probe(src.check.as_ref()) == ProbeResult::Present;
+            let present = source_present(name, src, workspace)
+                || run_probe(src.check.as_ref()) == ProbeResult::Present;
             let state = if present {
                 ProbeResult::Present
             } else {
@@ -3231,12 +3230,12 @@ mod tests {
     /// the reason survives even if the shipped entry changes shape again.
     #[test]
     fn a_build_stage_source_in_the_store_needs_no_dest() {
-        SdkIndex::parse(
-            "[source.x]\nversion = \"1\"\nbuild_stage = true\nlocation = \"store\"\n",
-        )
-        .unwrap()
-        .validate()
-        .expect("a store source derives its path; requiring `dest` here refuses the real index");
+        SdkIndex::parse("[source.x]\nversion = \"1\"\nbuild_stage = true\nlocation = \"store\"\n")
+            .unwrap()
+            .validate()
+            .expect(
+                "a store source derives its path; requiring `dest` here refuses the real index",
+            );
     }
 
     /// issue 0603 — a `header` probe answers about the `-dev` package, where

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
@@ -606,6 +606,31 @@ pub struct CheckProbe {
     /// declares.
     #[serde(default)]
     pub path: Option<String>,
+    /// RFC-0097 D12 — `python3 -c "import <module>"` succeeds.
+    ///
+    /// Not expressible as [`Self::runs`]: that value is split on whitespace and
+    /// spawned directly, so `python3 -c 'import rosidl_adapter'` becomes four
+    /// argv entries and `-c` receives `'import`. And not expressible as
+    /// [`Self::path`] either — the rung that motivated it is ROS's own
+    /// `rosidl_adapter`, where the directory existing is a PROXY and being
+    /// importable is the property. `scripts/cyclonedds/msg_to_cyclone_idl.py`
+    /// says exactly that, and refuses rather than hand back a findable copy
+    /// that cannot import.
+    ///
+    /// Asked of `python3` on PATH, which is the interpreter the build's own
+    /// python steps run under. A host with no `python3` cannot answer at all,
+    /// so the probe abstains rather than reporting the module absent.
+    #[serde(default)]
+    pub python_import: Option<String>,
+    /// RFC-0097 D12 — an environment variable naming an existing DIRECTORY.
+    ///
+    /// The escape hatch several of our own build steps already honour
+    /// (`NROS_ROSIDL_ADAPTER_BIN_DIR`). Without it a `--check` reports MISSING
+    /// — and exits NONZERO — on a host that is deliberately and correctly
+    /// configured. `[gated.*]` already models presence this way; this is the
+    /// same question asked from a probe.
+    #[serde(default)]
+    pub env: Option<String>,
 }
 
 impl CheckProbe {
@@ -980,6 +1005,31 @@ pub struct SourcePackage {
     /// source to its top tree only. Submodule mode only.
     #[serde(default = "default_true")]
     pub recursive: bool,
+    /// RFC-0097 D12 — a TARGET BUILD pulls this in, so no board provisions it
+    /// and `nros setup <board>` cannot pre-empt it.
+    ///
+    /// `rosidl` is the motivating one: it rides `[rmw.cyclonedds]`, which a
+    /// plain `nros setup <board>` (rmw defaults to zenoh) never resolves, so a
+    /// host with no ROS met it as a BUILD FAILURE deep inside the cyclone
+    /// msg→IDL step. The failure text there is already right; the TIMING was
+    /// wrong. Setting this puts the source on `nros setup --check`, which is
+    /// where "what will a build need" is the question being asked.
+    ///
+    /// This is NOT the top-level `build_sources` set, which is what the ROOT
+    /// workspace needs on every host — and whose own comment explicitly
+    /// excludes the cross-only trees, `rosidl` among them.
+    #[serde(default)]
+    pub build_stage: bool,
+    /// Does the build have this ALREADY, from somewhere that is not our
+    /// vendored copy?
+    ///
+    /// The tree at `dest` is the LAST rung of a ladder, not the only one — a
+    /// host with ROS sourced has `rosidl_adapter` and needs nothing
+    /// provisioned. Without this probe a `--check` would report every such host
+    /// MISSING and exit nonzero. `None` ⇒ the presence test is just "is `dest`
+    /// populated".
+    #[serde(default)]
+    pub check: Option<CheckProbe>,
 }
 
 fn default_true() -> bool {
@@ -1004,6 +1054,8 @@ impl Default for SourcePackage {
             submodule: None,
             shallow: true,
             recursive: true,
+            build_stage: false,
+            check: None,
         }
     }
 }
@@ -1334,6 +1386,30 @@ impl SdkIndex {
                     }
                 }
                 SourceProvision::None => {}
+            }
+        }
+        // RFC-0097 D12 — a build-stage source is REPORTED by `nros setup
+        // --check`, and the report asks whether its provisioned directory is
+        // populated. What it needs is therefore a RESOLVABLE LOCATION, which is
+        // not the same as an authored `dest`: phase-440 (RFC-0095 D1/D2) gives a
+        // store source a DERIVED path and removes its `dest` precisely so nobody
+        // can spell that location twice.
+        //
+        // Requiring `dest` here was the first version of this rule, and it was
+        // wrong in the one case that exists: `rosidl` is both the only
+        // build-stage source and a store source, so the two rules landing
+        // together would have refused the shipped index and left every `nros`
+        // unable to read its own manifest. `source_dir_of` answers both shapes,
+        // so the check is "can anything name where this lives".
+        for (name, src) in &self.source {
+            let resolvable = src.dest.is_some() || src.location == SourceLocation::Store;
+            if src.build_stage && !resolvable {
+                bail!(
+                    "source '{name}' is `build_stage = true` but nothing says where it \
+                     lives — `nros setup --check` reports it by asking whether its \
+                     provisioned directory is populated. Give it a `dest`, or \
+                     location = \"store\" for a version-keyed path the store derives"
+                );
             }
         }
         Ok(())

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -1644,6 +1644,8 @@ mod tests {
             submodule: None,
             shallow: true,
             recursive: true,
+            build_stage: false,
+            check: None,
         };
         assert_eq!(
             provision_source("lwip", &clone, &ws, false, None).unwrap(),

--- a/packages/cli/nros-cli/tests/doctor_without_a_workspace.rs
+++ b/packages/cli/nros-cli/tests/doctor_without_a_workspace.rs
@@ -86,7 +86,11 @@ fn doctor_outside_a_workspace_still_fails_on_an_unresolvable_pin() {
     .unwrap();
 
     let (code, text) = doctor_in(&cwd, &store);
-    assert_ne!(code, Some(0), "an unresolvable pin must not exit 0:\n{text}");
+    assert_ne!(
+        code,
+        Some(0),
+        "an unresolvable pin must not exit 0:\n{text}"
+    );
     assert!(
         text.contains("0.9.9"),
         "it must name the version the project asked for:\n{text}"

--- a/packages/cli/nros-cli/tests/doctor_without_a_workspace.rs
+++ b/packages/cli/nros-cli/tests/doctor_without_a_workspace.rs
@@ -1,0 +1,94 @@
+//! RFC-0097 D12, through the real binary: **`nros doctor` with no workspace
+//! verifies the INSTALL** instead of refusing to run.
+//!
+//! `nros-cli-core/src/cmd/doctor.rs`'s `install_report_tests` cover what the
+//! report SAYS. This file covers whether a user standing in a directory that is
+//! not a nano-ros checkout can reach it at all — which is a different question,
+//! and was answered "no" until D12. Measured on 2026-09-10 from `/tmp`:
+//!
+//! ```text
+//! Error: could not auto-detect the nano-ros workspace root; pass --workspace <path> explicitly
+//! ```
+//!
+//! A user who has just run `install.sh` has no workspace to pass. The one
+//! person who needed the answer was the one person refused it.
+//!
+//! Every knob here is passed as CHILD-process environment, so nothing in this
+//! test process is mutated and no other test can race it. `NROS_STORE` points
+//! at a tempdir (the report must never read the developer's real store) and
+//! `NROS_OFFLINE` keeps the RFC-0097 D5 index fetch off the network.
+
+use std::{path::Path, process::Command};
+
+fn doctor_in(cwd: &Path, store: &Path) -> (Option<i32>, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_nros"))
+        .arg("doctor")
+        .current_dir(cwd)
+        .env("NROS_STORE", store)
+        .env("NROS_OFFLINE", "1")
+        // The launcher must not dispatch out of this test, and the workspace
+        // walk must not find one above the tempdir.
+        .env_remove("NROS_WORKSPACE_ROOT")
+        .env_remove("NROS_WORKSPACE")
+        .output()
+        .expect("failed to exec nros");
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.code(), text)
+}
+
+/// The acceptance: it runs, it succeeds, and it reports the install.
+#[test]
+fn doctor_outside_a_workspace_reports_the_install_and_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let cwd = tmp.path().join("fresh-user");
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let (code, text) = doctor_in(&cwd, &store);
+    assert!(
+        !text.contains("could not auto-detect"),
+        "D12: no workspace is a different QUESTION, not a failure:\n{text}"
+    );
+    assert_eq!(code, Some(0), "a healthy install exits 0:\n{text}");
+    for needle in ["store", "launcher", "pin"] {
+        assert!(
+            text.contains(needle),
+            "the install report must cover `{needle}`:\n{text}"
+        );
+    }
+    assert!(
+        text.contains(&store.display().to_string()),
+        "it must name the store it read — and that store is $NROS_STORE, never \
+         a hardcoded ~/.nros:\n{text}"
+    );
+}
+
+/// And it still FAILS when the install is broken: a project pinning a nano-ros
+/// the store cannot produce cannot be built, so `doctor` must say so with a
+/// non-zero exit. Without this the verb would be unfalsifiable — it would exit
+/// 0 whatever it found.
+#[test]
+fn doctor_outside_a_workspace_still_fails_on_an_unresolvable_pin() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    // A store toolchain, so the launcher decision reaches the pin at all.
+    let bin = store.join("sdk").join("nros").join("0.7.9").join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(bin.join("nros"), b"#!/bin/sh\nexit 0\n").unwrap();
+
+    let cwd = tmp.path().join("someone-elses-project");
+    std::fs::create_dir_all(&cwd).unwrap();
+    std::fs::write(
+        cwd.join("nros-toolchain.toml"),
+        "[toolchain]\nversion = \"0.9.9\"\n",
+    )
+    .unwrap();
+
+    let (code, text) = doctor_in(&cwd, &store);
+    assert_ne!(code, Some(0), "an unresolvable pin must not exit 0:\n{text}");
+    assert!(
+        text.contains("0.9.9"),
+        "it must name the version the project asked for:\n{text}"
+    );
+}

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -158,6 +158,14 @@ KNOB_CLASS = {
     # goldens it rewrites are compared byte-for-byte on every other run.
     "NROS_UPDATE_GOLDEN": ("infra", "test-only golden regeneration"),
     "NROS_CARGO_FLAGS": ("infra", "the --locked shim"),
+    # phase-443 W1 (RFC-0097 D5) — the SDK index is FETCHED and cached in the
+    # store rather than read out of the release asset, so an index that moves 70
+    # times per 60 days stops forcing a CLI release. Both are infrastructure:
+    # one names WHERE to fetch (the sibling of scripts/install.sh's
+    # NROS_INSTALL_URL) and one is a bool. Neither sizes anything, so neither
+    # has a rung.
+    "NROS_INDEX_URL": ("infra", "where the SDK index is fetched from; a mirror or a file:// copy"),
+    "NROS_INDEX_REFRESH": ("infra", "re-fetch even when the cache is warm; a bool, so it has no rung"),
     "NROS_LINK_IP": ("infra", "link toggle"),
     "NROS_PLATFORMS_DIR": ("infra", "the ladder's own search path"),
     "NROS_PLATFORM_NAME": ("infra", "the ladder's own platform rung input"),
@@ -459,6 +467,11 @@ NON_READ_CALLEES = {
     "set_var", "remove_var", "with_env",  # WRITES an environment
     "push", "insert",  # builds a list / a fact map
     "get", "contains", "contains_key", "starts_with",  # inspects one
+    # phase-443 W5. `Some("NROS_X")` CONSTRUCTS an Option holding the name --
+    # in practice an `assert_eq!(probe.env.as_deref(), Some("NROS_X"))` checking
+    # that an index entry declares the right override variable. It cannot be a
+    # read: the environment is never consulted by wrapping a string literal.
+    "Some",
 }
 
 _CALL_RE = r'([A-Za-z_][A-Za-z0-9_:]*)\s*\(\s*&?"({prefix}_[A-Z0-9_]+)"'


### PR DESCRIPTION
Implements **phase-443 W1 and W5** (RFC-0097 D5, D12). They ship together because both touch `cmd/setup.rs`.

## W1 — the index is fetched and cached, not read out of the asset

`nros-sdk-index.toml` moves **70 times per 60 days** and has no ABI: it is a manifest of *pointers* into nano-ros-sdk's per-tool releases, so a newer index is readable by an older CLI. Shipping it inside the release asset made each of those 70 commits a reason to cut a CLI release.

It is now fetched into `<store>/fetch/` and cached there, with the shipped copy kept as the **fallback** rather than the source — a first run with no network and no cache still works. The offline path is *named* in the failure text (`NROS_INDEX_URL`, the sibling of `scripts/install.sh`'s `NROS_INSTALL_URL`), and a response this binary cannot parse never becomes the cache.

## W5 — the build stage is a `--check` question, not a build failure

`rosidl` is pulled in by a *target build*, not by a board. `nros setup <board>` resolves the board's packages plus the chosen rmw's, and the rmw defaults to zenoh, so a plain board setup never reaches `[rmw.cyclonedds]` and never provisions it — a host with no ROS met it mid-compile. The failure text was already right; the **timing** was wrong.

`build_stage = true` marks such a source and `nros setup --check` reports it with its remedy. The presence test is a **ladder**: a host with ROS sourced has `rosidl_adapter` importable and needs nothing provisioned, so a directory probe alone would report every such host MISSING and exit nonzero on a correct setup.

`nros doctor` with **no workspace** now verifies the *install* — launcher, store, pin resolution — instead of refusing. The user who has just run `install.sh` has nothing to point it at and was the one user it declined to answer.

## Verification

Eight mutations, seven caught, **one survivor that was a bad test**: moving the cache to `<store>/sdk` left `the_cache_is_derived_from_the_store_root_it_was_given` green, because it asserted `starts_with` and `<store>/sdk/fetch/...` has the store as a prefix too. `<store>/sdk` is not a hypothetical wrong answer — it is `sdk_store::store_root()`, and it is where this landed once already in phase-440. Strengthened, then re-run: no survivors.

Three gates then caught what the tests did not — a hand-rolled temp+rename (`check-atomic-sync-writes`), two unclassified knobs and an unknown idiom (`check-config-knob-census`), and the stale-CLI symptom.

`just check fast` 292/292 · 1054 lib tests · 2 integration tests.

## ⚠️ Known collision with #830, which is ahead of this in the queue

`validate()` refuses `build_stage = true` with no `dest`. #830 gives `[source.rosidl]` `location = "store"` and **removes** its `dest`. Once both land the shipped index has both properties and the validator rejects it.

This fails **loudly**: `sdk_index.rs` loads the real `nros-sdk-index.toml` through `validate()` in its own test suite, so the rebase that brings them together goes red locally and in CI rather than shipping a CLI that cannot read its own index. The rule wants widening to *"a build-stage source needs a resolvable location"* — an authored `dest` or a derived store path — which needs #830's `SourceLocation` to exist first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)