### PR TITLE
docs(phase-444): the RMW report is clean; the records under it were not

### DIFF
--- a/docs/design/0038-zero-copy-data-transport.md
+++ b/docs/design/0038-zero-copy-data-transport.md
@@ -163,7 +163,7 @@ The buffered path is where a DDS backend has something to gain, and for Cyclone
 that gain is large but unrelated to loans: upstream's serialized take is
 `dds_takecdr` → `ddsi_serdata_to_ser` into the caller's buffer, one `memcpy`
 (`rmw_node.cpp:3572`), where ours decodes to a typed struct and re-encodes. See
-[#0969](../issues/0969-cyclone-take-cdr-round-trip.md).
+[#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md).
 
 ### micro-XRCE-DDS (the production MCU peer — most relevant)
 
@@ -483,7 +483,7 @@ backend calls.
 | zenoh-pico C backend | n/a | **populate** the slot → call the Rust `ZenohSubscriber` leaf |
 | zpico `ZenohSubscriber` (Rust leaf) | implemented (subscriber.rs:1043) | the leaf the slot invokes; gains size-class pools (D1) |
 | xrce (C backend) | no slot | populate the slot over its shared static pool, or leave NULL (buffered) |
-| cyclonedds (C backend) | no slot | leave NULL (buffered) — **permanently**, not "first". Upstream returns `RMW_RET_UNSUPPORTED` for the loan take without shared memory, and its SHM path copies anyway (see the survey amendment). The win for this backend is on the buffered path: [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) |
+| cyclonedds (C backend) | no slot | leave NULL (buffered) — **permanently**, not "first". Upstream returns `RMW_RET_UNSUPPORTED` for the loan take without shared memory, and its SHM path copies anyway (see the survey amendment). The win for this backend is on the buffered path: [#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md) |
 | mock (Rust, test-only) | falls back | buffered fallback permanently |
 
 Land the executor scaffold first (done, behind the fallback), then the CFFI vtable

--- a/docs/issues/1088-cyclone-take-request-destroys-and-reports-empty.md
+++ b/docs/issues/1088-cyclone-take-request-destroys-and-reports-empty.md
@@ -39,3 +39,12 @@ timeouts. Nothing counts the drop.
 Reserve the correlation slot **before** the destructive take, or peek before
 taking. Report exhaustion as a distinct condition — `WOULD_BLOCK` reaching the
 caller, or a counted-and-logged drop — never as an empty queue.
+
+## Status — 2026-09-10: half fixed
+
+`bd9948e23d` reserves the correlation slot BEFORE the destructive take, so a request is
+no longer consumed and lost. The second half of the Fix above is NOT done: the
+`service_take_request` adapter still maps `WOULD_BLOCK` to `taken = false` with `OK`, so
+a saturated server reads as an empty queue. That is now contract-correct about
+consumption — the sample stays on the reader — but not about observability. No
+regression test was added. Carried as phase-444 W1.

--- a/docs/issues/archived/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/archived/0969-cyclone-take-cdr-round-trip.md
@@ -1,7 +1,7 @@
 ---
 id: 969
 title: "The Cyclone RMW deserializes every received sample and re-serializes it, so `take_serialized` costs a decode, an encode and two heap allocations per take"
-status: open
+status: resolved
 area: [rmw, memory]
 severity: high
 related: [0958, 0781, 0896, phase-391, phase-403, rfc-0035, 0038]
@@ -100,7 +100,7 @@ control loop.
 > at ~6 KB. So of the three costs asserted here, the CPU one is real at every
 > size and the allocation one is a trade, not a win.
 
-**Real-time bound.** [phase 391](../roadmap/phase-391-allocation-unification-and-tier-model.md) argues
+**Real-time bound.** [phase 391](../../roadmap/phase-391-allocation-unification-and-tier-model.md) argues
 the heap holds infrastructure while payload buffers stay static, and derives a
 Robson bound from that. Every Cyclone take allocates a *payload-sized* block, and
 the ostream's growth-by-realloc allocates a second one whose size depends on the
@@ -112,7 +112,7 @@ big-endian peer emits big-endian. So the caller does not receive the wire
 representation — it receives a re-encoding, with an encapsulation header we
 synthesized. This is why the sizing work has to reason about
 `MAX_SERIALIZED_SIZE_XCDR1` for this backend while the wire carries XCDR2
-(see [#0964](archived/0964-two-different-sizes-for-the-same-type.md)). Taking the serdata's
+(see [#0964](0964-two-different-sizes-for-the-same-type.md)). Taking the serdata's
 own bytes removes the discrepancy rather than documenting it.
 
 ## Direction
@@ -129,13 +129,13 @@ the same treatment. The request path in `src/service.cpp:657` mirrors it and
 should be checked, not assumed.
 
 **Not in scope here:** the publish direction, which genuinely needs the sertype we
-do not own — that is [#0970](archived/0970-cyclone-rmw-should-own-its-sertype.md), and it
+do not own — that is [#0970](0970-cyclone-rmw-should-own-its-sertype.md), and it
 subsumes this fix if it lands first.
 
 **Also not in scope:** filling the ABI's `take_loaned_message` slot for this
 backend. Upstream returns `RMW_RET_UNSUPPORTED` for it without shared-memory
 support, and even its SHM path ends in a `memcpy`; see the amendment to
-[design 0038](../design/0038-zero-copy-data-transport.md). Removing the round trip
+[design 0038](../../design/0038-zero-copy-data-transport.md). Removing the round trip
 is the whole of the available win on the buffered path.
 
 ## Verification — measured
@@ -161,7 +161,7 @@ real-time budget most dislikes. The after figure is exactly 2.00 across 199
 messages.
 
 **Correcting this section as first written:** it said the
-[phase 394](../roadmap/phase-394-memory-campaign-ledger.md) ledger could report
+[phase 394](../../roadmap/phase-394-memory-campaign-ledger.md) ledger could report
 allocation count per take. It cannot — that instrument reads static RAM out of an
 ELF symbol table. Runtime allocation needed an instrument and did not have one.
 
@@ -183,7 +183,7 @@ the header either. Two consequences survive this issue rather than being removed
 by it — a deserialiser must tolerate trailing bytes (nros-serdes reads by
 position, so it does), and a receive buffer cut to a type's exact
 `MAX_SERIALIZED_SIZE` can be up to 3 bytes short of what a remote peer delivers.
-That belongs to [#0964](archived/0964-two-different-sizes-for-the-same-type.md).
+That belongs to [#0964](0964-two-different-sizes-for-the-same-type.md).
 
 ## The third site was CHECKED 2026-09-03 — still unconverted, and the reason is 0976
 
@@ -199,7 +199,7 @@ assumed". Checked. It is NOT converted:
 
 **And the interesting part: converting it would REMOVE adapters, not conflict
 with them.** The first read of this is that the five action adapters
-([#0976](archived/0976-service-action-adapters-tested-only-against-ourselves.md)) block the
+([#0976](0976-service-action-adapters-tested-only-against-ourselves.md)) block the
 change, because they reshape bytes the typed path produces. The direction matters:
 
 * `strip_goal_id_len_at` and `strip_nested_cdr_at` correct bytes WE generate.
@@ -247,7 +247,7 @@ that witness, converting this path would have changed the action wire format wit
 nothing in the tree able to tell.
 
 **Not measured, and not expected to move:** delivery rate at the fragment sizes
-in [#0917](0917-an536-fragmented-sample-never-syncs.md). That cliff is the
+in [#0917](../0917-an536-fragmented-sample-never-syncs.md). That cliff is the
 LAN9118's RX FIFO capacity and has nothing to do with serialisation. What should
 move on that lane is per-message CPU and allocation, so the rate below the cliff
 and the jitter — an an536 measurement still owed.
@@ -492,7 +492,7 @@ the two curves cross at roughly **8 KB of reply payload**:
 
 Flat-versus-linear is the more useful half. A fixed ~8.4 KB per exchange is easy
 to bound and impossible to shrink; a payload-proportional cost is the opposite.
-For [phase 391](../roadmap/phase-391-allocation-unification-and-tier-model.md)'s
+For [phase 391](../../roadmap/phase-391-allocation-unification-and-tier-model.md)'s
 Robson bound the linear one is the better shape — it is derivable from the type's
 own `MAX_SERIALIZED_SIZE`, which is exactly what issue 0896 makes available —
 whereas the old constant was a number nobody could attribute.
@@ -650,3 +650,11 @@ wrong is worse than no bench — it answers confidently.
 
 The check now prints the decoded length at every point and every run above shows
 it matching. Timings collected before it matched were discarded, not adjusted.
+
+## Resolution — 2026-09-10
+
+Both receive paths now take the wire CDR straight from the serdata: `subscriber.cpp`
+(`dds_takecdr` then `ddsi_serdata_to_ser` into the caller's buffer) and the service
+path's `take_typed_wire` (`41195b84f8`). The publish direction was #0970, resolved. The
+removed cost is measured above (45.5 ns per 36 B reply). Found still `open` by the
+phase-444 review.

--- a/docs/issues/archived/0970-cyclone-rmw-should-own-its-sertype.md
+++ b/docs/issues/archived/0970-cyclone-rmw-should-own-its-sertype.md
@@ -141,7 +141,7 @@ cannot avoid.
 allocations.** This section first went on to say per-message allocation was
 "otherwise gone" from the service and action data path. The ledger does not
 support that claim and the runtime measurement contradicts it — see
-[#0969](../0969-cyclone-take-cdr-round-trip.md), where the allocation COUNT comes
+[#0969](0969-cyclone-take-cdr-round-trip.md), where the allocation COUNT comes
 out unchanged before and after, and the BYTES cross over at ~6 KB rather than
 falling. A site disappearing from a ledger is not a call disappearing at runtime.
 

--- a/docs/issues/archived/1008-wait-for-service-never-waits.md
+++ b/docs/issues/archived/1008-wait-for-service-never-waits.md
@@ -3,7 +3,7 @@ id: 1008
 title: "`wait_for_service` returns `Ok(true)` immediately on every real backend —
   its fast path calls `is_server_ready()`, whose trait default is `true` and
   which only zenoh overrides"
-status: open
+status: resolved
 type: bug
 area: api, rmw
 related: [phase-379, rfc-0018]
@@ -74,3 +74,12 @@ under rclcpp's NAME:
 The call sites become `matches!(…, Ok(true))`, so `Ok(false)` **and** `Err` both
 fall through to the wait loop. That is the behaviour the fast path's comment
 already claims: "already proven once" should mean proven, not assumed.
+
+## Resolution — 2026-09-10
+
+Fixed by `3941b569a2` (phase-379 W6 decision 2): `is_server_ready` is deleted,
+`service_is_ready` returns the two-channel result in all three languages, and
+`wait_for_service` takes `Ok(true)` only (`handles.rs:2192`), so `Ok(false)` and `Err`
+both fall through to the wait loop. `packages/rmw/cffi/tests/server_available.rs` was
+updated in the same commit. The file stayed `open` for a week after the fix shipped;
+found by the phase-444 review.

--- a/docs/issues/archived/1237-posix-port-yield-from-foreign-thread.md
+++ b/docs/issues/archived/1237-posix-port-yield-from-foreign-thread.md
@@ -3,7 +3,7 @@ id: 1237
 title: "Cyclone's receive thread calls FreeRTOS scheduler primitives on the
   freertos-posix lane, and the port asserts: `vPortYield` from a
   non-FreeRTOS thread"
-status: open
+status: resolved
 type: bug
 area: platform, rmw
 severity: high
@@ -148,3 +148,9 @@ Fixed by declining the wake slot on this board (option 1). Verified:
 This filing originally guessed the wrong function and said what would refute
 it. The core named `nros_platform_wake_signal`, so that guess was corrected
 here rather than quietly dropped.
+
+## Resolution — 2026-09-10
+
+Closed on the Status section above: the wake slot is declined on this board, verified
+before and after. The file stayed `open` after the code shipped (`a9a9febcd2` records
+that the code half had already landed); found by the phase-444 review.

--- a/docs/reference/cyclonedds-known-limitations.md
+++ b/docs/reference/cyclonedds-known-limitations.md
@@ -33,7 +33,7 @@ because Cyclone 0.10.5 does not expose `dds_writer_lookup_serdatatype()`, and
 pointed at upstream
 [cyclonedds#1342](https://github.com/eclipse-cyclonedds/cyclonedds/issues/1342)
 as the thing to wait for. Two corrections
-([#0969](../issues/0969-cyclone-take-cdr-round-trip.md),
+([#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md),
 [#0970](../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md)):
 
 * `dds_takecdr` takes a reader entity and nothing else, so the RECEIVE side was
@@ -72,7 +72,7 @@ running the Rust, C and C++ action clients against a stock ROS 2 server shows
 identical decline counts — three independent producers agreeing the corrections
 have nothing left to correct. The runtime already emits the fixed `octet[16]`
 (publisher.cpp's 233.6 note). So
-[#0969](../issues/0969-cyclone-take-cdr-round-trip.md)'s expectation that
+[#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md)'s expectation that
 converting this path would DELETE these adapters rather than preserve them is
 measured on the write side.
 
@@ -325,7 +325,7 @@ this in any external integration guide.
 
 **Measured, and 5× lower than this section used to describe.** Per publish+take
 round trip, on the same harness before and after
-[#0969](../issues/0969-cyclone-take-cdr-round-trip.md) /
+[#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md) /
 [#0970](../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md):
 
 | | allocs @1 msg | allocs @200 msgs | per message |
@@ -354,7 +354,7 @@ allocation pressure" is no longer true, which is why it is no longer here.
 
 **Still allocating per message:** `src/service.cpp` — three sites, one per
 request and two per reply. The take side is
-[#0969](../issues/0969-cyclone-take-cdr-round-trip.md)'s third site
+[#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md)'s third site
 (`take_typed_wire`, which re-encodes XCDR1 native-endian — a correctness
 question, not only a cost one); the witness situation is
 [#0976](../issues/archived/0976-service-action-adapters-tested-only-against-ourselves.md).
@@ -427,7 +427,7 @@ There is no receive buffer here to size:
 * the destination is the CALLER's buffer, whose capacity arrives on every `take`
   and is authoritative there.
 
-Before [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) there was exactly
+Before [#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md) there was exactly
 one candidate consumer — the `dds_ostream` that re-serialised the typed sample
 grew by `realloc`, and an initial size would have saved those reallocs. That
 ostream went with the round trip, and with it the last thing a hint could have

--- a/docs/roadmap/archived/phase-393-rmw-contract-remainder.md
+++ b/docs/roadmap/archived/phase-393-rmw-contract-remainder.md
@@ -1,6 +1,10 @@
 # Phase 393 — what is left of the RMW contract, and what deliberately is not
 
-**Status (2026-08-30). W1, W2 and W2a DONE; W3 holds. The contract work this
+**Status (2026-09-10). COMPLETE — superseded by [phase-444](../phase-444-rmw-fix-up.md),
+which carries #1021 and the per-backend remainder. The counts below are the 2026-08-30
+reading, kept as history.**
+
+Earlier status (2026-08-30). W1, W2 and W2a DONE; W3 holds. The contract work this
 doc scoped is finished — what remains is VERIFICATION, which is a different
 thing and is called out below.** Measured with `just check rmw-slot-producers`:
 produced 53, default 7, unimplemented 0, **inert 14**, and
@@ -171,9 +175,9 @@ holds the evidence, the item is *close it*.
 
 | issue | why it belongs here |
 | --- | --- |
-| [#0970](../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md) | the Cyclone backend borrows Cyclone's generated sertype instead of registering its own — the contract gap behind the CDR round trip. **RESOLVED**; the removed decode+encode is worth ~46 ns/message (176 ns at 16 KB), measured in 0969. Its allocation-site ledger reads 2 -> 1, which is SITES and not runtime calls — the runtime count did not move |
-| [#0971](../issues/archived/0971-take-sequence-cannot-say-why-it-stopped.md) | `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it |
-| [#0976](../issues/archived/0976-service-action-adapters-tested-only-against-ourselves.md) | five action adapters in the Cyclone service path reshape the CDR to match ROS 2, exercised only by nano-ros talking to itself. This is the VERIFICATION remainder W3 names |
+| [#0970](../../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md) | the Cyclone backend borrows Cyclone's generated sertype instead of registering its own — the contract gap behind the CDR round trip. **RESOLVED**; the removed decode+encode is worth ~46 ns/message (176 ns at 16 KB), measured in 0969. Its allocation-site ledger reads 2 -> 1, which is SITES and not runtime calls — the runtime count did not move |
+| [#0971](../../issues/archived/0971-take-sequence-cannot-say-why-it-stopped.md) | `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it |
+| [#0976](../../issues/archived/0976-service-action-adapters-tested-only-against-ourselves.md) | five action adapters in the Cyclone service path reshape the CDR to match ROS 2, exercised only by nano-ros talking to itself. This is the VERIFICATION remainder W3 names |
 
 
 ## Adopted issues (2026-09-04) — a backend that does not build in a shipped configuration
@@ -182,11 +186,11 @@ Two open issues had no phase and are the same statement: a backend must compile
 in the configurations the platform layer actually selects, and neither of these
 does.
 
-* **[#1023](../issues/archived/1023-sertype-hosted-includes-break-freestanding.md)** —
+* **[#1023](../../issues/archived/1023-sertype-hosted-includes-break-freestanding.md)** —
   `nros_sertype.cpp` includes `<memory>` and `<string>` unconditionally, so
   cyclonedds cannot compile freestanding. Archived issue 0112's class at a new
   site, with the sibling TU in the same directory already carrying the lesson.
-* **[#1021](../issues/1021-zenoh-pico-1-8-0-matching-off-build-break.md)** —
+* **[#1021](../../issues/1021-zenoh-pico-1-8-0-matching-off-build-break.md)** —
   zenoh-pico 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`, which is
   exactly what nano-ros passes on Zephyr. Upstream's, carried on our patch line.
 

--- a/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
+++ b/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
@@ -973,7 +973,7 @@ Four open issues describe the gap between what this phase claims and what a
 ported node gets. They had no home; they belong here because each is a place the
 parity CLAIM and the parity MEASUREMENT disagree.
 
-* **[#1008](../issues/1008-wait-for-service-never-waits.md)** — `wait_for_service`
+* **[#1008](../issues/archived/1008-wait-for-service-never-waits.md)** — `wait_for_service`
   returns `Ok(true)` immediately on every real backend. The API is present and
   the behaviour is not, which is the exact failure mode a parity ledger exists to
   catch and did not.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -668,7 +668,7 @@ in this backend to size. The sample arrives in a serdata sized by the sample, an
 the destination is the caller's buffer, whose capacity arrives on every `take`.
 The one candidate consumer — the `dds_ostream` that re-serialised the typed
 sample and grew by `realloc` — went with the CDR round trip in
-[issue 0969](../issues/0969-cyclone-take-cdr-round-trip.md). So the hint is
+[issue 0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md). So the hint is
 INAPPLICABLE here rather than unimplemented, and the ordering note below is
 correspondingly wrong: W3f does not make W3c/W3d/W3e observable on a Cyclone
 image, because nothing in this backend was ever going to route on the hint. What
@@ -1590,7 +1590,7 @@ holds the evidence, the item is *close it*.
 | --- | --- |
 | [#0852](../issues/0852-zephyr-serial-rx-is-polled-and-overruns.md) | the zenoh read task inherits the executor's priority on Zephyr |
 | [#0880](../issues/0880-tcm-unused-while-sram-exhausted.md) | 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted |
-| [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a full round trip. **Round trip removed; cost measured** — ~46 ns/message floor (176 ns at 16 KB). The allocation saving this row assumed did NOT appear: count unchanged, bytes a crossover at ~6 KB. Remaining: the third site, per 0976 |
+| [#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a full round trip. **Round trip removed; cost measured** — ~46 ns/message floor (176 ns at 16 KB). The allocation saving this row assumed did NOT appear: count unchanged, bytes a crossover at ~6 KB. Remaining: the third site, per 0976 |
 
 
 ## Adopted issue (2026-09-04)

--- a/docs/roadmap/phase-444-rmw-fix-up.md
+++ b/docs/roadmap/phase-444-rmw-fix-up.md
@@ -1,0 +1,112 @@
+# Phase 444 — RMW fix-up: what the contract report shows, and what the issue records hid
+
+**Status (2026-09-10). Not started. Opened from a review of the RMW report; supersedes
+phase-393, which is archived in the same change.**
+
+Implements RFC-0054 (the C headers are the ABI SSoT). Continues phase-393 (archived).
+
+## Why this phase exists
+
+Phase-393 closed on *"the contract work this doc scoped is finished — what remains is
+VERIFICATION"*, and the tools still agree. That claim holds. What it did not cover is
+everything between "the slot exists" and "the slot is right": per-backend coverage the
+aggregate hides, correctness issues with no home or the wrong home, and issue records
+that lag the code.
+
+## The report, measured 2026-09-10
+
+| tool | reading |
+| --- | --- |
+| `just check rmw-api-parity` | 88 contract symbols, **0 gap**, 20 declined with reasons, 7 answered by an inert slot |
+| `just check rmw-abi-shape` | 65 mirrored: 15 identical, 39 with declared arg differences, 9 grouped, **0 undeclared differences, 0 missing slots** |
+| `just check rmw-slot-producers` | 68 slots: 58 produced, 4 default, 6 inert |
+
+Phase-393's own status block had drifted from this (it read produced 53, default 7,
+inert 14, and listed as inert the on-new-* callbacks, content filter and network-flow
+slots that phase-407 declined and removed). Per backend, of 68 slots:
+
+| backend | filled | graph |
+| --- | --- | --- |
+| cyclonedds | 39 | **1 / 12** |
+| rust-adapter (every Rust backend) | 42 | 11 / 12 — a trampoline per slot, so this row cannot answer per backend |
+| xrce | 24 | 0 / 12 — declared `UNSUPPORTED`, tested |
+| uorb | 18 | 0 / 12 |
+
+## The records lagged the code
+
+Of the 23 open issues in the `rmw` area, **9 had a `fix(...)` commit naming them**. A fix
+commit is evidence, not a verdict: #1127 has one and its lane still stops before the
+cells. Each was read against its own acceptance:
+
+| issue | verdict | basis |
+| --- | --- | --- |
+| #1008 | **closed here** | `3941b569a2` deleted `is_server_ready`; `wait_for_service` takes `Ok(true)` only (`handles.rs:2192`); `cffi/tests/server_available.rs` updated in the same commit |
+| #1237 | **closed here** | its own Status section: wake slot declined on the board, before/after measured |
+| #0969 | **closed here** | both receive paths take wire CDR from the serdata (`subscriber.cpp`, and `take_typed_wire` via `41195b84f8`); cost measured in the issue; publish half was #0970 |
+| #1088 | **open — half fixed** | `bd9948e23d` reserves the slot before the destructive take, so nothing is lost; the adapter still maps `WOULD_BLOCK` to `taken = false` + `OK`, which the issue's own Fix rules out; no regression test |
+| #0902 | open | two leak arms fixed (`b56e3d50a8` and its predecessor); the 20–90 % symptom never re-measured |
+| #1039 | open | 1 of 4 revised-acceptance boxes ticked |
+| #1139 | open | "Acceptance, still unmet" |
+| #1127 | open | the live-peer lane still stops in its fixture build |
+| #0852 | open, **not this phase** | Zephyr transport priorities; 1 of its 5 fix items landed |
+
+## Work items
+
+### W1 — #1088's other half
+
+The Cyclone `service_take_request` adapter still collapses `WOULD_BLOCK` to
+`taken = false` with `OK`. That is now contract-correct about *consumption* — the sample
+stays on the reader for the next take — but a saturated server is indistinguishable from
+an idle one, which is the half the issue's Fix names. Surface exhaustion (a distinct
+code or a counted, logged condition) and add the regression test the fix never got.
+
+**Acceptance.** A test with more than `kRequestSlots` requests outstanding that asserts
+none is lost AND that exhaustion is observable; it fails against the current adapter.
+
+### W2 — #0902, measured
+
+The mechanism fixes landed without a re-measurement of the symptom. This needs a router
+and a live peer, which is why it has not happened.
+
+**Acceptance.** The goal completion rate, measured on a freshly built image over enough
+runs to separate it from the 20–90 % the issue recorded.
+
+### W3 — Cyclone's graph reader (11 of 12 slots)
+
+Cyclone fills `get_node_names` and leaves eleven graph slots `nullptr`
+(`nros-rmw-cyclonedds/src/vtable.cpp`). Phase-381 W5 scoped one slot, and #0791 and #1137
+are both resolved — #1137 correctly ruled the eleven `UNSUPPORTED` answers intended — so
+**nothing owns the rest**. A Cyclone node appears in `ros2 node list` and cannot say
+whether anything subscribes to its topics: the asymmetry phase-381 named as the defect.
+Needs a reader for `ros_discovery_info`, which `graph.cpp` only writes.
+
+**Acceptance.** `rmw-slot-producers` shows cyclonedds graph 12 / 12, and
+`native-graph-rust-cyclone-r2n` asserts beyond node names against a live peer. This is
+phase-sized and may be split out.
+
+### W4 — gates whose reach is narrower than their rule
+
+* **#1092** — `rmw-abi-shape` licenses a deviation without pinning it; the "39 declared"
+  figure above rests on those declarations.
+* **#1219** — RFC-0071's `check-rmw-agnostic` was never written.
+
+### W5 — #1021, carried from phase-393
+
+zenoh-pico 1.8.0 does not build with `Z_FEATURE_MATCHING=0`, which Zephyr passes.
+Phase-393 adopted it as a backend-build contract; archiving 393 moves it here.
+
+## A lesson the review surfaced
+
+`#[must_use]` went on `Executor::declare_parameter` (phase-428 W6) with a check of
+`cargo check -p nros-node --features std`. The two callers that dropped the value were in
+another crate, behind `param-services`, inside a module gated on `rmw-cffi` — never
+compiled by that check, which therefore passed. Every `nros` build with those features
+then failed on main, including the live-peer lane (fixed in PR #855). A check that does
+not enable the features that compile the callers checks nothing: the same "clean over code
+it never built" shape as the lane that counted skips as passes.
+
+## What this phase does NOT do
+
+* Change the contract. 0 gap stays 0; the 20 declined stay declined with their reasons.
+* Verify produced slots against live peers in general — phases 433 and 441.
+* Platform build issues (#1039 NuttX, #0852 Zephyr priorities).


### PR DESCRIPTION
Opens phase-444 based on a review of the RMW report, and archives phase-393, which it supersedes.

## The contract holds

| tool | reading |
| --- | --- |
| `rmw-api-parity` | 88 symbols, **0 gap**, 20 declined with reasons |
| `rmw-abi-shape` | 65 mirrored, **0 undeclared differences, 0 missing slots** |
| `rmw-slot-producers` | 68 slots, 58 produced, 4 default, 6 inert |

Phase-393's status block no longer matched these numbers. It still read 53/7/14, and it listed as inert several slots that phase-407 had declined and removed.

## The issue records did not

Of the 23 open issues in the `rmw` area, **9 have a `fix(...)` commit that names them**. A fix commit is evidence of work, not proof of closure: #1127 has one, and its lane still stops before reaching the cells. So I checked each against **its own acceptance criteria** before closing anything:

| | |
| --- | --- |
| **#1008** closed | `3941b569a2`: `wait_for_service` now takes only `Ok(true)`, and its test was updated in the same commit |
| **#1237** closed | its own Status section records the fix, measured before and after |
| **#0969** closed | both receive paths now take the wire CDR directly from the serdata; the cost is measured in the issue |
| **#1088** kept open, half fixed | the data loss is fixed, but the adapter still reports a saturated server as an empty queue, which the issue's own Fix section rules out; no regression test was added |
| #0902, #1039, #1139, #1127 | kept open, each with its reason recorded |

In my first pass at this roadmap I listed #1088 as unfixed, top of the list, based on its issue file alone. Reading the code corrected that. The same check showed the records can't be trusted without reading the code behind them.

## Phase-444 work items

- **W1**: the other half of #1088, plus its regression test.
- **W2**: re-measure #0902's completion rate.
- **W3**: the Cyclone graph reader. **11 of its 12 slots are `nullptr`, and no issue or phase owns them.** Phase-381 W5 scoped only one slot, and #0791 and #1137 are both resolved.
- **W4**: #1092 and #1219, gates whose coverage is narrower than the rule they enforce.
- **W5**: #1021, carried over from phase-393.

## Links

Moving four files into `archived/` changed the relative depth of their links. I rewrote every internal link in #0969 and phase-393, plus eight external links that referred to the moved files by path. `check-markdown-links` caught four links in phase-393 that I had missed: a `sort -u` in my own link listing had collapsed them into one. The count of dead links in archived documents is now **420**, down from the 422 baseline.

## Verification

`roadmap-status`, `issue-index`, `prose-issue-refs`, `doc-refs`, `doc-commit-citations` and `markdown-links` all pass. `just check fast` passes 291 of 292. The failing gate is `third-party-is-submodules`, which trips on an untracked `third-party/make/` on this host that this PR doesn't touch.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lee2SrWhASryz9dd5F28mS
