### PR TITLE
feat(phase-443 W2): the release records the four axes instead of asserting them equal

### DIFF
--- a/.github/workflows/release-nros.yml
+++ b/.github/workflows/release-nros.yml
@@ -11,28 +11,66 @@
 # glibc, its toolchain and whatever was in its environment, and nothing
 # afterwards can tell you which.
 #
-# WHAT A RELEASE MUST ASSERT ABOUT ITSELF
+# WHAT A RELEASE RECORDS ABOUT ITSELF — RFC-0097 D7, phase-443 W2
 #
 # The last time nano-ros shipped a prebuilt `nros`, the binary emitted code
 # that had drifted from the runtime, and drifted generated code COMPILES — so
-# the failure was silent and the download was withdrawn (phase-288 D1/D2). The
-# checks below are what makes shipping safe again, and each one is here because
-# it is the property a user cannot verify for themselves:
+# the failure was silent and the download was withdrawn (phase-288 D1/D2).
+#
+# This workflow used to answer that by ASSERTING three versions equal: the
+# release version, `NROS_CODEGEN_VERSION`, and `[tool.nros].version` in the
+# index. The coupling was mechanised, which is why it never drifted; it is also
+# why nothing could move alone. RFC-0097 measured what that cost — on `main`,
+# 2026-09-10: `packages/cli` 710 commits per 60 days, the runtime crates the CLI
+# compiles 248, `nros-sdk-index.toml` 70, and `NROS_CODEGEN_VERSION` 2, ALL
+# TIME. The axis carrying every compatibility promise moves twice, ever; the
+# artifact carrying it would have moved ~450 times as often.
+#
+# So the release now RECORDS its components instead. `share/nros/manifest.toml`
+# declares all four, and only `codegen` promises anything:
+#
+#     version  = "0.7.9"      the toolchain
+#     codegen  = 7            the ONLY field that can invalidate existing output
+#     index    = "2026-09-10" pointers into nano-ros-sdk
+#     nano_ros = "abc1234"    the runtime commit
+#
+# `0.7.1` and `0.7.9` both declaring `codegen = 7` is the whole feature: a user
+# takes either and re-emits nothing. `nros pin <version>` reads two manifests
+# out of the store and says so before it moves anything.
+#
+# ONE equality survives, because it is the one that is TRUE: the manifest's
+# `codegen` must equal `NROS_CODEGEN_VERSION` in the tree this binary was built
+# from. That is not a coupling between axes — it is the manifest being about the
+# artifact, and it is the assertion phase-288's silent failure actually needed.
+# It cannot be got wrong by construction either: the manifest is stamped by
+# `nros toolchain manifest`, which takes the number from the binary's own
+# `abi_guard::EMITTED_VERSION` and has no `--codegen` flag. `check-release-manifest`
+# gates that this step still exists and that the retired equalities stay retired.
+#
+# The other two are now REPORTED, not enforced: the index's pinned version and
+# the crate version are printed beside the release version so drift is visible.
 #
 #   source-stamp        the binary matches the checkout it was built from
-#   --codegen-version   it equals `NROS_CODEGEN_VERSION` in that same tree
-#   version agreement   the tag, the crate version and `[tool.nros].version`
-#                       in the index describe one artifact
+#   manifest codegen    it equals `NROS_CODEGEN_VERSION` in that same tree
 #
 # WHAT THE ASSET CONTAINS, and why each part is not optional
 #
 #   bin/nros                          the binary
+#   share/nros/manifest.toml          what this release is MADE OF (RFC-0097 D7)
+#                                     — read by `nros pin` and
+#                                     `nros toolchain manifest`, never parsed
+#                                     out of a filename
 #   share/nros/VERSION                the STORE version (`0.5.0-nros1`), which
 #                                     `nros --version` does not print — without
 #                                     it `install.sh` cannot name the prefix the
 #                                     index pins, and a later
 #                                     `nros setup --tool nros` installs a second
-#                                     copy of the same binary
+#                                     copy of the same binary. NOT replaced by
+#                                     the manifest: `install.sh` chooses the
+#                                     prefix in POSIX shell before anything is
+#                                     unpacked, and must not need a TOML parser
+#                                     to do it. The workflow writes both from
+#                                     one input, so they agree by construction
 #   share/nros/nros-sdk-index.toml    a released `nros` has no checkout to find
 #                                     an index in, so `nros setup <board>` fails
 #                                     outright without this (phase-431 W5,
@@ -50,7 +88,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "store version to release, e.g. 0.5.0-nros1 (must equal [tool.nros].version)"
+        description: "store version to release, e.g. 0.5.0-nros1 (recorded, not asserted equal to anything — RFC-0097 D7)"
         required: true
         type: string
       publish:
@@ -94,52 +132,77 @@ jobs:
           # this, so it is asserted here rather than assumed.
           "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
 
-      - name: Verify the release describes itself
+      - name: Record what this release is made of
         run: |
           set -euo pipefail
           nros="$GITHUB_WORKSPACE/packages/cli/target/release/nros"
           want_version='${{ inputs.version }}'
+          stage="$RUNNER_TEMP/prefix"
+          mkdir -p "$stage/share/nros"
 
-          # 1. The codegen version the binary emits must be the one THIS TREE's
-          #    runtime accepts. A release claiming a compatibility it does not
-          #    have is the exact failure that withdrew the last one.
-          emitted="$("$nros" --codegen-version)"
-          declared="$(sed -n 's/^pub const NROS_CODEGEN_VERSION: u32 = \([0-9]\+\);.*/\1/p' \
+          # RECORD. `codegen` is taken by the binary from its own
+          # `abi_guard::EMITTED_VERSION` — there is no flag for it, so this
+          # cannot record a number the binary does not emit. `index` is a DATE
+          # (the index is a table of pointers into `nano-ros-sdk`, which
+          # publishes per-tool and has no version of its own, RFC-0097 D5).
+          #
+          # `actions/checkout@v4` fetches depth 1, so a path-limited `git log`
+          # is empty unless HEAD itself touched the index. Falling back to
+          # HEAD's own date keeps the field HONEST for a shallow clone: "the
+          # index as of this commit" is true either way, where an empty string
+          # would only look like a missing field.
+          index_date="$(git log -1 --format=%cs -- nros-sdk-index.toml || true)"
+          [ -n "$index_date" ] || index_date="$(git log -1 --format=%cs)"
+          "$nros" toolchain manifest \
+              --store-version "$want_version" \
+              --index "$index_date" \
+              --nano-ros "$(git rev-parse --short HEAD)" \
+              --write "$stage/share/nros/manifest.toml"
+          cat "$stage/share/nros/manifest.toml"
+
+          # THE ONE EQUALITY THAT SURVIVES. The manifest promises that code
+          # emitted by this binary compiles against this tree's runtime, and
+          # that promise is checkable here and nowhere downstream: drifted
+          # generated code COMPILES, so a wrong number is silent forever
+          # (phase-288 D1/D2). Everything else this workflow used to assert has
+          # become a printed NOTE below.
+          manifest_codegen="$(sed -n 's/^codegen = \([0-9]\+\)$/\1/p' "$stage/share/nros/manifest.toml")"
+          tree_codegen="$(sed -n 's/^pub const NROS_CODEGEN_VERSION: u32 = \([0-9]\+\);.*/\1/p' \
               packages/core/nros-core/src/codegen_version.rs)"
-          if [ "$emitted" != "$declared" ]; then
-              echo "::error::the binary emits codegen version $emitted, the tree declares $declared" >&2
+          if [ -z "$manifest_codegen" ] || [ -z "$tree_codegen" ]; then
+              echo "::error::could not read the codegen version (manifest '$manifest_codegen', tree '$tree_codegen')" >&2
               exit 1
           fi
-          echo "codegen version: $emitted (binary and tree agree)"
+          if [ "$manifest_codegen" != "$tree_codegen" ]; then
+              echo "::error::the manifest records codegen $manifest_codegen, the tree declares $tree_codegen" >&2
+              exit 1
+          fi
+          echo "codegen $manifest_codegen: the manifest and packages/core/nros-core agree"
 
-          # 2. The index must already pin the version being released. The store
-          #    prefix is named from it, and `install.sh` reads it out of the
-          #    asset — three places, one string.
+          # REPORTED, NOT ENFORCED. These two used to be hard failures, and
+          # they are exactly the couplings D7 removes: an index edit and a CLI
+          # version bump are invisible to already-generated code, so neither may
+          # block a release. They are still worth SEEING, because a surprise
+          # here is usually a mistake — just not one this workflow gets to
+          # decide.
           indexed="$(sed -n '/^\[tool\.nros\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' nros-sdk-index.toml)"
-          if [ "$indexed" != "$want_version" ]; then
-              echo "::error::releasing $want_version but [tool.nros].version is $indexed — bump the index first" >&2
-              exit 1
-          fi
-
-          # 3. The store version is the crate version plus a repackaging
-          #    counter, so the crate version must be its prefix. This catches
-          #    releasing `0.6.0-nros1` off a 0.5.0 tree, which would install
-          #    under a name that promises code the binary does not have.
           crate="$("$nros" --version | awk '{print $NF}')"
-          case "$want_version" in
-              "$crate"-nros*) ;;
-              *)
-                  echo "::error::version $want_version is not <crate>-nrosN for crate version $crate" >&2
-                  exit 1
-                  ;;
-          esac
-          echo "version: $want_version (crate $crate, index agrees)"
+          echo "note: releasing   $want_version"
+          echo "note: crate       $crate"
+          echo "note: index pins  ${indexed:-<none>}"
+          if [ "$indexed" != "$want_version" ]; then
+              printf '::warning::%s\n' \
+                  "[tool.nros].version is '${indexed:-<none>}', not '$want_version' — a later 'nros setup --tool nros' resolves a different prefix until the index is bumped."
+          fi
 
       - name: Stage the prefix
         run: |
           set -euo pipefail
+          # `share/nros/manifest.toml` is already here — the recording step
+          # wrote it into this same prefix, so what was verified is what ships.
           stage="$RUNNER_TEMP/prefix"
           mkdir -p "$stage/bin" "$stage/share/nros"
+          test -f "$stage/share/nros/manifest.toml"
           cp packages/cli/target/release/nros "$stage/bin/nros"
           printf '%s\n' '${{ inputs.version }}' >"$stage/share/nros/VERSION"
           cp nros-sdk-index.toml "$stage/share/nros/nros-sdk-index.toml"
@@ -184,7 +247,14 @@ jobs:
           cd "$RUNNER_TEMP"
           "$installed" --codegen-version
           "$installed" setup --list >/dev/null
-          echo "the asset installs, fronts, and finds its own index"
+          # RFC-0097 D7 — the manifest must survive the install and be READ back
+          # by the installed binary, from the file, at the prefix it landed in.
+          # An asset whose manifest the CLI cannot read is an asset for which
+          # `nros pin` cannot answer the re-emit question, which is the whole
+          # point of shipping it.
+          "$installed" toolchain manifest | tee "$RUNNER_TEMP/read-back.toml"
+          grep -qx "codegen = $("$installed" --codegen-version)" "$RUNNER_TEMP/read-back.toml"
+          echo "the asset installs, fronts, finds its own index, and declares its components"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -207,6 +277,12 @@ jobs:
           # sit where YAML expects a key (CLAUDE.md's pitfall index).
           printf '%s\n' \
             "The \`nros\` CLI, codegen version $("$nros" --codegen-version)." \
+            "" \
+            "Coming from another release that declares the SAME codegen version?" \
+            "Nothing is re-emitted — take it (RFC-0097 D7). \`nros pin <version>\`" \
+            "reads both manifests out of your store and says so before it moves" \
+            "your \`nros-toolchain.toml\`; \`nros toolchain manifest\` prints what" \
+            "an installed toolchain declares." \
             "" \
             "Install:" \
             "" \

--- a/just/check/workflows.just
+++ b/just/check/workflows.just
@@ -407,6 +407,21 @@ vendor-fetch-pinned:
 version-lockstep:
     @./scripts/check-version-lockstep.sh
 
+# RFC-0097 D7 / phase-443 W2 — a release RECORDS its components, and blocks on
+# exactly ONE equality. `release-nros.yml` used to assert three versions equal;
+# only `NROS_CODEGEN_VERSION` (2 changes, all time) can invalidate a user's
+# existing generated code, and it is the only one that may fail a release.
+#
+# Gated rather than remembered because the retired assertions are two lines each
+# and each reads as prudence in isolation, which is how a coupling comes back.
+# The manifest's FILENAME is read out of the Rust module that parses it, and the
+# R4 rule is a property of every failing path rather than a ban on the two old
+# wordings — a reintroduction would be written in new words (the 2026-07-28
+# audit's shape). Pure text over one YAML + one Rust file, ~0.05 s.
+[group("main")]
+release-manifest:
+    @python3 scripts/check-release-manifest.py
+
 # phase-413 W2 — a job asserts its runner's labels AFTER `just setup`, never
 # before. `runner-doctor.sh` looks for `build/qemu/bin/qemu-system-arm` FIRST
 # and `just setup tier2` is what creates it, so doctoring first asks the host

--- a/packages/cli/nros-cli-core/src/cmd/mod.rs
+++ b/packages/cli/nros-cli-core/src/cmd/mod.rs
@@ -38,6 +38,7 @@ pub mod new_entry;
 pub mod new_node;
 pub mod new_platform;
 pub mod new_system;
+pub mod pin;
 pub mod plan;
 pub mod profile;
 pub mod scaffold_deploy;
@@ -158,6 +159,12 @@ pub enum Cmd {
     /// Refuses while a known pin names the version, and refuses equally when no
     /// pin file could be consulted: unestablished is not the same as false.
     Toolchain(toolchain::Args),
+
+    /// phase-443 W2 — report this project's `nros-toolchain.toml`, or move it.
+    /// A bump reports the CODEGEN DELTA between the two toolchains' declared
+    /// `share/nros/manifest.toml` first, so an upgrade that would invalidate
+    /// already-generated code warns before anything is written (RFC-0097 D7).
+    Pin(pin::Args),
 
     /// phase-336 — the cargo build-profile table (CMAKE_BUILD_TYPE mapping,
     /// flags, artifact dir, env-injected definitions). The bridge cmake/bash

--- a/packages/cli/nros-cli-core/src/cmd/pin.rs
+++ b/packages/cli/nros-cli-core/src/cmd/pin.rs
@@ -1,0 +1,474 @@
+//! `nros pin` — read, and move, this project's `nros-toolchain.toml`
+//! (RFC-0097 D7, phase-443 W2; the pin itself is phase-440 W7).
+//!
+//! ```text
+//!   nros pin                      what does this project pin, and what is it made of
+//!   nros pin <store version>      move the pin — reporting the codegen delta FIRST
+//! ```
+//!
+//! ## The one question this verb exists to answer
+//!
+//! A user upgrading nano-ros wants to know one thing: *does this force me to
+//! regenerate?* RFC-0097 measured why that is not the same question as "did the
+//! version change" — `packages/cli` moved 710 times in 60 days,
+//! `NROS_CODEGEN_VERSION` twice in the project's life. So the verdict comes
+//! from the `codegen` field of each toolchain's own
+//! `share/nros/manifest.toml`, never from comparing version STRINGS, and never
+//! from an asset filename.
+//!
+//! Two releases declaring the same `codegen` produce
+//! [`CodegenDelta::Same`] however far apart their versions are; one declaring a
+//! different `codegen` produces a warning that names `nros sync`.
+//!
+//! ## Why the report is printed before the pin is written
+//!
+//! D7's acceptance is that a codegen change "warns before doing anything". That
+//! is an ORDERING claim, so it is structural here rather than a matter of care:
+//! [`execute`] builds the whole [`Survey`], prints it, and only then writes. A
+//! test asserts the ordering on the returned outcome rather than by reading a
+//! terminal.
+//!
+//! It warns rather than refuses because the runtime declares a RANGE
+//! (`nros_core::codegen_version`), so a bump is not always breaking — and
+//! because a refusal a user cannot override is how `--force` flags get added.
+//! What must never happen is silence: drifted generated code compiles.
+//!
+//! ## Moving a pin is a source edit
+//!
+//! `pin::write` refuses to overwrite, which is deliberate (issues 0359/0378 one
+//! layer up: a pin moves only when a dev means it). Typing `nros pin <version>`
+//! IS a dev meaning it, so this verb goes through [`super::super::orchestration::pin::set`],
+//! the overwriting spelling, and nothing else in the crate calls it.
+
+use std::path::{Path, PathBuf};
+
+use clap::Args as ClapArgs;
+use eyre::{Result, bail};
+
+use crate::orchestration::{
+    pin::{self, Pin},
+    release_manifest::{self, CodegenDelta, Found},
+    store,
+};
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    /// The store version to pin to, exactly as `toolchains/<version>` spells it
+    /// (`0.7.9-nros1`) — not the crate version `nros --version` prints. Omit to
+    /// report the current pin and change nothing.
+    //
+    // `id`, and no `long`: the binary sets `propagate_version = true`, so clap
+    // generates a `--version` flag on every subcommand and a field named
+    // `version` collides with it — a startup `debug_assert` panic on this verb
+    // alone, in every build. `nros toolchain uninstall` carries the same note
+    // for the same reason.
+    #[arg(id = "pin-version", value_name = "VERSION")]
+    pub version: Option<String>,
+
+    /// The project directory. Defaults to the working directory; the pin is
+    /// searched for at or above it, the way cargo finds a workspace root.
+    #[arg(long, value_name = "PATH")]
+    pub dir: Option<PathBuf>,
+
+    /// Store root. Defaults to `$NROS_STORE`, else `$NROS_HOME`, else
+    /// `~/.nros` — never an absolute literal (RFC-0095 D2).
+    #[arg(long, value_name = "PATH")]
+    pub root: Option<PathBuf>,
+
+    /// Report the delta and write nothing.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+/// Everything the verb learned before it decided anything — gathered once, so
+/// the decision is a pure function of it and its tests need no installed store.
+#[derive(Clone, Debug)]
+pub struct Survey {
+    /// The directory the pin search started from.
+    pub project: PathBuf,
+    /// The pin that is there now, if any.
+    pub current: Option<Pin>,
+    /// The manifest of the currently pinned toolchain, if it is installed and
+    /// declares one.
+    pub current_manifest: Option<Found>,
+    /// The version asked for, if this is a bump.
+    pub target: Option<String>,
+    /// The manifest of the target toolchain, if it is installed and declares
+    /// one.
+    pub target_manifest: Option<Found>,
+}
+
+impl Survey {
+    /// The codegen verdict for a bump. `None` when nothing was asked for — a
+    /// bare report compares nothing.
+    #[must_use]
+    pub fn delta(&self) -> Option<CodegenDelta> {
+        self.target.as_ref()?;
+        Some(CodegenDelta::between(
+            self.current_manifest.as_ref().map(Found::codegen),
+            self.target_manifest.as_ref().map(Found::codegen),
+        ))
+    }
+}
+
+/// Gather. Reads the pin file and at most two manifests; writes nothing.
+pub fn survey(project: &Path, root: &Path, target: Option<&str>) -> Result<Survey> {
+    let current = pin::find_and_load(project)?;
+    let current_manifest = match &current {
+        Some(p) => release_manifest::for_store_version(root, &p.version)?,
+        None => None,
+    };
+    let target_manifest = match target {
+        Some(v) => release_manifest::for_store_version(root, v)?,
+        None => None,
+    };
+    Ok(Survey {
+        project: project.to_path_buf(),
+        current,
+        current_manifest,
+        target: target.map(str::to_string),
+        target_manifest,
+    })
+}
+
+/// The lines this verb prints, in order. Returned rather than printed so the
+/// ORDERING claim — the warning comes before the write — is assertable.
+#[must_use]
+pub fn report(s: &Survey) -> Vec<String> {
+    let mut out = Vec::new();
+    match &s.current {
+        Some(p) => {
+            out.push(format!("pinned: {} ({})", p.version, p.path.display()));
+            out.push(describe_manifest("  ", p, s.current_manifest.as_ref()));
+        }
+        None => out.push(format!(
+            "pinned: NOTHING — no {} at or above {}.\n\
+             \x20   This project floats: `nros build` will write a pin \
+             (RFC-0095 D9), and until it does, firmware built here is \
+             reproducible only by accident.",
+            pin::FILE_NAME,
+            s.project.display()
+        )),
+    }
+    let Some(target) = &s.target else {
+        return out;
+    };
+    out.push(match &s.target_manifest {
+        Some(f) => format!(
+            "target: {target}\n\x20   codegen {}   ({})",
+            f.codegen(),
+            f.path.display()
+        ),
+        None => format!(
+            "target: {target} — not installed in this store, or it declares no \
+             share/nros/{}.",
+            release_manifest::FILE_NAME
+        ),
+    });
+    if let Some(delta) = s.delta() {
+        let from = s
+            .current
+            .as_ref()
+            .map_or("(unpinned)", |p| p.version.as_str());
+        out.push(release_manifest::describe_delta(&delta, from, target));
+    }
+    out
+}
+
+fn describe_manifest(indent: &str, p: &Pin, m: Option<&Found>) -> String {
+    match m {
+        Some(f) => {
+            let mut s = format!("{indent}codegen {}", f.codegen());
+            if let Some(i) = &f.manifest.index {
+                s.push_str(&format!("   index {i}"));
+            }
+            if let Some(n) = &f.manifest.nano_ros {
+                s.push_str(&format!("   nano-ros {n}"));
+            }
+            s.push_str(&format!("\n{indent}{}", f.path.display()));
+            s
+        }
+        None => format!(
+            "{indent}codegen UNKNOWN — {} is not installed in this store, or it \
+             predates share/nros/{} (RFC-0097 D7).",
+            p.version,
+            release_manifest::FILE_NAME
+        ),
+    }
+}
+
+/// What [`execute`] did.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// A bare report. Nothing was touched.
+    Reported,
+    /// `--dry-run`: the report was produced and the pin left alone.
+    WouldWrite { path: PathBuf, version: String },
+    /// The pin now names `version`.
+    Wrote { path: PathBuf, version: String },
+}
+
+/// Report, then act — in that order, which is the point.
+///
+/// `emit` is called with each line AS IT IS PRODUCED, not handed a `Vec`
+/// afterwards. That distinction is the whole test surface: a version of this
+/// that wrote the pin first and then appended the same lines to a buffer
+/// produces an identical transcript, and an ordering assertion over that
+/// transcript passes — measured, 2026-09-10, against exactly that mutation. A
+/// sink lets a test observe the FILESYSTEM at the moment each line arrives, so
+/// "warns before doing anything" is checked against the thing it is about.
+pub fn execute(
+    project: &Path,
+    root: &Path,
+    target: Option<&str>,
+    dry_run: bool,
+    emit: &mut dyn FnMut(&str),
+) -> Result<Outcome> {
+    let s = survey(project, root, target)?;
+    for line in report(&s) {
+        emit(&line);
+    }
+    let Some(version) = s.target.clone() else {
+        return Ok(Outcome::Reported);
+    };
+    if s.current.as_ref().is_some_and(|c| c.version == version) {
+        emit(&format!("pin already names {version} — unchanged."));
+        return Ok(Outcome::Reported);
+    }
+    let path = project.join(pin::FILE_NAME);
+    if dry_run {
+        emit(&format!("--dry-run: would write {}", path.display()));
+        return Ok(Outcome::WouldWrite { path, version });
+    }
+    let written = pin::set(project, &version)?;
+    emit(&format!(
+        "wrote {} — this project now pins nano-ros {version}. Commit it.",
+        written.display()
+    ));
+    Ok(Outcome::Wrote {
+        path: written,
+        version,
+    })
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let project = match args.dir {
+        Some(d) => d,
+        None => std::env::current_dir()?,
+    };
+    if !project.is_dir() {
+        bail!("{} is not a directory", project.display());
+    }
+    let root = args.root.clone().unwrap_or_else(store::root);
+    // Printed as produced, for the same reason the sink exists: the report must
+    // have REACHED the user before the pin moves, and a buffer flushed at the
+    // end cannot promise that when the write fails half way.
+    execute(
+        &project,
+        &root,
+        args.version.as_deref(),
+        args.dry_run,
+        &mut |line: &str| println!("{line}"),
+    )
+    .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a store holding two toolchains with the given codegen numbers.
+    fn store_with(root: &Path, entries: &[(&str, Option<u32>)]) {
+        for (version, codegen) in entries {
+            let prefix = root.join("toolchains").join(version);
+            std::fs::create_dir_all(prefix.join("share/nros")).unwrap();
+            std::fs::write(prefix.join("bin_placeholder"), b"").unwrap();
+            if let Some(c) = codegen {
+                std::fs::write(
+                    release_manifest::path_in_prefix(&prefix),
+                    release_manifest::render(&release_manifest::ReleaseManifest {
+                        version: (*version).to_string(),
+                        codegen: *c,
+                        index: Some("2026-09-10".into()),
+                        nano_ros: Some("abc1234".into()),
+                    }),
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    /// Run `execute` and capture, for every line, WHAT THE PIN FILE HELD AT THE
+    /// MOMENT IT WAS EMITTED.
+    ///
+    /// A plain `Vec<String>` is not enough, and that is measured rather than
+    /// assumed: a mutation that wrote the pin first and then appended the same
+    /// lines produced an identical transcript, so the ordering assertion over it
+    /// passed. Recording the filesystem beside each line is what makes "warns
+    /// before doing anything" a claim about doing rather than about printing.
+    fn run_capturing(
+        project: &Path,
+        root: &Path,
+        target: Option<&str>,
+        dry_run: bool,
+    ) -> (Outcome, Vec<(String, Option<String>)>) {
+        let pin_path = project.join(pin::FILE_NAME);
+        let mut seen: Vec<(String, Option<String>)> = Vec::new();
+        let outcome = {
+            let mut sink = |line: &str| {
+                seen.push((line.to_string(), std::fs::read_to_string(&pin_path).ok()));
+            };
+            execute(project, root, target, dry_run, &mut sink).unwrap()
+        };
+        (outcome, seen)
+    }
+
+    /// Just the lines.
+    fn lines_of(seen: &[(String, Option<String>)]) -> Vec<String> {
+        seen.iter().map(|(l, _)| l.clone()).collect()
+    }
+
+    /// The feature: same `codegen`, different everything else, no warning and
+    /// no re-emit instruction anywhere in the report.
+    #[test]
+    fn a_bump_between_equal_codegens_does_not_warn() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("store");
+        let project = dir.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        store_with(&root, &[("0.7.1-nros1", Some(7)), ("0.7.9-nros4", Some(7))]);
+        std::fs::write(project.join(pin::FILE_NAME), pin::render("0.7.1-nros1")).unwrap();
+
+        let (out, seen) = run_capturing(&project, &root, Some("0.7.9-nros4"), false);
+        let joined = lines_of(&seen).join("\n");
+        assert!(
+            !joined.contains("warning"),
+            "equal codegen must not warn:\n{joined}"
+        );
+        assert!(joined.contains("UNCHANGED"), "{joined}");
+        assert!(!joined.contains("nros sync"), "{joined}");
+        assert!(matches!(out, Outcome::Wrote { .. }), "{out:?}");
+        assert_eq!(
+            pin::load(&project.join(pin::FILE_NAME)).unwrap().version,
+            "0.7.9-nros4"
+        );
+    }
+
+    /// The ordering claim, asserted against the FILESYSTEM: at the instant the
+    /// warning reaches the user, the pin still names the old toolchain.
+    #[test]
+    fn a_differing_codegen_warns_before_the_pin_is_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("store");
+        let project = dir.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        store_with(&root, &[("0.7.9-nros1", Some(7)), ("0.8.0-nros1", Some(8))]);
+        std::fs::write(project.join(pin::FILE_NAME), pin::render("0.7.9-nros1")).unwrap();
+
+        let (out, seen) = run_capturing(&project, &root, Some("0.8.0-nros1"), false);
+        let (warn_line, pin_when_warned) = seen
+            .iter()
+            .find(|(l, _)| l.starts_with("warning: codegen 7 -> 8"))
+            .unwrap_or_else(|| panic!("no codegen warning in {seen:#?}"));
+        assert!(warn_line.contains("nros sync"), "{warn_line}");
+        // THE claim: when the user was warned, the pin still named the OLD
+        // toolchain. Nothing had been done yet.
+        assert_eq!(
+            pin_when_warned.as_deref(),
+            Some(pin::render("0.7.9-nros1").as_str()),
+            "the pin had already moved by the time the warning was emitted"
+        );
+        // And the move did then happen.
+        assert!(matches!(out, Outcome::Wrote { .. }), "{out:?}");
+        assert_eq!(
+            pin::load(&project.join(pin::FILE_NAME)).unwrap().version,
+            "0.8.0-nros1"
+        );
+    }
+
+    /// A toolchain that predates manifests leaves the question unanswered, and
+    /// the verb says so rather than assuming it is fine.
+    #[test]
+    fn a_toolchain_without_a_manifest_reports_unknown_not_same() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("store");
+        let project = dir.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        store_with(&root, &[("0.6.0-nros1", None), ("0.7.0-nros1", Some(7))]);
+        std::fs::write(project.join(pin::FILE_NAME), pin::render("0.6.0-nros1")).unwrap();
+
+        let s = survey(&project, &root, Some("0.7.0-nros1")).unwrap();
+        assert!(matches!(
+            s.delta(),
+            Some(CodegenDelta::Unknown {
+                from_known: false,
+                to_known: true
+            })
+        ));
+        let joined = report(&s).join("\n");
+        assert!(joined.contains("UNKNOWN"), "{joined}");
+        assert!(joined.contains("nros sync"), "{joined}");
+    }
+
+    /// `--dry-run` reports and writes nothing — the half that proves the report
+    /// is not a consequence of the write.
+    #[test]
+    fn dry_run_reports_the_delta_and_leaves_the_pin_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("store");
+        let project = dir.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        store_with(&root, &[("0.7.9-nros1", Some(7)), ("0.8.0-nros1", Some(8))]);
+        let pin_path = project.join(pin::FILE_NAME);
+        std::fs::write(&pin_path, pin::render("0.7.9-nros1")).unwrap();
+        let before = std::fs::read_to_string(&pin_path).unwrap();
+
+        let (out, seen) = run_capturing(&project, &root, Some("0.8.0-nros1"), true);
+        assert!(matches!(out, Outcome::WouldWrite { .. }), "{out:?}");
+        assert_eq!(std::fs::read_to_string(&pin_path).unwrap(), before);
+        // Every line was emitted against an unchanged pin, not just the last.
+        for (line, at) in &seen {
+            assert_eq!(at.as_deref(), Some(before.as_str()), "{line}");
+        }
+        assert!(
+            lines_of(&seen)
+                .iter()
+                .any(|l| l.starts_with("warning: codegen 7 -> 8"))
+        );
+    }
+
+    /// A bare report compares nothing and touches nothing.
+    #[test]
+    fn a_bare_report_names_the_pin_and_its_codegen() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("store");
+        let project = dir.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        store_with(&root, &[("0.7.9-nros1", Some(7))]);
+        std::fs::write(project.join(pin::FILE_NAME), pin::render("0.7.9-nros1")).unwrap();
+
+        let (out, seen) = run_capturing(&project, &root, None, false);
+        assert_eq!(out, Outcome::Reported);
+        let joined = lines_of(&seen).join("\n");
+        assert!(joined.contains("pinned: 0.7.9-nros1"), "{joined}");
+        assert!(joined.contains("codegen 7"), "{joined}");
+        assert!(joined.contains("index 2026-09-10"), "{joined}");
+    }
+
+    /// An unpinned project is a reported state, not an error.
+    #[test]
+    fn an_unpinned_project_says_so_and_can_be_pinned() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("store");
+        let project = dir.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        store_with(&root, &[("0.7.9-nros1", Some(7))]);
+
+        let (out, seen) = run_capturing(&project, &root, Some("0.7.9-nros1"), false);
+        let lines = lines_of(&seen);
+        assert!(lines[0].contains("pinned: NOTHING"), "{:?}", lines[0]);
+        // Reported as floating BEFORE the pin existed — not after writing one.
+        assert_eq!(seen[0].1, None, "the pin existed when the report started");
+        assert!(matches!(out, Outcome::Wrote { .. }), "{out:?}");
+    }
+}

--- a/packages/cli/nros-cli-core/src/cmd/toolchain.rs
+++ b/packages/cli/nros-cli-core/src/cmd/toolchain.rs
@@ -29,9 +29,12 @@
 use std::path::{Path, PathBuf};
 
 use clap::{Args as ClapArgs, Subcommand};
-use eyre::{Result, bail};
+use eyre::{Result, WrapErr, bail};
 
-use crate::orchestration::store::{self, format_size};
+use crate::orchestration::{
+    pin, release_manifest,
+    store::{self, format_size},
+};
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
@@ -44,6 +47,45 @@ pub enum Sub {
     /// Remove one nano-ros toolchain from the store. Refuses while a known pin
     /// names the version — or while no pin file could be consulted at all.
     Uninstall(UninstallArgs),
+    /// phase-443 W2 — read, or stamp, `share/nros/manifest.toml`: what a
+    /// release DECLARES it is made of (RFC-0097 D7).
+    Manifest(ManifestArgs),
+}
+
+/// `nros toolchain manifest` — RFC-0097 D7's file, both directions.
+///
+/// With no arguments it READS: the manifest of the toolchain this binary
+/// belongs to. With `--write` it STAMPS one, which is what
+/// `.github/workflows/release-nros.yml` calls while staging the asset.
+///
+/// The release workflow calls the binary it just built rather than `printf`-ing
+/// four lines of YAML, and that is the whole design: `codegen` comes from
+/// [`crate::abi_guard::EMITTED_VERSION`], so a manifest cannot claim a codegen
+/// version its own binary does not emit. There is no `--codegen` flag, and
+/// adding one would give the field back the drift the file exists to remove.
+#[derive(Debug, ClapArgs)]
+pub struct ManifestArgs {
+    /// The STORE version being released (`0.5.0-nros1`) — the string a pin
+    /// names, not the crate version `nros --version` prints.
+    //
+    // Deliberately NOT `--version`: `propagate_version = true` on the binary
+    // generates that flag on every subcommand, so this spelling would collide
+    // at startup. The name is also the more accurate of the two here.
+    #[arg(long, value_name = "VERSION")]
+    pub store_version: Option<String>,
+
+    /// When the `nros-sdk-index.toml` in this asset was last moved (a date).
+    #[arg(long, value_name = "DATE")]
+    pub index: Option<String>,
+
+    /// The nano-ros commit this was built from.
+    #[arg(long = "nano-ros", value_name = "COMMIT")]
+    pub nano_ros: Option<String>,
+
+    /// Write the manifest here instead of printing it. Requires
+    /// `--store-version`.
+    #[arg(long, value_name = "PATH")]
+    pub write: Option<PathBuf>,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -84,7 +126,58 @@ pub fn run(args: Args) -> Result<()> {
     let cwd = std::env::current_dir().ok();
     match args.command {
         Sub::Uninstall(a) => uninstall(a, cwd.as_deref()),
+        Sub::Manifest(a) => manifest(a),
     }
+}
+
+/// RFC-0097 D7's file, read or written.
+pub fn manifest(args: ManifestArgs) -> Result<()> {
+    if let Some(version) = &args.store_version {
+        let m = release_manifest::stamp(version, args.index.as_deref(), args.nano_ros.as_deref());
+        let rendered = release_manifest::render(&m);
+        let Some(out) = &args.write else {
+            print!("{rendered}");
+            return Ok(());
+        };
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("create {}", parent.display()))?;
+        }
+        std::fs::write(out, &rendered).wrap_err_with(|| format!("write {}", out.display()))?;
+        println!("wrote {} (codegen {})", out.display(), m.codegen);
+        return Ok(());
+    }
+    if args.write.is_some() {
+        bail!(
+            "--write needs --store-version: a manifest that cannot name its release records nothing."
+        );
+    }
+
+    // Read mode: what does the release this binary belongs to declare?
+    let exe = std::env::current_exe()?;
+    match release_manifest::for_exe(&exe)? {
+        Some(found) => {
+            println!("{}", found.path.display());
+            print!("{}", release_manifest::render(&found.manifest));
+        }
+        None => {
+            // Not an error. A contributor's `packages/cli/target/**` build is
+            // in no release at all, and a pre-W2 asset shipped VERSION alone —
+            // different facts, so they are reported as different sentences.
+            let where_from = pin::running_version(&exe)
+                .map(|(v, o)| format!("{v} (from the {})", o.label()))
+                .unwrap_or_else(|| "none — this is not an installed release".to_string());
+            println!(
+                "no share/nros/{} beside {}\n\
+                 store version: {where_from}\n\
+                 A release cut before RFC-0097 D7 declares no components, so \n\
+                 `nros pin` cannot answer the codegen question for it.",
+                release_manifest::FILE_NAME,
+                exe.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 /// `uninstall`, with the directory pin discovery walks up from passed IN — the

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -199,6 +199,7 @@ pub fn run(cmd: cmd::Cmd) -> Result<()> {
         // for the same reason `doctor` does: that is when you are looking.
         cmd::Cmd::Store(args) => cmd::store::run(args),
         cmd::Cmd::Toolchain(args) => cmd::toolchain::run(args),
+        cmd::Cmd::Pin(args) => cmd::pin::run(args),
         cmd::Cmd::Profile(args) => cmd::profile::run(args),
         cmd::Cmd::Metadata(args) => cmd::metadata::run(args),
         cmd::Cmd::Plan(args) => cmd::plan::run(args),

--- a/packages/cli/nros-cli-core/src/orchestration/mod.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/mod.rs
@@ -37,7 +37,11 @@ pub mod params;
 pub mod pin;
 pub mod plan;
 pub mod planner;
+
 pub mod prereq_resolve;
+/// RFC-0097 D7 / phase-443 W2 — `share/nros/manifest.toml`, what a release
+/// DECLARES about itself instead of asserting three versions equal.
+pub mod release_manifest;
 pub use nros_orchestration_ir::rtos_realizer;
 pub mod schema;
 pub mod sdk_index;

--- a/packages/cli/nros-cli-core/src/orchestration/pin.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/pin.rs
@@ -176,6 +176,21 @@ pub fn write(dir: &Path, version: &str) -> Result<PathBuf> {
     Ok(path)
 }
 
+/// Write a pin into `dir`, REPLACING one that is already there.
+///
+/// The overwriting spelling of [`write`], and the ONLY caller is `nros pin
+/// <version>` — a user typing that command IS the "a dev means it" [`write`]'s
+/// refusal exists to require, so re-refusing it there would leave editing the
+/// file by hand as the only way to take an upgrade. Nothing automatic reaches
+/// this: `nros build`'s D9 path still goes through [`write`], so
+/// `nros self update` cannot move a pin.
+pub fn set(dir: &Path, version: &str) -> Result<PathBuf> {
+    let path = dir.join(FILE_NAME);
+    std::fs::write(&path, render(version))
+        .wrap_err_with(|| format!("write the toolchain pin {}", path.display()))?;
+    Ok(path)
+}
+
 /// How [`running_version`] learned the version — printed beside it, because a
 /// version with no provenance is a number a reader has to trust.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/packages/cli/nros-cli-core/src/orchestration/release_manifest.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/release_manifest.rs
@@ -1,0 +1,519 @@
+//! `share/nros/manifest.toml` — what a release is MADE OF (RFC-0097 D7,
+//! phase-443 W2).
+//!
+//! ```toml
+//! version  = "0.7.9"      # the toolchain: CLI + codegen + runtime
+//! codegen  = 7            # the ONLY field that can invalidate existing output
+//! index    = "2026-09-10" # pointers into nano-ros-sdk
+//! nano_ros = "abc1234"    # the runtime commit
+//! ```
+//!
+//! ## Why a file, and why it replaces three assertions
+//!
+//! Four axes carry a version and one artifact carries all four, so any of them
+//! moving forces a release of the whole. Measured on `main`, 2026-09-10:
+//! `packages/cli` **710** commits per 60 days, the runtime crates the CLI
+//! compiles **248**, `nros-sdk-index.toml` **70**, and `NROS_CODEGEN_VERSION` —
+//! the only axis that can make a user's *existing* generated code wrong
+//! (RFC-0090) — **2, all time**.
+//!
+//! `release-nros.yml` did not merely bundle them, it **asserted they were
+//! equal**: the release version against `NROS_CODEGEN_VERSION`, and against
+//! `[tool.nros] version` in the index. The coupling was mechanised, which is
+//! why it never drifted; it is also why nothing could move alone.
+//!
+//! D7 replaces asserting with RECORDING. `0.7.1` and `0.7.9` both declaring
+//! `codegen = 7` is the whole feature: a user takes either and nothing is
+//! re-emitted. `0.8.0` declaring `codegen = 8` is a compatibility event, and
+//! [`CodegenDelta`] is how a user is told *before* they take it.
+//!
+//! ## One equality survives, because it is the one that is true
+//!
+//! The manifest's `codegen` must equal the `NROS_CODEGEN_VERSION` of the tree
+//! the binary was built from. That is not a coupling between axes; it is the
+//! manifest being *about* the artifact. It is asserted at release time by
+//! `.github/workflows/release-nros.yml`, and the fact that it is asserted is
+//! itself gated by `check-release-manifest`.
+//!
+//! It cannot be got wrong here, either: [`stamp`] takes the number from
+//! [`crate::abi_guard::EMITTED_VERSION`], the constant this binary actually
+//! emits into generated code. A manifest rendered by the binary it describes
+//! cannot lie about the one field that matters.
+//!
+//! ## Read, never parsed out of a filename
+//!
+//! Nothing derives a component version from an asset name, a directory name or
+//! a release tag. `nros-linux-x86_64.tar.zst` says nothing; the store prefix
+//! `sdk/nros/0.5.0-nros1` says only which directory it is in. Every function
+//! here reaches a FILE — the same argument `scripts/install.sh` already makes
+//! for `share/nros/VERSION` ("a filename is a claim while a file inside the
+//! artifact is the artifact").
+//!
+//! ## What this does NOT replace
+//!
+//! `share/nros/VERSION` stays, unchanged and still written by the release
+//! workflow. `scripts/install.sh` reads it to choose the store prefix *before
+//! anything is installed*, in POSIX shell, with a documented fallback for a
+//! pre-W5 asset that carries neither file. Giving the installer a second file
+//! to learn would buy nothing and would put the prefix decision behind a TOML
+//! parse. [`Found::version`] and the VERSION file agree by construction — the
+//! workflow writes both from one input.
+//!
+//! ## The acceptance range, and why the warning is a warning
+//!
+//! `nros_core::codegen_version` declares a range,
+//! `[NROS_CODEGEN_VERSION_MIN, NROS_CODEGEN_VERSION]`, and RFC-0097 D6 keeps it
+//! narrow deliberately. So a `codegen` bump does not *always* invalidate
+//! existing output — it does when the old number falls out of the new runtime's
+//! range, which is a property of the runtime being installed and not of this
+//! file. [`CodegenDelta::Differs`] is therefore reported as a WARNING that names
+//! the remedy, never as a refusal: a false alarm costs one `nros sync`, and the
+//! silent version of this is the failure that withdrew the last release
+//! (phase-288 D1/D2 — drifted generated code COMPILES).
+
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr, bail};
+use serde::Deserialize;
+
+/// The file's name inside `share/nros/`.
+pub const FILE_NAME: &str = "manifest.toml";
+
+/// What a release declares about itself.
+///
+/// `index` and `nano_ros` are optional because they are PROVENANCE: a manifest
+/// that cannot name the commit it was cut from is still a manifest that can
+/// answer the re-emit question. `version` and `codegen` are not optional,
+/// because a manifest missing either answers nothing at all.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct ReleaseManifest {
+    /// The STORE version (`0.5.0-nros1`) — the string a pin names and a store
+    /// prefix is called, not the crate version `nros --version` prints. Same
+    /// distinction `orchestration::pin` states at length, for the same reason.
+    pub version: String,
+    /// `NROS_CODEGEN_VERSION`. The only field that can invalidate output a user
+    /// already has.
+    pub codegen: u32,
+    /// When the `nros-sdk-index.toml` in this asset was last moved. A date, not
+    /// a version: the index is a manifest of pointers into `nano-ros-sdk`,
+    /// which publishes per-tool and has no version of its own (RFC-0097 D5).
+    #[serde(default)]
+    pub index: Option<String>,
+    /// The `nano-ros` commit this was built from.
+    #[serde(default)]
+    pub nano_ros: Option<String>,
+}
+
+/// A manifest and the file it came from — printed in every message, because
+/// "which release said that" is the first question when two disagree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Found {
+    pub path: PathBuf,
+    pub manifest: ReleaseManifest,
+}
+
+impl Found {
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.manifest.version
+    }
+
+    #[must_use]
+    pub fn codegen(&self) -> u32 {
+        self.manifest.codegen
+    }
+}
+
+/// Render a manifest, byte for byte. Split out so the round trip is a unit test
+/// with no filesystem, and so the header lives in exactly one place.
+///
+/// Hand-written rather than `toml::to_string`: the comments are the reason a
+/// human opening this file learns what `codegen` means, and a serializer drops
+/// them.
+#[must_use]
+pub fn render(m: &ReleaseManifest) -> String {
+    let mut s = String::new();
+    s.push_str(
+        "# What this nano-ros release is MADE OF (RFC-0097 D7).\n\
+         #\n\
+         # These are four INDEPENDENT axes, recorded rather than asserted equal.\n\
+         # Only `codegen` carries a compatibility promise: two releases that\n\
+         # declare the same `codegen` accept the same generated code, so moving\n\
+         # between them re-emits nothing. A DIFFERENT `codegen` is a\n\
+         # compatibility event — regenerate with `nros sync`.\n\
+         #\n\
+         # `nros pin <version>` reports the delta before it moves your pin.\n\n",
+    );
+    s.push_str(&format!("version = \"{}\"\n", m.version));
+    s.push_str(&format!("codegen = {}\n", m.codegen));
+    if let Some(i) = &m.index {
+        s.push_str(&format!("index = \"{i}\"\n"));
+    }
+    if let Some(n) = &m.nano_ros {
+        s.push_str(&format!("nano_ros = \"{n}\"\n"));
+    }
+    s
+}
+
+/// A manifest for THIS binary: `codegen` comes from
+/// [`crate::abi_guard::EMITTED_VERSION`], never from an argument.
+///
+/// This is the whole reason the release workflow calls the binary it just built
+/// instead of `printf`-ing four lines of YAML: the number a manifest claims and
+/// the number the binary emits are then the same number by construction, and
+/// the surviving equality check has something real to compare against.
+#[must_use]
+pub fn stamp(version: &str, index: Option<&str>, nano_ros: Option<&str>) -> ReleaseManifest {
+    ReleaseManifest {
+        version: version.to_string(),
+        codegen: crate::abi_guard::EMITTED_VERSION,
+        index: index.map(str::to_string),
+        nano_ros: nano_ros.map(str::to_string),
+    }
+}
+
+/// Read one manifest file.
+///
+/// A file that exists and cannot be read as this schema is an ERROR, never an
+/// absent manifest — the asymmetry `pin::load` and `store::load_pin_file`
+/// already state: "no manifest" and "I could not tell" must not reach a caller
+/// as one value. A user acting on "no manifest" re-emits nothing.
+pub fn load(path: &Path) -> Result<ReleaseManifest> {
+    let raw = std::fs::read_to_string(path)
+        .wrap_err_with(|| format!("read the release manifest {}", path.display()))?;
+    let m: ReleaseManifest = toml::from_str(&raw).wrap_err_with(|| {
+        format!(
+            "parse the release manifest {} — it must carry at least\n\n    \
+             version = \"<store version>\"\n    codegen = <n>\n",
+            path.display()
+        )
+    })?;
+    if m.version.trim().is_empty() {
+        bail!(
+            "{} declares an empty `version`. A release that cannot name itself \
+             is unreadable, not unversioned.",
+            path.display()
+        );
+    }
+    Ok(m)
+}
+
+/// `<prefix>/share/nros/manifest.toml`. CONSTRUCTED, never searched for.
+#[must_use]
+pub fn path_in_prefix(prefix: &Path) -> PathBuf {
+    prefix.join("share").join("nros").join(FILE_NAME)
+}
+
+/// The manifest of the release installed at `prefix`, if it carries one.
+///
+/// `Ok(None)` is the pre-W2 asset: it shipped `share/nros/VERSION` and no
+/// manifest, which is a real state on any host that installed before this
+/// landed. `Err` is a manifest that is there and broken.
+pub fn for_prefix(prefix: &Path) -> Result<Option<Found>> {
+    let path = path_in_prefix(prefix);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    Ok(Some(Found {
+        manifest: load(&path)?,
+        path,
+    }))
+}
+
+/// The manifest of the release that `exe` belongs to (`<exe>/../..` is the
+/// prefix — the same two-parent walk `pin::running_version` and
+/// `dispatch::bundled_installer` do).
+pub fn for_exe(exe: &Path) -> Result<Option<Found>> {
+    let Some(prefix) = exe.parent().and_then(Path::parent) else {
+        return Ok(None);
+    };
+    for_prefix(prefix)
+}
+
+/// Every prefix a toolchain `version` could occupy under store `root`, newest
+/// layout first.
+///
+/// Derived from [`super::pin::candidate_bins`] rather than re-spelled, so the
+/// two `toolchains/<v>` vs `sdk/nros/<v>` layouts have ONE definition. Two
+/// copies is how a reader teaches only the new name and writes a lookup that
+/// recognises no installed host.
+#[must_use]
+pub fn candidate_prefixes(root: &Path, version: &str) -> Vec<PathBuf> {
+    super::pin::candidate_bins(root, version)
+        .into_iter()
+        .filter_map(|bin| Some(bin.parent()?.parent()?.to_path_buf()))
+        .collect()
+}
+
+/// The manifest of an INSTALLED toolchain, by store version.
+///
+/// `Ok(None)` means either "that version is not in this store" or "it is, and
+/// it predates manifests" — both of which leave the codegen question
+/// unanswerable, which is what [`CodegenDelta::Unknown`] exists to say out
+/// loud.
+pub fn for_store_version(root: &Path, version: &str) -> Result<Option<Found>> {
+    for prefix in candidate_prefixes(root, version) {
+        if let Some(found) = for_prefix(&prefix)? {
+            return Ok(Some(found));
+        }
+    }
+    Ok(None)
+}
+
+/// What moving between two toolchains does to a user's already-generated code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CodegenDelta {
+    /// Both declare the same number. **Nothing is re-emitted.** This is the
+    /// case D7 exists to make sayable, and the reason a CLI may move 710 times
+    /// in 60 days without touching a user's `generated/` tree.
+    Same(u32),
+    /// The number moves. A compatibility event.
+    Differs { from: u32, to: u32 },
+    /// At least one side declares nothing, so the question has no answer here.
+    /// Treated as "assume you must re-emit": a false alarm costs one
+    /// `nros sync`, and being silently wrong is the failure that withdrew the
+    /// last release.
+    Unknown {
+        /// Which side(s) could not be read, for the message.
+        from_known: bool,
+        to_known: bool,
+    },
+}
+
+impl CodegenDelta {
+    /// Compare two optional declarations.
+    #[must_use]
+    pub fn between(from: Option<u32>, to: Option<u32>) -> Self {
+        match (from, to) {
+            (Some(a), Some(b)) if a == b => CodegenDelta::Same(a),
+            (Some(a), Some(b)) => CodegenDelta::Differs { from: a, to: b },
+            (a, b) => CodegenDelta::Unknown {
+                from_known: a.is_some(),
+                to_known: b.is_some(),
+            },
+        }
+    }
+
+    /// Must the user regenerate? True for [`Self::Differs`] AND for
+    /// [`Self::Unknown`] — see the variant's own note on why unknown is not
+    /// "probably fine".
+    #[must_use]
+    pub fn requires_reemit(self) -> bool {
+        !matches!(self, CodegenDelta::Same(_))
+    }
+}
+
+/// The report `nros pin` prints, and the thing a test asserts on instead of
+/// scraping stdout.
+///
+/// Multi-line and deliberately ordered: the VERDICT first, the remedy second,
+/// the provenance last. A user who reads one line has read the one that decides
+/// whether their tree still builds.
+#[must_use]
+pub fn describe_delta(delta: &CodegenDelta, from_version: &str, to_version: &str) -> String {
+    match delta {
+        CodegenDelta::Same(n) => format!(
+            "codegen {n}: UNCHANGED from {from_version} to {to_version}.\n\
+             \x20   Your generated code stays valid — nothing to re-emit."
+        ),
+        CodegenDelta::Differs { from, to } => format!(
+            "warning: codegen {from} -> {to} ({from_version} -> {to_version}).\n\
+             \x20   This is a COMPATIBILITY EVENT: code generated by {from_version} \
+             was emitted against codegen {from},\n\
+             \x20   and {to_version} emits {to}. Regenerate before building:\n\
+             \x20       nros sync\n\
+             \x20   Drifted generated code COMPILES, so nothing downstream will \
+             tell you (RFC-0090)."
+        ),
+        CodegenDelta::Unknown {
+            from_known,
+            to_known,
+        } => {
+            let which = match (from_known, to_known) {
+                (false, false) => format!("neither {from_version} nor {to_version} declares one"),
+                (false, true) => format!("{from_version} declares none"),
+                (true, false) => format!("{to_version} declares none"),
+                (true, true) => unreachable!("both known is Same or Differs"),
+            };
+            format!(
+                "warning: codegen version UNKNOWN — {which}.\n\
+                 \x20   A release that predates RFC-0097 D7 ships no \
+                 share/nros/{FILE_NAME}, so this cannot be answered from the \
+                 store.\n\
+                 \x20   Assume you must regenerate:\n\
+                 \x20       nros sync"
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ReleaseManifest {
+        ReleaseManifest {
+            version: "0.7.9-nros1".to_string(),
+            codegen: 7,
+            index: Some("2026-09-10".to_string()),
+            nano_ros: Some("abc1234".to_string()),
+        }
+    }
+
+    #[test]
+    fn render_round_trips_through_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(FILE_NAME);
+        std::fs::write(&path, render(&sample())).unwrap();
+        assert_eq!(load(&path).unwrap(), sample());
+    }
+
+    /// The provenance fields are optional; the two that answer the re-emit
+    /// question are not.
+    #[test]
+    fn a_manifest_without_provenance_still_loads_and_one_without_codegen_does_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(FILE_NAME);
+
+        std::fs::write(&path, "version = \"0.1.0-nros1\"\ncodegen = 3\n").unwrap();
+        let m = load(&path).unwrap();
+        assert_eq!(m.codegen, 3);
+        assert_eq!(m.index, None);
+        assert_eq!(m.nano_ros, None);
+        // And it round-trips without inventing empty keys.
+        assert!(!render(&m).contains("index"));
+
+        std::fs::write(&path, "version = \"0.1.0-nros1\"\n").unwrap();
+        assert!(
+            load(&path).is_err(),
+            "a manifest with no codegen answers nothing"
+        );
+
+        std::fs::write(&path, "version = \"\"\ncodegen = 3\n").unwrap();
+        assert!(
+            load(&path).is_err(),
+            "an empty version is unreadable, not unversioned"
+        );
+    }
+
+    /// `Ok(None)` (no manifest) and `Err` (a broken one) must not collapse:
+    /// acting on the first re-emits nothing.
+    #[test]
+    fn absent_is_not_broken() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("sdk/nros/0.1.0-nros1");
+        std::fs::create_dir_all(prefix.join("share/nros")).unwrap();
+        assert_eq!(for_prefix(&prefix).unwrap(), None);
+        std::fs::write(path_in_prefix(&prefix), "codegen = \"seven\"\n").unwrap();
+        assert!(for_prefix(&prefix).is_err());
+    }
+
+    /// Both store layouts resolve, and the prefix list is derived from
+    /// `pin::candidate_bins` so it cannot know only one of them.
+    #[test]
+    fn both_store_layouts_resolve_by_construction() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        assert_eq!(
+            candidate_prefixes(root, "1.2.3-nros4"),
+            vec![
+                root.join("toolchains/1.2.3-nros4"),
+                root.join("sdk/nros/1.2.3-nros4"),
+            ]
+        );
+        for (rel, codegen) in [
+            ("toolchains/9.0.0-nros1", 9u32),
+            ("sdk/nros/8.0.0-nros1", 8),
+        ] {
+            let prefix = root.join(rel);
+            std::fs::create_dir_all(prefix.join("share/nros")).unwrap();
+            std::fs::write(
+                path_in_prefix(&prefix),
+                render(&ReleaseManifest {
+                    version: rel.rsplit('/').next().unwrap().to_string(),
+                    codegen,
+                    index: None,
+                    nano_ros: None,
+                }),
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            for_store_version(root, "9.0.0-nros1")
+                .unwrap()
+                .unwrap()
+                .codegen(),
+            9
+        );
+        assert_eq!(
+            for_store_version(root, "8.0.0-nros1")
+                .unwrap()
+                .unwrap()
+                .codegen(),
+            8
+        );
+        assert_eq!(for_store_version(root, "7.0.0-nros1").unwrap(), None);
+    }
+
+    /// The feature, stated as a test: same number, no re-emit — even though
+    /// every other field differs.
+    #[test]
+    fn two_releases_with_the_same_codegen_require_no_reemit() {
+        let a = ReleaseManifest {
+            version: "0.7.1-nros1".into(),
+            codegen: 7,
+            index: Some("2026-01-01".into()),
+            nano_ros: Some("1111111".into()),
+        };
+        let b = ReleaseManifest {
+            version: "0.7.9-nros4".into(),
+            codegen: 7,
+            index: Some("2026-09-10".into()),
+            nano_ros: Some("9999999".into()),
+        };
+        let d = CodegenDelta::between(Some(a.codegen), Some(b.codegen));
+        assert_eq!(d, CodegenDelta::Same(7));
+        assert!(!d.requires_reemit());
+        let msg = describe_delta(&d, &a.version, &b.version);
+        assert!(
+            !msg.contains("warning"),
+            "no warning for an unchanged codegen: {msg}"
+        );
+        assert!(msg.contains("nothing to re-emit"), "{msg}");
+    }
+
+    #[test]
+    fn a_different_codegen_warns_and_names_the_remedy() {
+        let d = CodegenDelta::between(Some(7), Some(8));
+        assert_eq!(d, CodegenDelta::Differs { from: 7, to: 8 });
+        assert!(d.requires_reemit());
+        let msg = describe_delta(&d, "0.7.9-nros1", "0.8.0-nros1");
+        assert!(
+            msg.starts_with("warning:"),
+            "the verdict comes first: {msg}"
+        );
+        assert!(msg.contains("nros sync"), "the remedy is named: {msg}");
+    }
+
+    /// Unknown is not "probably fine".
+    #[test]
+    fn an_undeclared_codegen_is_treated_as_a_reemit() {
+        for (from, to) in [(None, Some(7)), (Some(7), None), (None, None)] {
+            let d = CodegenDelta::between(from, to);
+            assert!(d.requires_reemit(), "{d:?}");
+            let msg = describe_delta(&d, "old", "new");
+            assert!(msg.starts_with("warning:"), "{msg}");
+            assert!(msg.contains("nros sync"), "{msg}");
+        }
+    }
+
+    /// `stamp` takes the number from the binary, not from a caller. This is the
+    /// property that makes the surviving release-time equality meaningful — a
+    /// caller that could pass a codegen number could pass the wrong one.
+    #[test]
+    fn stamp_takes_codegen_from_the_binary_never_from_an_argument() {
+        let m = stamp("0.7.9-nros1", Some("2026-09-10"), Some("abc1234"));
+        assert_eq!(m.codegen, crate::abi_guard::EMITTED_VERSION);
+        assert_eq!(m.version, "0.7.9-nros1");
+    }
+}

--- a/scripts/check-release-manifest.py
+++ b/scripts/check-release-manifest.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""A release RECORDS its components, and blocks on exactly one equality.
+
+RFC-0097 D7, phase-443 W2.
+
+## What this gate is for
+
+`release-nros.yml` used to ASSERT three versions equal — the release version,
+`NROS_CODEGEN_VERSION`, and `[tool.nros].version` in the index. RFC-0097
+measured why that is the wrong shape: on `main`, 2026-09-10, `packages/cli`
+moved 710 times in 60 days, `nros-sdk-index.toml` 70, and
+`NROS_CODEGEN_VERSION` 2 in the project's life. Only the last can make a user's
+existing generated code wrong, so only the last may block anything.
+
+D7 replaces asserting with RECORDING, in `share/nros/manifest.toml`. That change
+is easy to make and easy to un-make: the retired assertions are each two lines
+and each looks prudent in isolation, which is exactly how a coupling comes back.
+So the four properties below are gated rather than remembered.
+
+## The four rules
+
+* **R1 — the asset carries the manifest.** The staged prefix must contain
+  `share/nros/<FILE_NAME>`, where FILE_NAME is READ OUT of the Rust module that
+  parses it. Not a literal here: a gate that spells the filename itself would go
+  green while the reader looked somewhere else.
+* **R2 — the manifest is stamped BY THE BINARY.** The workflow must invoke
+  `toolchain manifest … --write`, and must not compose the file itself with
+  `printf`/`echo`/`cat >`. This is what makes the recorded `codegen` unable to
+  disagree with the binary's own `abi_guard::EMITTED_VERSION` — it is taken from
+  the constant and there is no flag for it.
+* **R3 — the surviving equality is present.** The workflow must read
+  `NROS_CODEGEN_VERSION` out of `packages/core/nros-core/src/codegen_version.rs`
+  and compare it against the number in the manifest it just wrote.
+* **R4 — no OTHER version comparison may block a release.** Every `exit 1` in
+  the workflow must sit in a paragraph that is about `codegen`. Stated as a
+  property of the fatal paths rather than as a ban on the two old wordings,
+  because a reintroduction would be written in new words — the shape the
+  2026-07-28 audit found in four gates whose reach was narrower than their rule.
+
+## Buildless
+
+Pure text over one YAML file and one Rust file. No CLI, no network, no store —
+it passes in a pristine worktree, which is the bar for the fast lane.
+
+Run: python3 scripts/check-release-manifest.py [--self-test]
+"""
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOW = os.path.join(ROOT, ".github", "workflows", "release-nros.yml")
+READER = os.path.join(
+    ROOT, "packages", "cli", "nros-cli-core", "src", "orchestration", "release_manifest.rs"
+)
+CODEGEN_SRC = "packages/core/nros-core/src/codegen_version.rs"
+
+# The Rust reader's own name for the file. Read, never spelled here.
+FILE_NAME_RE = re.compile(r'pub const FILE_NAME: &str = "([^"]+)"')
+
+# A shell line that composes the manifest by hand instead of asking the binary.
+HAND_WRITTEN_RE = re.compile(
+    r"^\s*(printf|echo|cat)\b.*(codegen\s*=|>\s*\S*share/nros/manifest\.toml)"
+)
+STAMP_RE = re.compile(r"toolchain\s+manifest\b")
+
+
+def manifest_file_name(reader_text):
+    """FILE_NAME as the Rust reader declares it."""
+    m = FILE_NAME_RE.search(reader_text)
+    return m.group(1) if m else None
+
+
+def fatal_paragraphs(text):
+    """Every `exit 1` and the contiguous non-blank block it ends.
+
+    A paragraph is the run of non-blank lines up to and including the `exit 1`.
+    Comments count: the reason a guard exists is written above it, and a guard
+    whose paragraph never says `codegen` is a guard about something else.
+    """
+    lines = text.splitlines()
+    out = []
+    for i, line in enumerate(lines):
+        if "exit 1" not in line:
+            continue
+        start = i
+        while start > 0 and lines[start - 1].strip():
+            start -= 1
+        out.append((i + 1, "\n".join(lines[start : i + 1])))
+    return out
+
+
+def violations(workflow_text, reader_text):
+    """Every rule broken, as (rule, message) pairs."""
+    bad = []
+    name = manifest_file_name(reader_text)
+    if not name:
+        bad.append(("R1", f"{READER} declares no `pub const FILE_NAME` to read the asset path from"))
+        return bad
+
+    staged = f"share/nros/{name}"
+    if staged not in workflow_text:
+        bad.append(
+            (
+                "R1",
+                f"the release stages no {staged} — the Rust reader looks there and "
+                f"would find nothing (`nros pin` could not answer the re-emit question)",
+            )
+        )
+
+    if not STAMP_RE.search(workflow_text) or "--write" not in workflow_text:
+        bad.append(
+            (
+                "R2",
+                "the manifest is not stamped by `nros toolchain manifest … --write`; "
+                "a manifest the workflow composes itself can record a codegen the "
+                "binary does not emit",
+            )
+        )
+    for n, line in enumerate(workflow_text.splitlines(), 1):
+        if HAND_WRITTEN_RE.match(line):
+            bad.append(("R2", f"line {n} composes the manifest by hand: {line.strip()[:90]}"))
+
+    if CODEGEN_SRC not in workflow_text:
+        bad.append(
+            (
+                "R3",
+                f"the release never reads {CODEGEN_SRC} — the one equality that "
+                "survives (manifest codegen == the tree's NROS_CODEGEN_VERSION) is gone",
+            )
+        )
+    elif not any("codegen" in p for _, p in fatal_paragraphs(workflow_text)):
+        bad.append(
+            (
+                "R3",
+                "the tree's NROS_CODEGEN_VERSION is read but no failing path depends "
+                "on it — a check that cannot fail is a check that is not there",
+            )
+        )
+
+    for n, para in fatal_paragraphs(workflow_text):
+        if "codegen" not in para:
+            bad.append(
+                (
+                    "R4",
+                    f"line {n}: a release-blocking failure that is not about codegen:\n"
+                    + "\n".join("        " + x for x in para.splitlines()[-4:]),
+                )
+            )
+    return bad
+
+
+# --------------------------------------------------------------------------
+# self-test — runs on the NORMAL path too, so a gate that cannot fail cannot
+# report OK.
+# --------------------------------------------------------------------------
+
+GOOD = """
+      - name: Record what this release is made of
+        run: |
+          set -euo pipefail
+          "$nros" toolchain manifest --store-version "$v" --write "$stage/share/nros/manifest.toml"
+          # THE ONE EQUALITY THAT SURVIVES.
+          manifest_codegen="$(sed -n 's/^codegen = \\([0-9]\\+\\)$/\\1/p' "$stage/share/nros/manifest.toml")"
+          tree_codegen="$(sed -n 's/.*= \\([0-9]\\+\\);.*/\\1/p' packages/core/nros-core/src/codegen_version.rs)"
+          if [ "$manifest_codegen" != "$tree_codegen" ]; then
+              echo "::error::codegen mismatch" >&2
+              exit 1
+          fi
+"""
+
+REINTRODUCED_INDEX_ASSERT = GOOD + """
+          indexed="$(sed -n 's/^version = "\\(.*\\)"/\\1/p' nros-sdk-index.toml)"
+          if [ "$indexed" != "$want_version" ]; then
+              echo "::error::bump the index first" >&2
+              exit 1
+          fi
+"""
+
+REINTRODUCED_CRATE_ASSERT = GOOD + """
+          crate="$("$nros" --version | awk '{print $NF}')"
+          case "$want_version" in
+              "$crate"-nros*) ;;
+              *) echo "::error::not <crate>-nrosN" >&2; exit 1 ;;
+          esac
+"""
+
+HAND_WRITTEN = """
+      - name: Record
+        run: |
+          printf 'codegen = %s\\n' "$n" >"$stage/share/nros/manifest.toml"
+          tree_codegen="$(sed -n 'p' packages/core/nros-core/src/codegen_version.rs)"
+          if [ "$a" != "$tree_codegen" ]; then
+              echo "codegen bad"
+              exit 1
+          fi
+"""
+
+NO_EQUALITY = """
+      - name: Record
+        run: |
+          "$nros" toolchain manifest --store-version "$v" --write "$stage/share/nros/manifest.toml"
+"""
+
+READER_STUB = 'pub const FILE_NAME: &str = "manifest.toml";'
+
+
+def self_test():
+    cases = [
+        ("the shipped shape passes", GOOD, READER_STUB, set()),
+        ("a reintroduced index assertion", REINTRODUCED_INDEX_ASSERT, READER_STUB, {"R4"}),
+        ("a reintroduced crate-prefix assertion", REINTRODUCED_CRATE_ASSERT, READER_STUB, {"R4"}),
+        ("a hand-composed manifest", HAND_WRITTEN, READER_STUB, {"R2"}),
+        ("no surviving codegen equality", NO_EQUALITY, READER_STUB, {"R3"}),
+        (
+            "a renamed manifest file the workflow did not follow",
+            GOOD,
+            'pub const FILE_NAME: &str = "components.toml";',
+            {"R1"},
+        ),
+    ]
+    failures = 0
+    for label, wf, reader, want in cases:
+        got = {rule for rule, _ in violations(wf, reader)}
+        if got != want:
+            print(f"  self-test FAIL [{label}]: expected {sorted(want) or 'no violations'}, got {sorted(got)}")
+            failures += 1
+    if failures:
+        print(f"check-release-manifest self-test: {failures} case(s) FAILED")
+        return 1
+    print(f"check-release-manifest self-test: OK ({len(cases)} cases)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    for path in (WORKFLOW, READER):
+        if not os.path.isfile(path):
+            print(f"check-release-manifest: {path} is missing — nothing records the release")
+            return 1
+    with open(WORKFLOW, encoding="utf-8") as fh:
+        workflow_text = fh.read()
+    with open(READER, encoding="utf-8") as fh:
+        reader_text = fh.read()
+
+    bad = violations(workflow_text, reader_text)
+    if bad:
+        print("check-release-manifest: the release does not record its components (RFC-0097 D7):")
+        for rule, msg in bad:
+            print(f"  [{rule}] {msg}")
+        print()
+        print("  A release DECLARES what it is made of; it does not assert three")
+        print("  versions equal. Only `codegen` can invalidate a user's existing")
+        print("  generated code, so only `codegen` may block a release.")
+        return 1
+
+    name = manifest_file_name(reader_text)
+    fatal = len(fatal_paragraphs(workflow_text))
+    print(
+        f"check-release-manifest: OK — the asset records share/nros/{name}, "
+        f"stamped by the binary; {fatal} release-blocking path(s), all about codegen."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/nros-installer-tests.sh
+++ b/tests/nros-installer-tests.sh
@@ -18,6 +18,15 @@
 #   3. bad checksum     -> refuses, and installs NOTHING
 #   4. absent .sha256   -> refuses (unverified is not a fallback)
 #   5. no asset at all  -> refuses, naming the source build as the way forward
+#   6. manifest read    -> the INSTALLED binary reads share/nros/manifest.toml
+#                          back out of its prefix (RFC-0097 D7); no component
+#                          version is ever parsed out of an asset or dir name
+#   7. codegen delta    -> `nros pin` across two installed toolchains: equal
+#                          codegen re-emits nothing and does not warn; a
+#                          different one warns, names `nros sync`, and (under
+#                          --dry-run) has written nothing when it does
+#   8. pre-W2 asset     -> VERSION alone still installs, and the binary reports
+#                          that the release declares nothing rather than guessing
 set -uo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -33,6 +42,11 @@ cli="$root/packages/cli/target/release/nros"
 FAILURES=0
 fail() { echo "FAIL: $*" >&2; FAILURES=$((FAILURES + 1)); }
 ok() { echo "  [OK] $*"; }
+# For an arm whose assertions are a straight sequence rather than an if/else:
+# `ok` after a `fail` would print a pass line for an arm that failed, which is
+# exactly the shape `check-no-vacuous-tests` exists to stop one level up.
+arm_start() { _arm_failures="$FAILURES"; }
+arm_ok() { [ "$FAILURES" -eq "$_arm_failures" ] && ok "$*"; }
 
 [ -x "$cli" ] || { echo "SKIP: no in-tree nros at $cli (just setup-cli)" >&2; exit 0; }
 for tool in python3 curl tar zstd; do
@@ -48,12 +62,41 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Build the asset in the shape a release has: prefix-rooted, with the store
-# version beside the binary.
+# version beside the binary — and, since RFC-0097 D7, the manifest that records
+# what the release is MADE OF.
+#
+# The manifest is stamped by the same verb `release-nros.yml` calls, so this
+# exercises the real emit path rather than a hand-written imitation of it: the
+# `codegen` number comes from the binary's own constant, which is the property
+# that makes the release-time equality check meaningful.
 mkdir -p "$tmp/serve" "$tmp/rel/bin" "$tmp/rel/share/nros"
 cp "$cli" "$tmp/rel/bin/nros"
 echo "9.9.9-nros7" >"$tmp/rel/share/nros/VERSION"
+# The codegen number the PACKAGED binary emits, read here rather than inside
+# arm 6. Arm 7 needs it, and under `set -u` a value defined only on arm 6's
+# success branch takes the whole script down when an EARLIER arm failed — one
+# broken arm would then hide every arm after it, which is the reverse of what a
+# multi-arm test is for. Arm 6 still asserts the INSTALLED binary reports the
+# same number, which is the claim that arm is about.
+emitted="$("$cli" --codegen-version)"
+"$cli" toolchain manifest \
+    --store-version 9.9.9-nros7 \
+    --index 2026-09-10 \
+    --nano-ros abc1234 \
+    --write "$tmp/rel/share/nros/manifest.toml" >/dev/null \
+    || { echo "SKIP: this nros has no \`toolchain manifest\` (rebuild: just setup-cli)" >&2; exit 0; }
 tar --zstd -cf "$tmp/serve/nros-asset.tar.zst" -C "$tmp/rel" bin share
 ( cd "$tmp/serve" && sha256sum nros-asset.tar.zst >nros-asset.tar.zst.sha256 )
+
+# A PRE-W2 asset: `share/nros/VERSION` and no manifest. That is a real state on
+# any host that installed before D7 landed, and the installer must be
+# indifferent to it — `install.sh` chooses the prefix from VERSION, in POSIX
+# shell, before anything is unpacked, and must never need a TOML parser.
+mkdir -p "$tmp/legacy/bin" "$tmp/legacy/share/nros"
+cp "$cli" "$tmp/legacy/bin/nros"
+echo "9.9.8-nros1" >"$tmp/legacy/share/nros/VERSION"
+tar --zstd -cf "$tmp/serve/legacy-asset.tar.zst" -C "$tmp/legacy" bin share
+( cd "$tmp/serve" && sha256sum legacy-asset.tar.zst >legacy-asset.tar.zst.sha256 )
 
 # Port 0 lets the OS choose, so parallel runs of this test cannot collide — the
 # fixed-port version of this file would have been a flake generator.
@@ -136,8 +179,91 @@ else
     ok "a missing release names the source build"
 fi
 
+# --- 6: the installed binary READS its own manifest, from the file ---------
+# RFC-0097 D7's "read by the CLI, not parsed out of a filename": the asset is
+# `nros-asset.tar.zst` and the prefix is `9.9.9-nros7`, so neither name carries
+# a codegen number. The only place it can come from is share/nros/manifest.toml.
+home="$tmp/h1"
+installed="$home/sdk/nros/9.9.9-nros7/bin/nros"
+if [ -x "$installed" ]; then
+    arm_start
+    [ "$("$installed" --codegen-version)" = "$emitted" ] \
+        || fail "6: the installed binary emits a different codegen than the one packaged"
+    "$installed" toolchain manifest >"$tmp/read-back.txt" 2>&1
+    nros_grep_q "^codegen = $emitted$" "$tmp/read-back.txt" \
+        || fail "6: the installed binary does not read back its own codegen
+$(cat "$tmp/read-back.txt")"
+    nros_grep_q "^index = \"2026-09-10\"$" "$tmp/read-back.txt" \
+        || fail "6: the manifest lost its index field in transit"
+    arm_ok "the installed binary reads share/nros/manifest.toml back from the prefix"
+else
+    fail "6: arm 1 left no installed binary to read a manifest from"
+fi
+
+# --- 7: same codegen -> no re-emit; different codegen -> warns FIRST -------
+# D7's acceptance, end to end through the real binary. The second toolchain is
+# fabricated in the store rather than installed, because what is under test is
+# the COMPARISON, and two releases that differ only in `codegen` cannot be built
+# from one checkout.
+arm_start
+store="$home"
+same="$store/sdk/nros/9.9.9-nros8"
+newer="$store/sdk/nros/9.9.9-nros9"
+mkdir -p "$same/share/nros" "$newer/share/nros"
+"$cli" toolchain manifest --store-version 9.9.9-nros8 --write "$same/share/nros/manifest.toml" >/dev/null
+sed "s/^codegen = .*/codegen = $((emitted + 1))/" "$tmp/rel/share/nros/manifest.toml" \
+    | sed 's/^version = .*/version = "9.9.9-nros9"/' >"$newer/share/nros/manifest.toml"
+
+proj="$tmp/proj"
+mkdir -p "$proj"
+printf '[toolchain]\nversion = "9.9.9-nros7"\n' >"$proj/nros-toolchain.toml"
+
+"$cli" pin --dir "$proj" --root "$store" --dry-run 9.9.9-nros8 >"$tmp/pin-same.txt" 2>&1 \
+    || fail "7: \`nros pin\` failed
+$(cat "$tmp/pin-same.txt")"
+if nros_grep_q "warning" "$tmp/pin-same.txt"; then
+    fail "7: two releases declaring the same codegen must not warn
+$(cat "$tmp/pin-same.txt")"
+fi
+nros_grep_q "UNCHANGED" "$tmp/pin-same.txt" \
+    || fail "7: the same-codegen verdict is not stated
+$(cat "$tmp/pin-same.txt")"
+
+"$cli" pin --dir "$proj" --root "$store" --dry-run 9.9.9-nros9 >"$tmp/pin-diff.txt" 2>&1 \
+    || fail "7: \`nros pin\` failed on a codegen change
+$(cat "$tmp/pin-diff.txt")"
+nros_grep_q "^warning: codegen $emitted -> $((emitted + 1))" "$tmp/pin-diff.txt" \
+    || fail "7: a codegen change did not warn
+$(cat "$tmp/pin-diff.txt")"
+nros_grep_q "nros sync" "$tmp/pin-diff.txt" \
+    || fail "7: the warning does not name the remedy"
+# And it warned BEFORE it would have acted: --dry-run wrote nothing.
+nros_grep_q '9\.9\.9-nros7' "$proj/nros-toolchain.toml" \
+    || fail "7: --dry-run moved the pin"
+arm_ok "same codegen: no re-emit; different codegen: warns, names the remedy, writes nothing"
+
+# --- 8: a pre-W2 asset still installs, and says what it cannot answer ------
+home="$tmp/h5"
+if run_install "$home" "$base/legacy-asset.tar.zst"; then
+    # `arm_ok`, not `ok`: measured 2026-09-10 against the S2 mutation below —
+    # with the "declares nothing" sentence removed, this arm printed its FAIL
+    # line AND an `[OK]` line for the same arm. The exit code was still right,
+    # so the lie was only in the transcript, which is the half a reader reads.
+    arm_start
+    legacy="$home/sdk/nros/9.9.8-nros1/bin/nros"
+    [ -x "$legacy" ] || fail "8: an asset with no manifest did not install"
+    "$legacy" toolchain manifest >"$tmp/legacy-manifest.txt" 2>&1
+    nros_grep_q "no share/nros/manifest.toml" "$tmp/legacy-manifest.txt" \
+        || fail "8: a manifest-less release must SAY it declares nothing
+$(cat "$tmp/legacy-manifest.txt")"
+    arm_ok "a pre-RFC-0097 asset installs from VERSION alone, and declares nothing rather than guessing"
+else
+    fail "8: an asset with no manifest failed to install
+$(cat "$home.log")"
+fi
+
 if [ "$FAILURES" -ne 0 ]; then
     echo "nros-installer-tests: $FAILURES failure(s)" >&2
     exit 1
 fi
-echo "nros-installer-tests: OK — installs, fronts, and refuses everything unverified."
+echo "nros-installer-tests: OK — installs, fronts, refuses everything unverified, and declares its components."


### PR DESCRIPTION
Implements **RFC-0097 D7** (phase-443 W2). RFC-0097 is PR #841, queued, not yet on `main`.

## What changes

`release-nros.yml` **asserted** that three versions were equal: the release version, `NROS_CODEGEN_VERSION`, and `[tool.nros] version` in the index. The coupling was mechanised, which is why it never drifted; it is also why nothing could move alone. Measured on `main`, 2026-09-10:

| axis | commits |
| --- | --- |
| `packages/cli` | 710 / 60d |
| runtime crates the CLI compiles | 248 / 60d |
| `nros-sdk-index.toml` | 70 / 60d |
| `NROS_CODEGEN_VERSION` | **2, all time** |

The axis carrying every compatibility promise moves twice, ever; the artifact carrying it would have moved ~450x as often.

So the release now **RECORDS** its components: `share/nros/manifest.toml`, carrying `version` / `codegen` / `index` / `nano_ros`. **`0.7.1` and `0.7.9` both declaring `codegen = 7` is the whole feature** — a user takes either and nothing is re-emitted.

**ONE equality survives, because it is the one that is true**: the manifest's `codegen` must equal the tree's `NROS_CODEGEN_VERSION`. That is not a coupling between axes, it is the manifest being *about* the artifact — and it is the assertion phase-288's silent withdrawal actually needed. It cannot be got wrong: the manifest is stamped by `nros toolchain manifest`, which takes the number from the binary's own `abi_guard::EMITTED_VERSION` and has **no `--codegen` flag**. The other two are printed as notes.

New surface:

* `nros toolchain manifest` — read the manifest of the release this binary belongs to, or `--write` one (what the workflow calls).
* `nros pin [<version>]` — report this project's `nros-toolchain.toml`, or move it, **reporting the codegen delta first**. `--dry-run` reports and writes nothing.
* `scripts/check-release-manifest.py` — R1 the asset carries the manifest (filename READ out of the Rust module that parses it), R2 the binary stamps it, R3 the surviving equality is present, R4 **no other version comparison may block a release** (stated as a property of every `exit 1` paragraph, not as a ban on the two old wordings — a reintroduction would be written in new words). Runs a 6-case selftest on the normal path.

## Verification — 15 mutations, all measured RED

| # | fix broken | test that went red |
| --- | --- | --- |
| M1 | `stamp` reads `abi_guard::EMITTED_VERSION` | `stamp_takes_codegen_from_the_binary_never_from_an_argument` |
| M2 | Unknown codegen forces a re-emit | `an_undeclared_codegen_is_treated_as_a_reemit` |
| M3 | report emitted BEFORE the pin moves | `a_differing_codegen_warns_before_the_pin_is_written`, `an_unpinned_project_says_so_and_can_be_pinned` |
| M4 | `candidate_prefixes` derived from `pin::candidate_bins` | `both_store_layouts_resolve_by_construction` |
| M5 | a broken manifest is `Err`, not absent | `absent_is_not_broken` |
| M6 | the verdict comes from `codegen`, not version strings | 4 `cmd::pin` tests |
| M7 | a pin move uses `pin::set`, not `pin::write` | 2 `cmd::pin` tests |
| M8 | an unchanged codegen does not warn | `two_releases_with_the_same_codegen_require_no_reemit` |
| M9 | an empty version is unreadable, not unversioned | `a_manifest_without_provenance_still_loads_and_one_without_codegen_does_not` |
| G1 | reader renames the file, workflow does not follow | `check-release-manifest [R1]` |
| G2 | workflow composes the manifest by hand | `check-release-manifest [R2]` |
| G3 | the surviving codegen equality is deleted | `check-release-manifest [R3]` |
| G4 | index assertion reintroduced as a hard failure | `check-release-manifest [R4]` |
| G5 | `violations()` neutered | the gate's own selftest, 5 cases |
| S1 | `for_exe` walks TWO parents to the prefix | installer arm 6 |
| S2 | a manifest-less release SAYS it declares nothing | installer arm 8 |

G1–G4 were run against the **real** workflow and reader, not the selftest stubs.

**M3 is the one the previous pass never reached**, and it needed the test strengthened. Its first version asserted the ORDERING over a transcript — and a mutation that wrote the pin first and then appended the *same lines* produced an identical transcript, so it passed. The test now records what the pin FILE held at the instant each line was emitted, which is what makes "warns before doing anything" a claim about doing rather than about printing.

### Two defects the mutation pass found in the tests

* **installer arm 8 printed `[OK]` for an arm that had already called `fail`** — measured under S2. The exit code was right, so the lie was only in the transcript, which is the half a reader reads. It uses `arm_start`/`arm_ok` now, like arms 6 and 7.
* **`emitted` was defined only inside arm 6's success branch**, and arm 7 does `$((emitted + 1))` under `set -u` — so one failing arm took the whole script down at rc 127 and hid every arm after it. Hoisted beside the asset build; measured by forcing arm 6 to its else branch, after which arms 7 and 8 still report.

## Argued rather than measured

I cannot cut a real release, so these acceptance clauses are argued from shape:

* **The workflow's steps run correctly on a runner.** `check-release-manifest` reads the YAML as text; the installer test builds an asset with the same `toolchain manifest` verb the workflow calls, so the *emit* path is real, but the *workflow* is not executed.
* **The shallow-clone index date.** `actions/checkout@v4` fetches depth 1, so the recording step's `git log -1 --format=%cs -- nros-sdk-index.toml` is empty unless HEAD touched the index; the fallback to HEAD's own date is reasoned, not run on a runner.
* **The release-notes and `Verify the asset installs` steps** are read, not executed.

Everything else — the manifest round trip, both store layouts, the codegen delta in all three states, the ordering, the install/read-back, and all four gate rules — is measured above.

## Collisions and non-assumptions

* **phase-443 W3+W4 (`work/phase-443-w3-w4-launcher-and-ci-pin`) MOVES `orchestration/pin.rs` into a new `nros-launcher` crate.** This branch EDITS that file (adding `pin::set`, the overwriting spelling). I am landing first and leaving the conflict to them; the change is deliberately not restructured to anticipate the move.
* **`nros sync` is NOT merged into `nros build`.** RFC-0097 D9 describes that as a decision, not a landed fact (`nros build --dry-run` in a fresh workspace still errors "this workspace has never been synced", from `builder::preflight::check`). Nothing here assumes one build verb — the codegen warning names `nros sync`, which is the verb that exists.

## Green locally

`just check fast` (291 ran, 2 env-skipped), `just check cli-tests`, `cargo clippy --workspace --all-targets` in `packages/cli`, `bash tests/nros-installer-tests.sh`, `cargo test -p nros-cli-core --lib -- release_manifest:: cmd::pin::` (14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
