### PR TITLE
feat(phase-443 W3+W4, RFC-0097): the launcher is its own artifact, and CI does not choose a toolchain nobody named

### DIFF
--- a/docs/roadmap/phase-443-release-composition.md
+++ b/docs/roadmap/phase-443-release-composition.md
@@ -74,6 +74,30 @@ launcher does not link the CLI's dependency graph (measured, not asserted); a
 contributor inside a checkout is unaffected, because dispatch declines at its
 own seam.
 
+**Landed.** `packages/cli/nros-launcher` — `dispatch.rs` and `pin.rs` MOVED out
+of `nros-cli-core` (which re-exports them at their old paths, so there is one
+parser of `nros-toolchain.toml`), plus `launch.rs` for the three states a
+launcher meets and a fronted toolchain cannot: an empty store, an unpinned
+project with no CLI to fall back to, and a cwd inside a checkout. The crate
+carries its OWN `version`, which is the point — the workspace version is the
+toolchain's, and sharing it is the coupling the split exists to break.
+
+Measured, not asserted: `tests/launcher_dependency_closure.rs` walks the
+launcher's link closure out of `packages/cli/Cargo.lock` — **27 crates against
+the toolchain's 192**, with `nros-cli-core`, `clap`, `minijinja`,
+`nros-pkg-index`, `nros-launch-parser` and `nros-entry-lower` named as forbidden
+and a ceiling that a new direct dependency trips.
+
+**Not done here, and it is the half a user meets:** `scripts/install.sh` still
+fronts `<store>/bin/nros` at the newest TOOLCHAIN's `bin/nros` through
+`sdk-front`, so nothing installs the launcher yet. Fronting it instead means the
+release asset must carry both binaries and `sdk-front` must learn which one it
+fronts — a change to `release-nros.yml`, which is W2's file. It belongs with
+W2's manifest, not ahead of it. Until then the launcher is a built, tested
+artifact that no install path delivers, and the dispatch a user actually gets is
+still W7's in-toolchain one (`nros-cli/tests/toolchain_dispatch.rs`, which
+still passes).
+
 ### W4 — CI refuses to write a pin (RFC-0097 D11)
 
 Pin-on-first-build is right interactively and wrong in CI: silently pinning to
@@ -83,6 +107,36 @@ the pin exists to prevent.
 *Acceptance:* non-interactive + no pin ⇒ refuse, naming `nros pin <version>`;
 interactive + no pin ⇒ write and say so; a test drives BOTH, since a guard with
 one arm exercised is half a guard.
+
+**Landed, with one correction to the acceptance above.** The refusal does NOT
+name `nros pin <version>`: at the time W4 landed there was no such verb in this
+tree, and a blocked CI job aimed at a command that does not run is a worse
+refusal than none. What always exists is the FILE, so the diagnostic prints
+exactly the `nros-toolchain.toml` that `nros build` would have written, and the
+fix is a copy-paste. Escape hatch: `NROS_ALLOW_PIN_WRITE_IN_CI=1`, named in
+every refusal.
+
+W2 (PR #859) adds `nros pin <version>` and `pin::set`. When it lands the refusal
+may name the verb BESIDE the file, never instead of it — the reader is on a
+runner, where they cannot run a verb either, and the file is what they have to
+commit. W2's `pin::set` belongs in `nros-launcher/src/pin.rs` now; that is the
+one conflict between the two work items, and it is mechanical.
+
+The rule is split across two places on purpose, because they know different
+things:
+
+* **`nros build` REFUSES** (`PinOutcome::RefusedInCi` → an `Err`). It knows it
+  is about to write into the user's source tree.
+* **the launcher WARNS** (`Source::DefaultInCi`), naming the version it took.
+  It parses no `argv` (RFC-0095 D8), so refusing there would refuse
+  `nros --version`, `nros setup --list` and `nros doctor` on every runner —
+  commands that write nothing and have no reproducibility to protect.
+
+The refusal is asked AFTER the three arms that write nothing anyway (a
+contributor's checkout, an already-pinned project, a binary with no store
+version). Ordering it first would fail every build in this repository's own CI,
+which builds inside a checkout; `a_checkout_in_ci_is_not_a_pin_refusal` and
+`an_existing_pin_is_read_identically_in_ci` are what hold it there.
 
 ### W5 — `setup --check` covers the build stage; `doctor` covers the install (D12)
 

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "clap_complete",
  "eyre",
  "nros-cli-core",
+ "nros-launcher",
  "tempfile",
 ]
 
@@ -810,6 +811,7 @@ dependencies = [
  "nros-entry-lower",
  "nros-lang",
  "nros-launch-parser",
+ "nros-launcher",
  "nros-msg-to-idl",
  "nros-orchestration-ir",
  "nros-pkg-index",
@@ -864,6 +866,16 @@ dependencies = [
  "nros-pkg-index",
  "quick-xml",
  "tempfile",
+]
+
+[[package]]
+name = "nros-launcher"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+ "serde",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -17,6 +17,9 @@ members = [
     "nros-launch-parser",
     "nros-cli-core",
     "nros-cli",
+    # phase-443 W3 (RFC-0097 D4) — the launcher, its OWN artifact and its own
+    # version. It must not gain dependencies; see its manifest.
+    "nros-launcher",
     "nros-msg-to-idl",
     # Phase 212.N.4 — build-script codegen library for Entry pkgs.
     "nros-build",
@@ -57,6 +60,7 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 # Workspace member dependencies
 cargo-nano-ros = { path = "cargo-nano-ros" }
 nros-cli-core = { path = "nros-cli-core" }
+nros-launcher = { path = "nros-launcher" }
 rosidl-bindgen = { path = "rosidl-bindgen" }
 rosidl-parser = { path = "rosidl-parser" }
 rosidl-resolve = { path = "rosidl-resolve" }

--- a/packages/cli/nros-cli-core/Cargo.toml
+++ b/packages/cli/nros-cli-core/Cargo.toml
@@ -48,6 +48,11 @@ eyre = "0.6"
 # re-exported as `pkg_index` / `launch_parser`.
 nros-pkg-index = { path = "../nros-pkg-index" }
 nros-launch-parser = { path = "../nros-launch-parser" }
+# phase-443 W3 (RFC-0097 D4) — the launcher is its own crate and binary now.
+# This crate re-exports its `pin` / `dispatch` / `store_root` / `checkout`
+# modules at their original paths, so there is ONE parser of
+# `nros-toolchain.toml` and one answer to "where is the store".
+nros-launcher = { workspace = true }
 thiserror = { workspace = true }
 minijinja = { workspace = true }
 nros-entry-lower = { workspace = true }

--- a/packages/cli/nros-cli-core/Cargo.toml
+++ b/packages/cli/nros-cli-core/Cargo.toml
@@ -22,13 +22,6 @@ default = []
 # Maintainer-only release subcommands (`nros release detect|publish|tag`).
 # Hidden from `nros --help` unless this feature is on at build time.
 release = []
-# Issue 0476, phase-443 — makes `test_support` public so an INTEGRATION test in
-# a sibling crate can reach `write_executable_stub`. `tests/toolchain_dispatch.rs`
-# writes a launcher and a stub and then EXECS them, which is exactly the ETXTBSY
-# race that helper exists to remove; without this the only alternative was a
-# second copy of the discipline in that file, and a second spelling of a fix is
-# how #282 became #326. Off by default, so a release build still ships nothing.
-test-support = []
 
 # Issue 0379: `planner.rs` still carries `#[cfg(feature = "play-launch-parser")]`
 # gates around dormant tests for the launch path RFC-0060 retired (the feature

--- a/packages/cli/nros-cli-core/src/abi_guard.rs
+++ b/packages/cli/nros-cli-core/src/abi_guard.rs
@@ -86,8 +86,12 @@ pub const SKIP_ENV: &str = "NROS_SKIP_VERSION_CHECK";
 /// has told us once has told us for both.
 pub const RUNTIME_ROOT_ENV: &str = "NROS_REPO_DIR";
 
-/// The marker that identifies a nano-ros source tree, relative to its root.
-const MONOREPO_MARKER: &str = "packages/core/nros-core/Cargo.toml";
+// The marker that identifies a nano-ros source tree, relative to its root.
+// Owned by `nros_launcher::checkout` since phase-443 W3 — see
+// `find_monorepo_root` below.
+// Re-exported rather than merely imported: the doc links above name it, and
+// a private import of a constant only the tests read is a warning.
+pub use nros_launcher::checkout::MONOREPO_MARKER;
 
 /// The runtime's own declaration of what it accepts, relative to the tree root.
 const CODEGEN_VERSION_SRC: &str = "packages/core/nros-core/src/codegen_version.rs";
@@ -141,19 +145,14 @@ impl Verb {
 /// Walk up from `start` to find the nano-ros source-tree root — the directory
 /// containing [`MONOREPO_MARKER`]. Returns `None` when `start` is not inside
 /// such a tree.
+///
+/// MOVED to `nros_launcher::checkout` by phase-443 W3 and re-exported here. The
+/// launcher asks this question FIRST (RFC-0097: *"inside a checkout the
+/// launcher is not involved"*), so it has to own the answer; a second walk with
+/// a second marker is how the launcher and the ownership guard would come to
+/// disagree about what a checkout is.
 pub fn find_monorepo_root(start: &Path) -> Option<PathBuf> {
-    let mut cur: Option<&Path> = if start.is_file() {
-        start.parent()
-    } else {
-        Some(start)
-    };
-    while let Some(dir) = cur {
-        if dir.join(MONOREPO_MARKER).is_file() {
-            return Some(dir.to_path_buf());
-        }
-        cur = dir.parent();
-    }
-    None
+    nros_launcher::checkout::find_monorepo_root(start)
 }
 
 /// Locate the nano-ros runtime tree whose acceptance range applies to a

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -902,11 +902,45 @@ fn pin_this_project(args: &Args) -> Result<()> {
     let Ok(exe) = std::env::current_exe() else {
         return Ok(());
     };
-    let outcome = crate::orchestration::pin::pin_on_first_build(&root, &exe)?;
-    if let Some(line) = crate::orchestration::pin::describe(&outcome) {
+    // RFC-0097 D11 — a pin is a source edit, so an automated session does not
+    // make one. The session is DETECTED here and passed in, because
+    // `pin_on_first_build` is a pure function of its arguments and its tests
+    // must not depend on whether the machine running them happens to set `$CI`
+    // (which, in this repo's own CI, it does).
+    let session = nros_launcher::session::Session::detect();
+    let outcome = crate::orchestration::pin::pin_on_first_build(&root, &exe, &session)?;
+    if let Some(line) = report_pin_outcome(&outcome)? {
         eprintln!("{line}");
     }
     Ok(())
+}
+
+/// Turn a [`PinOutcome`](crate::orchestration::pin::PinOutcome) into what the
+/// build does about it: a line to print, nothing, or an ERROR.
+///
+/// Split out from [`pin_this_project`] so RFC-0097 D11's *build* half is
+/// reachable by a test. It is the half that is easy to get wrong and impossible
+/// to see: the refusal already exists as a value one crate over
+/// (`PinOutcome::RefusedInCi`) and `toolchain_pin_dispatch.rs` covers it
+/// thoroughly — but a caller that printed it as a warning and carried on would
+/// pass every one of those tests while doing exactly the thing D11 forbids.
+/// Without this seam the only way to that code path is a full `nros build`
+/// against a real store, which is not a test anyone would keep.
+pub(crate) fn report_pin_outcome(
+    outcome: &crate::orchestration::pin::PinOutcome,
+) -> Result<Option<String>> {
+    let line = crate::orchestration::pin::describe(outcome);
+    if outcome.is_refusal() {
+        // Not a warning. Proceeding would build against a toolchain nobody
+        // recorded, which is precisely the unreproducible build the pin exists
+        // to prevent — and a CI job that goes green on it has hidden the
+        // problem rather than found it.
+        eyre::bail!(
+            "{}",
+            line.unwrap_or_else(|| "refusing to write a toolchain pin".to_string())
+        );
+    }
+    Ok(line)
 }
 
 /// How one plan's native command reaches the operating system.
@@ -3223,5 +3257,89 @@ mod multi_image_drive_tests {
     fn a_waited_handover_fails_on_a_non_zero_exit() {
         let e = perform(&nullary("false"), Handover::Wait).expect_err("`false` exits 1");
         assert!(format!("{e:#}").contains("exited"), "{e:#}");
+    }
+}
+
+/// RFC-0097 D11's BUILD half — phase-443 W4.
+///
+/// `toolchain_pin_dispatch.rs` covers the decision (which outcome each session
+/// produces). This covers what `nros build` DOES with it, which is a separate
+/// claim and the one that carries the acceptance: a refusal that reaches the
+/// user as a printed warning is not a refusal, and every test one crate over
+/// would still pass.
+#[cfg(test)]
+mod pin_report_tests {
+    use super::report_pin_outcome;
+    use crate::orchestration::pin::{Pin, PinOutcome};
+    use std::path::PathBuf;
+
+    /// The refusal STOPS the build, and the error the user sees is the full
+    /// diagnostic — the variable that decided, the file to write, the escape
+    /// hatch — not a summary that sends them looking for it.
+    #[test]
+    fn a_ci_refusal_becomes_an_error_carrying_the_whole_diagnostic() {
+        let outcome = PinOutcome::RefusedInCi {
+            version: "0.5.0-nros1".to_string(),
+            dir: PathBuf::from("/w/my-robot"),
+            var: "CI",
+        };
+        let err = report_pin_outcome(&outcome).expect_err("a refusal must fail the build");
+        let text = format!("{err:#}");
+        assert!(
+            text.contains("$CI"),
+            "name the variable that decided:\n{text}"
+        );
+        assert!(
+            text.contains("version = \"0.5.0-nros1\""),
+            "print the pin to write:\n{text}"
+        );
+        assert!(
+            text.contains("NROS_ALLOW_PIN_WRITE_IN_CI"),
+            "name the escape hatch:\n{text}"
+        );
+    }
+
+    /// The negative control, and the reason the refusal is a single arm rather
+    /// than "is this CI?" asked here: every other outcome is advisory. A
+    /// `report_pin_outcome` that failed on all of them would pass the test
+    /// above and break every build in this repository's own CI, which builds
+    /// inside a checkout.
+    #[test]
+    fn every_other_outcome_lets_the_build_proceed() {
+        let wrote = PinOutcome::Wrote {
+            path: PathBuf::from("/w/my-robot/nros-toolchain.toml"),
+            version: "0.5.0-nros1".to_string(),
+        };
+        assert!(
+            report_pin_outcome(&wrote)
+                .expect("writing a pin is not a failure")
+                .is_some_and(|l| l.contains("0.5.0-nros1")),
+            "a written pin is reported"
+        );
+
+        let already = PinOutcome::Already(Pin {
+            path: PathBuf::from("/w/my-robot/nros-toolchain.toml"),
+            version: "0.5.0-nros1".to_string(),
+        });
+        assert!(
+            report_pin_outcome(&already)
+                .expect("a pinned project builds")
+                .is_some()
+        );
+
+        // A contributor is told nothing at all — their nano-ros is the clone
+        // they are standing in.
+        assert_eq!(
+            report_pin_outcome(&PinOutcome::InCheckout(PathBuf::from("/src/nano-ros")))
+                .expect("a checkout builds"),
+            None
+        );
+
+        assert!(
+            report_pin_outcome(&PinOutcome::NoRunningVersion)
+                .expect("an unpinnable binary still builds")
+                .is_some(),
+            "the user is warned that the project is still unpinned"
+        );
     }
 }

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -54,12 +54,8 @@ pub mod stale_guard;
 // Issue 0455 — one `scratch_dir` for every unit test in this crate. Nine
 // hand-written `temp_dir().join(...)` spellings raced each other; the
 // differences between them WERE the bug. Test-only, so it ships nothing.
-// `test-support` additionally exposes it to integration tests in sibling
-// crates (phase-443): `nros-cli`'s launcher tests exec what they write, which
-// is the same ETXTBSY race, and the rule is one helper rather than a second
-// spelling of it.
-#[cfg(any(test, feature = "test-support"))]
-pub mod test_support;
+#[cfg(test)]
+mod test_support;
 // Phase 219.A — Entry-pkg codegen (`nros codegen entry`). The shared
 // pkg-index walk + launch.xml parser also live here so the cmake-fn
 // path (`nano_ros_entry(LAUNCH …)`), the Rust proc-macro

--- a/packages/cli/nros-cli-core/src/orchestration/mod.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/mod.rs
@@ -11,9 +11,16 @@ pub mod bridge_gen;
 pub mod cargo_metadata_schema;
 pub mod cmake_preset;
 pub mod config;
-/// phase-440 W7 (RFC-0095 D8) — the launcher: read the pin, ensure that
-/// toolchain, `exec` it. Three jobs; a fourth is a bug.
-pub mod dispatch;
+// phase-440 W7 (RFC-0095 D8) — the launcher: read the pin, ensure that
+// toolchain, `exec` it. Three jobs; a fourth is a bug.
+//
+// phase-443 W3 MOVED the file to the `nros-launcher` crate (RFC-0097 D4): the
+// launcher is now its own binary, so the logic that selects a version can stop
+// shipping inside the version being selected. Re-exported at its original path
+// because this binary is still fronted on installed hosts and still calls
+// `redispatch()` before clap — and because one parser of `nros-toolchain.toml`
+// in the tree is the whole point of moving it rather than copying it.
+pub use nros_launcher::dispatch;
 pub mod facade;
 /// phase-383 W1 — `[image.<id>]`, the buildable unit (RFC-0065 D6).
 pub mod image;
@@ -33,8 +40,10 @@ pub mod model_ingest;
 pub mod names;
 pub mod nros_config;
 pub mod params;
-/// phase-440 W7 (RFC-0095 D7/D9) — `nros-toolchain.toml`, the per-project pin.
-pub mod pin;
+// phase-440 W7 (RFC-0095 D7/D9) — `nros-toolchain.toml`, the per-project pin.
+// MOVED to `nros-launcher` by phase-443 W3, re-exported here; see `dispatch`
+// above.
+pub use nros_launcher::pin;
 pub mod plan;
 pub mod planner;
 

--- a/packages/cli/nros-cli-core/src/orchestration/store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/store.rs
@@ -55,31 +55,20 @@ use super::{
 /// [`super::sdk_store::front_dir`] (`<root>/bin`) are its two established
 /// children and now derive from it, so the resolution order has one spelling
 /// rather than three copies that could disagree about `NROS_STORE`.
+///
+/// MOVED to `nros_launcher::store_root` by phase-443 W3 and re-exported here:
+/// the launcher is a separate binary now (RFC-0097 D4) and constructs every
+/// path it touches under this root, so it cannot ask this crate where the root
+/// is — and two implementations is how a launcher comes to look in a different
+/// store from the `nros toolchain` verbs that fill it.
 pub fn root() -> PathBuf {
-    if let Some(s) = std::env::var_os("NROS_STORE") {
-        return PathBuf::from(s);
-    }
-    if let Some(h) = std::env::var_os("NROS_HOME") {
-        return PathBuf::from(h);
-    }
-    if let Some(h) = std::env::var_os("HOME") {
-        return PathBuf::from(h).join(".nros");
-    }
-    PathBuf::from(".nros")
+    nros_launcher::store_root::root()
 }
 
 /// Which environment variable answered [`root`] — for the header line, so a
 /// reader never has to guess whose store they are about to shrink.
 pub fn root_origin() -> &'static str {
-    if std::env::var_os("NROS_STORE").is_some() {
-        "$NROS_STORE"
-    } else if std::env::var_os("NROS_HOME").is_some() {
-        "$NROS_HOME"
-    } else if std::env::var_os("HOME").is_some() {
-        "$HOME/.nros"
-    } else {
-        "./.nros (no $HOME)"
-    }
+    nros_launcher::store_root::root_origin()
 }
 
 /// A top-level directory of the store, and how deep its entries sit.

--- a/packages/cli/nros-cli-core/src/test_support.rs
+++ b/packages/cli/nros-cli-core/src/test_support.rs
@@ -102,63 +102,12 @@ pub fn scratch_dir(tag: &str) -> PathBuf {
 /// A retry-on-`ETXTBSY` loop also works (0 escapes, 141 backoffs in the same
 /// experiment) but masks the race instead of removing it, and pays latency on
 /// every hit.
-/// Issue 0476, the same rule for a binary that already exists.
-///
-/// [`write_executable_stub`] removes the ETXTBSY race by never holding a write
-/// descriptor in THIS process. `std::fs::copy` holds one, so a test that copies
-/// a real binary into a store and then execs it is exposed exactly as a test
-/// that wrote a script would be — and it is the harder case to spot, because
-/// nothing about `fs::copy` looks like writing an executable.
-///
-/// `cp` preserves the mode of a source that is already executable; the explicit
-/// `chmod` is for a source whose mode does not survive (a fixture checked out
-/// without the bit, a `CARGO_BIN_EXE_*` on a filesystem that drops it).
-pub fn copy_executable(src: &std::path::Path, dst: &std::path::Path) {
-    let ok = std::process::Command::new("cp")
-        .arg(src)
-        .arg(dst)
-        .status()
-        .unwrap_or_else(|e| panic!("spawn cp {} -> {}: {e}", src.display(), dst.display()))
-        .success();
-    assert!(
-        ok,
-        "cp failed copying {} -> {}",
-        src.display(),
-        dst.display()
-    );
-
-    let ok = std::process::Command::new("chmod")
-        .arg("755")
-        .arg(dst)
-        .status()
-        .unwrap_or_else(|e| panic!("spawn chmod for {}: {e}", dst.display()))
-        .success();
-    assert!(ok, "chmod failed on {}", dst.display());
-}
-
-pub fn write_executable_stub(path: &std::path::Path, script: &str) {
-    let src = path.with_extension("stub-src");
-    std::fs::write(&src, script)
-        .unwrap_or_else(|e| panic!("write stub source {}: {e}", src.display()));
-
-    let ok = std::process::Command::new("cp")
-        .arg(&src)
-        .arg(path)
-        .status()
-        .unwrap_or_else(|e| panic!("spawn cp for {}: {e}", path.display()))
-        .success();
-    assert!(ok, "cp failed writing stub {}", path.display());
-
-    let ok = std::process::Command::new("chmod")
-        .arg("755")
-        .arg(path)
-        .status()
-        .unwrap_or_else(|e| panic!("spawn chmod for {}: {e}", path.display()))
-        .success();
-    assert!(ok, "chmod failed on stub {}", path.display());
-
-    let _ = std::fs::remove_file(&src);
-}
+/// Issue 0476 — the ONE spelling of "put an executable here safely" now lives in
+/// `nros-launcher`, the lowest crate every launcher test can reach. This crate
+/// depends on it, so re-exporting is what keeps that a single spelling: two
+/// copies of a discipline is how #282 became #326, and a helper about a race is
+/// exactly the kind that must not be forked.
+pub(crate) use nros_launcher::test_support::write_executable_stub;
 
 /// Scope model discovery to the fixture under test, once per test process.
 ///

--- a/packages/cli/nros-cli-core/tests/toolchain_pin_dispatch.rs
+++ b/packages/cli/nros-cli-core/tests/toolchain_pin_dispatch.rs
@@ -23,6 +23,15 @@ use nros_cli_core::orchestration::{
     dispatch::{self, Context, Decision},
     pin::{self, PinOutcome},
 };
+use nros_launcher::session::Session;
+
+/// A developer at a keyboard — the session every test here means unless it is
+/// ABOUT RFC-0097 D11. Passed explicitly rather than detected, so a run on a
+/// machine that exports `$CI` (this repo's own CI does) measures the same thing
+/// as a run on a laptop.
+fn dev() -> Session {
+    Session::interactive()
+}
 
 /// A store entry that looks like one `scripts/install.sh` wrote: a prefix with
 /// `bin/nros` in it. Returns the binary path, which is what a launcher execs
@@ -68,7 +77,7 @@ fn first_build_writes_a_pin() {
     let exe = install_toolchain(&store, "0.5.0-nros1");
     let proj = project(tmp.path(), "my-robot");
 
-    let outcome = pin::pin_on_first_build(&proj, &exe).unwrap();
+    let outcome = pin::pin_on_first_build(&proj, &exe, &dev()).unwrap();
     let PinOutcome::Wrote { path, version } = outcome else {
         panic!("expected a pin to be written, got {outcome:?}");
     };
@@ -93,10 +102,10 @@ fn a_second_build_does_not_move_the_pin() {
     let new = install_toolchain(&store, "0.6.0-nros1");
     let proj = project(tmp.path(), "my-robot");
 
-    pin::pin_on_first_build(&proj, &old).unwrap();
+    pin::pin_on_first_build(&proj, &old, &dev()).unwrap();
     let before = std::fs::read_to_string(proj.join("nros-toolchain.toml")).unwrap();
 
-    let outcome = pin::pin_on_first_build(&proj, &new).unwrap();
+    let outcome = pin::pin_on_first_build(&proj, &new, &dev()).unwrap();
     let PinOutcome::Already(p) = &outcome else {
         panic!("a second build must find the pin, not rewrite it: {outcome:?}");
     };
@@ -137,11 +146,11 @@ fn a_pin_is_found_from_a_subdirectory() {
     let root = project(tmp.path(), "my-robot");
     let deep = project(tmp.path(), "my-robot/src/talker_pkg/src");
 
-    pin::pin_on_first_build(&root, &exe).unwrap();
+    pin::pin_on_first_build(&root, &exe, &dev()).unwrap();
     let found = pin::find(&deep).expect("the walk up must reach the root pin");
     assert_eq!(found, root.join("nros-toolchain.toml"));
 
-    let outcome = pin::pin_on_first_build(&deep, &exe).unwrap();
+    let outcome = pin::pin_on_first_build(&deep, &exe, &dev()).unwrap();
     assert!(
         matches!(outcome, PinOutcome::Already(_)),
         "a build from a subdirectory must use the root pin, not write its own: {outcome:?}"
@@ -165,12 +174,133 @@ fn a_binary_with_no_store_version_pins_nothing_and_says_so() {
     std::fs::write(&exe, b"x").unwrap();
     let proj = project(tmp.path(), "my-robot");
 
-    let outcome = pin::pin_on_first_build(&proj, &exe).unwrap();
+    let outcome = pin::pin_on_first_build(&proj, &exe, &dev()).unwrap();
     assert_eq!(outcome, PinOutcome::NoRunningVersion);
     assert!(!proj.join("nros-toolchain.toml").exists());
     assert!(
         pin::describe(&outcome).unwrap().contains("UNPINNED"),
         "the user must be told they still have D9's bug"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RFC-0097 D11 (phase-443 W4) — CI refuses to WRITE a pin
+// ---------------------------------------------------------------------------
+
+/// The acceptance clause, literally: an automated session does not mutate the
+/// project's source, and the failure text names the fix.
+///
+/// `nros toolchain install` has no pin-writing path of its own — `nros build`
+/// is the only thing in the tree that writes `nros-toolchain.toml` — so this is
+/// where the whole rule lives.
+#[test]
+fn an_automated_session_refuses_to_write_a_pin_and_names_the_fix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    let outcome = pin::pin_on_first_build(&proj, &exe, &Session::automated("CI")).unwrap();
+    let PinOutcome::RefusedInCi { version, var, .. } = &outcome else {
+        panic!("expected a refusal, got {outcome:?}");
+    };
+    assert_eq!(version, "0.5.0-nros1");
+    assert_eq!(*var, "CI");
+    assert!(
+        outcome.is_refusal(),
+        "the caller must be able to turn this into an ERROR — a warning here \
+         goes green against a toolchain nobody recorded"
+    );
+    assert!(
+        !proj.join("nros-toolchain.toml").exists(),
+        "a refusal that leaves the file behind is not a refusal"
+    );
+
+    let text = pin::describe(&outcome).unwrap();
+    assert!(
+        text.contains("$CI"),
+        "name the variable that decided:\n{text}"
+    );
+    assert!(
+        text.contains("version = \"0.5.0-nros1\""),
+        "print the pin to write, so the fix is a copy-paste:\n{text}"
+    );
+    assert!(
+        text.contains("NROS_ALLOW_PIN_WRITE_IN_CI"),
+        "name the escape hatch:\n{text}"
+    );
+}
+
+/// The other half: *"a CI job that resolves a pin gets the same toolchain a
+/// dev's machine does."* An ALREADY-pinned project is untouched by the rule —
+/// that is the reproducible case, and the common one, and refusing it would be
+/// the opposite of what D11 asks for.
+#[test]
+fn an_existing_pin_is_read_identically_in_ci() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    pin::pin_on_first_build(&proj, &exe, &dev()).unwrap();
+    let before = std::fs::read_to_string(proj.join("nros-toolchain.toml")).unwrap();
+
+    let outcome = pin::pin_on_first_build(&proj, &exe, &Session::automated("CI")).unwrap();
+    let PinOutcome::Already(p) = &outcome else {
+        panic!("a pinned project must resolve in CI, not refuse: {outcome:?}");
+    };
+    assert_eq!(p.version, "0.5.0-nros1");
+    assert_eq!(
+        before,
+        std::fs::read_to_string(proj.join("nros-toolchain.toml")).unwrap(),
+        "reading a pin in CI must not rewrite it"
+    );
+}
+
+/// A contributor's checkout is untouched by the rule, and this is not academic:
+/// this repo's OWN CI builds inside a checkout, so a refusal ordered before the
+/// checkout arm would have failed every in-tree build the day it landed.
+#[test]
+fn a_checkout_in_ci_is_not_a_pin_refusal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let root = project(tmp.path(), "nano-ros");
+    std::fs::create_dir_all(root.join("packages/core/nros-core")).unwrap();
+    std::fs::write(root.join("packages/core/nros-core/Cargo.toml"), "").unwrap();
+    let ws = project(tmp.path(), "nano-ros/examples/workspaces/rust");
+
+    let outcome = pin::pin_on_first_build(&ws, &exe, &Session::automated("CI")).unwrap();
+    assert!(
+        matches!(outcome, PinOutcome::InCheckout(_)),
+        "a checkout must be reported as one, in CI too: {outcome:?}"
+    );
+    assert!(!outcome.is_refusal());
+}
+
+/// "Someone who really means it." With the escape hatch the pin IS written, so
+/// the hatch is a live path rather than a documented intention.
+#[test]
+fn the_escape_hatch_lets_an_automated_session_write_a_pin() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let exe = install_toolchain(&store, "0.5.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    let session = Session::detect_with(|k| match k {
+        "CI" => Some("true".into()),
+        "NROS_ALLOW_PIN_WRITE_IN_CI" => Some("1".into()),
+        _ => None,
+    });
+    let outcome = pin::pin_on_first_build(&proj, &exe, &session).unwrap();
+    assert!(
+        matches!(outcome, PinOutcome::Wrote { .. }),
+        "the hatch must actually write: {outcome:?}"
+    );
+    assert_eq!(
+        pin::load(&proj.join("nros-toolchain.toml"))
+            .unwrap()
+            .version,
+        "0.5.0-nros1"
     );
 }
 
@@ -289,7 +419,7 @@ fn a_checkout_is_never_dispatched_away_from() {
     );
     // And the same directory pins nothing, for the same reason.
     assert!(matches!(
-        pin::pin_on_first_build(&ws, &launcher).unwrap(),
+        pin::pin_on_first_build(&ws, &launcher, &dev()).unwrap(),
         PinOutcome::InCheckout(_)
     ));
 }

--- a/packages/cli/nros-cli/Cargo.toml
+++ b/packages/cli/nros-cli/Cargo.toml
@@ -32,7 +32,9 @@ nros-cli-core = { path = "../nros-cli-core" }
 # `tests/toolchain_dispatch.rs` builds a fake store in a tempdir: the launcher
 # must be tested against a store that is NOT the developer's `~/.nros`.
 tempfile = "3.10"
-# Issue 0476 — that same test writes a launcher and a stub and then EXECS them.
-# `test-support` exposes the ONE helper that removes the ETXTBSY race, rather
-# than this file growing a second copy of the discipline.
-nros-cli-core = { path = "../nros-cli-core", features = ["test-support"] }
+# ...and installs executables into it that it then RUNS, so it uses the ONE
+# spelling of "put an executable here safely" (issue 0476). It lives in
+# `nros-launcher` because that is the lowest crate every launcher test can
+# reach — `nros-cli-core` depends on it, so a helper there would be a cycle for
+# the launcher's own tests.
+nros-launcher = { workspace = true }

--- a/packages/cli/nros-cli/tests/toolchain_dispatch.rs
+++ b/packages/cli/nros-cli/tests/toolchain_dispatch.rs
@@ -27,19 +27,19 @@ use std::{
     process::Command,
 };
 
+use nros_launcher::test_support::{copy_executable, write_executable_stub};
+
 /// Install the real binary as the launcher for `version`.
+///
+/// Through `test_support::copy_executable`, never `std::fs::copy`: this test
+/// execs what it just wrote, which is issue 0476's exact shape. Measured while
+/// finishing phase-443 W3 — `an_unpinned_project_runs_in_the_launcher` failed 1
+/// of 4 full `packages/cli` runs and passed 4 of 4 solo.
 fn install_launcher(store: &Path, version: &str) -> PathBuf {
     let bin = store.join("sdk/nros").join(version).join("bin");
     std::fs::create_dir_all(&bin).unwrap();
     let exe = bin.join("nros");
-    // NOT `fs::copy` — issue 0476. This binary is EXEC'd a few lines later, and
-    // a write descriptor held in this process is inherited by any sibling
-    // thread's fork until that child execs, which the kernel reports as
-    // ETXTBSY. It passes on an idle machine and fails on a loaded CI runner.
-    nros_cli_core::test_support::copy_executable(
-        std::path::Path::new(env!("CARGO_BIN_EXE_nros")),
-        &exe,
-    );
+    copy_executable(Path::new(env!("CARGO_BIN_EXE_nros")), &exe);
     exe
 }
 
@@ -50,9 +50,7 @@ fn install_stub(store: &Path, version: &str) -> PathBuf {
     let bin = store.join("sdk/nros").join(version).join("bin");
     std::fs::create_dir_all(&bin).unwrap();
     let exe = bin.join("nros");
-    // Same rule as `install_launcher`, and this is the shape issue 0476 was
-    // filed against: written here, exec'd there.
-    nros_cli_core::test_support::write_executable_stub(
+    write_executable_stub(
         &exe,
         "#!/bin/sh\n\
          echo \"STUB-TOOLCHAIN\"\n\

--- a/packages/cli/nros-launcher/Cargo.toml
+++ b/packages/cli/nros-launcher/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "nros-launcher"
+# NOT `version.workspace = true`, and that is the whole point of RFC-0097 D4.
+#
+# The workspace version is the TOOLCHAIN's version — it moves with every one of
+# the 710 `packages/cli` commits per 60 days. A launcher that shared it would
+# re-release on each of them, which is the coupling this crate exists to break.
+# So this number is the launcher's own axis and moves when the LAUNCHER's
+# behaviour does: the pin schema, the store layout it constructs paths in, or
+# the handover contract. Bump it by hand, and say why in the commit.
+#
+# `scripts/check-version-lockstep.sh` reads `[workspace.package].version` from
+# the two workspace roots and is unaffected by a member that opts out.
+version = "0.1.0"
+publish = false
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "The `nros` launcher: read the project's toolchain pin, ensure that toolchain, exec it."
+homepage.workspace = true
+documentation.workspace = true
+
+[lib]
+name = "nros_launcher"
+path = "src/lib.rs"
+
+[[bin]]
+name = "nros-launcher"
+path = "src/main.rs"
+
+# Deliberately tiny. A launcher must build and run on a host with no toolchain
+# installed, and every dependency added here is one more thing that can stop
+# that being true. `clap` is NOT among them — the launcher parses no argv
+# (RFC-0095 D8); see `src/main.rs`.
+[dependencies]
+eyre = "0.6"
+serde = { workspace = true }
+toml = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/packages/cli/nros-launcher/src/checkout.rs
+++ b/packages/cli/nros-launcher/src/checkout.rs
@@ -1,0 +1,33 @@
+//! Is a path inside a nano-ros checkout?
+//!
+//! MOVED from `nros_cli_core::abi_guard` (which re-exports it, so there is one
+//! spelling). It has to live in the launcher crate because the launcher's very
+//! first question is this one: RFC-0095 D0/D5 give the contributor audience a
+//! different answer from the user audience, and RFC-0097 states it for the
+//! launcher directly — *"inside a checkout the launcher is not involved: the
+//! ownership guard requires that clone's own build and dispatch declines at its
+//! own seam."*
+
+use std::path::{Path, PathBuf};
+
+/// The file whose presence marks a nano-ros source tree.
+pub const MONOREPO_MARKER: &str = "packages/core/nros-core/Cargo.toml";
+
+/// Walk up from `start` to find the nano-ros source-tree root — the directory
+/// containing [`MONOREPO_MARKER`]. Returns `None` when `start` is not inside
+/// such a tree.
+#[must_use]
+pub fn find_monorepo_root(start: &Path) -> Option<PathBuf> {
+    let mut cur: Option<&Path> = if start.is_file() {
+        start.parent()
+    } else {
+        Some(start)
+    };
+    while let Some(dir) = cur {
+        if dir.join(MONOREPO_MARKER).is_file() {
+            return Some(dir.to_path_buf());
+        }
+        cur = dir.parent();
+    }
+    None
+}

--- a/packages/cli/nros-launcher/src/dispatch.rs
+++ b/packages/cli/nros-launcher/src/dispatch.rs
@@ -65,7 +65,7 @@ use std::{
 
 use eyre::{Result, bail};
 
-use super::pin;
+use crate::pin;
 
 /// Set on the child by [`redispatch`]. Its VALUE is the version that was asked
 /// for, so a child that finds it disagreeing with its own store version can say
@@ -125,7 +125,7 @@ pub fn decide(ctx: &Context) -> Result<Decision> {
     // A checkout is the contributor audience (RFC-0095 D0). Asked before the
     // pin, because an in-tree workspace may legitimately carry one for a test
     // and it must not aim a contributor at the store.
-    if crate::abi_guard::find_monorepo_root(&ctx.cwd).is_some() {
+    if crate::checkout::find_monorepo_root(&ctx.cwd).is_some() {
         return Ok(Decision::Proceed("the cwd is inside a nano-ros checkout"));
     }
     let Some((mine, _origin)) = pin::running_version(&ctx.exe) else {
@@ -168,16 +168,28 @@ pub fn bundled_installer(exe: &Path) -> Option<PathBuf> {
 /// D8 job 2, performed: fetch the pinned toolchain through the installer that
 /// shipped with this launcher.
 ///
+/// Takes `exe` and `store` rather than a [`Context`], because the STANDALONE
+/// launcher ([`crate::launch`]) has the same job to do and a different context
+/// type. One implementation of the fetch was the argument for delegating to
+/// `install.sh` in the first place; two callers of it is not a reason to grow a
+/// second.
+///
 /// Returns the binary it installed. `Err` names the pin and the remedy — never
 /// a bare "not found", because at this point the user has a pin they wrote (or
 /// that `nros build` wrote for them) and a store that does not answer it, and
 /// the two commands that fix it are different.
-fn fetch(ctx: &Context, version: &str, pin_path: &Path, looked_in: &[PathBuf]) -> Result<PathBuf> {
+pub fn fetch(
+    exe: &Path,
+    store: &Path,
+    version: &str,
+    pin_path: &Path,
+    looked_in: &[PathBuf],
+) -> Result<PathBuf> {
     let looked = looked_in
         .iter()
         .map(|p| format!("\n\x20     {}", p.display()))
         .collect::<String>();
-    let Some(installer) = bundled_installer(&ctx.exe) else {
+    let Some(installer) = bundled_installer(exe) else {
         bail!(
             "this project pins nano-ros {version} and the store does not have it.{looked}\n\
              \x20   pinned by: {}\n\
@@ -209,7 +221,7 @@ fn fetch(ctx: &Context, version: &str, pin_path: &Path, looked_in: &[PathBuf]) -
             pin_path.display()
         );
     }
-    pin::installed_bin(&ctx.store, version).ok_or_else(|| {
+    pin::installed_bin(store, version).ok_or_else(|| {
         eyre::eyre!(
             "the installer reported success but {version} is still not in the store.{looked}\n\
              \x20   pinned by: {}",
@@ -233,7 +245,7 @@ pub fn redispatch() -> Result<()> {
     let ctx = Context {
         exe,
         cwd,
-        store: super::store::root(),
+        store: crate::store_root::root(),
         dispatched: std::env::var(DISPATCHED_ENV).ok(),
         skip: std::env::var_os(SKIP_ENV).is_some(),
     };
@@ -244,7 +256,7 @@ pub fn redispatch() -> Result<()> {
             version,
             pin_path,
             looked_in,
-        } => fetch(&ctx, &version, &pin_path, &looked_in)?,
+        } => fetch(&ctx.exe, &ctx.store, &version, &pin_path, &looked_in)?,
     };
     let version = pin::running_version(&bin)
         .map(|(v, _)| v)
@@ -254,8 +266,11 @@ pub fn redispatch() -> Result<()> {
 }
 
 /// Become `bin`. Never returns on success.
+///
+/// `pub` because the standalone launcher binary ends here too — the handover is
+/// the one thing both spellings of the launcher must perform identically.
 #[cfg(unix)]
-fn exec(bin: &Path, version: &str, args: &[OsString]) -> Result<()> {
+pub fn exec(bin: &Path, version: &str, args: &[OsString]) -> Result<()> {
     use std::os::unix::process::CommandExt;
     let err = std::process::Command::new(bin)
         .args(args)
@@ -265,7 +280,7 @@ fn exec(bin: &Path, version: &str, args: &[OsString]) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-fn exec(bin: &Path, version: &str, args: &[OsString]) -> Result<()> {
+pub fn exec(bin: &Path, version: &str, args: &[OsString]) -> Result<()> {
     let status = std::process::Command::new(bin)
         .args(args)
         .env(DISPATCHED_ENV, version)

--- a/packages/cli/nros-launcher/src/launch.rs
+++ b/packages/cli/nros-launcher/src/launch.rs
@@ -1,0 +1,419 @@
+//! What the launcher does, as a value — RFC-0097 D4 + D11.
+//!
+//! [`dispatch::decide`](crate::dispatch::decide) answers a different question,
+//! and the difference is why this is not a fourth arm bolted onto it. That one
+//! is asked by a TOOLCHAIN that may have been fronted: every arm it can take
+//! ends in "carry on in this process", because there is always a full CLI here
+//! to carry on as. A launcher has no CLI at all, so three states that are
+//! `Proceed` there are terminal here and each needs its own message:
+//!
+//! | state | toolchain (`dispatch::decide`) | launcher (this module) |
+//! | --- | --- | --- |
+//! | no pin | `Proceed` — run as myself | pick the newest installed, or refuse |
+//! | store has no toolchain | `Proceed` — I am one | [`Plan::NothingInstalled`] |
+//! | cwd in a checkout | `Proceed` — contributor | [`Plan::InCheckout`], refuse |
+//!
+//! ## The unpinned case, and why the launcher WARNS where `nros build` REFUSES
+//!
+//! An unpinned project on a developer's machine gets the newest installed
+//! toolchain, the way `rustup` falls back to the default toolchain. In CI that
+//! same rule silently selects whatever the runner image happens to carry —
+//! RFC-0097 D11's defect one step EARLIER than the pin write, because not even
+//! a file records what was chosen.
+//!
+//! The launcher's answer is a LOUD LINE naming the version it took and the pin
+//! that would fix it ([`Source::DefaultInCi`]), not a refusal. The two halves
+//! of D11 are enforced at different places on purpose:
+//!
+//! * **the launcher cannot know the verb.** It parses no `argv` (D8), so
+//!   refusing here would refuse `nros --version`, `nros setup --list` and
+//!   `nros doctor` on every runner — commands that write nothing, produce no
+//!   artifact and have no reproducibility to protect. A launcher that makes CI
+//!   unusable for the verbs that are fine is not enforcing D11, it is guessing;
+//! * **`nros build` knows exactly what it is about to do**, which is write a
+//!   file into the user's source tree, so it refuses
+//!   ([`crate::pin::PinOutcome::RefusedInCi`]).
+//!
+//! The net effect for the operation D11 is about is unchanged — an unpinned
+//! `nros build` in CI fails, having said why twice — while everything else
+//! keeps working and says which toolchain answered.
+
+use std::path::{Path, PathBuf};
+
+use crate::{
+    checkout, dispatch,
+    pin::{self, FILE_NAME},
+    session::{ALLOW_ENV, Session},
+};
+
+/// Who chose the toolchain.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Source {
+    /// A `nros-toolchain.toml` named it. Reproducible.
+    Pin(PathBuf),
+    /// Nothing named it; the newest installed was taken. The `rustup` default-
+    /// toolchain rule, and fine on a developer's machine.
+    Default,
+    /// [`Source::Default`] in an automated session — RFC-0097 D11. Same choice,
+    /// but it carries a warning, because in CI "the newest installed" is
+    /// whatever the runner image happens to have rather than anything a person
+    /// decided.
+    DefaultInCi { var: &'static str },
+}
+
+impl Source {
+    /// How the choice is described on the one line the launcher prints.
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self {
+            Source::Pin(p) => format!("pinned by {}", p.display()),
+            Source::Default => "no pin — newest installed".to_string(),
+            Source::DefaultInCi { var } => {
+                format!("no pin — newest installed, and ${var} is set")
+            }
+        }
+    }
+}
+
+/// Everything [`resolve`] needs, gathered once so the decision touches no
+/// process state and its tests need no environment.
+#[derive(Clone, Debug)]
+pub struct Context {
+    /// The launcher binary itself. Only used to find the installer it shipped
+    /// with ([`dispatch::bundled_installer`]).
+    pub exe: PathBuf,
+    /// Where the project is — the cwd, in production.
+    pub cwd: PathBuf,
+    /// The store root ([`crate::store_root::root`] in production).
+    pub store: PathBuf,
+    /// `$NROS_TOOLCHAIN_DISPATCH`, if set. A launcher that finds it set was
+    /// exec'd BY a toolchain, and must not exec again.
+    pub dispatched: Option<String>,
+    /// Interactive or automated (RFC-0097 D11).
+    pub session: Session,
+}
+
+/// What the launcher will do. Every non-`Exec` arm is terminal and carries what
+/// its message needs, because a launcher has nothing to fall back to.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Plan {
+    /// Become this binary.
+    Exec {
+        version: String,
+        bin: PathBuf,
+        source: Source,
+    },
+    /// A pin names a version the store does not have. Fetchable, if this
+    /// launcher shipped with an installer.
+    Missing {
+        version: String,
+        pin_path: PathBuf,
+        looked_in: Vec<PathBuf>,
+    },
+    /// The store holds no toolchain at all, and no pin named one.
+    ///
+    /// The state a freshly installed launcher is in, and the reason the
+    /// launcher must not simply fail to start: "nothing installed, run X" is
+    /// the single most likely thing it will ever have to say.
+    NothingInstalled { store: PathBuf },
+    /// The cwd is inside a nano-ros checkout. RFC-0097: *"inside a checkout the
+    /// launcher is not involved"* — the ownership guard (`stale_guard`,
+    /// phase-431 W1) requires that clone's own build, so dispatching a store
+    /// toolchain here would only earn its refusal one frame later.
+    InCheckout { root: PathBuf },
+    /// `$NROS_TOOLCHAIN_DISPATCH` is set, so a toolchain exec'd US.
+    ///
+    /// The one failure mode a launcher must not have is an exec loop, and this
+    /// is the shape it would take: a fronted launcher reached through a
+    /// toolchain that dispatched to it.
+    AlreadyDispatched { version: String },
+}
+
+/// The launcher decision — a pure function of [`Context`] and the filesystem.
+///
+/// Reads two things off disk: whether a pin exists on the walk up from `cwd`,
+/// and what the store's toolchain directories hold. It never reads `argv`
+/// (RFC-0095 D8) and never writes anything.
+pub fn resolve(ctx: &Context) -> eyre::Result<Plan> {
+    if let Some(version) = &ctx.dispatched {
+        return Ok(Plan::AlreadyDispatched {
+            version: version.clone(),
+        });
+    }
+    if let Some(root) = checkout::find_monorepo_root(&ctx.cwd) {
+        return Ok(Plan::InCheckout { root });
+    }
+    if let Some(p) = pin::find_and_load(&ctx.cwd)? {
+        return Ok(match pin::installed_bin(&ctx.store, &p.version) {
+            Some(bin) => Plan::Exec {
+                version: p.version,
+                bin,
+                source: Source::Pin(p.path),
+            },
+            None => Plan::Missing {
+                looked_in: pin::candidate_bins(&ctx.store, &p.version),
+                version: p.version,
+                pin_path: p.path,
+            },
+        });
+    }
+    // Unpinned from here down.
+    let newest = installed_versions(&ctx.store).pop();
+    // "Nothing is installed" is reported ahead of D11's refusal on purpose:
+    // both are true, and only one of them is actionable here. Telling a user
+    // with an empty store to commit a pin would name a version that exists
+    // nowhere.
+    let Some(version) = newest else {
+        return Ok(Plan::NothingInstalled {
+            store: ctx.store.clone(),
+        });
+    };
+    let source = match ctx.session.ci_var() {
+        Some(var) => Source::DefaultInCi { var },
+        None => Source::Default,
+    };
+    match pin::installed_bin(&ctx.store, &version) {
+        Some(bin) => Ok(Plan::Exec {
+            version,
+            bin,
+            source,
+        }),
+        // `installed_versions` only reports a version whose `bin/nros` is
+        // there, so this is unreachable in practice — and it is an arm rather
+        // than an `unwrap` because "the store changed under us" is a real thing
+        // and a panic is a bad way to say it.
+        None => Ok(Plan::NothingInstalled {
+            store: ctx.store.clone(),
+        }),
+    }
+}
+
+/// Every toolchain version installed under `store`, oldest first.
+///
+/// Reads BOTH layouts for the same reason [`pin::candidate_bins`] constructs
+/// both: RFC-0095 D2's `toolchains/<version>` is a rename of the
+/// `sdk/nros/<version>` `scripts/install.sh` writes today, and a launcher that
+/// knew only the new name would see an empty store on every host that exists.
+///
+/// A directory only counts when it actually holds a `bin/nros`. A half-removed
+/// toolchain is a directory too, and `exec`ing into one is a worse error than
+/// not seeing it.
+#[must_use]
+pub fn installed_versions(store: &Path) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for dir in [store.join("toolchains"), store.join("sdk").join("nros")] {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            let Ok(name) = e.file_name().into_string() else {
+                continue;
+            };
+            if !e.path().join("bin").join("nros").is_file() {
+                continue;
+            }
+            if !out.contains(&name) {
+                out.push(name);
+            }
+        }
+    }
+    // `sort_by_cached_key`, not `sort_by`: `natural_key` allocates, and a plain
+    // comparator recomputes both sides on every comparison. Cached is also what
+    // clippy's `unnecessary_sort_by` asks for, and the borrow checker rules out
+    // the `sort_by_key` it suggests (the key owns its `String`s).
+    out.sort_by_cached_key(|v| natural_key(v));
+    out
+}
+
+/// One chunk of a version string for natural ordering.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum Chunk {
+    // Numbers sort BELOW text at the same position so `0.5.0` < `0.5.0-nros1`:
+    // the shorter one runs out of chunks first, and `Vec`'s ordering makes the
+    // prefix smaller. The variant order here only decides the mixed case.
+    Num(u64),
+    Text(String),
+}
+
+/// Natural (`sort -V`-ish) ordering key.
+///
+/// Lexicographic ordering is wrong for exactly the strings this compares:
+/// `0.10.0-nros1` sorts BELOW `0.9.0-nros1` as text, so a store holding both
+/// would default to the older one — silently, and only after ten releases. The
+/// SDK store has the same rule for the same reason (issue 0500's
+/// `COMPARE NATURAL ORDER DESCENDING`).
+fn natural_key(s: &str) -> Vec<Chunk> {
+    let mut out = Vec::new();
+    let mut rest = s;
+    while !rest.is_empty() {
+        let digits = rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+        if digits > 0 {
+            // A run longer than a u64 is not a version; keep it as text rather
+            // than saturating two different numbers to the same value.
+            match rest[..digits].parse::<u64>() {
+                Ok(n) => out.push(Chunk::Num(n)),
+                Err(_) => out.push(Chunk::Text(rest[..digits].to_string())),
+            }
+            rest = &rest[digits..];
+            continue;
+        }
+        let text = rest
+            .find(|c: char| c.is_ascii_digit())
+            .unwrap_or(rest.len())
+            .max(1);
+        out.push(Chunk::Text(rest[..text].to_string()));
+        rest = &rest[text..];
+    }
+    out
+}
+
+/// The message for a terminal [`Plan`] — the whole reason each arm carries its
+/// own data.
+///
+/// One place, so the text and the decision cannot drift, and so a test can
+/// assert what a user is told without running a process.
+#[must_use]
+pub fn explain(plan: &Plan) -> String {
+    match plan {
+        Plan::Exec {
+            version, source, ..
+        } => format!("nros: toolchain {version} ({})", source.label()),
+        Plan::Missing {
+            version, pin_path, ..
+        } => format!(
+            "this project pins nano-ros {version} and the store does not have it.\n\
+             \x20   pinned by: {}",
+            pin_path.display()
+        ),
+        Plan::NothingInstalled { store } => format!(
+            "no nano-ros toolchain is installed.\n\
+             \x20   store: {}\n\
+             This is the launcher; the toolchain it launches is a separate \
+             artifact (RFC-0097 D4),\n\
+             and this store has none of them yet. Install one:\n\
+             \x20   curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh\n\
+             Then `nros build` in your project.",
+            store.display()
+        ),
+        Plan::InCheckout { root } => format!(
+            "the current directory is inside a nano-ros CHECKOUT, so the launcher \
+             stands aside.\n\
+             \x20   checkout: {}\n\
+             A checkout builds with its OWN `nros` — a store toolchain run here \
+             is refused one\n\
+             frame later by the ownership guard anyway (phase-431 W1), and it \
+             would emit with\n\
+             emitters nobody in that tree can see. Build and use the checkout's \
+             own CLI:\n\
+             \x20   ./scripts/bootstrap.sh      (contributors: just setup-cli)\n\
+             \x20   source ./activate.sh",
+            root.display()
+        ),
+        Plan::AlreadyDispatched { version } => format!(
+            "this launcher was reached from a toolchain that had already \
+             dispatched ({version}).\n\
+             That is an exec loop, and a launcher must not have one. The \
+             toolchain at\n\
+             ${} = {version} either does not exist or does not agree about its \
+             own version.\n\
+             Override for a deliberate experiment: {}=1",
+            dispatch::DISPATCHED_ENV,
+            dispatch::SKIP_ENV,
+        ),
+    }
+}
+
+/// The line an automated session gets when nothing named a toolchain —
+/// RFC-0097 D11, the launcher's half.
+///
+/// `Some` only for [`Source::DefaultInCi`]. Printed BEFORE the `exec`, because
+/// after it this process is gone; that is also why it is a separate function
+/// from [`explain`], which describes states that never reach an `exec` at all.
+///
+/// It names the version that was taken, so the warning is a record of what
+/// happened rather than a note that something might have. Without the version
+/// the reader has to reconstruct the store's contents at that moment, which on
+/// a runner is exactly the thing that no longer exists.
+#[must_use]
+pub fn warning(plan: &Plan) -> Option<String> {
+    let Plan::Exec {
+        version,
+        source: Source::DefaultInCi { var },
+        ..
+    } = plan
+    else {
+        return None;
+    };
+    Some(format!(
+        "warning: this project has no {FILE_NAME} and ${var} is set, so it ran \
+         {version} —\n\
+         \x20   whatever this runner happens to have installed, chosen by \
+         nobody (RFC-0097 D11).\n\
+         \x20   An unpinned `nros build` here will REFUSE rather than pin, \
+         because a pin is a\n\
+         \x20   source edit. Write {FILE_NAME} beside your project and commit \
+         it:\n\n\
+         {}\n\
+         \x20   To silence this and let an automated session choose: \
+         {ALLOW_ENV}=1",
+        pin::render(version)
+            .lines()
+            .map(|l| format!("\x20       {l}\n"))
+            .collect::<String>(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_with(root: &Path, rels: &[&str]) {
+        for rel in rels {
+            let bin = root.join(rel).join("bin");
+            std::fs::create_dir_all(&bin).unwrap();
+            std::fs::write(bin.join("nros"), b"x").unwrap();
+        }
+    }
+
+    /// `0.10.0` is NEWER than `0.9.0`, and text ordering says otherwise.
+    ///
+    /// The bug this forecloses is invisible for the project's first nine
+    /// releases and then silently defaults every unpinned project to an older
+    /// toolchain, so it is worth a test rather than a comment.
+    #[test]
+    fn versions_order_naturally_not_lexicographically() {
+        let tmp = tempfile::tempdir().unwrap();
+        store_with(
+            tmp.path(),
+            &[
+                "toolchains/0.9.0-nros1",
+                "toolchains/0.10.0-nros1",
+                "toolchains/0.10.0-nros2",
+            ],
+        );
+        let got = installed_versions(tmp.path());
+        assert_eq!(
+            got,
+            vec!["0.9.0-nros1", "0.10.0-nros1", "0.10.0-nros2"],
+            "natural order, oldest first"
+        );
+    }
+
+    /// Both store layouts are seen, and a directory with no `bin/nros` is not a
+    /// toolchain — a half-removed one must not be exec'd into.
+    #[test]
+    fn both_layouts_count_and_an_empty_directory_does_not() {
+        let tmp = tempfile::tempdir().unwrap();
+        store_with(
+            tmp.path(),
+            &["toolchains/0.6.0-nros1", "sdk/nros/0.5.0-nros1"],
+        );
+        std::fs::create_dir_all(tmp.path().join("toolchains/0.7.0-nros1")).unwrap();
+        assert_eq!(
+            installed_versions(tmp.path()),
+            vec!["0.5.0-nros1", "0.6.0-nros1"]
+        );
+    }
+}

--- a/packages/cli/nros-launcher/src/lib.rs
+++ b/packages/cli/nros-launcher/src/lib.rs
@@ -1,0 +1,60 @@
+//! The launcher — RFC-0097 D4, over phase-440 W7's `dispatch.rs`.
+//!
+//! ## Why this is a crate and not a module
+//!
+//! W7 put the launcher logic in `nros-cli-core`, so the binary that SELECTS a
+//! version was shipped by the version being selected. RFC-0097 measured what
+//! that costs: `packages/cli` takes **710 commits per 60 days**, and a launcher
+//! that shares an artifact with it re-releases on every one of them, while
+//! carrying no compatibility promise of its own.
+//!
+//! rustup's `rustup` and `cargo` are separate artifacts for the same reason: *a
+//! proxy that outlives what it proxies cannot share a release with it.*
+//!
+//! So the split is by ARTIFACT, and this crate is the small half:
+//!
+//! ```text
+//!   $NROS_STORE/bin/nros              the launcher   (this crate's bin)
+//!     read nros-toolchain.toml
+//!     ensure toolchains/<pinned>
+//!     exec  toolchains/<pinned>/bin/nros "$@"
+//!
+//!   $NROS_STORE/toolchains/<v>/bin/nros   the toolchain (packages/cli/nros-cli)
+//! ```
+//!
+//! ## What moved here, and what did NOT get copied
+//!
+//! [`pin`] and [`dispatch`] are phase-440 W7's files, MOVED (`git mv`), not
+//! reimplemented — `nros-cli-core` re-exports them at their old paths, so
+//! `orchestration::pin::…` and `orchestration::dispatch::…` still resolve and
+//! there is exactly one parser of `nros-toolchain.toml` in the tree. Same for
+//! [`store_root::root`] (was `orchestration::store::root`) and
+//! [`checkout::find_monorepo_root`] (was `abi_guard::find_monorepo_root`): a
+//! launcher needs both, and a second spelling of either is how the launcher and
+//! the toolchain come to disagree about which store, or which checkout, they
+//! are looking at.
+//!
+//! [`launch`] is the new part: the launcher's own resolution, which differs
+//! from [`dispatch::decide`] in three ways it cannot share (an unpinned project
+//! must still resolve to SOMETHING, a store with no toolchain at all is a real
+//! state a launcher must report rather than crash in, and CI must refuse rather
+//! than choose — RFC-0097 D11).
+
+pub mod checkout;
+pub mod dispatch;
+pub mod launch;
+pub mod pin;
+pub mod session;
+pub mod store_root;
+/// Test-only helpers, reached by this crate's tests and by `nros-cli`'s
+/// launcher tests. `#[doc(hidden)]` — not part of the launcher's surface; see
+/// the module header for why it is here and not in `nros-cli-core`.
+#[doc(hidden)]
+pub mod test_support;
+
+/// This launcher's own version — NOT the toolchain's.
+///
+/// Reported by `nros --version` on its own line, above whatever the toolchain
+/// prints. Without that line the split buys nothing observable: a user looking
+/// at one version string cannot tell which artifact answered.
+pub const LAUNCHER_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/packages/cli/nros-launcher/src/main.rs
+++ b/packages/cli/nros-launcher/src/main.rs
@@ -1,0 +1,129 @@
+//! `nros-launcher` — the binary users install, and the only one that outlives a
+//! toolchain (RFC-0097 D4).
+//!
+//! Installed as `$NROS_STORE/bin/nros`, so what a user types is `nros`. It
+//! resolves the project's pin, ensures that toolchain, and `exec`s it. That is
+//! the whole program.
+//!
+//! ## It parses no `argv`, with ONE exception, and the exception is safe
+//!
+//! RFC-0095 D8: *"it must keep working when it is OLDER than what it
+//! launches."* An older launcher does not know a newer toolchain's flags, so
+//! anything it parses it can get wrong on behalf of a binary that would have
+//! got it right. Every argument is therefore forwarded byte for byte.
+//!
+//! The exception is a leading `--version` / `-V`, and it does NOT change what
+//! the child receives: the launcher prints one extra line and forwards the
+//! argument anyway. It exists because the split has to be observable — a user
+//! looking at one version string cannot tell which of the two artifacts
+//! answered, and "the launcher has its own release cadence" is not a claim
+//! anyone can check from the outside without it:
+//!
+//! ```console
+//! $ nros --version
+//! nros-launcher 0.1.0
+//! nros 0.5.0
+//! ```
+//!
+//! The second line is the toolchain's, printed after the `exec`. With no
+//! toolchain installed the first line still appears — which is the point of
+//! testing that state rather than assuming it.
+//!
+//! ## Exit codes
+//!
+//! `0` when it handed over (the child's code, after `exec`) or when it answered
+//! `--version`; `1` for every terminal [`launch::Plan`] arm, each of which
+//! prints what to do next. A launcher that cannot run the command must not exit
+//! 0 — a CI job would read that as a build that passed.
+
+use std::{ffi::OsString, process::ExitCode};
+
+use nros_launcher::{
+    LAUNCHER_VERSION, dispatch,
+    launch::{self, Plan},
+    session::Session,
+    store_root,
+};
+
+/// Is the first argument a bare version query?
+///
+/// FIRST only, and an exact match. `nros build --version-file x` must not be
+/// mistaken for one, and a subcommand's own `--version` (clap's
+/// `propagate_version`) is the toolchain's business, not ours.
+fn is_version_query(args: &[OsString]) -> bool {
+    args.first()
+        .and_then(|a| a.to_str())
+        .is_some_and(|a| a == "--version" || a == "-V")
+}
+
+fn main() -> ExitCode {
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    let version_query = is_version_query(&args);
+    if version_query {
+        // Before the resolution, so it is printed even when the resolution
+        // fails — "which launcher is this?" is a question whose answer must not
+        // depend on the store being in a good state.
+        println!("nros-launcher {LAUNCHER_VERSION}");
+    }
+
+    let ctx = launch::Context {
+        exe: std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("nros")),
+        cwd: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+        store: store_root::root(),
+        dispatched: std::env::var(dispatch::DISPATCHED_ENV).ok(),
+        session: Session::detect(),
+    };
+
+    let plan = match launch::resolve(&ctx) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("nros: {e:?}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // RFC-0097 D11's launcher half, printed BEFORE the handover because after
+    // the `exec` this process is gone. `None` for every other plan.
+    if let Some(w) = launch::warning(&plan) {
+        eprintln!("nros: {w}");
+    }
+
+    let bin = match &plan {
+        Plan::Exec { bin, .. } => bin.clone(),
+        Plan::Missing {
+            version,
+            pin_path,
+            looked_in,
+        } => match dispatch::fetch(&ctx.exe, &ctx.store, version, pin_path, looked_in) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("nros: {e:?}");
+                return ExitCode::FAILURE;
+            }
+        },
+        terminal => {
+            eprintln!("nros: {}", launch::explain(terminal));
+            // A version query was ANSWERED — the launcher's own line is above,
+            // and the note explains why no toolchain line follows it. Reporting
+            // failure there would make `nros --version` a broken command on a
+            // host that simply has nothing installed yet.
+            return if version_query {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            };
+        }
+    };
+
+    let version = nros_launcher::pin::running_version(&bin)
+        .map(|(v, _)| v)
+        .unwrap_or_default();
+    match dispatch::exec(&bin, &version, &args) {
+        // `exec` does not return on success, so reaching here is the failure.
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("nros: {e:?}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/packages/cli/nros-launcher/src/pin.rs
+++ b/packages/cli/nros-launcher/src/pin.rs
@@ -40,6 +40,17 @@
 //! `nros self update` — which moves the fronted binary and nothing else
 //! (RFC-0095 D7) — cannot move a pin even by accident.
 //!
+//! ## …except from CI (RFC-0097 D11)
+//!
+//! D9's write is right interactively and wrong in an automated session:
+//! pinning to whatever that runner happens to have installed produces a green
+//! build against a toolchain nobody chose, recorded in a file nobody reviewed.
+//! So [`pin_on_first_build`] takes a [`Session`] and REFUSES to write when it
+//! declares itself automated, naming the file to write and the escape hatch.
+//! The refusal is placed after the three arms that write nothing anyway, so a
+//! CI job on an already-pinned project — the reproducible case, and the common
+//! one — is not touched by it.
+//!
 //! ## What W6 already assumed about this file
 //!
 //! `store::PIN_FILE_NAMES` names `nros-toolchain.toml` and reads any file it
@@ -54,6 +65,8 @@ use std::path::{Path, PathBuf};
 
 use eyre::{Result, WrapErr, bail};
 use serde::Deserialize;
+
+use crate::session::Session;
 
 /// The pin file's name. `store::PIN_FILE_NAMES` names the same constant, so
 /// there is one spelling of it in the crate.
@@ -304,6 +317,32 @@ pub enum PinOutcome {
     /// to write. Reported, not silent: an unpinned project is D9's bug, and the
     /// user needs to know they still have it.
     NoRunningVersion,
+    /// RFC-0097 D11 — everything was in place to write a pin, and the session
+    /// declared itself automated. A pin is a source edit; CI does not make
+    /// those.
+    RefusedInCi {
+        /// The version that WOULD have been written. Carried so the diagnostic
+        /// can print the exact file the user should commit — a refusal that
+        /// makes the reader go and find the version is a worse refusal.
+        version: String,
+        /// Where the pin would have gone.
+        dir: PathBuf,
+        /// The environment variable that declared this automated.
+        var: &'static str,
+    },
+}
+
+impl PinOutcome {
+    /// Whether this outcome must STOP the build rather than print a line.
+    ///
+    /// The other four are advisory — the build proceeds and the message is
+    /// context. [`PinOutcome::RefusedInCi`] is not: proceeding would build
+    /// against a toolchain nobody recorded, which is the reproducibility bug
+    /// the pin exists to prevent, so the caller turns it into an error.
+    #[must_use]
+    pub const fn is_refusal(&self) -> bool {
+        matches!(self, PinOutcome::RefusedInCi { .. })
+    }
 }
 
 /// RFC-0095 D9, performed.
@@ -312,8 +351,8 @@ pub enum PinOutcome {
 /// a pure function of two paths and its tests need no installed store on the
 /// host running them — the same argument `stale_guard::refuse_if_stale` makes
 /// for `workspace`, and `store_reclaim.rs` for the pin search directory.
-pub fn pin_on_first_build(workspace: &Path, exe: &Path) -> Result<PinOutcome> {
-    if let Some(root) = crate::abi_guard::find_monorepo_root(workspace) {
+pub fn pin_on_first_build(workspace: &Path, exe: &Path, session: &Session) -> Result<PinOutcome> {
+    if let Some(root) = crate::checkout::find_monorepo_root(workspace) {
         return Ok(PinOutcome::InCheckout(root));
     }
     if let Some(existing) = find_and_load(workspace)? {
@@ -322,6 +361,19 @@ pub fn pin_on_first_build(workspace: &Path, exe: &Path) -> Result<PinOutcome> {
     let Some((version, _origin)) = running_version(exe) else {
         return Ok(PinOutcome::NoRunningVersion);
     };
+    // RFC-0097 D11, asked HERE and not earlier, which is what keeps the blast
+    // radius honest. The three arms above are the ones that write nothing
+    // anyway: a contributor's checkout, a project that is already pinned, a
+    // binary with no version to name. Refusing before them would turn a
+    // perfectly reproducible CI build — one that reads an existing pin — into
+    // an error, which is the opposite of what D11 asks for.
+    if let Some(var) = session.ci_var() {
+        return Ok(PinOutcome::RefusedInCi {
+            version,
+            dir: workspace.to_path_buf(),
+            var,
+        });
+    }
     let path = write(workspace, &version)?;
     Ok(PinOutcome::Wrote { path, version })
 }
@@ -346,6 +398,42 @@ pub fn describe(outcome: &PinOutcome) -> Option<String> {
         // A contributor is told nothing: their nano-ros is the clone they are
         // standing in, they know it, and a line on every build would be noise.
         PinOutcome::InCheckout(_) => None,
+        // RFC-0097 D11. The text names a fix that EXISTS, and the FILE is the
+        // one thing that always does — `render` is exactly what `nros build`
+        // would have written, printed in full so the fix is a copy-paste rather
+        // than an expedition.
+        //
+        // phase-443's own acceptance asked this to name `nros pin <version>`.
+        // At the time of writing there is no such verb in this tree, and aiming
+        // a blocked CI job at a command that does not run is a worse refusal
+        // than none. W2 (PR #859) adds one; when it lands, this text may name
+        // it BESIDE the file, never instead of it — a user reading a refusal on
+        // a runner cannot run a verb there either, and the file is what they
+        // have to commit.
+        PinOutcome::RefusedInCi { version, dir, var } => Some(format!(
+            "nros build: this project is UNPINNED and ${var} is set, so nothing \
+             was pinned.\n\
+             \x20   A pin is a SOURCE EDIT, and CI does not make those: pinning \
+             here would\n\
+             \x20   record whatever this runner happens to have installed, and a \
+             build green\n\
+             \x20   against an unrecorded toolchain is the bug the pin exists to \
+             prevent\n\
+             \x20   (RFC-0097 D11; the Cargo.lock rule of issues 0359/0378, one \
+             layer up).\n\
+             \x20   Fix it on a developer machine — run `nros build` there once, \
+             or write\n\
+             \x20   {}/{FILE_NAME} by hand:\n\n\
+             {}\n\
+             \x20   then commit it.\n\
+             \x20   To pin from an automated session anyway: {}=1",
+            dir.display(),
+            render(version)
+                .lines()
+                .map(|l| format!("\x20       {l}\n"))
+                .collect::<String>(),
+            crate::session::ALLOW_ENV,
+        )),
         PinOutcome::NoRunningVersion => Some(
             "nros build: warning: this project is UNPINNED and this `nros` has no \
              store version to pin it to.\n\

--- a/packages/cli/nros-launcher/src/session.rs
+++ b/packages/cli/nros-launcher/src/session.rs
@@ -1,0 +1,168 @@
+//! Is this an automated session? — RFC-0097 D11.
+//!
+//! > phase-440 W7's pin-on-first-build (RFC-0095 D9) is right interactively and
+//! > wrong in CI: silently pinning to whatever is latest produces a green build
+//! > against an unrecorded toolchain, which is the reproducibility bug the pin
+//! > exists to prevent.
+//!
+//! Two consumers, one question, so it is answered in one place:
+//!
+//! * [`crate::pin::pin_on_first_build`] must not WRITE a pin from CI — a pin is
+//!   a source edit, and the `Cargo.lock` rule (issues 0359/0378) is that a
+//!   lockfile moves when a developer means it;
+//! * [`crate::launch::resolve`] must not CHOOSE a default toolchain from CI —
+//!   the store's contents on a runner are incidental, so "newest installed" is
+//!   a toolchain nobody chose. Same defect one step earlier: the pin would at
+//!   least have been recorded.
+//!
+//! ## Why environment variables and not a tty probe
+//!
+//! `isatty` answers "is a human watching", which is nearly the right question
+//! and fails on both sides here: a `nros build` inside `$(…)` on a developer's
+//! machine has no tty and SHOULD pin, and a CI runner with a pty allocated
+//! (`docker run -t`, `ssh -t`, most self-hosted setups) has one and MUST NOT.
+//! `CI` and `GITHUB_ACTIONS` are the conventional declarations and every
+//! provider sets at least the first; a declaration beats an inference.
+//!
+//! ## The escape hatch
+//!
+//! [`ALLOW_ENV`] exists because "I really do mean it" is a legitimate thing to
+//! say — a container that IS the developer's machine, a release job that
+//! deliberately materialises a pin. Named in every refusal, in the same family
+//! as `NROS_ALLOW_SUBMODULE_REWIND` and `NROS_SKIP_STALE_CHECK`: the escape is
+//! a sentence the user has to write.
+
+/// The conventional declarations, in the order they are reported.
+///
+/// `CI` alone would do for every provider we have met; `GITHUB_ACTIONS` is
+/// listed too so the diagnostic can name the variable that actually decided,
+/// which is the first thing someone debugging an unexpected refusal asks.
+pub const CI_ENV_VARS: [&str; 2] = ["CI", "GITHUB_ACTIONS"];
+
+/// Say it anyway. Set to any non-empty value.
+pub const ALLOW_ENV: &str = "NROS_ALLOW_PIN_WRITE_IN_CI";
+
+/// Whether this process may perform a source edit (write a pin) or choose a
+/// toolchain nobody named.
+///
+/// A value, not a function call, so every consumer's decision is a pure
+/// function of its arguments and its tests need no `set_var` — which is a
+/// process-global that leaks between the parallel test processes nextest runs
+/// (the hazard issue 1101 documents, one crate over).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Session {
+    /// `Some(var)` when an environment variable declares this an automated
+    /// session AND the escape hatch is not set. The variable is carried, not
+    /// just a bool, because the refusal names it.
+    pub ci: Option<&'static str>,
+}
+
+impl Session {
+    /// A developer at a keyboard. The default in every test that is not ABOUT
+    /// the CI rule.
+    #[must_use]
+    pub const fn interactive() -> Self {
+        Self { ci: None }
+    }
+
+    /// An automated session that declared itself through `var`.
+    #[must_use]
+    pub const fn automated(var: &'static str) -> Self {
+        Self { ci: Some(var) }
+    }
+
+    /// Read the environment. The only place in the tree that does.
+    #[must_use]
+    pub fn detect() -> Self {
+        Self::detect_with(|k| std::env::var_os(k))
+    }
+
+    /// [`Self::detect`] with the lookup passed IN.
+    ///
+    /// Not a testing convenience bolted on: `set_var` is `unsafe` in edition
+    /// 2024 and is a process-global besides, so a test that set `CI` would
+    /// decide the answer for every other test sharing the process. The ORDER of
+    /// the two rules below is the thing worth pinning — the escape hatch has to
+    /// beat the declaration, not merely appear beside it — and with the lookup
+    /// as an argument that is a pure function a test can ask about directly.
+    #[must_use]
+    pub fn detect_with(lookup: impl Fn(&str) -> Option<std::ffi::OsString>) -> Self {
+        let declared = |k: &str| lookup(k).is_some_and(|v| !v.is_empty());
+        if declared(ALLOW_ENV) {
+            return Self::interactive();
+        }
+        for var in CI_ENV_VARS {
+            // A variable that is present but EMPTY is not a declaration.
+            // `CI=` appears in `env -i CI= …` and in shells that export empty
+            // defaults, and treating it as "this is CI" would refuse builds on
+            // machines that never opted in.
+            if declared(var) {
+                return Self::automated(var);
+            }
+        }
+        Self::interactive()
+    }
+
+    /// The variable that declared this automated, if any.
+    #[must_use]
+    pub const fn ci_var(&self) -> Option<&'static str> {
+        self.ci
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<std::ffi::OsString> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k| {
+            owned
+                .iter()
+                .find(|(name, _)| name == k)
+                .map(|(_, v)| std::ffi::OsString::from(v))
+        }
+    }
+
+    /// Each conventional variable declares CI on its own, and the refusal is
+    /// able to name WHICH one did.
+    #[test]
+    fn either_conventional_variable_declares_an_automated_session() {
+        assert_eq!(Session::detect_with(env(&[])).ci_var(), None);
+        assert_eq!(
+            Session::detect_with(env(&[("CI", "true")])).ci_var(),
+            Some("CI")
+        );
+        assert_eq!(
+            Session::detect_with(env(&[("GITHUB_ACTIONS", "true")])).ci_var(),
+            Some("GITHUB_ACTIONS")
+        );
+    }
+
+    /// The escape hatch is not "unset CI" — it is a separate assertion, and it
+    /// must WIN over a declaration rather than merely sitting beside it. Order
+    /// the other way round and the hatch would be unreachable on every runner,
+    /// which is the only place anyone would type it.
+    #[test]
+    fn the_escape_hatch_overrides_a_declaration() {
+        assert_eq!(
+            Session::detect_with(env(&[("CI", "true"), (ALLOW_ENV, "1")])).ci_var(),
+            None
+        );
+    }
+
+    /// `CI=` is not a declaration. Shells and `env -i CI=` produce it, and
+    /// refusing on it would refuse on machines that never opted in.
+    #[test]
+    fn an_empty_value_is_not_a_declaration() {
+        assert_eq!(Session::detect_with(env(&[("CI", "")])).ci_var(), None);
+        // …and an empty escape hatch does not disarm a real declaration.
+        assert_eq!(
+            Session::detect_with(env(&[("CI", "true"), (ALLOW_ENV, "")])).ci_var(),
+            Some("CI")
+        );
+    }
+}

--- a/packages/cli/nros-launcher/src/store_root.rs
+++ b/packages/cli/nros-launcher/src/store_root.rs
@@ -1,0 +1,43 @@
+//! Where the store is — RFC-0095 D2's one answer.
+//!
+//! MOVED from `nros_cli_core::orchestration::store` (which re-exports it as
+//! `store::root` / `store::root_origin`, its long-standing spelling). The
+//! launcher constructs every path it touches under this root, so it cannot
+//! depend on the toolchain crate to tell it where the root is — and a second
+//! implementation is how a launcher comes to look in a different store from the
+//! `nros toolchain` verbs that fill it.
+//!
+//! Never a literal `~/.nros`: `$NROS_STORE` is how a distrobox gets its own
+//! store while sharing `$HOME` (issue 1248).
+
+use std::path::PathBuf;
+
+/// The store root: `$NROS_STORE`, else `$NROS_HOME`, else `$HOME/.nros`.
+#[must_use]
+pub fn root() -> PathBuf {
+    if let Some(s) = std::env::var_os("NROS_STORE") {
+        return PathBuf::from(s);
+    }
+    if let Some(h) = std::env::var_os("NROS_HOME") {
+        return PathBuf::from(h);
+    }
+    if let Some(h) = std::env::var_os("HOME") {
+        return PathBuf::from(h).join(".nros");
+    }
+    PathBuf::from(".nros")
+}
+
+/// Which environment variable answered [`root`] — for the header line, so a
+/// reader never has to guess whose store they are about to shrink.
+#[must_use]
+pub fn root_origin() -> &'static str {
+    if std::env::var_os("NROS_STORE").is_some() {
+        "$NROS_STORE"
+    } else if std::env::var_os("NROS_HOME").is_some() {
+        "$NROS_HOME"
+    } else if std::env::var_os("HOME").is_some() {
+        "$HOME/.nros"
+    } else {
+        "./.nros (no $HOME)"
+    }
+}

--- a/packages/cli/nros-launcher/src/test_support.rs
+++ b/packages/cli/nros-launcher/src/test_support.rs
@@ -1,0 +1,78 @@
+//! Helpers for tests that install an executable and then RUN it — issue 0476.
+//!
+//! ## Why this lives in the launcher crate
+//!
+//! Three test files build a fake store and exec what they put in it:
+//! `nros-launcher/tests/launcher_binary.rs`,
+//! `nros-cli/tests/toolchain_dispatch.rs`, and whatever the next launcher test
+//! is. They need ONE spelling of "put an executable here safely", and this is
+//! the lowest crate all of them can reach: `nros-cli-core` depends on
+//! `nros-launcher`, so a helper there would be a dependency cycle for the
+//! launcher's own tests.
+//!
+//! It is `#[doc(hidden)]` and two `Command` spawns; it costs the shipped binary
+//! nothing worth measuring, and the alternative — a `test-support` feature that
+//! only tests enable — is one more thing that can be silently off.
+//!
+//! ## The hazard
+//!
+//! ```ignore
+//! std::fs::copy(src, &dst)?;              // write descriptor, open HERE
+//! std::process::Command::new(&dst).status()?;   // ...can still be ETXTBSY
+//! ```
+//!
+//! `O_CLOEXEC` (which Rust sets) closes a descriptor at **exec**, not at
+//! **fork**. Between any sibling test thread's fork and its child's exec, that
+//! child holds a copy of every descriptor open in this process — including the
+//! write handle above. An `execve` landing in that window sees a writer and the
+//! kernel returns `ETXTBSY` ("Text file busy"). Tests run as THREADS in one
+//! process and this repository's test suites spawn constantly, so the window is
+//! open all the time.
+//!
+//! Measured while finishing phase-443 W3: `nros-cli`'s
+//! `an_unpinned_project_runs_in_the_launcher` failed 1 of 4 full
+//! `packages/cli` runs on this machine and passed 4 of 4 solo — the shape that
+//! reads as "someone else's flake" for as long as nobody looks.
+//!
+//! The fix is to never hold the descriptor: `cp` and `chmod` run as CHILD
+//! processes, so the only write handle lives in a process our forks do not copy
+//! from, and it is gone before the file is ever executed. A retry loop also
+//! works and masks the race instead of removing it.
+
+use std::path::Path;
+
+fn must(program: &str, args: &[&std::ffi::OsStr], what: &str) {
+    let ok = std::process::Command::new(program)
+        .args(args)
+        .status()
+        .unwrap_or_else(|e| panic!("spawn {program} for {what}: {e}"))
+        .success();
+    assert!(ok, "{program} failed: {what}");
+}
+
+/// Copy an existing binary to `dst` and make it executable, without holding a
+/// write descriptor in this process.
+///
+/// `cp` preserves the mode of a source that is already executable; the explicit
+/// `chmod` is for a source whose mode does not survive (a `CARGO_BIN_EXE_*` on
+/// a filesystem that drops the bit).
+pub fn copy_executable(src: &Path, dst: &Path) {
+    let what = format!("{} -> {}", src.display(), dst.display());
+    must("cp", &[src.as_os_str(), dst.as_os_str()], &what);
+    must(
+        "chmod",
+        [std::ffi::OsStr::new("755"), dst.as_os_str()].as_slice(),
+        &what,
+    );
+}
+
+/// Write a shell-script stub at `path` and make it executable.
+///
+/// The script text goes to a sidecar first. That file is never executed, so its
+/// descriptor is harmless; only the `cp`'d copy is ever run.
+pub fn write_executable_stub(path: &Path, script: &str) {
+    let src = path.with_extension("stub-src");
+    std::fs::write(&src, script).unwrap_or_else(|e| panic!("write {}: {e}", src.display()));
+    copy_executable(&src, path);
+    let _ = std::fs::remove_file(&src);
+}

--- a/packages/cli/nros-launcher/tests/launcher_binary.rs
+++ b/packages/cli/nros-launcher/tests/launcher_binary.rs
@@ -1,0 +1,298 @@
+//! The launcher as an ARTIFACT — phase-443 W3, RFC-0097 D4.
+//!
+//! `launcher_resolution.rs` covers what it decides. This file covers the three
+//! claims that are about the binary itself, and that no unit test can make:
+//!
+//! * it **runs with no toolchain installed** — the state a freshly installed
+//!   launcher is in, and the one the phase-440 W7 module could not be in,
+//!   because it WAS the toolchain;
+//! * its **own version is separately reportable** — without this the split
+//!   buys nothing observable, since a user reading one version string cannot
+//!   tell which of the two artifacts answered;
+//! * a **toolchain update does not replace it** — the property the whole split
+//!   exists for, measured as bytes on disk rather than asserted in prose.
+//!
+//! Cheap by construction: no fixtures, no provisioning, no network. The store
+//! is a tempdir named by `$NROS_STORE`, and the toolchain is a shell script,
+//! which is the right stand-in rather than a shortcut — what is under test is
+//! the handover, and a script can PROVE what it received in a way a second copy
+//! of a binary cannot.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use nros_launcher::test_support::{copy_executable, write_executable_stub};
+
+/// The launcher, installed where `scripts/install.sh` fronts it: `<store>/bin/
+/// nros`. A COPY, not a symlink into a toolchain prefix — that is the property
+/// `a_toolchain_update_does_not_replace_the_launcher` measures.
+///
+/// Through `test_support`, never `std::fs::copy`: this test execs what it just
+/// wrote, which is issue 0476's exact shape.
+fn install_launcher(store: &Path) -> PathBuf {
+    let bin = store.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let exe = bin.join("nros");
+    copy_executable(Path::new(env!("CARGO_BIN_EXE_nros-launcher")), &exe);
+    exe
+}
+
+/// A stand-in toolchain that reports what it was handed.
+fn install_stub(store: &Path, version: &str) -> PathBuf {
+    let bin = store.join("sdk/nros").join(version).join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let exe = bin.join("nros");
+    write_executable_stub(
+        &exe,
+        &format!(
+            "#!/bin/sh\n\
+             echo \"nros {version} (STUB-TOOLCHAIN)\"\n\
+             echo \"DISPATCH=${{NROS_TOOLCHAIN_DISPATCH:-unset}}\"\n\
+             for a in \"$@\"; do echo \"ARG=$a\"; done\n"
+        ),
+    );
+    exe
+}
+
+fn pin(project: &Path, version: &str) {
+    std::fs::create_dir_all(project).unwrap();
+    std::fs::write(
+        project.join("nros-toolchain.toml"),
+        format!("[toolchain]\nversion = \"{version}\"\n"),
+    )
+    .unwrap();
+}
+
+/// Run the launcher with an environment nothing on the host can decide.
+///
+/// `CI` / `GITHUB_ACTIONS` are REMOVED unless a test asks for them: this suite
+/// runs in CI, and a launcher that refuses an unpinned project there (RFC-0097
+/// D11 — correctly) would otherwise make half of these tests measure the runner
+/// rather than the code.
+fn run_in(launcher: &Path, cwd: &Path, store: &Path, args: &[&str], ci: Option<&str>) -> Out {
+    let mut cmd = Command::new(launcher);
+    cmd.args(args)
+        .current_dir(cwd)
+        .env("NROS_STORE", store)
+        .env_remove("NROS_HOME")
+        .env_remove("CI")
+        .env_remove("GITHUB_ACTIONS")
+        .env_remove("NROS_ALLOW_PIN_WRITE_IN_CI")
+        .env_remove("NROS_TOOLCHAIN_DISPATCH");
+    if let Some(var) = ci {
+        cmd.env(var, "true");
+    }
+    let out = cmd.output().expect("failed to run the launcher");
+    Out {
+        ok: out.status.success(),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        all: format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    }
+}
+
+struct Out {
+    ok: bool,
+    stdout: String,
+    all: String,
+}
+
+fn run(launcher: &Path, cwd: &Path, store: &Path, args: &[&str]) -> Out {
+    run_in(launcher, cwd, store, args, None)
+}
+
+/// W3's first acceptance clause, literally: a launcher with NO toolchain
+/// installed must start and say what to run.
+///
+/// It fails (exit non-zero) because it could not run the command — a launcher
+/// that exited 0 here would read to CI as a build that passed — but it fails
+/// with an answer, not with a crash.
+#[test]
+fn the_launcher_runs_with_no_toolchain_installed_and_says_what_to_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store);
+    let proj = tmp.path().join("my-robot");
+    std::fs::create_dir_all(&proj).unwrap();
+
+    let out = run(&launcher, &proj, &store, &["build"]);
+    assert!(
+        !out.ok,
+        "a launcher that cannot run the command must not exit 0:\n{}",
+        out.all
+    );
+    assert!(
+        out.all.contains("no nano-ros toolchain is installed"),
+        "expected the nothing-installed report:\n{}",
+        out.all
+    );
+    assert!(
+        out.all.contains("install.sh"),
+        "the report must name what to run:\n{}",
+        out.all
+    );
+}
+
+/// W3's third acceptance clause: *"`nros --version` must distinguish launcher
+/// from toolchain, or the split buys nothing observable."*
+///
+/// Two lines, in order: the launcher's own version, then whatever the toolchain
+/// prints. The argument is still forwarded verbatim, which the `ARG=` line
+/// proves — the launcher adds a line, it does not consume a flag.
+#[test]
+fn version_distinguishes_the_launcher_from_the_toolchain_it_launches() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store);
+    install_stub(&store, "0.6.0-nros1");
+    let proj = tmp.path().join("my-robot");
+    pin(&proj, "0.6.0-nros1");
+
+    let out = run(&launcher, &proj, &store, &["--version"]);
+    assert!(out.ok, "{}", out.all);
+    assert!(
+        out.stdout.contains("nros-launcher "),
+        "the launcher must report its OWN version:\n{}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains("nros 0.6.0-nros1 (STUB-TOOLCHAIN)"),
+        "the toolchain's version must follow it:\n{}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.find("nros-launcher ") < out.stdout.find("nros 0.6.0-nros1"),
+        "launcher first, then the toolchain it launched:\n{}",
+        out.stdout
+    );
+    assert!(
+        out.all.contains("ARG=--version"),
+        "`--version` must still be FORWARDED, not consumed:\n{}",
+        out.all
+    );
+}
+
+/// The launcher answers `--version` even with an empty store — and exits 0,
+/// because the question it was asked was answered. This is the one place the
+/// two acceptance clauses meet, and the reason the version line is printed
+/// BEFORE the store is resolved.
+#[test]
+fn version_works_with_no_toolchain_installed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store);
+    let proj = tmp.path().join("my-robot");
+    std::fs::create_dir_all(&proj).unwrap();
+
+    let out = run(&launcher, &proj, &store, &["--version"]);
+    assert!(
+        out.ok,
+        "`nros --version` must not be a broken command on a host with an empty store:\n{}",
+        out.all
+    );
+    assert!(out.stdout.contains("nros-launcher "), "{}", out.stdout);
+    assert!(
+        out.all.contains("no nano-ros toolchain is installed"),
+        "and it must say why no toolchain line followed:\n{}",
+        out.all
+    );
+}
+
+/// The property the split exists for, measured rather than asserted: installing
+/// a NEWER toolchain changes the store and leaves the launcher binary byte for
+/// byte identical — while the launcher immediately starts handing over to it.
+///
+/// This is what "a toolchain update does not replace the launcher" means in a
+/// world where both binaries are called `nros`.
+#[test]
+fn a_toolchain_update_does_not_replace_the_launcher() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store);
+    install_stub(&store, "0.6.0-nros1");
+    let proj = tmp.path().join("my-robot");
+    std::fs::create_dir_all(&proj).unwrap();
+
+    let before = std::fs::read(&launcher).unwrap();
+    let first = run(&launcher, &proj, &store, &["build"]);
+    assert!(
+        first.all.contains("nros 0.6.0-nros1 (STUB-TOOLCHAIN)"),
+        "{}",
+        first.all
+    );
+
+    // "Update the toolchain" — a second version lands in the store. Nothing
+    // else happens; in particular nothing writes to `<store>/bin`.
+    install_stub(&store, "0.7.0-nros1");
+
+    let after = std::fs::read(&launcher).unwrap();
+    assert_eq!(
+        before, after,
+        "installing a toolchain rewrote the launcher binary"
+    );
+    let second = run(&launcher, &proj, &store, &["build"]);
+    assert!(
+        second.all.contains("nros 0.7.0-nros1 (STUB-TOOLCHAIN)"),
+        "the same launcher must now hand over to the newer toolchain:\n{}",
+        second.all
+    );
+}
+
+/// RFC-0097 D11 through the real binary: an unpinned project in an automated
+/// session is told, on stderr, which toolchain ran and how to pin it — and the
+/// toolchain still runs, because the launcher cannot tell `build` from
+/// `--version` and refusing both is not enforcing D11.
+///
+/// The refusal belongs to `nros build`, which knows it is about to write source
+/// (`toolchain_pin_dispatch.rs`, one crate over).
+#[test]
+fn an_unpinned_project_in_ci_is_warned_about_through_the_real_binary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let launcher = install_launcher(&store);
+    install_stub(&store, "0.6.0-nros1");
+    let proj = tmp.path().join("my-robot");
+    std::fs::create_dir_all(&proj).unwrap();
+
+    let out = run_in(&launcher, &proj, &store, &["build"], Some("GITHUB_ACTIONS"));
+    assert!(
+        out.all.contains("$GITHUB_ACTIONS"),
+        "name the variable that decided:\n{}",
+        out.all
+    );
+    assert!(
+        out.all.contains("nros-toolchain.toml"),
+        "name the fix:\n{}",
+        out.all
+    );
+    assert!(
+        out.all.contains("nros 0.6.0-nros1 (STUB-TOOLCHAIN)"),
+        "the toolchain still runs — only `nros build` refuses:\n{}",
+        out.all
+    );
+    assert!(
+        !proj.join("nros-toolchain.toml").exists(),
+        "the launcher must never write a pin file"
+    );
+
+    // The negative control, on the same store and the same runner: WITH a pin
+    // there is nothing to warn about. Without this, a launcher that printed the
+    // warning unconditionally would pass the assertions above.
+    pin(&proj, "0.6.0-nros1");
+    let pinned = run_in(&launcher, &proj, &store, &["build"], Some("GITHUB_ACTIONS"));
+    assert!(
+        pinned.all.contains("nros 0.6.0-nros1 (STUB-TOOLCHAIN)"),
+        "a pinned project must build in CI exactly as on a laptop:\n{}",
+        pinned.all
+    );
+    assert!(
+        !pinned.all.contains("$GITHUB_ACTIONS"),
+        "a pinned CI build must get no D11 warning at all:\n{}",
+        pinned.all
+    );
+}

--- a/packages/cli/nros-launcher/tests/launcher_dependency_closure.rs
+++ b/packages/cli/nros-launcher/tests/launcher_dependency_closure.rs
@@ -1,0 +1,167 @@
+//! The launcher does not link the CLI's dependency graph — phase-443 W3.
+//!
+//! The acceptance clause says *"measured, not asserted"*, and that word is the
+//! whole test. "It is a small crate" is a claim a manifest comment can make and
+//! then quietly stop being true: `nros-launcher`'s manifest asks a reader not
+//! to add dependencies, and nothing so far checks that anybody listened. A
+//! dependency arrives one `cargo add` at a time, and the one that finally makes
+//! the launcher unbuildable on a bare host will look exactly like the four
+//! before it.
+//!
+//! So this reads the RESOLVE — `packages/cli/Cargo.lock`, the file that decides
+//! what actually gets compiled — and walks the launcher's link closure out of
+//! it. No `cargo` subprocess: the lock is a checked-in file, so this needs no
+//! network, no registry and no build (the "no compilation inside tests" rule),
+//! and it measures the same thing on a runner as on a laptop.
+//!
+//! ## Why the walk is seeded from the manifest, not from the lock's own node
+//!
+//! `Cargo.lock` records a WORKSPACE MEMBER's dev-dependencies in the same
+//! `dependencies` list as its real ones — `tempfile` and its 20-crate rustix
+//! subtree would be counted as things the launcher links, which they are not.
+//! Registry packages have no dev-dependencies in the lock at all (cargo never
+//! resolves them), so seeding the walk with the launcher's own
+//! `[dependencies]` table gives exactly the closure that ends up in the binary.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+/// The `packages/cli` workspace root, from this crate's manifest directory.
+fn cli_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("nros-launcher sits inside packages/cli")
+        .to_path_buf()
+}
+
+/// `name -> dependency names`, read out of the lock.
+fn lock_graph() -> BTreeMap<String, Vec<String>> {
+    let raw = std::fs::read_to_string(cli_root().join("Cargo.lock")).expect("read Cargo.lock");
+    let doc: toml::Value = toml::from_str(&raw).expect("parse Cargo.lock");
+    let mut graph: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for pkg in doc["package"].as_array().expect("[[package]] array") {
+        let name = pkg["name"].as_str().expect("package name").to_string();
+        let deps: Vec<String> = pkg
+            .get("dependencies")
+            .and_then(toml::Value::as_array)
+            .map(|a| {
+                a.iter()
+                    // Entries are `"name"` or `"name version"` or
+                    // `"name version (source)"` — the name is the first word.
+                    .filter_map(|d| d.as_str())
+                    .map(|d| d.split_whitespace().next().unwrap_or(d).to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        // A name can appear twice when two semver-incompatible versions are
+        // resolved; the union is the right answer for a reachability question.
+        graph.entry(name).or_default().extend(deps);
+    }
+    graph
+}
+
+/// Everything reachable from `seeds`, `seeds` included.
+fn closure(graph: &BTreeMap<String, Vec<String>>, seeds: &[String]) -> BTreeSet<String> {
+    let mut seen: BTreeSet<String> = seeds.iter().cloned().collect();
+    let mut queue: VecDeque<String> = seeds.iter().cloned().collect();
+    while let Some(n) = queue.pop_front() {
+        for c in graph.get(&n).into_iter().flatten() {
+            if seen.insert(c.clone()) {
+                queue.push_back(c.clone());
+            }
+        }
+    }
+    seen
+}
+
+/// The crates named in a manifest's `[dependencies]` table.
+fn declared_dependencies(manifest: &std::path::Path) -> Vec<String> {
+    let raw = std::fs::read_to_string(manifest)
+        .unwrap_or_else(|e| panic!("read {}: {e}", manifest.display()));
+    let doc: toml::Value = toml::from_str(&raw).expect("parse manifest");
+    doc.get("dependencies")
+        .and_then(toml::Value::as_table)
+        .map(|t| t.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// The launcher's link closure, computed the way the module header describes.
+fn launcher_closure(graph: &BTreeMap<String, Vec<String>>) -> BTreeSet<String> {
+    let seeds =
+        declared_dependencies(&std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"));
+    assert!(
+        !seeds.is_empty(),
+        "the launcher's own [dependencies] table could not be read — this test \
+         would then measure nothing and pass"
+    );
+    closure(graph, &seeds)
+}
+
+/// A ceiling, not the exact number.
+///
+/// Exact would fail on any transitive bump in `serde` or `toml` and teach the
+/// next person to update the constant without reading it, which is how a
+/// ratchet becomes a rubber stamp. The measured closure at the time of writing
+/// is **27**; the headroom absorbs a transitive bump and nothing like a new
+/// direct dependency (`clap` alone is 12).
+const CEILING: usize = 45;
+
+/// The clause itself: the CLI's graph is not in the launcher's.
+///
+/// Named crates rather than only a count, because the count could be met while
+/// linking exactly the wrong thing — `nros-cli-core` is one edge and 192
+/// crates, and a `nros-launcher` that grew a convenience import of it would
+/// still be "one dependency more".
+#[test]
+fn the_launcher_does_not_link_the_clis_dependency_graph() {
+    let graph = lock_graph();
+    let launcher = launcher_closure(&graph);
+
+    for banned in [
+        // The toolchain itself, and the reason this crate was split out.
+        "nros-cli-core",
+        // Argument parsing: RFC-0095 D8 — the launcher parses no `argv`, so a
+        // `clap` here would be evidence that it started to.
+        "clap",
+        // Templating, package discovery, launch parsing: the toolchain's work,
+        // none of which a launcher can have a reason to do.
+        "minijinja",
+        "nros-pkg-index",
+        "nros-launch-parser",
+        "nros-entry-lower",
+    ] {
+        assert!(
+            !launcher.contains(banned),
+            "`{banned}` is in the launcher's link closure. The launcher must \
+             build and run on a host with no toolchain installed, and each of \
+             these is a piece of the toolchain.\nclosure: {launcher:?}"
+        );
+    }
+}
+
+/// The ratchet. The clause above says *which* crates are forbidden; this says
+/// the closure did not grow past the point where "deliberately tiny" stops
+/// describing it — a dependency nobody thought to ban is still a dependency.
+#[test]
+fn the_launcher_closure_stays_small_and_is_a_fraction_of_the_toolchains() {
+    let graph = lock_graph();
+    let launcher = launcher_closure(&graph);
+    let toolchain = closure(&graph, &["nros-cli-core".to_string()]);
+
+    assert!(
+        launcher.len() <= CEILING,
+        "the launcher's link closure is {} crates (ceiling {CEILING}). Adding a \
+         dependency here is a decision about whether `nros` still starts on a \
+         host with nothing installed — make it deliberately, in the manifest's \
+         own words, and move this number with a reason.\nclosure: {launcher:?}",
+        launcher.len()
+    );
+    // The ratio is what RFC-0097 D4 is about: the launcher must be able to
+    // outlive the toolchain, which it cannot do while sharing its graph.
+    assert!(
+        launcher.len() * 3 <= toolchain.len(),
+        "the launcher links {} crates and the toolchain {} — the split has \
+         stopped buying anything",
+        launcher.len(),
+        toolchain.len()
+    );
+}

--- a/packages/cli/nros-launcher/tests/launcher_resolution.rs
+++ b/packages/cli/nros-launcher/tests/launcher_resolution.rs
@@ -1,0 +1,327 @@
+//! What the launcher DECIDES — phase-443 W3/W4, RFC-0097 D4 + D11.
+//!
+//! Every test builds a fake store in a tempdir and asks
+//! [`launch::resolve`](nros_launcher::launch::resolve) about it. Nothing reads
+//! `$NROS_STORE`, `$CI` or the process working directory: the store root, the
+//! project directory and the session are all parameters, so these run in
+//! parallel with everything else and observe nothing global — and, importantly
+//! for W4, they measure the same thing on a laptop and on a runner that
+//! exports `$CI`.
+//!
+//! `launcher_binary.rs` is the other half: whether the decision reaches an
+//! `exec`, through the real binary.
+
+use std::path::{Path, PathBuf};
+
+use nros_launcher::{
+    launch::{self, Context, Plan, Source},
+    session::Session,
+};
+
+/// A store entry that looks like one `scripts/install.sh` wrote.
+fn install_toolchain(store: &Path, version: &str) -> PathBuf {
+    let bin = store.join("sdk").join("nros").join(version).join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let exe = bin.join("nros");
+    std::fs::write(&exe, b"#!/bin/sh\nexit 0\n").unwrap();
+    exe
+}
+
+/// A user's project. Explicitly NOT a checkout — the tempdir root guarantees no
+/// `packages/core/nros-core/Cargo.toml` above it.
+fn project(dir: &Path, rel: &str) -> PathBuf {
+    let p = dir.join(rel);
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn pin_at(dir: &Path, version: &str) {
+    std::fs::write(
+        dir.join("nros-toolchain.toml"),
+        format!("[toolchain]\nversion = \"{version}\"\n"),
+    )
+    .unwrap();
+}
+
+fn ctx(cwd: &Path, store: &Path, session: Session) -> Context {
+    Context {
+        // The launcher's own path only matters for finding a bundled
+        // installer, which none of these have.
+        exe: store.join("bin").join("nros"),
+        cwd: cwd.to_path_buf(),
+        store: store.to_path_buf(),
+        dispatched: None,
+        session,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// W3 — the launcher resolves, including the states a toolchain never meets
+// ---------------------------------------------------------------------------
+
+/// The acceptance sentence, as a test: *"the launcher builds and runs with no
+/// toolchain installed — it must be able to report 'nothing installed, run X'
+/// rather than failing to start."*
+///
+/// The state a freshly installed launcher is in, and the one a launcher that
+/// shipped inside the toolchain could not be in at all.
+#[test]
+fn an_empty_store_is_reported_with_the_command_that_fixes_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    std::fs::create_dir_all(&store).unwrap();
+    let proj = project(tmp.path(), "my-robot");
+
+    let plan = launch::resolve(&ctx(&proj, &store, Session::interactive())).unwrap();
+    let Plan::NothingInstalled { .. } = &plan else {
+        panic!("expected NothingInstalled, got {plan:?}");
+    };
+    let text = launch::explain(&plan);
+    assert!(
+        text.contains("install.sh"),
+        "the report must name what to run:\n{text}"
+    );
+    assert!(
+        text.contains(&store.display().to_string()),
+        "and which store it looked in:\n{text}"
+    );
+}
+
+/// An unpinned project on a developer's machine falls back to the newest
+/// installed toolchain, the way `rustup` falls back to a default toolchain —
+/// and NEWEST is natural order, so a store holding 0.9 and 0.10 picks 0.10.
+#[test]
+fn an_unpinned_project_takes_the_newest_installed_toolchain() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.9.0-nros1");
+    let newest = install_toolchain(&store, "0.10.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    let plan = launch::resolve(&ctx(&proj, &store, Session::interactive())).unwrap();
+    assert_eq!(
+        plan,
+        Plan::Exec {
+            version: "0.10.0-nros1".to_string(),
+            bin: newest,
+            source: Source::Default,
+        }
+    );
+}
+
+/// A pin beats the default, from a SUBDIRECTORY, and names an OLDER version
+/// than the store's newest — the case where "did the pin decide?" is actually
+/// answerable.
+#[test]
+fn a_pin_beats_the_newest_installed_even_from_a_subdirectory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let pinned = install_toolchain(&store, "0.5.0-nros1");
+    install_toolchain(&store, "0.10.0-nros1");
+    let root = project(tmp.path(), "my-robot");
+    pin_at(&root, "0.5.0-nros1");
+    let deep = project(tmp.path(), "my-robot/src/talker_pkg/src");
+
+    let plan = launch::resolve(&ctx(&deep, &store, Session::interactive())).unwrap();
+    assert_eq!(
+        plan,
+        Plan::Exec {
+            version: "0.5.0-nros1".to_string(),
+            bin: pinned,
+            source: Source::Pin(root.join("nros-toolchain.toml")),
+        }
+    );
+}
+
+/// A pin the store cannot answer is `Missing`, not a silent fallback to the
+/// newest. Falling back would build the project with a toolchain nobody chose
+/// while a file on disk says otherwise, which is worse than refusing.
+#[test]
+fn an_unanswerable_pin_does_not_fall_back_to_the_newest_installed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.10.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    pin_at(&proj, "0.7.0-nros3");
+
+    let plan = launch::resolve(&ctx(&proj, &store, Session::interactive())).unwrap();
+    let Plan::Missing { version, .. } = &plan else {
+        panic!("expected Missing, got {plan:?}");
+    };
+    assert_eq!(version, "0.7.0-nros3");
+}
+
+/// RFC-0097: *"inside a checkout the launcher is not involved."* The ownership
+/// guard (`stale_guard`, phase-431 W1) requires that clone's own build, so a
+/// launcher that dispatched a store toolchain here would only earn its refusal
+/// one frame later — with a worse message.
+#[test]
+fn a_checkout_makes_the_launcher_stand_aside() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.10.0-nros1");
+    let root = project(tmp.path(), "nano-ros");
+    std::fs::create_dir_all(root.join("packages/core/nros-core")).unwrap();
+    std::fs::write(root.join("packages/core/nros-core/Cargo.toml"), "").unwrap();
+    let inside = project(tmp.path(), "nano-ros/examples/native/rust/talker");
+
+    let plan = launch::resolve(&ctx(&inside, &store, Session::interactive())).unwrap();
+    let Plan::InCheckout { .. } = &plan else {
+        panic!("expected InCheckout, got {plan:?}");
+    };
+    let text = launch::explain(&plan);
+    assert!(
+        text.contains("setup-cli") || text.contains("bootstrap.sh"),
+        "a contributor must be told how to get the checkout's own CLI:\n{text}"
+    );
+}
+
+/// The one failure mode a launcher must not have. A launcher reached from a
+/// toolchain that already dispatched would exec it again, forever.
+#[test]
+fn an_already_dispatched_marker_refuses_rather_than_looping() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.10.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    let mut c = ctx(&proj, &store, Session::interactive());
+    c.dispatched = Some("0.10.0-nros1".to_string());
+
+    let plan = launch::resolve(&c).unwrap();
+    let Plan::AlreadyDispatched { .. } = &plan else {
+        panic!("expected AlreadyDispatched, got {plan:?}");
+    };
+    assert!(launch::explain(&plan).contains("exec loop"));
+}
+
+// ---------------------------------------------------------------------------
+// W4 — CI does not choose a toolchain nobody named (RFC-0097 D11)
+// ---------------------------------------------------------------------------
+
+/// The launcher half of D11. Unpinned + CI is the same defect as a pin written
+/// from CI, one step earlier — the runner's incidental store contents decide,
+/// and nothing records what was chosen.
+///
+/// The launcher WARNS rather than refusing, and the warning is what turns
+/// "silently different" into "different, and it said so": it carries the
+/// version that ran. Refusing here would refuse `nros --version` and
+/// `nros setup --list` too, because the launcher parses no `argv` and cannot
+/// tell them apart from a build. `nros build` is where the refusal lives —
+/// `toolchain_pin_dispatch.rs`, one crate over.
+#[test]
+fn an_unpinned_project_in_ci_warns_with_the_version_it_took() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.10.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    let plan = launch::resolve(&ctx(&proj, &store, Session::automated("CI"))).unwrap();
+    let Plan::Exec { source, .. } = &plan else {
+        panic!("expected Exec, got {plan:?}");
+    };
+    assert_eq!(*source, Source::DefaultInCi { var: "CI" });
+
+    let text = launch::warning(&plan).expect("an unpinned CI run must warn");
+    assert!(
+        text.contains("$CI"),
+        "name the variable that decided:\n{text}"
+    );
+    assert!(
+        text.contains("0.10.0-nros1"),
+        "name the version that actually ran — that is what makes it not \
+         silent:\n{text}"
+    );
+    assert!(
+        text.contains("version = \"0.10.0-nros1\""),
+        "print the pin, so the fix is a copy-paste rather than an expedition:\n{text}"
+    );
+    assert!(
+        text.contains("NROS_ALLOW_PIN_WRITE_IN_CI"),
+        "name the escape hatch:\n{text}"
+    );
+    // …and the launcher still writes nothing. Only `nros build` may.
+    assert!(!proj.join("nros-toolchain.toml").exists());
+}
+
+/// The negative control: the two states that must NOT warn. Without this, a
+/// `warning` that returned `Some` for everything would pass the test above.
+#[test]
+fn nothing_else_warns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.10.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    // Unpinned on a laptop.
+    let dev = launch::resolve(&ctx(&proj, &store, Session::interactive())).unwrap();
+    assert_eq!(launch::warning(&dev), None);
+
+    // Pinned in CI — the reproducible case, and the common one.
+    pin_at(&proj, "0.10.0-nros1");
+    let ci = launch::resolve(&ctx(&proj, &store, Session::automated("CI"))).unwrap();
+    assert_eq!(launch::warning(&ci), None);
+}
+
+/// The other half of the acceptance: *"a CI job that resolves a pin gets the
+/// same toolchain a dev's machine does."* Same project, same store, two
+/// sessions, one answer — the refusal must be about the ABSENCE of a pin, never
+/// about being CI.
+#[test]
+fn a_pinned_project_resolves_identically_in_ci_and_on_a_developer_machine() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.5.0-nros1");
+    install_toolchain(&store, "0.10.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+    pin_at(&proj, "0.5.0-nros1");
+
+    let dev = launch::resolve(&ctx(&proj, &store, Session::interactive())).unwrap();
+    let ci = launch::resolve(&ctx(&proj, &store, Session::automated("GITHUB_ACTIONS"))).unwrap();
+    assert_eq!(
+        dev, ci,
+        "a pinned project must not resolve differently in CI"
+    );
+    assert!(matches!(dev, Plan::Exec { .. }));
+}
+
+/// "Someone who really means it" — the escape hatch is what
+/// [`Session::interactive`] represents, and with it CI behaves like a laptop.
+#[test]
+fn the_escape_hatch_lets_an_automated_session_choose() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    install_toolchain(&store, "0.10.0-nros1");
+    let proj = project(tmp.path(), "my-robot");
+
+    // `Session::detect_with` is what reads `$NROS_ALLOW_PIN_WRITE_IN_CI`; here
+    // it is exercised end to end rather than hand-constructed, so the hatch's
+    // NAME is covered too.
+    let session = Session::detect_with(|k| match k {
+        "CI" => Some("true".into()),
+        "NROS_ALLOW_PIN_WRITE_IN_CI" => Some("1".into()),
+        _ => None,
+    });
+    let plan = launch::resolve(&ctx(&proj, &store, session)).unwrap();
+    assert!(
+        matches!(plan, Plan::Exec { .. }),
+        "the hatch must let CI choose: {plan:?}"
+    );
+}
+
+/// An empty store in CI reports the store, not D11. Both statements are true
+/// and only one is actionable: telling someone with nothing installed to commit
+/// a pin would name a version that exists nowhere — and `warning` has no
+/// version to put in it either.
+#[test]
+fn an_empty_store_in_ci_reports_the_store_rather_than_the_pin_rule() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    std::fs::create_dir_all(&store).unwrap();
+    let proj = project(tmp.path(), "my-robot");
+
+    let plan = launch::resolve(&ctx(&proj, &store, Session::automated("CI"))).unwrap();
+    assert!(
+        matches!(plan, Plan::NothingInstalled { .. }),
+        "got {plan:?}"
+    );
+}


### PR DESCRIPTION
Finishes **phase-443 W3 + W4** (RFC-0097 D4 / D11). Resumes an earlier session's
WIP commit, which was cut off mid-test-edit; that commit is squashed into this
one, verified.

## W3 — the launcher is its own artifact

`dispatch.rs` was a module inside the binary that carries the toolchain, so the
thing that SELECTS a version shipped with the version being selected.
`packages/cli` takes **710 commits per 60 days**; a launcher sharing that
artifact re-releases on every one of them while carrying no compatibility
promise of its own.

`dispatch.rs` and `pin.rs` **move** into a new `packages/cli/nros-launcher`
crate, joined by `store_root.rs` (was `orchestration::store::root`) and
`checkout.rs` (was `abi_guard::find_monorepo_root`). `nros-cli-core` re-exports
all four at their original paths, so there is exactly ONE parser of
`nros-toolchain.toml`, one answer to "where is the store", and one definition of
"is this a checkout".

`launch.rs` is the new part: a launcher meets three states a fronted toolchain
cannot — an empty store, an unpinned project with no CLI to fall back to, and a
cwd inside a checkout. `dispatch::decide` answers `Proceed` to all three.

The crate keeps its own `version`, deliberately not `version.workspace = true`.

### Acceptance, measured

| clause | how |
| --- | --- |
| runs with NO toolchain installed | `the_launcher_runs_with_no_toolchain_installed_and_says_what_to_run` — starts, names `install.sh` and the store, exits non-zero |
| a toolchain update does not replace it | launcher binary compared byte for byte across a store gaining a newer toolchain, and the same launcher then hands over to it |
| `nros --version` distinguishes the two | `nros-launcher 0.1.0` then the toolchain's line; `--version` is still FORWARDED (`ARG=--version`), and answering it exits 0 even on an empty store |
| does not link the CLI's dependency graph | `launcher_dependency_closure.rs` walks `packages/cli/Cargo.lock` from the launcher's own `[dependencies]`: **27 crates against `nros-cli-core`'s 192** |

## W4 — CI does not choose, or write, a toolchain nobody named

`Session` answers "is this automated?" once, from `CI` / `GITHUB_ACTIONS` (a
declaration beats an `isatty` inference), with `NROS_ALLOW_PIN_WRITE_IN_CI` as
the escape hatch that BEATS the declaration.

The rule lands in two places because they know different things:

- **`nros build` REFUSES** — `PinOutcome::RefusedInCi` becomes an `Err`. It
  knows it is about to write into the user's source tree.
- **the launcher WARNS** — `Source::DefaultInCi`, naming the version it took. It
  parses no argv (D8), so refusing there would refuse `nros --version`,
  `nros setup --list` and `nros doctor` on every runner.

The refusal is asked AFTER the three arms that write nothing anyway (checkout,
already-pinned, no store version). Ordering it first would fail every build in
this repository's own CI, which builds inside a checkout.

It does not name `nros pin <version>` as the phase doc asked: no such verb
exists yet. It prints the exact `nros-toolchain.toml` to commit instead. The
phase doc records the correction.

## Mutation pass — 25 mutations, 25 RED, 0 GREEN

Every fix was removed in turn and the named test noticed. Two fixes had **no
test** when this was picked up and gained one:

- `nros build` turning `RefusedInCi` into an error — extracted as
  `report_pin_outcome`, so D11's build half is reachable without a real store;
- the dependency closure — the "measured, not asserted" clause had nothing
  measuring it.

## Also here

`nros-cli`'s `an_unpinned_project_runs_in_the_launcher` failed **1 of 4** full
`packages/cli` runs and passed **4 of 4** solo — issue 0476's ETXTBSY race, in
the launcher dispatch test, exactly where that issue predicted.
`nros_launcher::test_support` is the one spelling of "install an executable you
are about to run" that every launcher test can reach (`nros-cli-core` depends on
`nros-launcher`, so a helper there would be a cycle).

## Not done here

`scripts/install.sh` still fronts `<store>/bin/nros` at the newest TOOLCHAIN, so
nothing installs the launcher yet. Fronting it means the release asset carries
both binaries and `sdk-front` learns which one it fronts — a change to
`release-nros.yml`, which is **W2's file (#859)**. Recorded in the phase doc.

`#859` also adds `pin::set` to `orchestration/pin.rs`, the file this PR moves.
That is the one conflict between the two, and it is mechanical: `set` goes into
`nros-launcher/src/pin.rs`.

## Verified locally

- `just check fast` — 290 gates green, 2 skipped (unprovisioned trees)
- `just check cli-tests` — the whole `packages/cli` workspace, green
- `just check cli-clippy`, `just check submodule-commits-reachable`,
  `just check cli-source-dirs` — green
- `just setup-cli` still builds, and the ownership guard still behaves on both
  arms (silent outside a checkout, 6 `stale_guard` + 6 `abi_guard` tests green)

Not run: `check-compile-smoke` / `check-workspace-all`. Both compile the ROOT
workspace; this diff touches only `packages/cli` and one roadmap doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
