### PR TITLE
docs(#1268-#1272): parameter services on a multi-node image, measured on Cyclone

### DIFF
--- a/docs/issues/1268-cyclone-param-services-unsupported-silently-dropped.md
+++ b/docs/issues/1268-cyclone-param-services-unsupported-silently-dropped.md
@@ -1,0 +1,74 @@
+---
+id: 1268
+title: "Parameter services never start on Cyclone: the rcl_interfaces service
+  types have no type descriptor, and the failure is retried and dropped on
+  every spin"
+status: open
+type: bug
+area: rmw, core
+severity: high
+related: [issue-0745, issue-1269, issue-1270]
+---
+
+## Symptom
+
+A downstream image (Autoware Safety Island: four C++ component nodes on one
+executor, Cyclone, `param_services` declared) declares all 21 of its
+parameters and boots. From ROS 2 on the image's own domain:
+
+- `ros2 service list` shows the image's two application services
+  (`/system/mrm/comfortable_stop/operate`, `/system/mrm/emergency_stop/operate`)
+  and none of the `<node>/list_parameters`, `get_parameters`, ... services;
+- `ros2 service call /mrm_handler/list_parameters ...` waits and never finds
+  the service;
+- the same listing on domain 0 shows nothing from the image either, so this is
+  not the domain split of issues 0801/0824.
+
+A temporary diagnostic that printed the result the executor discards gave:
+
+```
+reconcile_parameter_services failed: Transport(Unsupported) (nodes=4)
+```
+
+## Cause
+
+Cyclone creates a service only if its request and reply types have a
+registered descriptor; `nros-rmw-cyclonedds/src/descriptors.cpp` documents that
+an unregistered type makes the create fail `UNSUPPORTED`. The backend bakes in
+exactly one descriptor of its own, `ParticipantEntitiesInfo` for the graph
+(`nros-rmw-cyclonedds/CMakeLists.txt`). The downstream's generated Cyclone
+typesupport covers its own message packages (`autoware_*`, `std_msgs`,
+`geometry_msgs`, ...). Nothing registers the `rcl_interfaces` service types the
+six parameter services use -- ListParameters, GetParameters, SetParameters,
+SetParametersAtomically, DescribeParameters, GetParameterTypes -- so
+`build_parameter_service_set` fails on the first of them.
+
+`reconcile_parameter_services` is called on every spin with its result
+discarded (`nros-node/src/executor/spin.rs`, `let _ = self.reconcile_parameter_services();`),
+so the executor retries a permanent failure forever and never says so.
+
+It was half known. A test comment in `nros-cli-core/src/codegen/entry/emit_c.rs`
+(issue 0745) says registration "fails outright on an RMW without
+service-server support (cyclonedds today)", and 0745 made the failure
+non-fatal. The stated cause is wrong -- Cyclone serves the image's own
+services -- and non-fatal plus discarded made the loss invisible.
+
+## Cost meanwhile
+
+The image still allocates the parameter store: 285,440 B at the default
+limits (32 slots of 8,920 B), for services no ROS 2 tool can reach.
+
+## Fix shape
+
+- Register the six `rcl_interfaces` service descriptors with the Cyclone
+  backend whenever `param-services` is on, the way `ParticipantEntitiesInfo`
+  is baked in.
+- Report a failed registration once through `nros_log`, and stop retrying a
+  failure that cannot change (`Unsupported`) on every spin.
+- Correct the 0745 test comment's stated cause.
+
+## Acceptance
+
+- `ros2 param list`, `get` and `set` reach every node of a multi-node Cyclone
+  image (this also needs issue 1269's node naming).
+- A registration failure is logged exactly once, naming the node and service.

--- a/docs/issues/1269-graph-node-set-differs-across-rmws.md
+++ b/docs/issues/1269-graph-node-set-differs-across-rmws.md
@@ -1,0 +1,54 @@
+---
+id: 1269
+title: "The ROS graph shows a different node set for the same image on each
+  RMW: zenoh announces every node, Cyclone announces one per session"
+status: open
+type: bug
+area: rmw
+severity: medium
+related: [issue-0105, issue-1268]
+---
+
+## Requirement
+
+The same image must present the same node set to ROS 2 whichever RMW it is
+built with. `ros2 node list`, and every tool that addresses a node by name
+(`ros2 param`, `ros2 node info`, launch introspection), must see the nodes the
+image composes, not an artifact of the transport.
+
+## What each RMW does today
+
+| RMW | nodes shown for a 4-node image | mechanism | evidence |
+| --- | --- | --- | --- |
+| zenoh | 4 | one liveliness token per node on the shared session | issue 0105, resolved in phase-268 |
+| Cyclone | 1 (`/node`) | one `ParticipantEntitiesInfo` per session with one node entry | measured; `graph.cpp` |
+| XRCE | not measured | the session is keyed by a single node name | `nros-rmw-xrce/src/session.c` |
+
+**Cyclone.** `nros-rmw-cyclonedds/src/graph.cpp` publishes
+`ros_discovery_info` with `node_entities_info_seq._length = 1`, carrying the
+one name `session.cpp` passes to `graph_init` for the whole session. A
+downstream image with four component nodes on one executor (Autoware Safety
+Island) shows `/node` in `ros2 node list`, and `ros2 param list /mrm_handler`
+answers "Node not found". Every reader and writer of the four nodes is
+attributed to that one node.
+
+Issue 0105 fixed exactly this -- "a multi-node entry now shows one graph node
+per launch component in `ros2 node list`" -- but through zenoh's per-node
+liveliness tokens, so the Cyclone graph publisher never got it.
+
+**XRCE** keys its session on one node name
+(`hash_session_key(node_name)` in `session.c`), which suggests the same
+collapse; it has not been run.
+
+## Fix shape
+
+- Cyclone: one `NodeEntitiesInfo` entry per node record, each carrying that
+  node's reader and writer GIDs, republished as nodes are added.
+- XRCE: measure, then the equivalent.
+- One matrix test that builds one multi-node image per RMW and asserts the
+  same `ros2 node list`, so the next divergence fails a test rather than a user.
+
+## Acceptance
+
+A 4-node image shows the same four nodes in `ros2 node list` on zenoh,
+Cyclone and XRCE, each with its own endpoints.

--- a/docs/issues/1270-param-service-buffers-48k-per-node.md
+++ b/docs/issues/1270-param-service-buffers-48k-per-node.md
@@ -1,0 +1,62 @@
+---
+id: 1270
+title: "Parameter services cost 48 KiB of buffers per node, and nothing shares
+  them, sizes them, or counts their RMW slots"
+status: open
+type: enhancement
+area: core, rmw
+severity: medium
+related: [issue-1268, issue-1271]
+---
+
+## What an image pays
+
+Declaring `param_services` gives every node six service servers (get, set,
+set_atomically, list, describe, get_types), built by
+`build_parameter_service_set` (`nros-node/src/executor/spin.rs`). Each is an
+`EmbeddedServiceServer` with a request and a reply buffer of
+`PARAM_SERVICE_BUFFER_SIZE` (4,096 B by default, `nros-node/build.rs`), boxed on
+the heap:
+
+| | per node | 4-node image |
+| --- | --- | --- |
+| buffers, 6 x (4,096 + 4,096) | 49,152 B | 196,608 B |
+| Cyclone entities | 6 x (2 topics + 1 reader + 1 writer) | 24 readers, 24 writers, 48 topics |
+| zenoh queryables | 6 | 24 |
+
+The parameter store comes on top: one per executor, 285,440 B at the default
+limits.
+
+For scale: the downstream this was measured on (Autoware Safety Island,
+MR-CANHUBK344) has a 94,208 B nros heap. The service buffers alone exceed it,
+even if the store were sized to the image's 25 scalar parameters (4,200 B).
+
+## Why it is larger than it needs to be
+
+- **The buffers are not shared.** All six services on all nodes are polled
+  from one spin, outside the executor arena, and each request is fully
+  handled before the next is read. One request/reply pair per executor would
+  serve them; today there are six per node.
+- **The buffer size is not derived.** 4,096 B is a constant; the largest
+  reply a node can produce (describe of all its parameters) follows from what
+  it declares.
+- **The RMW slots are not counted.** The entity inventory deliberately leaves
+  them out ("NOT included: the parameter (6) and lifecycle (5) service
+  families, which a feature enables and this inventory cannot see. An image
+  carrying them must state the knob", `nros-cli-core/src/entity_inventory.rs`).
+  So an image that declares `param_services` gets its queryable and service
+  pools sized as if it had not.
+
+## Fix shape
+
+- Share one request/reply buffer across the parameter services of an
+  executor.
+- Size it from the image's declared parameters (the worst reply), with the
+  current constant as the fallback when those are unknown.
+- Count six service servers per node in the entity inventory whenever the
+  bringup declares `param_services`.
+
+## Not measured
+
+`sizeof(RmwServiceServer)` per backend, and the zenoh `SERVICE_BUFFER` slot
+each queryable holds.

--- a/docs/issues/1271-param-service-reply-overflow-is-silent.md
+++ b/docs/issues/1271-param-service-reply-overflow-is-silent.md
@@ -1,0 +1,55 @@
+---
+id: 1271
+title: "A parameter service request or reply that does not fit is dropped
+  silently: no reply, no log, and the client only times out"
+status: open
+type: bug
+area: core
+severity: medium
+related: [issue-1270]
+---
+
+## What happens
+
+The parameter services bound their wire messages with fixed caps -- 64
+sequence elements and 256-byte strings (`nros-node/src/parameter_services.rs`)
+-- and stream each reply into the fixed `PARAM_SERVICE_BUFFER_SIZE` reply
+buffer (`nros-rmw/src/traits.rs`). What happens past each cap:
+
+| case | behaviour |
+| --- | --- |
+| request with more than 64 names, or a string over 256 B | deserialize error, no reply |
+| `list_parameters` matching more than 64 names | cut to 64, silently; extra prefixes dropped silently |
+| stored value too large for the wire (e.g. a byte array over 64) | `get` answers NOT_SET |
+| string over 256 B in a reply | sent as `""`, not truncated |
+| reply larger than the buffer | serialize error, `ServiceReplyFailed`, no reply |
+
+The last row is the one that hides: the spin discards the error
+(`unwrap_or(0)` and `if let Ok` in `nros-node/src/executor/spin.rs`), so the
+ROS 2 client waits out its timeout and nothing on the image says why.
+
+A rough estimate, not measured: `describe_parameters` for about 40 parameters
+exceeds the 4,096 B default.
+
+## Why it matters
+
+These are the cases a user reaches first on a real node: `ros2 param dump`
+describes everything, and Autoware nodes declare dozens of parameters. A
+refusal they can read ("reply too large for PARAM_SERVICE_BUFFER_SIZE") is the
+difference between raising a knob and filing a bug about discovery.
+
+## Fix shape
+
+- Log each overflow once per service, naming the cap and the knob.
+- Where the service has an error field (`SetParametersResult.reason`), answer
+  with it instead of dropping the request.
+- Flag truncation in `list_parameters` (and document it) rather than cutting
+  the list without a trace.
+- Size the reply buffer from the declared parameters (issue 1270) so the
+  default case does not overflow at all.
+
+## Evidence
+
+Found by reading; none of the rows above has been triggered on a running
+image yet. A test that describes N parameters for N past the threshold would
+pin the boundary.

--- a/docs/issues/1272-launch-params-land-on-node-zero.md
+++ b/docs/issues/1272-launch-params-land-on-node-zero.md
@@ -1,0 +1,52 @@
+---
+id: 1272
+title: "Launch parameters for every node of a multi-node entry are declared on
+  the executor's primary node, with their types guessed from strings"
+status: open
+type: bug
+area: codegen, core
+severity: medium
+related: [issue-0745, issue-1269]
+---
+
+## What happens
+
+A launch file can set parameters per node. In a multi-node entry, all of them
+end up on node 0:
+
+- **C++ entries.** The entry emitter writes one
+  `nros_cpp_declare_param(executor, "<name>", "<value>")` per node parameter
+  (`nros-cli-core/src/codegen/entry/emit_c.rs`). The call carries no node, and
+  `nros_cpp_declare_param` (`nros-cpp/src/params_shim.rs`) calls
+  `executor.declare_parameter(name, value)`, which declares on the executor's
+  PRIMARY node.
+- **Rust entries.** `nros::main!` gathers every node's parameters into one
+  flat list, and `apply_param_services` declares each with the same
+  `declare_parameter` (`nros/src/main_macro.rs`, `nros/src/node_runtime.rs`).
+
+Consequences:
+
+- a parameter set for node B is held by node A, so `ros2 param get /B x`
+  cannot find it (once node naming works at all, see issue 1269) and B reads
+  its own default;
+- two nodes that set the same name collide: the second declaration is
+  refused.
+
+## Types are guessed
+
+The value reaches the store as a string and its type is inferred -- bool,
+then i64, then f64, otherwise string (`infer_param_value`). The resolved model
+has no array type: a YAML sequence becomes a string list, baked as a
+comma-joined string, so a `double[]` parameter arrives as a string.
+
+## Not observed on a running image
+
+The downstream this was found beside (Autoware Safety Island) sets no launch
+parameters, so it has not hit this; both paths were traced by reading.
+
+## Fix shape
+
+- Seed each parameter on its own node: `declare_parameter_on(<node key>, ...)`,
+  and give the C++ shim the node index.
+- Carry the parameter's type from the resolver (or from a declaration, if the
+  contract grows one) instead of inferring it from the text.


### PR DESCRIPTION
Files #1268-#1272, found while moving Autoware Safety Island (four C++ component nodes on one executor, Cyclone) onto `param_services`. Docs only; no code changes.

- #1268: the six parameter services never start on Cyclone. The `rcl_interfaces` service types have no registered descriptor, so creation returns `Transport(Unsupported)` (measured with a temporary print of the discarded result), and `reconcile_parameter_services` retries it on every spin with the result dropped. A test comment from issue 0745 already calls Cyclone "an RMW without service-server support"; it does serve the image's own services, so the stated cause is wrong and the non-fatal path made the loss invisible.
- #1269: the same image shows 4 nodes on zenoh and one `/node` on Cyclone, because `graph.cpp` announces one `NodeEntitiesInfo` per session. The node set must not depend on the RMW; XRCE is unmeasured and likely collapses the same way.
- #1270: 6 x (4 KiB request + 4 KiB reply) of service buffers per node, unshared and not derived (196 KiB for four nodes, more than the board's whole nros heap), and the entity inventory leaves the parameter services' RMW slots out.
- #1271: a parameter request or reply past the wire caps gets no reply and no log; the client only times out.
- #1272: every node's launch parameters are declared on the executor's primary node, with types guessed from strings.

Local checks: `issue-index`, `prose-issue-refs`, `doc-commit-citations`, `doc-recipe-refs`, `archived-issue-status` and `string-conventions` pass. The full fast tier was run from a worktree and fails only `capability-conditionals` and `xrce-vendored-versions`, both because the worktree lacks the zenoh-pico submodule and the vendored XRCE tree; the push used the hook's documented `NROS_SKIP_PREPUSH_CHECKS=1` for that reason only, and CI runs the fast tier in full.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKY5TGsRzN9SVs1e4c8BoH
