### PR TITLE
fix(RFC-0095 D3): build-all's gate read make and ninja from third-party/ after both moved to the store

### DIFF
--- a/justfile
+++ b/justfile
@@ -412,9 +412,22 @@ build-all:
     #
     # A `case` on the captured string is fork-free and composes with the chain
     # through a plain variable.
+    #
+    # The pinned make and ninja live in the STORE (RFC-0095 D3), resolved through
+    # `nros sdk-path` — constructed from the index pin, never searched on PATH
+    # (issue 0625) — which is exactly how `build-all-jobserver.sh`, the script this
+    # gates, resolves them. This block read `third-party/make/make` and
+    # `third-party/ninja/ninja` until 2026-09-10, after both had moved: the gate
+    # and the script looked in different places, so on every host that had
+    # migrated, `build-all` silently took the slow static split. The helpers answer
+    # non-zero when a tool is absent, hence `|| …=""` — a bare assignment under
+    # this recipe's `set -e` would end it (issue 1249).
+    source scripts/build/jobserver-pool.sh
+    _nros_make="$(nros_pinned_make)" || _nros_make=""
+    _nros_ninja="$(nros_pinned_ninja)" || _nros_ninja=""
     _nros_make_ver=""
-    if [ -x third-party/make/make ]; then
-        _nros_make_ver=$(third-party/make/make --version 2>/dev/null | head -1)
+    if [ -n "$_nros_make" ]; then
+        _nros_make_ver=$("$_nros_make" --version 2>/dev/null | head -1)
     fi
     case "$_nros_make_ver" in
         *4.4*) _nros_make_44=1 ;;
@@ -422,7 +435,7 @@ build-all:
     esac
     if [ -z "${NROS_NO_JOBSERVER:-}" ] \
        && [ "$_nros_make_44" = 1 ] \
-       && [ -x third-party/ninja/ninja ]; then
+       && [ -n "$_nros_ninja" ]; then
         echo "build-all: unified jobserver path (make 4.4 + ninja 1.13; NROS_NO_JOBSERVER=1 to opt out)"
         exec just build-all-jobserver
     fi

--- a/scripts/build/jobserver-pool.sh
+++ b/scripts/build/jobserver-pool.sh
@@ -53,6 +53,18 @@ nros_pinned_make() {
     printf '%s\n' "$dir/bin/make"
 }
 
+# The pinned ninja's absolute path, or empty — `nros_pinned_make`'s sibling, for
+# the same reason: constructed from the index pin, never searched on PATH. ninja
+# >=1.13 is the half that JOINS make 4.4's fifo jobserver; the index pins 1.13.x,
+# so existence is the check here and the version floor is the pin's.
+nros_pinned_ninja() {
+    command -v nros >/dev/null 2>&1 || return 1
+    local dir
+    dir="$(nros sdk-path ninja 2>/dev/null)" || return 1
+    [ -n "$dir" ] && [ -x "$dir/bin/ninja" ] || return 1
+    printf '%s\n' "$dir/bin/ninja"
+}
+
 nros_pool_available() {
     local units="$2"
     [ "${NROS_JOBSERVER:-}" = "1" ] && return 1

--- a/scripts/check-third-party-is-submodules.sh
+++ b/scripts/check-third-party-is-submodules.sh
@@ -13,18 +13,19 @@
 # That is also what made the box mirror unfixable (issue 1248): its rules told
 # source from build output BY NAME, in directories where the two lived together.
 #
-# `make/` and `ninja/` are gone — both are provisioned into the store and their
-# consumers already read it there ("the store rather than `third-party/make/`",
-# jobserver-pool.sh). The residue was 1.2 MB of nothing.
+# `make/` and `ninja/` are gone — both are provisioned into the store, and their
+# consumers read it there. That sentence used to end "already", and it was not
+# true: `build-all`'s gate in `justfile` kept reading `third-party/make/make` and
+# `third-party/ninja/ninja` after the move, so every migrated host silently lost
+# the jobserver path. A directory rule whose READERS are unchecked has a reach
+# narrower than the rule (0196's shape) — hence the reference scan below.
 #
-# THE ONE DECLARED EXCEPTION, and why it is not fixed here
+# THE DECLARED EXCEPTION IS GONE
 #
-# `[source.rosidl]` still has `dest = "third-party/ros/rosidl"`, and
-# `msg_to_cyclone_idl.py` resolves it as its last ladder rung so the cyclone
-# msg->IDL step works with no ROS install. Moving it needs `dest` to be able to
-# name the STORE, which is RFC-0095 D2/D4 and lands with phase-440 W4. Declaring
-# it here rather than deleting the rule keeps the ratchet honest: the exception
-# is visible, has a reason, and has somewhere to go.
+# `ros` was one: `[source.rosidl]` could only name a workspace-relative `dest`.
+# phase-440 let `dest` name the STORE, rosidl moved there, and `EXCEPTIONS` is
+# empty (see the note beside it). Its one READER keeps a documented legacy
+# fallback, which the reference scan declares separately in `REF_EXCEPTIONS`.
 #
 # The list may only SHRINK. A new name here is a new provisioning root inside a
 # directory that is supposed to have none.
@@ -45,6 +46,26 @@ cd "$repo_root" || exit 2
 # provisioning root inside a directory that is supposed to have none.
 EXCEPTIONS=""
 
+# Provisioning roots moved OUT of third-party/: make, ninja, ros (RFC-0095 D3) and
+# zenoh (RFC-0075). The directory scan refuses them as DIRECTORIES; the reference
+# scan refuses CODE that still reads them.
+RETIRED="make ninja ros zenoh"
+# `third-party/<root>` with nothing path-like before it (so the
+# `packages/cli/third-party/...` tree is not this) and a non-name character or
+# end-of-line after it (so `ros-launch-manifest` is not `ros`). No `\b`: it is
+# zero-width, ugrep rejects it outright, and behind a `2>/dev/null` that is a
+# scan reporting "no references" over a tree full of them — measured while this
+# rule was being written.
+RETIRED_PAT="(^|[^/A-Za-z0-9_.-])third-party/($(tr ' ' '|' <<< "$RETIRED"))([^A-Za-z0-9_.-]|\$)"
+
+# Files allowed to READ a retired root, each with its reason. May only SHRINK,
+# and a listed file that no longer reads one is a STALE entry and fails.
+#   scripts/cyclonedds/msg_to_cyclone_idl.py — resolves the STORE first
+#     (`nros sdk-path --source rosidl`) and keeps the pre-phase-440 location
+#     BELOW it, so an earlier-provisioned host keeps working with no migration
+#     step. A documented fallback, not a reader that missed the move.
+REF_EXCEPTIONS="scripts/cyclonedds/msg_to_cyclone_idl.py"
+
 # Submodule PARENTS: the first path component under third-party/ for every
 # declared submodule. Read from .gitmodules, never from a directory walk, so an
 # uninitialised submodule still counts as one (a bare clone has empty dirs).
@@ -63,6 +84,14 @@ fi
 # proving `nros_grep_q` behaves rather than that this gate uses it.
 is_parent()    { nros_grep_q -x -- "$1" <<< "$2"; }
 is_exception() { nros_grep_q -w -- "$1" <<< "$2"; }
+# A CODE line that reads a retired root. A comment is prose, not a read — the
+# retirement is explained in comments in several places, correctly.
+is_retired_ref() {
+    local body="${1#"${1%%[![:space:]]*}"}"
+    case "$body" in \#*|//*) return 1 ;; esac
+    nros_grep_q -E -- "$RETIRED_PAT" <<< "$1"
+}
+is_ref_exception() { case " $2 " in *" $1 "*) return 0 ;; esac; return 1; }
 
 # SELFTEST, called unconditionally below — not behind a flag. A selftest nobody
 # runs decays into a comment (check-gate-selftests). These drive the same two
@@ -79,6 +108,18 @@ selftest() {
     _st "a PREFIX of a parent is not a parent"  1 "$(is_parent dd     "$parents"; echo $?)"
     _st "a declared exception is recognised"    0 "$(is_exception ros    "ros"; echo $?)"
     _st "an undeclared name is not exempt"      1 "$(is_exception notros "ros"; echo $?)"
+    # Built, never written out, so this file does not scan as a reader itself.
+    local tp="third-party"
+    _st "a code read of a retired root"         0 "$(is_retired_ref "    if [ -x $tp/make/make ]; then"; echo $?)"
+    _st "ninja likewise"                        0 "$(is_retired_ref "   && [ -x $tp/ninja/ninja ]; then"; echo $?)"
+    _st "a path in a python string is a read"   0 "$(is_retired_ref "    root / \"$tp/ros/rosidl\""; echo $?)"
+    _st "a '#' comment naming it is prose"      1 "$(is_retired_ref "    # the store rather than $tp/make/"; echo $?)"
+    _st "a '//' comment likewise"               1 "$(is_retired_ref "// $tp/zenoh/zenoh is gone"; echo $?)"
+    _st "packages/cli/$tp is not repo-root"     1 "$(is_retired_ref "git -C packages/cli/$tp/make x"; echo $?)"
+    _st "a longer name is not the root"         1 "$(is_retired_ref "see $tp/ros-launch-manifest"; echo $?)"
+    _st "a submodule parent is not retired"     1 "$(is_retired_ref "cd $tp/dds/cyclonedds"; echo $?)"
+    _st "a listed file is a ref exception"      0 "$(is_ref_exception a/b.py "a/b.py c.sh"; echo $?)"
+    _st "a PREFIX of a listed file is not"      1 "$(is_ref_exception a/b "a/b.py c.sh"; echo $?)"
     return "$fail"
 }
 
@@ -112,5 +153,39 @@ for e in $EXCEPTIONS; do
     }
 done
 
+# REFERENCE scan: one `git grep` over what RUNS — recipes, scripts, cmake,
+# workflows. Its status is branched on like `nros_grep_q`'s: 1 is "none", and
+# past 1 is a scan that did not run, which must never read as a clean tree.
+rc=0
+refs="$(git grep -nE "$RETIRED_PAT" -- justfile 'just/*.just' 'scripts/**' \
+    'cmake/**' '.github/**')" || rc=$?
+case "$rc" in
+    0|1) : ;;
+    *)  echo "check-third-party-is-submodules: the reference scan did not run" >&2
+        echo "    (git grep exit $rc) — refusing to call the tree clean without it." >&2
+        exit 2 ;;
+esac
+refs_seen=" "
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    file="${hit%%:*}"; rest="${hit#*:}"; line="${rest#*:}"
+    is_retired_ref "$line" || continue
+    if is_ref_exception "$file" "$REF_EXCEPTIONS"; then
+        refs_seen="$refs_seen$file "; continue
+    fi
+    problems=$((problems + 1))
+    echo "check-third-party-is-submodules: $file:${rest%%:*} reads a retired root" >&2
+    echo "    ${line#"${line%%[![:space:]]*}"}" >&2
+    echo "    The tool is in the store now — resolve it with \`nros sdk-path <tool>\`" >&2
+    echo "    (see nros_pinned_make / nros_pinned_ninja). RFC-0095 D3." >&2
+done <<< "$refs"
+for e in $REF_EXCEPTIONS; do
+    is_ref_exception "$e" "$refs_seen" && continue
+    problems=$((problems + 1))
+    echo "check-third-party-is-submodules: '$e' is a declared reference exception but" >&2
+    echo "    no longer reads a retired root — delete it from REF_EXCEPTIONS (the list" >&2
+    echo "    may only shrink)." >&2
+done
+
 [ "$problems" -eq 0 ] || exit 1
-echo "check-third-party-is-submodules: OK ($(wc -l <<< "$parents") submodule parent(s), $(wc -w <<< "$EXCEPTIONS") declared exception(s))"
+echo "check-third-party-is-submodules: OK ($(wc -l <<< "$parents") submodule parent(s), $(wc -w <<< "$EXCEPTIONS") declared exception(s); no code reads a retired root ($RETIRED) outside $(wc -w <<< "$REF_EXCEPTIONS") declared reference exception(s))"


### PR DESCRIPTION
`just build-all` decides whether to take the unified jobserver path by checking whether pinned make 4.4 and ninja 1.13 exist. It checked `third-party/make/make` and `third-party/ninja/ninja`.

RFC-0095 D3 moved both into the store, and the script this check guards, `build-all-jobserver.sh`, already resolves them there with `nros sdk-path`. **The check and the script looked in different places**, so on every host that had migrated, `build-all` silently fell back to the slow static split. Nothing reported it, because the fallback still builds correctly, just slowly.

## Measured both ways

| | result |
| --- | --- |
| this host (store tools not installed) | static split, as before |
| `NROS_STORE` → stub make 4.4.1 + ninja | **jobserver path** |

`nros sdk-path` honours `NROS_STORE`, so the second row is a real store lookup, not a mock.

## Fix

`build-all` now sources `jobserver-pool.sh` and calls `nros_pinned_make` and a new sibling, `nros_pinned_ninja`. Both build the path from the index pin and never search PATH (issue 0625), because a system make 4.3 that comes first on PATH would answer, and its jobserver can't be joined by ninja. The helpers return non-zero when a tool is absent, so each call is written `x="$(helper)" || x=""`. A bare assignment under the recipe's `set -e` would end the recipe (issue 1249).

## Gate coverage

`check-third-party-is-submodules` refused retired roots as **directories** but never checked who **reads** them. Its coverage was narrower than its rule (issue 0196), which is how these reads outlived the move. It now also scans what runs (justfile, `just/`, `scripts/`, `cmake/`, `.github/`) for code that reads a root retired by RFC-0095 D3 or RFC-0075 (`make`, `ninja`, `ros`, `zenoh`).

- It runs as a single `git grep`, and any exit status above 1 means the scan did not run. That exits 2 instead of passing as a clean tree.
- The pattern contains **no `\b`**. `\b` is zero-width, and ugrep rejects it outright. My first dry run of this rule sent stderr to `/dev/null` and reported "no references" over a tree that contained five. That is exactly the failure this gate exists to prevent, and I reproduced it while writing it.
- Comment lines are treated as prose, not reads, because several comments correctly explain the retirement.
- `REF_EXCEPTIONS` has one entry, `msg_to_cyclone_idl.py`. It checks the store first and deliberately keeps the pre-phase-440 `third-party/ros/rosidl` as a fallback below it. The list can only shrink, and an entry whose file stops reading a retired root fails as stale.

**Controls:**
- Emptying `REF_EXCEPTIONS` makes the gate flag `msg_to_cyclone_idl.py:84` and `:90`.
- A bogus entry is flagged as stale.
- Run against `origin/main`'s justfile, the pattern finds exactly the three reads this PR fixes.
- The new selftest cases exercise the same classifier.

## Verification

- `bash -n` passes on both scripts.
- `just check set-e-bare-assignment` passes.
- `just check fast` passes 292 of 293. The one failure is this gate itself, reporting two **untracked** directories on the machine I wrote this on (`third-party/make`, `third-party/ros`). They are leftovers on that host, not part of this change.

**Not changed:** the `[prereq.make]` comment in `nros-sdk-index.toml` is also stale. It says "there is no `[tool.make]`", but one exists. Fixing it properly means giving the prereq `providers`, which changes provisioning behaviour. That belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lee2SrWhASryz9dd5F28mS
