### PR TITLE
docs(phase-443) + fix(#1211): what landed, and a gate that read the filesystem

### DIFF
--- a/docs/roadmap/phase-443-release-composition.md
+++ b/docs/roadmap/phase-443-release-composition.md
@@ -1,6 +1,7 @@
 # Phase 443 — release composition
 
-**Status (2026-09-10). All work items open.** Implements
+**Status (2026-09-10). All six work items implemented; W1/W5 and W3/W4 are in
+review.** Implements
 [RFC-0097](../design/0097-release-composition-and-version-axes.md). Makes the
 `nano-ros` release say what it contains, so the axis that carries compatibility
 can be read without reading the ones that do not.
@@ -115,6 +116,68 @@ whether an upgrade costs them a re-emit, which is the whole user-visible point.
 W3 is independent. W4 and W5 are small correctness fixes to phase-440's own
 work. W6 is docs and can land any time, but it is what makes the product usable
 by someone who has not read this repository.
+
+## What landed, and where the plan was wrong
+
+| item | PR | note |
+| --- | --- | --- |
+| RFC-0097 | #841 | merged |
+| W6 — product shape | #852 | merged |
+| W2 — the release declares its components | #859 | merged |
+| W1 + W5 — index leaves the binary; `--check` covers the build stage | #854 | in review |
+| W3 + W4 — the launcher is its own crate; CI does not choose a toolchain | #860 | in review |
+
+W1 and W5 shipped together because both edit `cmd/setup.rs`; W3 and W4 because
+both live in the launcher. That was a scheduling choice, not a design one.
+
+### D9 is a decision, not a description — `nros sync` is NOT merged into `nros build`
+
+Measured while writing W6's documentation, on a fresh copy of
+`examples/templates/multi-node-workspace` with `generated/` and `build/` removed:
+
+```
+$ nros build --dry-run
+Error: missing prerequisites for this build:
+  - generated message bindings (this workspace has never been synced)
+      run: nros sync
+```
+
+raised by `builder::preflight::check`. So the docs claiming "`nros build` runs
+`nros sync` for you" were the false ones and were corrected; the ones telling a
+user to sync first are currently right. **D9 remains unimplemented**, and
+nothing in W1–W6 assumes otherwise. Whoever implements it should expect the doc
+edits to move back.
+
+### W4's refusal is at the BUILD seam, not the launcher
+
+W4's acceptance said "non-interactive + no pin ⇒ refuse". The implementation
+splits it, and the split is right: **the launcher parses no `argv`** (D8), so a
+refusal there would also refuse `nros --version`, `nros setup --list` and
+`nros doctor` on every runner — commands that write nothing and have no
+reproducibility to protect. The launcher therefore emits a loud line naming the
+version it took and the pin that would fix it (`Source::DefaultInCi`), and the
+refusal lives where the verb is known.
+
+### A build-stage source needs a RESOLVABLE location, not a `dest`
+
+W5's first rule was `build_stage && dest.is_none() ⇒ refuse`, because the report
+asks whether `dest` is populated. phase-440 (#830) then gave `[source.rosidl]`
+`location = "store"` and REMOVED its `dest` — deliberately, since RFC-0095 D2
+derives a store path so nobody can spell it twice. `rosidl` is simultaneously
+the only build-stage source, so the two correct rules meeting refused the
+SHIPPED index. Measured by restoring the old rule: **9 tests fail, not 2** —
+every test that loads `nros-sdk-index.toml`, i.e. an `nros` that cannot read its
+own manifest. The rule is now "can anything name where this lives".
+
+### The ETXTBSY helper has ONE home, and it is the launcher
+
+Two work items independently hit issue 0476 — a test writes or copies an
+executable and then execs it, and `O_CLOEXEC` closes at exec, not fork, so a
+sibling thread's fork holds a write handle. Measured at 4/60 failures on a
+loaded machine, 0/60 with the fix. Both fixes were correct; the placement is
+decided by layering. `nros-cli-core` DEPENDS on `nros-launcher` after W3, so the
+helper lives in `nros-launcher` and cli-core re-exports it — a helper about a
+race is the worst kind to keep two copies of.
 
 ## Non-goals
 

--- a/scripts/check-package-directories.py
+++ b/scripts/check-package-directories.py
@@ -31,11 +31,23 @@ is how `packages/codegen` outlived its own retirement note.
 Run: python3 scripts/check-package-directories.py [--self-test]
 """
 
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+from git_hook_env import nros_clear_inherited_git_env  # noqa: E402
+
+# Before the first git call, at module scope so no entry path can skip it. The
+# self-test below builds a throwaway repository, and an inherited `GIT_DIR`
+# overrides both `cwd=` and `git -C` (issue 0986). This gate is on
+# `check-fast`, which the pre-push hook runs, so that environment is the
+# NORMAL one here, not an exotic case.
+nros_clear_inherited_git_env()
 
 # Each site states the set once, as a brace list. The regex spans newlines
 # because both files wrap it -- ARCHITECTURE breaks inside the braces.
@@ -48,7 +60,34 @@ BRACE_LIST = re.compile(r"`packages/\{([^}]*)\}/`", re.S)
 
 
 def actual_dirs(repo):
-    return sorted(p.name for p in (Path(repo) / "packages").iterdir() if p.is_dir())
+    """The package directories the REPOSITORY has, from git rather than disk.
+
+    `iterdir()` was the first version and it reported a contributor's local
+    tooling state as a documentation defect: an untracked
+    `packages/.claude/settings.local.json` made this gate red on a docs-only
+    commit, blaming CLAUDE.md and ARCHITECTURE for "omitting .claude" — two
+    files that would be wrong to mention it.
+
+    The documented list describes the workspace, and a directory git tracks
+    nothing in is not part of it. This is also the repo's standing rule for
+    enumerating the tree: ask git, never walk the filesystem.
+
+    A directory holding only ignored or untracked files therefore does not
+    appear, which is the intended difference and not an oversight.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(repo), "ls-files", "-z", "--", "packages/"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    names = set()
+    for rel in out.split("\0"):
+        parts = rel.split("/")
+        # "packages/<name>/..." — a file directly in packages/ names no dir.
+        if len(parts) >= 3 and parts[0] == "packages":
+            names.add(parts[1])
+    return sorted(names)
 
 
 def offenders(repo=None):
@@ -100,7 +139,25 @@ def self_test():
         root = Path(td)
         for name in ("alpha", "beta"):
             (root / "packages" / name).mkdir(parents=True)
+            # A TRACKED file, because `actual_dirs` asks git and a directory
+            # git knows nothing about is deliberately invisible to it.
+            (root / "packages" / name / "Cargo.toml").write_text("[package]\n")
         (root / "docs" / "design").mkdir(parents=True)
+        # A real repository: the enumeration is a `git ls-files`, so a plain
+        # temp tree would exercise a code path that does not exist.
+        env = nros_clear_inherited_git_env(dict(os.environ))
+        for args in (
+            ["init", "-q"],
+            ["-c", "user.email=t@t", "-c", "user.name=t", "add", "-A"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(root), *args], check=True, env=env, capture_output=True
+            )
+        # The local dirt that made this gate red on a docs-only commit: an
+        # untracked dot-directory under `packages/`. It must NOT be reported,
+        # and `iterdir()` reported it.
+        (root / "packages" / ".claude").mkdir()
+        (root / "packages" / ".claude" / "settings.local.json").write_text("{}\n")
         for i, (body, want, want_why, name) in enumerate(cases):
             text = f"Workspace: `packages/{body}/`, examples/.\n" if body.startswith("{") else body
             for rel in SITES:


### PR DESCRIPTION
Two commits, both fallout from finishing phase-443.

## `docs(phase-443)` — what landed, and the four places the plan was wrong

The phase doc said *"all work items open"* while five of six were merged or in review, and recorded nothing about what implementation discovered. A plan that only records its intentions is a plan nobody can learn from. Four corrections, each measured:

- **D9 is a decision, not a description.** `nros sync` is **not** merged into `nros build` — a fresh workspace answers `nros build --dry-run` with *"this workspace has never been synced"*, from `builder::preflight::check`. The docs claiming otherwise were the false ones and were corrected in #852. D9 remains unimplemented, and nothing in W1–W6 assumes it.
- **W4's refusal belongs at the build seam, not the launcher.** The launcher parses no `argv` (D8), so refusing there would also refuse `nros --version` and `nros doctor` on every runner — verbs that write nothing and have no reproducibility to protect.
- **A build-stage source needs a resolvable *location*, not a `dest`.** W5's rule and #830's store move were each correct and together refused the shipped index; restoring the old rule fails **9** tests, not 2.
- **The ETXTBSY helper has one home.** Two work items hit issue 0476 independently; layering decides placement, because `nros-cli-core` depends on `nros-launcher` after W3.

## `fix(#1211)` — the layout gate read the filesystem

`check-package-directories` walked `packages/` with `iterdir()`, so an untracked `packages/.claude/settings.local.json` — one contributor's tool state, dated April, tracked by nothing — made the gate red on a **docs-only** commit:

```
CLAUDE.md: omits .claude
docs/design/ARCHITECTURE.md: omits .claude
```

blaming two files that would be wrong to mention it. Any local directory does this, to anyone who has one.

The documented list describes the *workspace*, and a directory git tracks nothing in is not part of it — which is also this repo's standing rule for reading the tree. The self-test built a plain temp directory, so it could not have caught this; it builds a real repository now, with an untracked `packages/.claude` beside the tracked packages. **Verified by mutation:** restoring `iterdir()` fails 4 of 6 cases, one reproducing the live message verbatim.

`git init` in a script the pre-push hook reaches needs the inherited git environment cleared first (issues 0986/0988) — `GIT_DIR` overrides both `cwd=` and `git -C`, and every agent worktree sets it. Uses the existing `scripts/lib/git_hook_env.py` helper, the idiom three sibling gates already follow.

`just check fast` 292/292 (1 env-skipped).

> Note for the maintainer: `packages/.claude/settings.local.json` is still on disk here. It is untracked and I have not touched it — it looks like local settings, not debris, so it is yours to keep or remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)