### PR TITLE
docs(#1264, #1266, #1267, #1273, #1274, #1275): what provisioning a runner from scratch measured

### DIFF
--- a/docs/issues/1264-platform-rmws-swallows-parser-stderr.md
+++ b/docs/issues/1264-platform-rmws-swallows-parser-stderr.md
@@ -1,0 +1,95 @@
+---
+id: 1264
+title: "`nros_platform_rmws` redirects the manifest parser's stderr to
+  /dev/null, so an interpreter that cannot read `fixtures.toml` is reported
+  as a platform that does not exist"
+status: open
+type: bug
+area: build, testing
+severity: medium
+found: 2026-09-10
+related: [phase-395]
+---
+
+## What this is
+
+`scripts/build/platform-rmws.sh`:
+
+```sh
+out="$(python3 "$root/scripts/build/fixtures-manifest.py" coords 2>/dev/null \
+    | awk -F'\x1f' -v p="$platform" '$2 == p { print $4 }' \
+    | grep -v '^$' \
+    | sort -u)"
+
+if [ -z "$out" ]; then
+    echo "nros_platform_rmws: no fixture rows for platform '$platform'" >&2
+    echo "  (known platforms come from examples/fixtures.toml)" >&2
+    return 1
+fi
+```
+
+Empty output has two causes and the function reports one of them. The parser
+printing nothing because the platform genuinely has no rows is the case the
+message describes. The parser DYING is the case it does not: `2>/dev/null`
+discards the traceback, the pipeline's status is `sort`'s, and `$out` is empty
+either way.
+
+## How it was found
+
+Provisioning a contained self-hosted runner on Ubuntu 22.04:
+
+```
+nros_platform_rmws: no fixture rows for platform 'threadx-riscv64'
+  (known platforms come from examples/fixtures.toml)
+error: recipe `setup` failed with exit code 1
+```
+
+`threadx-riscv64` appears in `examples/fixtures.toml` 42 times, with four
+`platform = "threadx-riscv64"` rows. The real cause was three layers away:
+Ubuntu 22.04 ships python3.10, which has no `tomllib`; `fixtures-manifest.py`
+falls back to `tomli`, which was not installed either; so it raised
+`ModuleNotFoundError` before reading a byte of the manifest.
+
+Running the same command by hand — without the redirect — says so in one line.
+The diagnosis cost far more than that, because the message was specific,
+confident, and about the wrong subject. It aims the reader at the manifest and
+at the platform NAME, which are both fine.
+
+## Why it matters beyond one host
+
+The message is load-bearing by design. The file says so:
+
+```
+# Deliberately NOT silent on failure: a platform with no rows is a caller error
+# (a typo'd name), and returning "nothing to provision" for it would reproduce
+# the bug this fixes one level up.
+```
+
+That reasoning is right, and the redirect defeats it for every failure mode
+that is not a typo. A probe that can only return "nothing" reads exactly like a
+clean result — the shape this repo has paid for repeatedly (the vacuous-test
+gate, the staleness probe, `check-one-producer-per-tool`'s own positive
+control).
+
+## Fix
+
+Distinguish the two. Capture stderr rather than discarding it, and check the
+parser's exit status separately from the emptiness of its output — noting
+issue 1249's rule, that a status meant for inspection dies at the assignment
+under `set -e` unless it is written `rc=0; out="$(...)" || rc=$?`.
+
+On a non-zero status, report what the parser said. On a zero status with empty
+output, the current message is correct and should stay exactly as it is.
+
+## Sweep
+
+`2>/dev/null` on a call whose emptiness is then interpreted is the class, not
+this one site. Grep for the pattern across `scripts/` before closing, and fix
+the siblings in the same commit.
+
+## Not this issue
+
+That the runner image lacked `tomli` is a container-provisioning gap, fixed in
+`scripts/ci/runner-bootstrap.sh` (PR #842). This issue is that the failure was
+unreadable, which would have been just as true on any python3.10 host without
+`tomli` installed.

--- a/docs/issues/1266-setup-fetch-blocks-extract.md
+++ b/docs/issues/1266-setup-fetch-blocks-extract.md
@@ -1,0 +1,85 @@
+---
+id: 1266
+title: "`nros setup` downloads, verifies and unpacks one package strictly in
+  series, and the download is silent — a 1.4 GB fetch is 15 minutes of a log
+  that looks hung"
+status: open
+type: tech-debt
+area: cli, build
+severity: medium
+found: 2026-09-10
+related: [issue-1267, issue-0374, issue-0385, rfc-0014]
+---
+
+## What this is
+
+`orchestration/sdk_store.rs::execute_install`, the `InstallAction::Prebuilt`
+arm, is three blocking steps in a row:
+
+```rust
+sh(&["curl", "-L", "--fail", "--silent", "--show-error", "-o", &archive…, url])?;
+verify_sha256(&archive, sha256)?;
+sh(&["tar", "-xf", &archive…, "-C", &prefix…])?;   // or the dist's own `install`
+```
+
+Network, then CPU, then disk — and nothing overlaps. While `tar` decompresses
+one package the link is idle; while `curl` runs the CPU is idle. The loop in
+`cmd/setup.rs:342` then starts the next package's `curl` only after this
+package's `tar` has finished, so the whole provisioning run alternates between
+using the network and using the machine, never both.
+
+## The silence is the part that gets reported first
+
+`curl` is invoked `--silent --show-error`. That is the right pair for a short
+fetch and wrong for a long one: no progress, no byte count, no rate.
+
+Measured on a contained-runner bootstrap, 2026-09-10:
+
+```
+21:49:55   nros setup --tool zephyr-sdk: prebuilt 0.16.8 (dist linux-x86_64)
+                → /home/runner/src/nano-ros/scripts/zephyr/sdk
+   …15 minutes with no further output at all…
+```
+
+The store was growing the whole time (~0.8 MB/s, checked with `du`), so nothing
+was wrong. But the only way to learn that was to `du` the store from outside the
+process. An operator watching the log sees a tool that stopped, and the honest
+reading of a 15-minute gap is "this is wedged", which is how a healthy
+provisioning run gets killed and restarted.
+
+## Fix
+
+Two independent pieces; either is worth having alone.
+
+**Progress.** Drop `--silent` for a fetch whose declared size is large, or use
+`--progress-bar` / `-w` to emit a periodic line. The constraint is that the
+output must stay readable when it is not a TTY — CI logs and
+`tmp/runner-bootstrap.log` are the normal case here, and a carriage-return
+progress bar renders in them as one very long line. A byte-count line every N
+seconds survives both.
+
+**Overlap.** Fetch package *n+1* while package *n* verifies and unpacks. That is
+a one-deep pipeline, not general concurrency: it needs no new policy about the
+store layout, the lock file, or ordering, because only one package is ever being
+INSTALLED. Issue 1267 is the larger change; this one is cheap and independent of
+it.
+
+`plan_install` is already pure (`Pure — does no I/O beyond reading the
+provenance marker`) and issue 0374 already added a pre-pass that resolves the
+whole plan before the first fetch. The separation a pipeline needs therefore
+exists; what is missing is a fetch that can be started early.
+
+## What NOT to do
+
+Do not reach for a download accelerator here on the strength of `aria2` being in
+the index. That entry is declared for `west sdk install` — Zephyr's own tool
+uses it — and is not a claim about our fetch path. Adding a second downloader
+beside `curl` is a second producer for one job, which is the shape
+`check-one-producer-per-tool` exists to refuse.
+
+## Where this was measured
+
+A contained self-hosted runner bootstrap on this workstation: 24 `nros setup`
+invocations across 11 distinct tools, plus the Zephyr SDK, plus source builds
+for `play_launch_parser` and `espflash`. The pre-Zephyr steps ran mostly warm
+(the store already held them) and the Zephyr SDK fetch was cold.

--- a/docs/issues/1266-setup-fetch-blocks-extract.md
+++ b/docs/issues/1266-setup-fetch-blocks-extract.md
@@ -8,7 +8,7 @@ type: tech-debt
 area: cli, build
 severity: medium
 found: 2026-09-10
-related: [issue-1267, issue-0374, issue-0385, rfc-0014]
+related: [issue-1267, issue-1273, issue-1274, issue-1275, issue-0374, issue-0385, rfc-0014]
 ---
 
 ## What this is

--- a/docs/issues/1267-setup-installs-packages-one-at-a-time.md
+++ b/docs/issues/1267-setup-installs-packages-one-at-a-time.md
@@ -1,0 +1,95 @@
+---
+id: 1267
+title: "`nros setup` installs its packages one at a time — the loop is
+  sequential in the CLI, so no caller can parallelise it"
+status: open
+type: tech-debt
+area: cli, build
+severity: medium
+found: 2026-09-10
+related: [issue-1266, issue-0374, issue-0500, rfc-0014]
+---
+
+## What this is
+
+`cmd/setup.rs:342`:
+
+```rust
+for name in &packages {
+    …
+    let action = plan_install(tool, &host, &prefix);
+    …
+    let provenance = execute(&other, name, &tool.version, &prefix, &tool.front)?;
+    lock.record(name, &provenance);
+}
+```
+
+One package at a time: resolve, download, unpack, record, next. There is no
+`rayon`, no `par_iter` and no spawn anywhere in the setup path — a grep across
+`packages/cli` (excluding `third-party/`) finds concurrency only in
+`test_support.rs`, `cargo-nano-ros/src/workflow.rs`, and play_launch.
+
+This is not something a caller can work around. `just setup <plat>` is a thin
+caller over `nros setup` — 81 call sites in `just/*.just`, zero `curl`/`wget`/
+`pip`/`apt-get install` in any setup recipe, and `check-one-producer-per-tool`
+holds it that way. So the serialisation is in the one place that does the work,
+and both the user front door (`nros setup`) and the dev front door (`just setup
+…`) inherit it.
+
+## Why the packages are safe to parallelise
+
+Each `[tool.*]` installs into `tool_prefix(root, name, version)` — a path keyed
+by name AND version — so two packages never write the same directory. The
+prefixes are disjoint by construction, not by convention.
+
+## Why it is still not a two-line change
+
+Four things are shared, and each needs a decision rather than a guess:
+
+1. **The lock file.** `lock.record(name, &provenance)` mutates one `lock` and
+   `lock.save(&lock_path)` writes once at the end. A join-then-record keeps the
+   current single-writer shape; recording from inside the workers does not.
+
+2. **`front_newest`.** `execute` fronts the tool into the shared store root
+   after installing. Two concurrent fronts touch the same front directory, and
+   the ordering rule they implement is issue 0500's: prefixes resolve
+   newest-version-first, and a stale entry that shadows a fresh one is a bug
+   that prints success on both paths. Fronting is the step that must stay
+   ordered even if the installs do not.
+
+3. **`bin_dirs`.** Pushed in loop order and folded onto the emitted
+   CMakePreset's `environment.PATH`. PATH order is significant; a parallel loop
+   must preserve the plan's order rather than completion order.
+
+4. **Output.** `eprintln!("  {:<22} {}", name, …)` interleaved across workers is
+   unreadable. Buffer per package and flush on completion, in plan order.
+
+Two further limits worth naming so nobody is surprised by the speedup being
+smaller than the package count. Source builds (`play_launch_parser`, `espflash`,
+qemu) each already use the whole machine through cargo/ninja, so running two
+concurrently mostly moves contention around — the win there is overlapping a
+source BUILD with another package's DOWNLOAD, not two builds. And a concurrency
+of N against one host saturates the link long before it saturates the CPU: on
+the run this was found in, the measured rate was ~0.8 MB/s.
+
+## Fix
+
+A bounded worker pool over the already-resolved plan, defaulting to a small
+number (4) and overridable. Keep the three ordered steps ordered: record, front,
+and print in plan order after the join.
+
+The plan/execute split this needs already exists — issue 0374 added a pre-pass
+that resolves the whole plan before the first fetch, so `source_build_names`
+could announce the long builds up front, and `plan_install` is documented as
+pure.
+
+Issue 1266 is the cheaper, independent half: overlapping the fetch of one
+package with the unpack of the previous one needs none of the four decisions
+above, because only one package is ever being installed.
+
+## Where this was measured
+
+A contained self-hosted runner bootstrap on this workstation, 2026-09-10: 24
+`nros setup` invocations across 11 distinct tools, plus the Zephyr SDK and two
+source builds. The same loop is every contributor's first hour, not only a
+runner's.

--- a/docs/issues/1267-setup-installs-packages-one-at-a-time.md
+++ b/docs/issues/1267-setup-installs-packages-one-at-a-time.md
@@ -7,7 +7,7 @@ type: tech-debt
 area: cli, build
 severity: medium
 found: 2026-09-10
-related: [issue-1266, issue-0374, issue-0500, rfc-0014]
+related: [issue-1266, issue-1273, issue-1274, issue-0374, issue-0500, rfc-0014]
 ---
 
 ## What this is
@@ -86,6 +86,23 @@ pure.
 Issue 1266 is the cheaper, independent half: overlapping the fetch of one
 package with the unpack of the previous one needs none of the four decisions
 above, because only one package is ever being installed.
+
+## Do the cheaper things first
+
+Two changes reduce what there is to parallelise, and neither needs any of the
+decisions above:
+
+* **issue 1273** — a tool that builds from source does so because the index has
+  no `dist` row for the host. Each source build removed is a serialisation point
+  removed, not just minutes: a source build takes the whole machine while the
+  network is idle, which is the ceiling on any worker pool here.
+* **issue 1274** — ask for the session's system packages ONCE, up front, instead
+  of printing an overlapping `apt install` line per `nros setup` call.
+
+DECIDED (2026-09-10): the same "gather, then do once" idea applies to stages
+beyond apt (`rustup target add`, repeated `--source` provisioning, re-resolved
+tools). Survey them when taking this issue rather than guessing the list — see
+1274.
 
 ## Where this was measured
 

--- a/docs/issues/1273-prefer-prebuilt-dist-over-source-build.md
+++ b/docs/issues/1273-prefer-prebuilt-dist-over-source-build.md
@@ -1,0 +1,93 @@
+---
+id: 1273
+title: "Tools that build from source do so because the index has no `dist` row
+  for the host, not because they must be built — the fix is index rows, not
+  CLI code"
+status: open
+type: tech-debt
+area: cli, build
+severity: medium
+found: 2026-09-10
+related: [issue-1266, issue-1267, issue-1274, rfc-0014, rfc-0062]
+---
+
+## What this is
+
+`plan_install` already prefers a prebuilt:
+
+```rust
+if Provenance::read(prefix).is_some()    { return InstallAction::Present }
+if let Some(d) = tool.dist_for(host)     { return InstallAction::Prebuilt { url, sha256, install } }
+if let Some(s) = &tool.source            { return InstallAction::Source { … } }
+```
+
+So a source build never means "this tool must be compiled". It means **the
+index has no `dist.<host>` row for it**. 15 tools carry one. The two that built
+from source during a contained-runner bootstrap were `espflash` and
+`play_launch_parser` — and each has a different right answer.
+
+No CLI change is needed for either. This is index and release work.
+
+## espflash — point at the upstream asset
+
+`[tool.espflash]` carries `upstream = "v4.5.0"` (the esp-rs release tag) and a
+`[tool.espflash.source]` recipe, and no dist. esp-rs publishes release binaries.
+A `dist.linux-x86_64 = { url, sha256 }` naming the upstream asset directly is
+all it needs.
+
+That pattern is already in the tree with its rationale written down, on
+`[tool.zephyr-sdk]`:
+
+> UNLIKE every other `[tool.*]` here, these URLs are UPSTREAM rather than
+> repackaged into NEWSLabNTU/nano-ros-sdk. Deliberate: the archive is 1.3 GiB
+> and we apply nothing to it, so a repack would cost a release asset per host
+> to add zero value.
+
+Two consequences that entry also records and a new one must respect: the
+archive's compression decides whether `sdk_store.rs`'s `zstd` preflight applies,
+and an upstream layout that is not `<prefix>/bin` needs the dist's own `install`
+step.
+
+**Survey the other source-only tools the same way** rather than fixing only the
+two this bootstrap happened to build. `cargo-nextest`, `sccache`, `mdbook`,
+`rustfilt`, `cargo-llvm-cov` and `cargo-show-asm` all publish release binaries
+upstream; each needs the same one-line row, or a recorded reason why not.
+
+## play_launch_parser — we build the dist, on our schedule
+
+DECIDED (2026-09-10): building it is fine, and we publish the artifact
+ourselves. `play_launch` has its own release cycle, so waiting on an upstream
+asset is waiting on somebody else's calendar for a repo we own.
+
+So: build it once, publish the dist into `NEWSLabNTU/nano-ros-sdk` the way the
+other repacked tools are published, and add the `dist.linux-x86_64` row. The
+index's `upstream = "838ce948…"` pin stays the record of what was built.
+
+## NOT cargo-binstall
+
+DECIDED (2026-09-10): not for now.
+
+It was considered and the reason to decline is worth keeping, because it will
+come up again. binstall resolves at RUN time from crates.io metadata and GitHub
+releases. The index's contract is the opposite of that: a pinned `url` plus
+`sha256`, `verify_sha256` before unpack, a `Provenance` marker written at the
+prefix, and a recorded `nros-sdk.lock` — the "locked in nros-sdk.lock" line
+every successful `nros setup` prints IS that promise. A binstall call inside
+`execute_install` would fetch something nobody pinned and nothing verified.
+
+It would also be a THIRD acquisition path beside `dist` and `source`, which is
+what `check-one-producer-per-tool` exists to refuse — it refused an
+apt-installed `make`/`ninja` in the runner image for exactly this reason
+(PR #842).
+
+If it returns, the shape that keeps both properties is binstall used
+MAINTAINER-SIDE and offline, as the thing that MINTS a dist row: resolve the
+asset, hash it, write `url + sha256` into the index. Same speed at install time,
+pin preserved, no new runtime path.
+
+## Why it is worth doing
+
+A source build is not just slower than a download — it takes the whole machine
+while the network sits idle, which is issue 1267's ceiling on any parallel
+install. Removing a source build removes a serialisation point, not only
+minutes.

--- a/docs/issues/1274-batch-system-package-ask-across-session.md
+++ b/docs/issues/1274-batch-system-package-ask-across-session.md
@@ -1,0 +1,80 @@
+---
+id: 1274
+title: "The system-package ask is batched inside one `nros setup` call and not
+  across a session, so one bootstrap prints three overlapping `apt install`
+  lines and acts on none of them"
+status: open
+type: tech-debt
+area: cli, build
+severity: medium
+found: 2026-09-10
+related: [issue-1266, issue-1267, issue-1273, issue-0368]
+---
+
+## What this is
+
+Within one `nros setup` call the packages are already composed into a single
+command — the batching people ask for exists:
+
+```
+sudo apt-get install -y aria2 doxygen graphviz libz3-dev make ninja-build parallel \
+  || { sudo apt-get update && sudo apt-get install -y … }
+```
+
+What does not exist is batching ACROSS the several `nros setup` calls a
+provisioning session makes. Measured on one contained-runner bootstrap
+(`just setup base`, then `qemu`, `threadx_riscv64`, `zephyr`): that block was
+printed THREE times with DIFFERENT subsets —
+
+```
+…install -y aria2 doxygen graphviz libz3-dev make ninja-build parallel
+…install -y aria2 doxygen graphviz libz3-dev parallel
+…install -y aria2 doxygen graphviz libz3-dev parallel
+```
+
+— so a contributor who runs the first command is still told about it twice more,
+and one who reads only the last is told about a subset.
+
+## And it prints rather than runs, on purpose
+
+This is not a bug to fix by adding sudo. Phase-327 W2 / issue 0368 F1: no
+provisioning step runs sudo, because one sudo failure used to cascade and abort
+every sudo-less step after it. `nros setup --system --sudo` exists for an
+operator who wants it executed.
+
+The problem is WHEN the ask happens, not that it is an ask. It arrives in the
+middle of a long run, is non-fatal by design, and therefore scrolls past. On a
+host where nobody can act on it — a container is the honest case, since
+`--cap-drop ALL --security-opt no-new-privileges` with a non-root user means
+`sudo apt` can NEVER succeed inside it — the notice is pure noise, and the run
+ends one package short of a label it claims.
+
+That is not hypothetical: it is how the runner image shipped five packages short
+(`aria2`, `doxygen`, `graphviz`, `libz3`, `gnu-parallel`), and separately how
+`wget` reached a 1.4 GiB download before failing at exit 91 (issue filed and
+fixed in PR #842).
+
+## Fix
+
+Resolve the union of every system package the WHOLE session needs, before any
+download starts, and ask once. A preflight, not a running commentary.
+
+Two properties to keep:
+
+* still no sudo by default — one printed command, or `--sudo` to execute it;
+* still per-manager, through the index (`prereq-packages.py` / `PrereqContext`),
+  never a hand-written list beside it (RFC-0062).
+
+## Batching is not only apt
+
+DECIDED (2026-09-10): the same "gather, then do once" applies to other stages of
+provisioning, and the survey belongs to whoever takes this issue rather than
+being guessed at here. Candidates seen in one bootstrap: `rustup target add`
+(invoked per platform verb, and `just workspace rust-targets` already has the
+shared list), submodule provisioning (`nros setup --source` called repeatedly
+with overlapping sets), and the repeated `nros setup --tool corrosion:
+present (skip)` lines that re-resolve the same tools per verb.
+
+Survey first, then batch what the survey justifies. A batch of one is a
+refactor with no payoff, and a batch of the wrong things reorders work that had
+an ordering reason (issue 0500).

--- a/docs/issues/1275-zephyr-manifest-pulls-unused-hals.md
+++ b/docs/issues/1275-zephyr-manifest-pulls-unused-hals.md
@@ -1,0 +1,104 @@
+---
+id: 1275
+title: "The west manifest's HAL allowlist pulls 2.5 GB of vendor HALs no board
+  we build needs — and whether Zephyr's espressif support makes our ESP-IDF
+  path a duplicate is an open question"
+status: open
+type: tech-debt
+area: build, testing
+severity: medium
+found: 2026-09-10
+related: [issue-1266, issue-1267, issue-1274]
+---
+
+## What this is
+
+`west.yml` narrows Zephyr's ~90 modules to 11 with a `name-allowlist`, which is
+the right shape. The question is which 11. Measured against an existing
+workspace on this host:
+
+| module | size | needed by |
+| --- | --- | --- |
+| `hal_nxp` | 1.3 G | nothing we build |
+| `hal_stm32` | 764 M | nothing we build |
+| `hal_espressif` | 275 M | see below |
+| `hal_nordic` | 224 M | nothing we build |
+| `cmsis` | 6.6 M | mps2_an385, qemu_cortex_a53 |
+
+Every Zephyr board in `examples/fixtures.toml`:
+
+```
+72  board = "native_sim/native/64"
+ 3  board = "mps2_an385"
+ 1  board = "qemu_cortex_a53/qemu_cortex_a53/smp"
+```
+
+`native_sim` needs no vendor HAL at all; the other two need `cmsis`. So roughly
+**2.5 GB of every `west update` is for silicon nothing in this repo targets** —
+paid by CI on every fresh workspace and by every contributor on their first
+setup.
+
+The manifest says as much itself:
+
+```yaml
+# HALs (add more as needed for your boards)
+- hal_stm32
+- hal_nordic
+- hal_espressif
+- hal_nxp
+```
+
+Added ahead of need, and nothing since has needed them.
+
+## Do not just delete the four
+
+Three of them (`hal_nxp`, `hal_stm32`, `hal_nordic`) have no plausible consumer
+here and the change is a four-line diff. But prove it rather than assume it: a
+Zephyr `prj.conf` or board fragment can pull a module without any fixture naming
+the board. Grep the conf tree and build one native_sim and one mps2_an385 leaf
+against the narrowed manifest before closing.
+
+Removing a module from the allowlist also does not reclaim an EXISTING
+workspace — `west update` does not prune. Say so in the change, or a reader
+measures no improvement and reverts it.
+
+## The espressif half is a real question, not a cleanup
+
+DECIDED (2026-09-10): research this separately rather than folding it into the
+allowlist change.
+
+esp32 IS a nano-ros platform — `platform = "esp32"` rows exist in
+`examples/fixtures.toml`, and `just/esp_idf.just` provisions the ESP-IDF
+toolchain for `esp32-c3-baremetal`. But that path builds through ESP-IDF, not
+through Zephyr, so `hal_espressif` in the Zephyr workspace is very likely unused
+by it.
+
+The larger question that raises: **Zephyr ships an espressif toolchain of its
+own, so is our separate ESP-IDF provisioning a duplicate?** If a Zephyr-hosted
+esp32 build would serve the same coordinates, we are carrying two toolchains,
+two provisioning paths and two sets of build rules for one target — which is the
+"two producers for one prefix" shape (issue 0500) one level up, at the toolchain
+rather than the tool.
+
+What the research has to answer, in this order:
+
+1. Does anything in the tree build an esp32 image THROUGH Zephyr today, or is
+   every esp32 coordinate ESP-IDF? (`examples/fixtures.toml`, the esp32 leaves,
+   `just/esp32.just` vs `just/esp_idf.just`.)
+2. If it is all ESP-IDF: does `hal_espressif` have any other consumer? If not,
+   it leaves the allowlist with the other three.
+3. Separately, and NOT a prerequisite for (2): could the ESP-IDF path be served
+   by Zephyr's espressif support instead? That is a platform-strategy question
+   with real costs on both sides — ESP-IDF is what Espressif supports and what
+   the esp32 examples are written against — so it wants a measurement and an RFC,
+   not a decision taken while deleting a manifest line.
+
+Answering (1) and (2) is enough to act on the allowlist. (3) can stay open.
+
+## Where this was measured
+
+A contained self-hosted runner bootstrap, 2026-09-10. `west update` spent the
+bulk of its wall time on `hal_espressif`, `hal_nordic`, `hal_nxp` and
+`hal_stm32`, in that order, before reaching `mbedtls`. It compounds with issue
+1266: that 2.5 GB is fetched in the middle of a sequence that reports no
+progress.


### PR DESCRIPTION
Six issues, all found by provisioning a contained self-hosted runner from an
empty store — which is the first environment in a long time to ask the
provisioning system every question honestly, with no warm caches and no
packages a developer laptop happens to have.

**Docs only.** No code in this PR. It is split out of #842 (the runner work) so
the findings reach `main` — and therefore `just issues` — while that PR is still
in flight, rather than sitting on a branch nobody queries.

| id | what |
| --- | --- |
| 1264 | `nros_platform_rmws` discards the manifest parser's stderr, so a python without `tomllib`/`tomli` is reported as a platform that does not exist — about a name present in that manifest 42 times |
| 1266 | fetch, verify and unpack are strictly serial, and `curl --silent` makes a 1.4 GB download look hung: 15 minutes of no output while the store grew the whole time |
| 1267 | the package loop is sequential in the CLI, so no caller can parallelise it; the prefixes are disjoint by construction, but the lock file, `front_newest`'s issue-0500 ordering, `bin_dirs`' PATH order and interleaved output each need a decision |
| 1273 | a tool builds from source because the index has no `dist.<host>` row, not because it must be built — index and release work, not CLI code |
| 1274 | the apt ask IS batched within one `nros setup` call and not across a session: one bootstrap printed it three times with three different subsets, and acted on none |
| 1275 | the west allowlist pulls 2.5 GB of vendor HALs (`hal_nxp` 1.3 G, `hal_stm32` 764 M, `hal_espressif` 275 M, `hal_nordic` 224 M) that no board in `fixtures.toml` needs |

Each records what was DECIDED, not only what was found, so the next person does
not re-litigate it:

* **cargo-binstall: no, for now.** It resolves at run time; the index's contract
  is a pinned `url` + `sha256`, verified before unpack, recorded in
  `nros-sdk.lock`. It would also be a third acquisition path beside `dist` and
  `source` — which `check-one-producer-per-tool` refused an apt-installed
  `make`/`ninja` for in #842. If it returns, it belongs maintainer-side, minting
  dist rows offline.
* **`play_launch_parser`: we build and publish the dist ourselves** into
  `nano-ros-sdk`. play_launch has its own release cycle; waiting on an upstream
  asset for a repo we own is waiting on our own calendar.
* **espflash and the other source-only tools: point at the upstream asset**, the
  pattern `[tool.zephyr-sdk]` already documents. Survey them all rather than
  fixing the two this bootstrap happened to hit.
* **Batching beyond apt** (`rustup target add`, repeated `--source`, re-resolved
  tools) is a survey for whoever takes 1274, not a guess made here.
* **The espressif HAL is held back from the allowlist change on purpose.** esp32
  IS a platform here, but it builds through ESP-IDF. Whether Zephyr's own
  espressif toolchain makes that a duplicate is a platform-strategy question
  worth measuring, not one to settle while deleting a manifest line.

Anyone working on the provisioning system: 1273, 1274 and 1275 are the
actionable ones, and 1273/1274 reduce what there is to parallelise before anyone
writes a worker pool for 1267.