### PR TITLE
feat(phase-436 A2): read the jitter and park probes from a C or C++ entry

### DIFF
--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -464,29 +464,38 @@ watched run.
 * **A1 — pin ASI to the phase-436 stack.** ASI pins `902ea135e`
   (2026-09-04), 851 commits behind main. Pin to this stack's head for the
   measurement work; re-pin to main once it merges.
-* **A2 — make the jitter probe READABLE from a C entry.** Nothing needs
-  declaring: `release-jitter-runtime`, like timer-overrun and alive
-  supervision, is spec-free — `check_release_jitter_rule` judges against the
-  spin cadence the caller already passes, so it runs on ASI as soon as the pin
-  moves. (An earlier draft of this item said a `MonitorSpec` was missing and
-  "nothing arms the rule". Wrong: only the rate and age rules take a declared
-  table, which the CLI bakes from the system model.)
+* **A2 — make the jitter probe READABLE from a C entry. Accessors DONE; the
+  cadence half is a design question, not the one-line call this said.**
+  Nothing needs declaring: `release-jitter-runtime`, like timer-overrun and
+  alive supervision, is spec-free. It judges against the spin cadence the
+  caller already passes, so it runs on ASI as soon as the pin moves. (An
+  earlier draft said a `MonitorSpec` was missing and "nothing arms the rule";
+  only the rate and age rules take a declared table.) What was missing is a way
+  out: a C entry's only signal was the violation line, at a whole period late.
 
-  What IS missing is a way out. On ASI's C arm the only signal is
-  `log_violation` — `contract violation: release-jitter-runtime …` — and it
-  fires only when a wake is a whole period late. The maximum, which is the
-  figure A3 compares against the trace, has no C or C++ accessor:
-  `release_jitter()` and `last_park()` are Rust-only. So A2 is an
-  `nros_cpp_executor_*` accessor for `(max_us, late, total)` and the park
-  attribution, plus the ASI side printing it on a cadence.
+  * **Delivered:** `nros_cpp_executor_release_jitter(handle, &max_us, &late,
+    &total, &granularity_us)` and `nros_cpp_executor_last_park(handle,
+    &bound_us, &achieved_us, &source, &platform_index)`, with `source` one of
+    `NROS_CPP_WAKE_SOURCE_*`. Every output pointer is optional.
+  * **Found while writing them:** `WakeSourceId`, `NextDeadlineFn`,
+    `ParkUntilFn` and `MAX_WAKE_SOURCES` were never re-exported from
+    `nros_node::executor`. `last_park()` returned a type no other crate could
+    name or match on, and the two registration calls took types nobody could
+    spell. Re-exported.
+  * **Reversed: do NOT make the Zephyr C arm call `set_spin_nominal_us`.** This
+    item said to, so the nominal would stop being inferred from the timeout.
+    But `release_jitter_granularity_us()` reads a declared cadence as "the
+    caller paces itself with a sleep finer than the wait" and reports 1 us. The
+    C arm is paced BY the wait: `spin_once(period_ms)`, which since W7 is the
+    tick-granular park. Declaring would make the report claim resolution the
+    loop does not have, which is issue 1194's failure. The API couples two
+    facts, the nominal to judge against and who paces the loop, and the C arm
+    needs the first without the second. Until they are split, the inferred
+    nominal (timeout == period) is the honest one there.
+  * **A2b — open:** split the nominal from the pacing claim, so a wait-paced
+    loop can declare its cadence without over-claiming.
+  * **Left for A3:** the ASI side printing these on a cadence.
 
-  The nominal it judges against is right on ASI only by coincidence: ASI's
-  FVP lane takes Zephyr's C arm, which does NOT call `set_spin_nominal_us` —
-  `zephyr_run_tiers.c` passes the tier period as the `spin_once` timeout
-  (`period_ms`, floored at `SPIN_PERIOD_FLOOR_MS = 1`), so the nominal is
-  inferred from the timeout and equals the declared 5 ms only because the two
-  are the same number. Make the C arm declare the cadence explicitly as part
-  of A2, so they stop being coupled by accident.
 * **A3 — a loaded FVP cross-check.** Run the control loop under load and
   compare `release_jitter()` and `last_park()` against an independent CTF
   capture of the same run. **Exit:** the probe's maximum and the trace's agree

--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -569,21 +569,37 @@ wired, so every other port parks on the millisecond `wake_wait_ms` floor.
   when that caller is bridged through a caller-owned deadline (or zenoh-pico
   gains `_z_condvar_wait_until`) and the symbol leaves the ABI.
 
-### Path E — Stack placement, then ASI's headroom rule.
+### Path E — Stack headroom: wired, and on ASI blind.
 
 * **E1 — issue 1232.** Zephyr ignores a tier's declared `stack_bytes`: every
-  spawned tier gets the fixed pool slot, and the boot tier runs on `main`'s
-  thread. ASI declares exactly one tier, and it is the boot tier.
-* **E2 — wire `set_min_stack_headroom_bytes` on ASI.** Only after E1. Wired
-  today it would report `main`'s headroom as the control tier's — a
-  plausible number for the wrong thread, the same failure as the jitter probe
-  that reported zero through three reviews. Depends on A1.
+  SPAWNED tier gets the fixed pool slot. It matters for images with spawned
+  tiers. It does not block ASI, whose only tier is the boot tier.
+* **E2 — ASI's headroom rule. Already WIRED; the gap is that it cannot
+  measure.** An earlier draft said wiring it would "report `main`'s headroom as
+  the control tier's, a plausible number for the wrong thread". Wrong: the
+  Zephyr C entry already derives the boot tier's bound from
+  `nros_zephyr_main_stack_size()`, and `stack_unused_bytes()` reads
+  `k_current_get()`, the thread `spin_once` runs on. For the boot tier that is
+  `main`, so the thread measured is the thread sized. Nothing to wire.
+
+  What IS wrong: Zephyr's accessor reports only with
+  `CONFIG_INIT_STACKS && CONFIG_THREAD_STACK_INFO` and returns 0 otherwise,
+  which the rule reads as "not instrumented" and skips. ASI's default FVP
+  build has `THREAD_STACK_INFO` but not `INIT_STACKS`, so the rule is armed
+  and returns early on every check. Only ASI's `--trace-stats` variant
+  (`CONFIG_THREAD_ANALYZER` selects `INIT_STACKS`) measures. **Exit:** ASI
+  decides where stack painting is paid for.
+* **E3 — say so when the rule is blind.** An armed rule that cannot measure
+  reads exactly like a clean result. That is the failure the entry's
+  "stack-headroom bound NOT set" line already guards against for the bound, one
+  step further on. The entry should report once when the port answers 0, the
+  same way.
 
 ### Order
 
 A1 → A2 → A3 first, with B1 alongside it (it is a decision, not code). Then
 B2 and D in parallel; C whenever — it is breadth, and each port is
-independent. E1 before E2, and E2 after A1.
+independent. E3 is small and independent; E1 only for images with spawned tiers.
 
 ## Sequencing (W1-W7, as delivered)
 

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -61,6 +61,28 @@
 #define NROS_CPP_DOMAIN_ID_INHERIT UINT32_MAX
 
 /**
+ * phase-436 A2 — which deadline source bounded a park, as
+ * [`nros_cpp_executor_last_park`] reports it. `PLATFORM` also carries the
+ * index the platform source was registered at.
+ */
+#define NROS_CPP_WAKE_SOURCE_CALLER_BUDGET 0
+
+/**
+ * A registered timer's next expiry bounded the park.
+ */
+#define NROS_CPP_WAKE_SOURCE_TIMER 1
+
+/**
+ * The backend's next internal event (lease, heartbeat) bounded the park.
+ */
+#define NROS_CPP_WAKE_SOURCE_SESSION 2
+
+/**
+ * A platform-registered deadline source bounded the park.
+ */
+#define NROS_CPP_WAKE_SOURCE_PLATFORM 3
+
+/**
  * Image-local discriminant of the linked backend's serialization format
  * (`nros_serdes::format::SerializationFormatId`). RFC-0088 D2 — image-local:
  * never persist it, never compare it across images.
@@ -1566,6 +1588,55 @@ nros_cpp_ret_t nros_cpp_executor_set_park_primitive(void *handle,
  * `handle` must be a live executor handle from this ABI, or NULL.
  */
 nros_cpp_ret_t nros_cpp_executor_set_spin_nominal_us(void *handle, uint64_t us);
+
+/**
+ * phase-436 A2 — read the release-jitter probe from a C or C++ entry.
+ *
+ * `max_us` is the worst wake past its nominal release since the executor
+ * opened; `late_wakes` / `total_wakes` separate one bad wake from a loop that
+ * is late every cycle. `granularity_us` is what the measurement is worth: a
+ * loop paced by the blocking wait cannot be judged finer than one park
+ * granule, and the executor says which case this is.
+ *
+ * Before this the only signal a C entry had was the `release-jitter-runtime`
+ * violation line, which fires only at a whole period late — so the maximum,
+ * the figure a trace is compared against, could not be read at all.
+ *
+ * Every output pointer may be NULL, meaning "not wanted". Nothing is written
+ * when the handle is refused.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL. Each
+ * non-NULL output must point at writable storage of its type.
+ */
+nros_cpp_ret_t nros_cpp_executor_release_jitter(void *handle,
+                                                uint64_t *max_us,
+                                                uint32_t *late_wakes,
+                                                uint32_t *total_wakes,
+                                                uint64_t *granularity_us);
+
+/**
+ * phase-436 A2 — how the last park was bounded, from a C or C++ entry.
+ *
+ * `bound_us` is the park the sources agreed on; `achieved_us` is what the
+ * platform was actually asked for after rounding up to what its primitive can
+ * express. They differ exactly when the request did not land on the
+ * platform's grid, and both are reported so the rounding is visible rather
+ * than silent. `source` is one of `NROS_CPP_WAKE_SOURCE_*`; `platform_index`
+ * is meaningful only for `NROS_CPP_WAKE_SOURCE_PLATFORM` and 0 otherwise.
+ *
+ * Every output pointer may be NULL. Nothing is written when the handle is
+ * refused.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL. Each
+ * non-NULL output must point at writable storage of its type.
+ */
+nros_cpp_ret_t nros_cpp_executor_last_park(void *handle,
+                                           uint64_t *bound_us,
+                                           uint64_t *achieved_us,
+                                           uint8_t *source,
+                                           uint8_t *platform_index);
 
 /**
  * Get current monotonic time in nanoseconds.

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3795,6 +3795,128 @@ pub unsafe extern "C" fn nros_cpp_executor_set_spin_nominal_us(
     NROS_CPP_RET_OK
 }
 
+/// phase-436 A2 — which deadline source bounded a park, as
+/// [`nros_cpp_executor_last_park`] reports it. `PLATFORM` also carries the
+/// index the platform source was registered at.
+pub const NROS_CPP_WAKE_SOURCE_CALLER_BUDGET: u8 = 0;
+/// A registered timer's next expiry bounded the park.
+pub const NROS_CPP_WAKE_SOURCE_TIMER: u8 = 1;
+/// The backend's next internal event (lease, heartbeat) bounded the park.
+pub const NROS_CPP_WAKE_SOURCE_SESSION: u8 = 2;
+/// A platform-registered deadline source bounded the park.
+pub const NROS_CPP_WAKE_SOURCE_PLATFORM: u8 = 3;
+
+/// The C encoding of a `WakeSourceId`: `(code, platform_index)`.
+///
+/// An exhaustive `match`, deliberately: a new wake source fails to compile here
+/// until it is given a code, rather than reaching C as a stale one.
+#[cfg(feature = "rmw-cffi")]
+fn wake_source_code(src: nros_node::executor::WakeSourceId) -> (u8, u8) {
+    use nros_node::executor::WakeSourceId as W;
+    match src {
+        W::CallerBudget => (NROS_CPP_WAKE_SOURCE_CALLER_BUDGET, 0),
+        W::Timer => (NROS_CPP_WAKE_SOURCE_TIMER, 0),
+        W::Session => (NROS_CPP_WAKE_SOURCE_SESSION, 0),
+        W::Platform(i) => (NROS_CPP_WAKE_SOURCE_PLATFORM, i),
+    }
+}
+
+/// phase-436 A2 — read the release-jitter probe from a C or C++ entry.
+///
+/// `max_us` is the worst wake past its nominal release since the executor
+/// opened; `late_wakes` / `total_wakes` separate one bad wake from a loop that
+/// is late every cycle. `granularity_us` is what the measurement is worth: a
+/// loop paced by the blocking wait cannot be judged finer than one park
+/// granule, and the executor says which case this is.
+///
+/// Before this the only signal a C entry had was the `release-jitter-runtime`
+/// violation line, which fires only at a whole period late — so the maximum,
+/// the figure a trace is compared against, could not be read at all.
+///
+/// Every output pointer may be NULL, meaning "not wanted". Nothing is written
+/// when the handle is refused.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL. Each
+/// non-NULL output must point at writable storage of its type.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_release_jitter(
+    handle: *mut c_void,
+    max_us: *mut u64,
+    late_wakes: *mut u32,
+    total_wakes: *mut u32,
+    granularity_us: *mut u64,
+) -> nros_cpp_ret_t {
+    let Some(ctx) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    let (max, late, total) = ctx.executor.release_jitter();
+    let granularity = ctx.executor.release_jitter_granularity_us();
+    unsafe {
+        if !max_us.is_null() {
+            *max_us = max;
+        }
+        if !late_wakes.is_null() {
+            *late_wakes = late;
+        }
+        if !total_wakes.is_null() {
+            *total_wakes = total;
+        }
+        if !granularity_us.is_null() {
+            *granularity_us = granularity;
+        }
+    }
+    NROS_CPP_RET_OK
+}
+
+/// phase-436 A2 — how the last park was bounded, from a C or C++ entry.
+///
+/// `bound_us` is the park the sources agreed on; `achieved_us` is what the
+/// platform was actually asked for after rounding up to what its primitive can
+/// express. They differ exactly when the request did not land on the
+/// platform's grid, and both are reported so the rounding is visible rather
+/// than silent. `source` is one of `NROS_CPP_WAKE_SOURCE_*`; `platform_index`
+/// is meaningful only for `NROS_CPP_WAKE_SOURCE_PLATFORM` and 0 otherwise.
+///
+/// Every output pointer may be NULL. Nothing is written when the handle is
+/// refused.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL. Each
+/// non-NULL output must point at writable storage of its type.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_last_park(
+    handle: *mut c_void,
+    bound_us: *mut u64,
+    achieved_us: *mut u64,
+    source: *mut u8,
+    platform_index: *mut u8,
+) -> nros_cpp_ret_t {
+    let Some(ctx) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    let (bound, src) = ctx.executor.last_park();
+    let achieved = ctx.executor.last_park_achieved_us();
+    let (code, index) = wake_source_code(src);
+    unsafe {
+        if !bound_us.is_null() {
+            *bound_us = bound;
+        }
+        if !achieved_us.is_null() {
+            *achieved_us = achieved;
+        }
+        if !source.is_null() {
+            *source = code;
+        }
+        if !platform_index.is_null() {
+            *platform_index = index;
+        }
+    }
+    NROS_CPP_RET_OK
+}
+
 /// Phase 274.W2 (RFC-0015 Model 1) — run a native multi-tier entry over one
 /// shared RMW session.
 ///
@@ -4502,3 +4624,80 @@ const _: () = {
         i += 1;
     }
 };
+
+// phase-436 A2 — reading the jitter and park probes from a C entry. The encoding
+// is tested directly; the null-handle contract is tested at the ABI. A live
+// executor's numbers are the Rust accessors', covered in `nros-node`.
+#[cfg(all(test, feature = "rmw-cffi"))]
+mod jitter_readout_tests {
+    use super::*;
+    use nros_node::executor::WakeSourceId;
+
+    #[test]
+    fn every_wake_source_maps_to_a_distinct_code() {
+        assert_eq!(
+            wake_source_code(WakeSourceId::CallerBudget),
+            (NROS_CPP_WAKE_SOURCE_CALLER_BUDGET, 0)
+        );
+        assert_eq!(
+            wake_source_code(WakeSourceId::Timer),
+            (NROS_CPP_WAKE_SOURCE_TIMER, 0)
+        );
+        assert_eq!(
+            wake_source_code(WakeSourceId::Session),
+            (NROS_CPP_WAKE_SOURCE_SESSION, 0)
+        );
+        assert_eq!(
+            wake_source_code(WakeSourceId::Platform(5)),
+            (NROS_CPP_WAKE_SOURCE_PLATFORM, 5)
+        );
+        let codes = [
+            NROS_CPP_WAKE_SOURCE_CALLER_BUDGET,
+            NROS_CPP_WAKE_SOURCE_TIMER,
+            NROS_CPP_WAKE_SOURCE_SESSION,
+            NROS_CPP_WAKE_SOURCE_PLATFORM,
+        ];
+        for i in 0..codes.len() {
+            for j in (i + 1)..codes.len() {
+                assert_ne!(codes[i], codes[j], "two wake sources share a code");
+            }
+        }
+    }
+
+    #[test]
+    fn a_null_handle_is_refused_and_writes_nothing() {
+        let (mut max, mut late, mut total, mut gran) = (7u64, 7u32, 7u32, 7u64);
+        let rc = unsafe {
+            nros_cpp_executor_release_jitter(
+                core::ptr::null_mut(),
+                &mut max,
+                &mut late,
+                &mut total,
+                &mut gran,
+            )
+        };
+        assert_eq!(rc, NROS_CPP_RET_INVALID_ARGUMENT);
+        assert_eq!(
+            (max, late, total, gran),
+            (7, 7, 7, 7),
+            "a refused call wrote its outputs"
+        );
+
+        let (mut bound, mut achieved, mut src, mut idx) = (7u64, 7u64, 7u8, 7u8);
+        let rc = unsafe {
+            nros_cpp_executor_last_park(
+                core::ptr::null_mut(),
+                &mut bound,
+                &mut achieved,
+                &mut src,
+                &mut idx,
+            )
+        };
+        assert_eq!(rc, NROS_CPP_RET_INVALID_ARGUMENT);
+        assert_eq!(
+            (bound, achieved, src, idx),
+            (7, 7, 7, 7),
+            "a refused call wrote its outputs"
+        );
+    }
+}

--- a/packages/core/nros-node/src/executor/mod.rs
+++ b/packages/core/nros-node/src/executor/mod.rs
@@ -140,10 +140,16 @@ pub use node::{CallbackGroup, NodeHandle};
 pub use node_record::{NodeBuilder, NodeId, NodeRecord};
 #[cfg(any(has_rmw, test))]
 pub use spin::Executor;
+// phase-436 — the wake-source seam's types. `Executor::last_park` RETURNS a
+// `WakeSourceId` and `register_wake_source` / `set_park_primitive` TAKE the two
+// fn-pointer types, so all four are already public API; without these a caller
+// outside the crate could receive a value it cannot name or match on.
 #[cfg(any(has_rmw, test))]
 pub use spin::SessionHandle;
 #[cfg(all(any(has_rmw, test), feature = "rmw-cffi"))]
 pub use spin::SessionSpec;
+#[cfg(any(has_rmw, test))]
+pub use spin::{MAX_WAKE_SOURCES, NextDeadlineFn, ParkUntilFn, WakeSourceId};
 #[cfg(any(has_rmw, test))]
 pub use storage::{
     ExecutorInlineStorage, ExecutorSizing, RegionUnit, RegionUnits, executor_storage_layout,


### PR DESCRIPTION
Based on #849. Until #849 merges, this diff includes its commits; **review only the top two**. Once #849 lands, the queue drops the carried commits by patch-id.

## What this does

Phase-436 A2: read the release-jitter and park probes from a C or C++ entry.

`release-jitter-runtime` runs on every C entry without being declared, but a C entry couldn't *read* it. Its only signal was the violation line, which fires only when a wake is a whole period late. The maximum, the late count and the park attribution, which are what a trace gets compared against, were Rust-only. ASI's FVP lane uses the Zephyr C entry, so the A3 cross-check had nothing to read.

- `nros_cpp_executor_release_jitter(h, &max_us, &late, &total, &granularity_us)`
- `nros_cpp_executor_last_park(h, &bound_us, &achieved_us, &source, &platform_index)`, where `source` is one of `NROS_CPP_WAKE_SOURCE_*`

Every output pointer is optional, and a refused handle writes nothing. The mapping from wake source to code is an exhaustive `match`, so adding a wake source fails to compile until it gets a code.

**Found along the way:** `WakeSourceId`, `NextDeadlineFn`, `ParkUntilFn` and `MAX_WAKE_SOURCES` were never re-exported from `nros_node::executor`. So `Executor::last_park()` returned a type no other crate could name or match on. All four are now re-exported.

## A reversal in the phase doc

A2 used to say "make the Zephyr C entry call `set_spin_nominal_us`". That would have been wrong. `release_jitter_granularity_us()` reads a declared cadence as "the caller paces itself" and reports 1 µs. But the C entry is paced *by* the wait (the tick-granular park since W7), so the report would claim precision the loop doesn't have, which is issue 1194's failure. The API ties two things together: the nominal to judge against, and who paces the loop. Splitting them is recorded as A2b, still open.

## Verified locally

- Test-first: the new test module failed to compile on exactly the seven missing items, and nothing else, then passed (2/2).
- `just regen-c-headers` → `check-cbindgen-headers` OK. The header gains the four codes and two declarations, nothing else.
- clippy `-D warnings` on nros-cpp and nros-node; nightly fmt clean.
- `check-api-parity` rc 0; `nros-node` lib tests 192/0.
- `just check cpp`: "All C++ checks passed!", so the C/C++ layer compiles against the regenerated header.
- `test-unit`: 1265 passed. The 3 "failures" are `[SKIPPED]` because there's no zenohd router here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
