### PR TITLE
feat(phase-445 W2): every board with a Rust triple states it, and a descriptor can carry a knob

### DIFF
--- a/docs/roadmap/phase-445-board-choice-generates-leaf-config.md
+++ b/docs/roadmap/phase-445-board-choice-generates-leaf-config.md
@@ -36,7 +36,7 @@ esp32 stack budgets.
   leaves' hand-set `ZPICO_MAX_QUERYABLES` goes when both have landed —
   acceptance a BUILD whose shim constant matches the hand-set value it
   replaces.
-- [ ] **W2 — complete the board descriptors (D4).** `[build] target` in every
+- [x] **W2 — complete the board descriptors (D4).** `[build] target` in every
   descriptor whose board has a Rust triple (mps2 first — the 19 hand-written
   leaves); `CC_<triple>`/`CFLAGS_<triple>` from the workspace configs; the
   hardware budgets (`NROS_HEAP_SIZE`, `ZPICO_SUBSCRIBER_LARGE_SIZE`,
@@ -69,8 +69,13 @@ esp32 stack budgets.
     both ways (`cannot find linker script`). Both workspace FreeRTOS images
     link and boot with the descriptor's `+ --gc-sections`. Gate:
     `check-board-build-target`.
-  - Still owed for the tick: a build of the s32z270 / mps3-an536 images (C++
-    CMake rows only; their triple value is unchanged).
+  - Built after the change, one image per changed board:
+    - mps2 bare-metal talker and mps2 FreeRTOS talker (both boot in QEMU);
+    - esp32 talker;
+    - NuttX ARM talker (boots);
+    - both workspace FreeRTOS images (both boot);
+    - `workspace-cpp-{mps3-an536,s32z270}-freertos` (mps3 boots to
+      "Network ready").
 - [ ] **W3 — `system.toml` in every single-package example (D3, D5, D8).** 178
   leaves (70 Rust, 52 C, 56 C++). `[image.X] board`, `[system] rmw/domain_id/locator`,
   network identity, `[[component]]` with entities where the board cannot be

--- a/docs/roadmap/phase-445-board-choice-generates-leaf-config.md
+++ b/docs/roadmap/phase-445-board-choice-generates-leaf-config.md
@@ -45,6 +45,32 @@ esp32 stack budgets.
   and `examples/workspaces/{rust,realtime-rust}/.cargo/config.toml` by BUILD,
   not by picking one. Gate: a descriptor with a Rust triple and no
   `[build] target` fails.
+  **Landed (2026-09-10, `feat/phase-445-w2-board-descriptors`):**
+  - `[build] target` added to mps2-an385, mps2-an385-freertos, s32z270 and
+    mps3-an536. `CC_thumbv7m_none_eabi` added to both mps2 boards; NuttX's
+    `CC_`/`CFLAGS_` were already there, identical to the workspace copies.
+    The 22 deploy leaves whose projection now supplies the triple drop their
+    own `[build]`. That is forced, because sync's conflict check intersects
+    keys; the value stays committed in the projection until W4/W6.
+  - `[board.knobs]` is now READ: the CLI refused any `[knobs]` in a
+    descriptor, so the RFC-0049 board rung existed only in tests.
+  - esp32 `[board.knobs.net] max_udp_sockets = 2`, measured delivered: 2
+    with the leaf's env line removed, 1 without the board facts.
+  - NOT board facts, and not moved:
+    - `NROS_HEAP_SIZE`: the leaf value equals the platform crate's default,
+      and a rung would override `dds-heap`.
+    - `ZPICO_NO_SMOLTCP`: a serial transport choice, set by 3 of 13 leaves on
+      one board.
+    - `ZPICO_SUBSCRIBER_LARGE_SIZE`: derived per image.
+    - `ESP_LOG`: already in `cargo_config` `[env]`; read by esp-println, not a
+      ladder knob.
+  - Link groups: the workspace `-Tmps2_an385.ld --nmagic` is the FreeRTOS
+    board's group, not a rival to bare-metal's `-Tlink.x`. Crossed builds fail
+    both ways (`cannot find linker script`). Both workspace FreeRTOS images
+    link and boot with the descriptor's `+ --gc-sections`. Gate:
+    `check-board-build-target`.
+  - Still owed for the tick: a build of the s32z270 / mps3-an536 images (C++
+    CMake rows only; their triple value is unchanged).
 - [ ] **W3 — `system.toml` in every single-package example (D3, D5, D8).** 178
   leaves (70 Rust, 52 C, 56 C++). `[image.X] board`, `[system] rmw/domain_id/locator`,
   network identity, `[[component]]` with entities where the board cannot be

--- a/examples/mps2-an385-baremetal/rust/action-client-rtic/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/action-client-rtic/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/action-client-rtic/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/action-client-rtic/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/action-server-rtic/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/action-server-rtic/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/action-server-rtic/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/action-server-rtic/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/listener-rtic-mixed/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/listener-rtic-mixed/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/listener-rtic-mixed/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/listener-rtic-mixed/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/listener-rtic/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/listener-rtic/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/listener-rtic/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/listener-rtic/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/listener/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/listener/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 nros-board-mps2-an385 = { path = "../../../../packages/boards/nros-board-mps2-an385" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/listener/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/listener/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/serial-listener/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/serial-listener/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 # Phase 132 — serial-only firmware. See serial-talker/.cargo/config.toml
 # for the full rationale; `zpico-sys`'s build.rs honours this env
 # var and skips the smoltcp glue that would otherwise fail to link.

--- a/examples/mps2-an385-baremetal/rust/serial-listener/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/serial-listener/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/serial-talker/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/serial-talker/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 # Phase 132 — serial-only firmware. `zpico-sys`'s `build.rs` reads
 # this env var and skips compiling smoltcp glue into `zpico.c` (no
 # `smoltcp_init` / `smoltcp_cleanup` link refs), defining

--- a/examples/mps2-an385-baremetal/rust/serial-talker/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/serial-talker/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/service-client-rtic/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/service-client-rtic/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/service-client-rtic/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/service-client-rtic/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/service-server-rtic/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/service-server-rtic/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/service-server-rtic/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/service-server-rtic/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/talker-rtic-mixed/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/talker-rtic-mixed/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/talker-rtic-mixed/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/talker-rtic-mixed/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/talker-rtic/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/talker-rtic/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../packages/boards/mps2-an385-pac" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/talker-rtic/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/talker-rtic/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/talker-xrce/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/talker-xrce/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 # Phase 132 — serial-only firmware. `zpico-sys`'s `build.rs` reads
 # this env var and skips compiling smoltcp glue into `zpico.c` (no
 # `smoltcp_init` / `smoltcp_cleanup` link refs), defining

--- a/examples/mps2-an385-baremetal/rust/talker-xrce/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/talker-xrce/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-baremetal/rust/talker/.cargo/config.toml
+++ b/examples/mps2-an385-baremetal/rust/talker/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = [ "../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 nros-board-mps2-an385 = { path = "../../../../packages/boards/nros-board-mps2-an385" }  # nros-managed

--- a/examples/mps2-an385-baremetal/rust/talker/.cargo/nros-board.toml
+++ b/examples/mps2-an385-baremetal/rust/talker/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-freertos/rust/action-client/.cargo/config.toml
+++ b/examples/mps2-an385-freertos/rust/action-client/.cargo/config.toml
@@ -1,6 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
 # nros-board-freertos/build.rs needs these to locate the FreeRTOS + CFFI platform
 # glue. Previously only the `just freertos` overlay / the run-plan test injected
 # them, forcing a compile-in-test fallback; carrying them here (relative to this

--- a/examples/mps2-an385-freertos/rust/action-client/.cargo/nros-board.toml
+++ b/examples/mps2-an385-freertos/rust/action-client/.cargo/nros-board.toml
@@ -17,11 +17,26 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-freertos/rust/action-server/.cargo/config.toml
+++ b/examples/mps2-an385-freertos/rust/action-server/.cargo/config.toml
@@ -1,6 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
 # nros-board-freertos/build.rs needs these to locate the FreeRTOS + CFFI platform
 # glue. Previously only the `just freertos` overlay / the run-plan test injected
 # them, forcing a compile-in-test fallback; carrying them here (relative to this

--- a/examples/mps2-an385-freertos/rust/action-server/.cargo/nros-board.toml
+++ b/examples/mps2-an385-freertos/rust/action-server/.cargo/nros-board.toml
@@ -17,11 +17,26 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-freertos/rust/listener/.cargo/config.toml
+++ b/examples/mps2-an385-freertos/rust/listener/.cargo/config.toml
@@ -1,6 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
 # nros-board-freertos/build.rs needs these to locate the FreeRTOS + CFFI platform
 # glue. Previously only the `just freertos` overlay / the run-plan test injected
 # them, forcing a compile-in-test fallback; carrying them here (relative to this

--- a/examples/mps2-an385-freertos/rust/listener/.cargo/nros-board.toml
+++ b/examples/mps2-an385-freertos/rust/listener/.cargo/nros-board.toml
@@ -17,11 +17,26 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-freertos/rust/service-client/.cargo/config.toml
+++ b/examples/mps2-an385-freertos/rust/service-client/.cargo/config.toml
@@ -1,6 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
 # nros-board-freertos/build.rs needs these to locate the FreeRTOS + CFFI platform
 # glue. Previously only the `just freertos` overlay / the run-plan test injected
 # them, forcing a compile-in-test fallback; carrying them here (relative to this

--- a/examples/mps2-an385-freertos/rust/service-client/.cargo/nros-board.toml
+++ b/examples/mps2-an385-freertos/rust/service-client/.cargo/nros-board.toml
@@ -17,11 +17,26 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-freertos/rust/service-server/.cargo/config.toml
+++ b/examples/mps2-an385-freertos/rust/service-server/.cargo/config.toml
@@ -1,6 +1,4 @@
 include = ["../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
 # nros-board-freertos/build.rs needs these to locate the FreeRTOS + CFFI platform
 # glue. Previously only the `just freertos` overlay / the run-plan test injected
 # them, forcing a compile-in-test fallback; carrying them here (relative to this

--- a/examples/mps2-an385-freertos/rust/service-server/.cargo/nros-board.toml
+++ b/examples/mps2-an385-freertos/rust/service-server/.cargo/nros-board.toml
@@ -17,11 +17,26 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/examples/mps2-an385-freertos/rust/talker/.cargo/config.toml
+++ b/examples/mps2-an385-freertos/rust/talker/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = [ "../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 # nros-board-freertos/build.rs needs these to locate the FreeRTOS + CFFI platform
 # glue. Previously only the `just freertos` overlay / the run-plan test injected
 # them, forcing a compile-in-test fallback; carrying them here (relative to this

--- a/examples/mps2-an385-freertos/rust/talker/.cargo/nros-board.toml
+++ b/examples/mps2-an385-freertos/rust/talker/.cargo/nros-board.toml
@@ -17,11 +17,26 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/just/check/platform.just
+++ b/just/check/platform.just
@@ -182,6 +182,14 @@ fixture-boards-declared:
 board-cargo-config-shape:
     @python3 scripts/check-board-cargo-config-shape.py
 
+# phase-445 W2 (RFC-0098 D4) — a board with a Rust triple states `[build]
+# target` in its descriptor. The two mps2 boards and both armv8r FreeRTOS boards
+# did not, so 19 mps2 leaves carried the triple in the leaf config RFC-0098
+# deletes. Hosted and Zephyr boards are exempt by kind, and reported as such.
+[private]
+board-build-target:
+    @python3 scripts/check-board-build-target.py
+
 # built (the packages/cli phase215_f integration test still covers it).
 [private]
 board-manifest-drift:

--- a/packages/boards/nros-board-esp32-qemu/nros-board.toml
+++ b/packages/boards/nros-board-esp32-qemu/nros-board.toml
@@ -48,3 +48,13 @@ closure_extra = "\n                .clock_us(nros_board_esp32_qemu::nros_platfor
 heap = true
 atomics = true
 threads = true
+
+# phase-445 W2 (RFC-0049 board rung, RFC-0098 D4) — a hardware budget, stated
+# once for the board. All three esp32 images (`esp32-c3-baremetal/rust/{talker,
+# listener}` and `workspaces/rust`'s `esp32_entry`) hand-set the same value in
+# their own `[env]`: it was phase-177's shrink from the old default 4 to fit the
+# esp32-c3 stack (cb8a642ac), and it is the only board that sets it at all.
+# Read by `nros-smoltcp/build.rs` through `BuildRungs::net_rungs`; the env
+# front-end `NROS_SMOLTCP_MAX_UDP_SOCKETS` still wins over it.
+[board.knobs.net]
+max_udp_sockets = 2

--- a/packages/boards/nros-board-mps2-an385-freertos/nros-board.toml
+++ b/packages/boards/nros-board-mps2-an385-freertos/nros-board.toml
@@ -10,14 +10,29 @@ supported_netstacks = ["lwip"]
 board_crate = "nros-board-mps2-an385-freertos"
 # Phase 252 (issue 0072) — forwards [safety] through the freertos family to zenoh.
 cargo_config = '''
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"
 '''
 
 # Issue 0273 — the C startup (`c/board_mps2.c` `Reset_Handler`) jumps to the Rust

--- a/packages/boards/nros-board-mps2-an385/nros-board.toml
+++ b/packages/boards/nros-board-mps2-an385/nros-board.toml
@@ -16,9 +16,20 @@ supported_netstacks = ["smoltcp"]
 board_crate = "nros-board-mps2-an385"
 # Phase 252 (issue 0072) — forwards [safety] to its zenoh backend.
 cargo_config = '''
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -27,6 +38,11 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"
 '''
 
 [board.entry]

--- a/packages/boards/nros-board-mps3-an536-freertos/nros-board.toml
+++ b/packages/boards/nros-board-mps3-an536-freertos/nros-board.toml
@@ -32,6 +32,10 @@ entry_kind = "board-run"
 supported_netstacks = ["lwip"]
 board_crate = "nros-board-mps3-an536-freertos"
 cargo_config = '''
+# phase-445 W2 (RFC-0098 D4) — every board with a Rust triple states it.
+[build]
+target = "armv8r-none-eabihf"
+
 [target.armv8r-none-eabihf]
 runner = "qemu-system-arm -machine mps3-an536 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [

--- a/packages/boards/nros-board-s32z270-freertos/nros-board.toml
+++ b/packages/boards/nros-board-s32z270-freertos/nros-board.toml
@@ -21,6 +21,10 @@ entry_kind = "board-run"
 supported_netstacks = ["lwip"]
 board_crate = "nros-board-s32z270-freertos"
 cargo_config = '''
+# phase-445 W2 (RFC-0098 D4) — every board with a Rust triple states it.
+[build]
+target = "armv8r-none-eabihf"
+
 [target.armv8r-none-eabihf]
 rustflags = [
     "-C", "link-arg=-Ts32z270_rtu.ld",

--- a/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
@@ -699,6 +699,52 @@ struct BoardFile {
     boards: Vec<BoardDescriptor>,
 }
 
+impl BoardFile {
+    /// Parse one `nros-board.toml`, acknowledging `[board.knobs]`.
+    ///
+    /// phase-445 W2. `[board.knobs]` is the RFC-0049 board rung; its reader is
+    /// `nros-platform-config`'s `BoardKnobsFile`, which a build script reaches
+    /// through `NROS_BOARD_TOML`. This reader does not USE knobs, but it must
+    /// not refuse them — and until now it did, because `BoardDescriptor` denies
+    /// unknown fields. With the top level also denied, no shipped descriptor
+    /// could carry a knob anywhere, so the rung existed only in tests.
+    ///
+    /// The table is VALIDATED here with the ladder's own type (every tenant
+    /// denies unknown keys), so a knob typo fails at catalog load naming the
+    /// descriptor, not in some build script three frames later. It is then
+    /// removed before the typed parse rather than modelled as a
+    /// `BoardDescriptor` field: that struct is built literally in several
+    /// places, and knobs are another reader's schema (the `priority_plan`
+    /// rule — acknowledged here, interpreted elsewhere).
+    ///
+    /// A file with no `[board.knobs]` takes the direct typed parse, so its
+    /// errors keep their line/column spans.
+    fn parse(text: &str) -> Result<Self, toml::de::Error> {
+        let direct = toml::from_str::<BoardFile>(text);
+        let Err(first) = direct else {
+            return direct;
+        };
+        let Ok(mut table) = text.parse::<toml::Table>() else {
+            return Err(first);
+        };
+        let mut had_knobs = false;
+        if let Some(toml::Value::Array(boards)) = table.get_mut("board") {
+            for entry in boards.iter_mut() {
+                if let toml::Value::Table(t) = entry
+                    && let Some(knobs) = t.remove("knobs")
+                {
+                    knobs.try_into::<nros_board_common::platform_config::Knobs>()?;
+                    had_knobs = true;
+                }
+            }
+        }
+        if !had_knobs {
+            return Err(first);
+        }
+        toml::Value::Table(table).try_into()
+    }
+}
+
 /// The `[build]` / `[target.<triple>]` shape of a `cargo_config` template.
 #[derive(Debug, Default, Deserialize)]
 struct CargoConfigTemplate {
@@ -846,7 +892,7 @@ impl BoardCatalog {
             }
             let text = std::fs::read_to_string(&descriptor_path)
                 .map_err(|e| BoardLoadError::Io(descriptor_path.clone(), e))?;
-            let file: BoardFile = toml::from_str(&text)
+            let file = BoardFile::parse(&text)
                 .map_err(|e| BoardLoadError::Parse(descriptor_path.clone(), e))?;
             // Absolute, like an extra root and for the same reason: the
             // workspace-relative form exists so IN-TREE paths in committed
@@ -1003,7 +1049,7 @@ impl BoardCatalog {
             Self::require_announcement(&dir, &descriptor_path)?;
             let text = std::fs::read_to_string(&descriptor_path)
                 .map_err(|e| BoardLoadError::Io(descriptor_path.clone(), e))?;
-            let file: BoardFile = toml::from_str(&text)
+            let file = BoardFile::parse(&text)
                 .map_err(|e| BoardLoadError::Parse(descriptor_path.clone(), e))?;
             // Workspace-relative, forward slashes — it goes into a COMMITTED
             // generated header, so an absolute host path would be drift the
@@ -2218,6 +2264,34 @@ entry_kind = "zephyr-staticlib"
             cat.descriptors.iter().any(|d| d.priority_plan.is_some()),
             "at least one in-tree board declares [board.priority_plan]; if none              does, this test has stopped covering the case it exists for"
         );
+    }
+
+    /// phase-445 W2 — `[board.knobs]` loads (another reader's rung), a knob typo
+    /// under it fails naming the key, and a top-level `[knobs]` is still the
+    /// misplaced table `BoardFile` refuses.
+    #[test]
+    fn board_knobs_are_acknowledged_validated_and_not_top_level() {
+        const HEAD: &str = "[[board]]\nnames = [\"demo\"]\nplatform = \"posix\"\n\
+                            toolchain = \"stable\"\nentry_kind = \"hosted-main\"\n";
+        let ok = BoardFile::parse(&format!("{HEAD}\n[board.knobs.net]\nmax_udp_sockets = 2\n"))
+            .expect("[board.knobs] must load");
+        assert_eq!(ok.boards.len(), 1);
+
+        let typo = BoardFile::parse(&format!("{HEAD}\n[board.knobs.net]\nmax_udp_sokets = 2\n"))
+            .expect_err("a knob typo must not load");
+        assert!(typo.to_string().contains("max_udp_sokets"), "{typo}");
+
+        let top = BoardFile::parse(&format!("[knobs.net]\nmax_udp_sockets = 2\n\n{HEAD}"))
+            .expect_err("top-level [knobs] is the misplaced table");
+        assert!(top.to_string().contains("knobs"), "{top}");
+
+        // The strip only ever removes `knobs`: any OTHER unknown key still
+        // fails, even in a file that also carries knobs.
+        let other = BoardFile::parse(&format!(
+            "{HEAD}supported_netstakcs = []\n\n[board.knobs.net]\nmax_udp_sockets = 2\n"
+        ))
+        .expect_err("a sibling typo must still fail");
+        assert!(other.to_string().contains("supported_netstakcs"), "{other}");
     }
 
     /// The other half of the same claim: a key nobody reads must now FAIL, and

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -1339,10 +1339,19 @@ pub fn run() {
     // `wire`). It used to live inside the tx arm; a second `load` for the wire
     // knobs would parse the same file twice and could disagree with itself if
     // one call site ever grew an option the other did not.
+    // `NROS_BOARD` rides beside `NROS_BOARD_TOML` from the same seam
+    // (`nros board-facts`) and names WHICH `[[board]]` when a file declares
+    // several — `packages/boards/nros-board-nuttx` declares two that differ in
+    // ISA, so a file-level answer would be issue 0606 one table over. Read
+    // BEFORE the load: phase-445 W2 made `[board.knobs]` per-entry, so the knob
+    // rung needs the name as much as the capabilities below do.
+    println!("cargo:rerun-if-env-changed=NROS_BOARD");
+    let board_name = env_get("NROS_BOARD");
     let board_knobs = env_get("NROS_BOARD_TOML").map(|path| {
         let p = PathBuf::from(&path);
         println!("cargo:rerun-if-changed={}", p.display());
-        platform_config::BoardKnobsFile::load(&p).unwrap_or_else(|e| panic!("{path}: {e}"))
+        platform_config::BoardKnobsFile::load_for_board(&p, board_name.as_deref())
+            .unwrap_or_else(|e| panic!("{path}: {e}"))
     });
     let tx_knobs = match (&platforms_tree, platform_name) {
         (Some(tree), Some(name)) => {
@@ -1490,13 +1499,7 @@ pub fn run() {
     // out-of-tree consumer — is byte-identical to before. See
     // `LinkPolicy::for_board` for why `supported_netstacks = []` is NOT the
     // predicate: four in-tree boards declare it and all four have sockets.
-    //
-    // `NROS_BOARD` rides beside `NROS_BOARD_TOML` from the same seam
-    // (`nros board-facts`) and names WHICH `[[board]]` when a file declares
-    // several — `packages/boards/nros-board-nuttx` declares two that differ in
-    // ISA, so a file-level answer would be issue 0606 one table over.
-    println!("cargo:rerun-if-env-changed=NROS_BOARD");
-    let board_name = env_get("NROS_BOARD");
+    // `board_name` (`NROS_BOARD`) is read above, beside the file it selects in.
     let board_capabilities = match (&platforms_tree, platform_name) {
         (Some(tree), Some(name)) => tree
             .capabilities_with_board(name, board_knobs.as_ref(), board_name.as_deref())

--- a/packages/testing/nros-tests/bins/qemu-baremetal-main-e2e/.cargo/config.toml
+++ b/packages/testing/nros-tests/bins/qemu-baremetal-main-e2e/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 nros-board-mps2-an385 = { path = "../../../../boards/nros-board-mps2-an385" }  # nros-managed

--- a/packages/testing/nros-tests/bins/qemu-baremetal-main-e2e/.cargo/nros-board.toml
+++ b/packages/testing/nros-tests/bins/qemu-baremetal-main-e2e/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/packages/testing/nros-tests/bins/rtic-run-plan-e2e/.cargo/config.toml
+++ b/packages/testing/nros-tests/bins/rtic-run-plan-e2e/.cargo/config.toml
@@ -1,7 +1,4 @@
 include = ["../../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-
 
 [patch.crates-io]
 mps2-an385-pac = { path = "../../../../boards/mps2-an385-pac" }  # nros-managed

--- a/packages/testing/nros-tests/bins/rtic-run-plan-e2e/.cargo/nros-board.toml
+++ b/packages/testing/nros-tests/bins/rtic-run-plan-e2e/.cargo/nros-board.toml
@@ -17,9 +17,20 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE. It was missing,
+# so 19 mps2 leaves (13 on this board) hand-wrote `[build] target` in their
+# own `.cargo/config.toml`, the only board family that had to.
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # cortex-m-rt's `link.x`. NOT `mps2_an385.ld`: that script belongs to the
+    # FreeRTOS board (`nros-board-mps2-an385-freertos`), whose C startup
+    # provides the vector table and reset handler cortex-m-rt provides here.
+    # phase-445 W2 measured both directions: this board linked with the other
+    # board's group fails, and vice versa (see that phase's W2 note).
     "-C", "link-arg=-Tlink.x",
     # phase-341 W1 — hoisted from the leaves. 25 of 32 `thumbv7m` leaf
     # configs carried this and 7 did not, which is drift, not a choice:
@@ -28,3 +39,8 @@ rustflags = [
     # because they are `#[used]` (CLAUDE.md records exactly this).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/freertos_entry/.cargo/config.toml
+++ b/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/freertos_entry/.cargo/config.toml
@@ -4,6 +4,3 @@
 # Cargo treats a missing include as a hard error during manifest parse, so a
 # stale depth makes the leaf unreadable rather than merely unpatched.
 include = ["../../../../../../../../nros-patch.toml", "nros-board.toml"]
-[build]
-target = "thumbv7m-none-eabi"
-

--- a/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/freertos_entry/.cargo/nros-board.toml
+++ b/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/freertos_entry/.cargo/nros-board.toml
@@ -17,11 +17,26 @@
 # the sibling `config.toml`, because a `[patch.crates-io]` in this file
 # would collide with the one that already lives there.
 
+# phase-445 W2 (RFC-0098 D4) — the board's triple, stated HERE rather than in
+# each leaf (6 FreeRTOS leaves hand-wrote it).
+[build]
+target = "thumbv7m-none-eabi"
+
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
+    # The board's own script (`c/board_mps2.c` startup + FreeRTOS). The
+    # `examples/workspaces/{rust,realtime-rust}` configs mirror THIS group for
+    # their FreeRTOS images — not the bare-metal board's `-Tlink.x`, which is
+    # cortex-m-rt's and a different board (phase-445 W2, measured by build).
     "-C", "link-arg=-Tmps2_an385.ld",
     "-C", "link-arg=--nmagic",
     # phase-341 W1 — hoisted from the leaves (see nros-board-mps2-an385).
     "-C", "link-arg=--gc-sections",
 ]
+
+# The cc-crate cross compiler for this triple — a board toolchain fact
+# (phase-445 W2; `examples/workspaces/rust/.cargo/config.toml` carried it for
+# its FreeRTOS image, `workspace-rust-qemu-freertos`).
+[env]
+CC_thumbv7m_none_eabi = "arm-none-eabi-gcc"

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -324,6 +324,12 @@ impl BuildRungs {
             .filter(|s| !s.is_empty())?;
         println!("cargo:rerun-if-env-changed=NROS_PLATFORM_NAME");
 
+        // phase-445 W2 — WHICH `[[board]]` in the file, for its `[board.knobs]`.
+        // `nros ws board-facts` emits it beside `NROS_BOARD_TOML`; absent is
+        // fine for a file declaring one board (or several that agree).
+        println!("cargo:rerun-if-env-changed=NROS_BOARD");
+        let board_name = std::env::var("NROS_BOARD").ok().filter(|s| !s.is_empty());
+
         let board = std::env::var("NROS_BOARD_TOML")
             .ok()
             .filter(|s| !s.is_empty())
@@ -332,7 +338,7 @@ impl BuildRungs {
                 // `rerun-if-env-changed` on a variable naming a PATH compares
                 // the spelling, and one directory has three spellings here.
                 println!("cargo:rerun-if-changed={raw}");
-                BoardKnobsFile::load(Path::new(&raw))
+                BoardKnobsFile::load_for_board(Path::new(&raw), board_name.as_deref())
                     .unwrap_or_else(|e| panic!("NROS_BOARD_TOML={raw}: {e}"))
             });
 
@@ -1177,6 +1183,19 @@ pub enum ConfigError {
         capability: String,
         boards: String,
     },
+    /// phase-445 W2 — the knob twin of [`Self::AmbiguousBoardCapability`]:
+    /// several `[[board]]` entries state different `[board.knobs]` and no
+    /// `NROS_BOARD` names one.
+    AmbiguousBoardKnobs {
+        path: String,
+        boards: String,
+    },
+    /// phase-445 W2 — a file states knobs both at the top level and under a
+    /// `[[board]]`. Two rungs in one file for the same board, with no rule for
+    /// which wins, is refused rather than merged.
+    BoardKnobsStatedTwice {
+        path: String,
+    },
     /// phase-400 W3 — `transport.kind` outside the `exactly-one-of` group.
     UnknownTransport {
         platform: String,
@@ -1230,6 +1249,17 @@ impl std::fmt::Display for ConfigError {
                 "nros-board.toml declares several boards ({boards}) that disagree about \
                  `[board.capabilities] {capability}`, and no NROS_BOARD names one. \
                  Set NROS_BOARD, or make the entries agree."
+            ),
+            ConfigError::AmbiguousBoardKnobs { path, boards } => write!(
+                f,
+                "{path}: declares several boards ({boards}) whose `[board.knobs]` differ, and \
+                 no NROS_BOARD names one. Set NROS_BOARD, or make the entries agree."
+            ),
+            ConfigError::BoardKnobsStatedTwice { path } => write!(
+                f,
+                "{path}: states `[knobs]` at the top level AND `[board.knobs]` under a board. \
+                 The board rung is `[board.knobs]` (the CLI refuses a top-level `[knobs]`); \
+                 move the top-level table under the board."
             ),
             ConfigError::UnknownTransport {
                 platform,
@@ -2550,11 +2580,60 @@ pub struct BoardEntryFacts {
     /// fact somebody declared.
     #[serde(default)]
     pub capabilities: BTreeMap<String, bool>,
+    /// phase-445 W2 — `[board.knobs]`, the board rung of the RFC-0049 ladder.
+    ///
+    /// Held RAW and typed only once selected ([`BoardKnobsFile::load_for_board`]
+    /// hoists it into [`BoardKnobsFile::knobs`], which every consumer reads).
+    /// Raw because two entries are compared for AGREEMENT when no board is
+    /// named, and `Knobs` has no equality.
+    ///
+    /// Why under the board and not at the top level: the CLI's `BoardFile`
+    /// denies a top-level `[knobs]`, so until this field existed NO shipped
+    /// descriptor could carry a knob at all — the top-level table this reader
+    /// already parsed was unreachable from the one file format that has to
+    /// load. Per-board for the same reason as issue 1143's capabilities: a
+    /// file may declare several boards.
+    #[serde(default)]
+    pub knobs: Option<toml::Value>,
     #[serde(flatten)]
     _rest: BTreeMap<String, toml::Value>,
 }
 
 impl BoardKnobsFile {
+    /// The `[board.knobs]` of the entry this build is, or `None` when that
+    /// entry states none. Same selection rule as [`Self::board_capabilities`]:
+    /// a named board wins; one entry needs no name; several entries must agree
+    /// (an entry stating nothing disagrees with one stating something).
+    fn select_board_knobs(
+        &self,
+        board: Option<&str>,
+        path: &str,
+    ) -> Result<Option<toml::Value>, ConfigError> {
+        if let Some(want) = board
+            && let Some(entry) = self
+                .boards
+                .iter()
+                .find(|b| b.names.iter().any(|n| n == want))
+        {
+            return Ok(entry.knobs.clone());
+        }
+        let Some(first) = self.boards.first() else {
+            return Ok(None);
+        };
+        if self.boards.iter().all(|b| b.knobs == first.knobs) {
+            return Ok(first.knobs.clone());
+        }
+        Err(ConfigError::AmbiguousBoardKnobs {
+            path: path.to_string(),
+            boards: self
+                .boards
+                .iter()
+                .map(|b| b.names.join("/"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        })
+    }
+
     /// `[board.capabilities]` for the named board — see
     /// [`PlatformsTree::capabilities_with_board`] for the selection rule.
     pub fn board_capabilities(
@@ -2601,15 +2680,50 @@ impl BoardKnobsFile {
         Ok(merged)
     }
 
+    /// [`Self::load_for_board`] with no board named — correct whenever the file
+    /// declares one board, or several that agree.
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
+        Self::load_for_board(path, None)
+    }
+
+    /// Load a board file and resolve its knob rung for `board` (`NROS_BOARD`).
+    ///
+    /// [`Self::knobs`] is the one field every consumer reads. It comes from the
+    /// selected entry's `[board.knobs]`; a top-level `[knobs]` (an out-of-tree
+    /// file the CLI never loads) is still honoured when no board states any.
+    pub fn load_for_board(path: &Path, board: Option<&str>) -> Result<Self, ConfigError> {
         let text = fs::read_to_string(path).map_err(|e| ConfigError::Io {
             path: path.display().to_string(),
             source: e,
         })?;
-        toml::from_str(&text).map_err(|e| ConfigError::Parse {
-            path: path.display().to_string(),
-            source: e,
-        })
+        Self::parse_for_board(&text, board, &path.display().to_string())
+    }
+
+    /// [`Self::load_for_board`] over text already read. `path` names the file in
+    /// errors only.
+    pub fn parse_for_board(
+        text: &str,
+        board: Option<&str>,
+        path: &str,
+    ) -> Result<Self, ConfigError> {
+        let parse = |source| ConfigError::Parse {
+            path: path.to_string(),
+            source,
+        };
+        let mut file: Self = toml::from_str(text).map_err(parse)?;
+        if let Some(raw) = file.select_board_knobs(board, path)? {
+            let top_level = text
+                .parse::<toml::Table>()
+                .map(|t| t.contains_key("knobs"))
+                .unwrap_or(false);
+            if top_level {
+                return Err(ConfigError::BoardKnobsStatedTwice {
+                    path: path.to_string(),
+                });
+            }
+            file.knobs = raw.try_into().map_err(parse)?;
+        }
+        Ok(file)
     }
 }
 
@@ -2635,6 +2749,70 @@ mod board_capability_tests {
         assert_eq!(caps.get("heap"), Some(&true));
         // Reading the top-level table instead would find nothing.
         assert!(f.capabilities.is_empty());
+    }
+
+    /// phase-445 W2 — `[board.knobs]` IS the board rung: a single-board file
+    /// needs no name, and the value lands in `knobs`, where every consumer
+    /// (`BuildRungs::*_rungs`, `nros config explain`, zpico's runner) reads.
+    #[test]
+    fn board_knobs_are_the_board_rung() {
+        let f = BoardKnobsFile::parse_for_board(
+            "[[board]]\nnames = [\"e\"]\n\n[board.knobs.net]\nmax_udp_sockets = 2\n",
+            None,
+            "t",
+        )
+        .expect("parse");
+        assert_eq!(f.knobs.net.max_udp_sockets, Some(2));
+        // Negative control: the same number NOT under a board is not read as
+        // this board's — `file()` is the raw parse with no selection.
+        let raw = file("[[board]]\nnames = [\"e\"]\n\n[board.knobs.net]\nmax_udp_sockets = 2\n");
+        assert_eq!(raw.knobs.net.max_udp_sockets, None);
+    }
+
+    /// Several boards that differ are selected by name, and REFUSED unnamed.
+    #[test]
+    fn differing_board_knobs_need_a_name() {
+        let text = "[[board]]\nnames = [\"a\"]\n[board.knobs.net]\nmax_udp_sockets = 1\n\n\
+                    [[board]]\nnames = [\"b\"]\n[board.knobs.net]\nmax_udp_sockets = 3\n";
+        let b = BoardKnobsFile::parse_for_board(text, Some("b"), "t").expect("b");
+        assert_eq!(b.knobs.net.max_udp_sockets, Some(3));
+        let err = BoardKnobsFile::parse_for_board(text, None, "t").expect_err("must refuse");
+        assert!(err.to_string().contains("a, b"), "{err}");
+        // One entry stating knobs and one stating none also disagree.
+        let partial = "[[board]]\nnames = [\"a\"]\n[board.knobs.net]\nmax_udp_sockets = 1\n\n\
+                       [[board]]\nnames = [\"b\"]\n";
+        assert!(BoardKnobsFile::parse_for_board(partial, None, "t").is_err());
+        // And a file whose entries state none is not ambiguous (nuttx today).
+        let none = "[[board]]\nnames = [\"a\"]\n\n[[board]]\nnames = [\"b\"]\n";
+        assert!(BoardKnobsFile::parse_for_board(none, None, "t").is_ok());
+    }
+
+    /// A knob typo under the board fails loud (the tenants deny unknown keys).
+    #[test]
+    fn a_misspelled_board_knob_is_an_error() {
+        let err = BoardKnobsFile::parse_for_board(
+            "[[board]]\nnames = [\"e\"]\n[board.knobs.net]\nmax_udp_sokets = 2\n",
+            None,
+            "t",
+        )
+        .expect_err("typo must not parse");
+        assert!(err.to_string().contains("max_udp_sokets"), "{err}");
+    }
+
+    /// Both spellings in one file is refused, not merged.
+    #[test]
+    fn knobs_stated_twice_are_refused() {
+        let err = BoardKnobsFile::parse_for_board(
+            "[knobs.net]\nmax_udp_sockets = 1\n\n[[board]]\nnames = [\"e\"]\n\
+             [board.knobs.net]\nmax_udp_sockets = 2\n",
+            None,
+            "t",
+        )
+        .expect_err("two rungs in one file");
+        assert!(
+            matches!(err, ConfigError::BoardKnobsStatedTwice { .. }),
+            "{err}"
+        );
     }
 
     /// A file with no `[board.capabilities]` contributes nothing, so the

--- a/scripts/check-board-build-target.py
+++ b/scripts/check-board-build-target.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""A board with a Rust triple states it: `[build] target` in its `cargo_config`.
+
+WHY THIS EXISTS (phase-445 W2, RFC-0098 D4). The board descriptor owns every
+board fact, and later waves GENERATE each image's cargo settings from it and
+delete the leaf `.cargo/config.toml` files. A fact the descriptor omits is then
+a fact no image gets. Measured on 2026-09-10: esp32, both NuttX boards and
+ThreadX-RV64 stated `[build] target`; the two mps2 boards and the two armv8r
+FreeRTOS boards did not — so 19 mps2 leaves hand-wrote
+`target = "thumbv7m-none-eabi"`, the one board family that had to, and the
+file RFC-0098 deletes was the only place their triple lived.
+
+THE RULE, per `[[board]]` entry of every tracked `packages/boards/**/nros-board.toml`:
+
+  * the board HAS a Rust triple when its `cargo_config` configures a
+    `[target.<triple>]`, or when it is a `board-run` board (a cross image whose
+    cargo settings come from this descriptor — it has a triple whether or not
+    the blob says so, and a blob that says nothing is the gap itself);
+  * such a board must set `[build] target`.
+
+Exempt, and REPORTED as exempt rather than silently skipped:
+
+  * `hosted-main` with no `[target.*]` — the host triple; there is no cross
+    target to state;
+  * `zephyr-staticlib` with no `[target.*]` — zephyr-lang-rust's
+    `_rust_map_target` chooses the triple inside the Zephyr build, and RFC-0098
+    leaves the Zephyr lane's configuration where it is.
+
+Whether `[build] target` NAMES one of the configured triples is
+`check-board-cargo-config-shape`'s rule, not repeated here.
+
+Discovery is the git index (`scripts/lib/tracked.py`, issue 0721), with the
+inherited repository environment cleared first (issue 0986): this runs from the
+`pre-push` hook's lane, where an inherited `GIT_DIR` names another index.
+
+Exit 0 when every board with a triple states it, 1 otherwise.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # 3.10 backport, same spelling as the sibling gates
+    import tomli as tomllib
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from git_hook_env import nros_clear_inherited_git_env  # noqa: E402
+from tracked import tracked  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Board kinds whose triple is NOT the descriptor's to state, and why.
+EXEMPT_KINDS = {
+    "hosted-main": "host triple",
+    "zephyr-staticlib": "zephyr-lang-rust maps the triple",
+}
+
+
+def descriptors(root):
+    """Tracked board descriptors — never a leaf's `.cargo/nros-board.toml`
+    projection, which shares the file name."""
+    # No `repo=`: the real root is inside the repo and resolves through the
+    # index; a `--self-test` temp root is outside it and is walked (tiny).
+    return [
+        p
+        for p in tracked(Path(root) / "packages" / "boards", name="nros-board.toml")
+        if ".cargo" not in p.parts
+    ]
+
+
+def check_entry(rel, entry):
+    """Returns (verdict, message): verdict is 'ok', 'exempt' or 'fail'."""
+    names = "/".join(entry.get("names", [])) or "<unnamed>"
+    kind = entry.get("entry_kind", "")
+    blob = entry.get("cargo_config")
+    cfg = {}
+    if blob is not None:
+        try:
+            cfg = tomllib.loads(blob)
+        except tomllib.TOMLDecodeError as e:
+            return "fail", f"{rel} [{names}]: `cargo_config` is not valid TOML: {e}"
+    triples = sorted(cfg.get("target", {}))
+    build_target = cfg.get("build", {}).get("target")
+
+    if not triples and kind in EXEMPT_KINDS:
+        return "exempt", f"{names} ({kind}: {EXEMPT_KINDS[kind]})"
+    has_triple = bool(triples) or kind == "board-run"
+    if not has_triple:
+        # A kind this gate does not know and no triple configured: say so
+        # rather than pass it as though it had been judged.
+        return "fail", (
+            f"{rel} [{names}]: entry_kind `{kind}` is not one this gate knows "
+            f"and the board configures no `[target.*]` — add the kind to "
+            f"EXEMPT_KINDS with a reason, or state the board's triple."
+        )
+    if isinstance(build_target, str) and build_target:
+        return "ok", names
+    where = f"configures {', '.join(triples)}" if triples else "is a `board-run` board"
+    return "fail", (
+        f"{rel} [{names}]: {where} but its `cargo_config` has no `[build] target`. "
+        f"Every image of this board would have to hand-write the triple in its own "
+        f"`.cargo/config.toml` — the file RFC-0098 deletes. Add "
+        f"`[build]\\ntarget = \"<triple>\"` to the blob."
+    )
+
+
+def scan(root):
+    oks, exempt, problems = [], [], []
+    for path in descriptors(root):
+        rel = os.path.relpath(path, root)
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as e:
+            problems.append(f"{rel}: not valid TOML: {e}")
+            continue
+        for entry in data.get("board", []):
+            verdict, msg = check_entry(rel, entry)
+            {"ok": oks, "exempt": exempt, "fail": problems}[verdict].append(msg)
+    return oks, exempt, problems
+
+
+def self_test():
+    """Negative controls — each rule must FIRE on the shape it names, every run."""
+    head = '[[board]]\nnames = ["x"]\nentry_kind = "{kind}"\n'
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp, "packages/boards/nros-board-x")
+        d.mkdir(parents=True)
+        path = d / "nros-board.toml"
+        # A decoy projection INSIDE the scanned tree, so the `.cargo` filter is
+        # actually exercised (the test bins and fixture entries carry these).
+        proj = d / "leaf" / ".cargo"
+        proj.mkdir(parents=True)
+
+        def run(kind, blob=None):
+            text = head.format(kind=kind)
+            if blob is not None:
+                text += "cargo_config = '''\n%s'''\n" % blob
+            path.write_text(text, encoding="utf-8")
+            return scan(tmp)
+
+        target = '[target.thumbv7m-none-eabi]\nrunner = "q"\n'
+        build = '[build]\ntarget = "thumbv7m-none-eabi"\n'
+
+        oks, _, problems = run("board-run", build + target)
+        assert oks == ["x"] and not problems, (oks, problems)
+
+        # THE case: mps2's shape before phase-445 W2.
+        _, _, problems = run("board-run", target)
+        assert any("no `[build] target`" in p for p in problems), problems
+
+        # A cross board with no blob at all is the gap, not an exemption.
+        _, _, problems = run("board-run")
+        assert any("`board-run` board" in p for p in problems), problems
+
+        # A hosted board that DOES configure a cross triple is judged, not exempt.
+        _, _, problems = run("hosted-main", target)
+        assert problems, "a configured triple outranks the kind exemption"
+
+        _, exempt, problems = run("hosted-main")
+        assert not problems and exempt, (exempt, problems)
+        _, exempt, problems = run("zephyr-staticlib")
+        assert not problems and exempt, (exempt, problems)
+
+        # An unknown kind is refused, never waved through.
+        _, _, problems = run("some-new-kind")
+        assert any("not one this gate knows" in p for p in problems), problems
+
+        # A leaf projection shares the file name and must not be read as a board.
+        (proj / "nros-board.toml").write_text(target, encoding="utf-8")
+        path.write_text(head.format(kind="hosted-main"), encoding="utf-8")
+        assert not scan(tmp)[2], "a `.cargo/nros-board.toml` projection is not a descriptor"
+    return 0
+
+
+def main(argv):
+    nros_clear_inherited_git_env()
+    self_test()
+    if "--self-test" in argv:
+        print("check-board-build-target self-test: OK")
+        return 0
+    # `--root <dir>` scans another tree (a negative control over real
+    # descriptors). It must sit OUTSIDE the repo: an in-repo untracked dir
+    # resolves through the index and yields nothing, which the empty-set
+    # refusal below turns into a failure rather than a vacuous pass.
+    root = ROOT
+    if "--root" in argv:
+        root = Path(argv[argv.index("--root") + 1]).resolve()
+    oks, exempt, problems = scan(root)
+    if problems:
+        print("check-board-build-target: FAILED")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    if not oks:
+        print("check-board-build-target: no board with a Rust triple found — refusing "
+              "to pass on an empty set")
+        return 1
+    print(f"check-board-build-target: OK ({len(oks)} board(s) with a triple state "
+          f"`[build] target`; {len(exempt)} exempt: {'; '.join(exempt)})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Implements phase-445 **W2** (RFC-0098 D4: the board descriptor owns every board fact).

| fact | from | to |
|---|---|---|
| `[build] target = "thumbv7m-none-eabi"` | 19 mps2 leaf configs, hand-written | mps2-an385 + mps2-an385-freertos descriptors |
| `[build] target = "armv8r-none-eabihf"` | nowhere (inferred) | s32z270-freertos + mps3-an536-freertos |
| `CC_thumbv7m_none_eabi` | `examples/workspaces/rust/.cargo/config.toml` | both mps2 descriptors |
| NuttX `CC_`/`CFLAGS_` | workspace configs | already identical in the NuttX descriptor |
| `NROS_SMOLTCP_MAX_UDP_SOCKETS = 2` | all three esp32 images' `[env]` | esp32 descriptor `[board.knobs.net] max_udp_sockets = 2` |

- **The board rung had no reader**: the CLI refused any `[knobs]` in a descriptor. `[board.knobs]` is now read (per board, via `NROS_BOARD`, the issue-1143 capabilities pattern), typo-checked by the CLI, and delivered to the zpico runner.
- 22 leaves lose their own `[build]` table — FORCED, not W6: sync's conflict check compares KEYS, so a duplicate `build.target` would make the next sync drop the leaf's board include (and its runner/rustflags). The value stays in the committed projection the leaf already includes. All 37 projections re-rendered and match.
- **Ruled NOT board facts**, with evidence: `NROS_HEAP_SIZE` (3/13 leaves, = the platform default; a board value would override `dds-heap`), `ZPICO_NO_SMOLTCP`/`NROS_LINK_IP` (a per-image transport choice), `ZPICO_SUBSCRIBER_LARGE_SIZE` (derived per image), `ESP_LOG` (esp-println reads it; `[env]` is its home).
- **The mps2 "link-group disagreement" was not one**: the workspace group belongs to the FreeRTOS board, the descriptor's to bare metal. Measured both crossings fail (`cannot find linker script mps2_an385.ld` / `link.x`); both workspace FreeRTOS images link with the descriptor group and boot to "Network ready".
- **Gate** `check-board-build-target` (fast lane, 294 gates derived): negative control — the four pre-W2 descriptors fail it, by name.

**Builds**, each with `cargo config get --show-origin` showing the value comes from the projection: mps2 bare-metal + FreeRTOS talkers link and boot in QEMU; esp32 talker `MAX_UDP_SOCKETS = 2` from the board (control: 1 without); NuttX ARM talker boots with linker/`CC_`/`CFLAGS_` from the projection; mps3-an536 and s32z270 C++ rows link, mps3 boots.

`just ci gate` passed all 6 steps on the previous base; on this base it stops at a pre-existing clippy `needless_borrow` in `pubsub_freertos_ros2_interop_e2e.rs:127` (from main's `fc234aba5`, not in this diff) — fixed separately.

**For later waves:** W4 must deliver the board knobs into `build/<image>/nros-cargo.toml`; W6 must not delete the esp32 leaf `[env]` line before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK