### PR TITLE
fix(nros-tests): needless borrow at pubsub_freertos_ros2_interop_e2e.rs:127 turned every local ci gate red

### DIFF
--- a/packages/testing/nros-tests/tests/pubsub_freertos_ros2_interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/pubsub_freertos_ros2_interop_e2e.rs
@@ -124,7 +124,7 @@ fn nros_freertos_mps2_publisher_reaches_ros2_topic_echo() {
         .unwrap_or_else(|e| skip!("zenohd failed to start on {FREERTOS_C_ENTRY_PORT}: {e}"));
     let peer_locator = format!("tcp/127.0.0.1:{FREERTOS_C_ENTRY_PORT}");
 
-    let mut guest = QemuProcess::start_mps2_an385_freertos_slirp(&entry)
+    let mut guest = QemuProcess::start_mps2_an385_freertos_slirp(entry)
         .unwrap_or_else(|e| panic!("boot freertos QEMU (mps2-an385): {e}"));
 
     // Poll `ros2 topic echo --once` until a sample lands. Each attempt pays


### PR DESCRIPTION
`start_mps2_an385_freertos_slirp(binary: &Path)` already receives a reference, so `&entry` is `&&` and `clippy -D warnings` refuses it (`needless_borrow`). Landed with `fc234aba5` (phase-441 W3). The merge queue does not run this clippy, so `main` stayed green while `just ci gate` — the lane CLAUDE.md says to run before every push — stopped at step 3 for everyone.

One character. Verified: `cargo clippy -p nros-tests --test pubsub_freertos_ros2_interop_e2e -- -D warnings` → rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK