### PR TITLE
fix(check): no merge-gating lane ran a host clippy — nros-node's own test target did not compile

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1115,7 +1115,20 @@ jobs:
       #
       # `test-unit` deliberately STAYS on the batch lane: 3 m 37 s per push is
       # the cost "PR cheap, batch thorough" was actually written for.
-      - name: just check workspace-all (feature combinations)
+      #
+      # CORRECTION, 2026-09-11. The 28 s above measured the EMBEDDED half only.
+      # The host half was `just check workspace`, which had become an `echo`
+      # claiming host clippy ran "in the fast tier" — it did not: issue 0466
+      # moved `check-test-targets` to `build-serial`, schedule only. So no
+      # merge-gating lane ran a host clippy, and 20 errors in nros-node's own
+      # test target plus a `needless_borrow` in nros-tests reached main. The
+      # host half is now `check-test-targets` — `--workspace --all-targets`
+      # and then every crate ALONE, because `--workspace` unifies features and
+      # hid the nros-node errors behind a sibling's `std`. It costs real time
+      # now; read this step's duration off the run, not off the 28 s. For
+      # scale only: `check-test-targets` alone (workspace + per crate + CLI)
+      # took 113 s locally on a WARM target dir — a cold runner pays more.
+      - name: just check workspace-all (host + embedded clippy)
         if: ${{ contains(fromJSON('["pull_request","merge_group","schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |
           source ./activate.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,11 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     it never belonged under the same cost argument, and a feature-combination
     break there costs a batch rather than a PR — `grouping_strategy` is ALLGREEN
     over 5 entries, so one `clippy::derivable_impls` error took #741, #768 and
-    #779 down 7-8 times each with no defect of their own. So a green `CI` on a pull request
+    #779 down 7-8 times each with no defect of their own. (That 28 s was the
+    EMBEDDED clippy alone: the host half was an `echo`, so until 2026-09-11 no
+    merge-gating lane ran a host clippy. It now runs `check-test-targets`,
+    workspace-wide AND per crate — `--workspace` unifies features, which hid
+    20 errors in nros-node's own test target.) So a green `CI` on a pull request
     means "it compiles and the source gates hold", NOT "the unit tests pass";
     nothing broken lands, because the queue runs them before the merge, but the
     feedback arrives at the queue and an ejection is how you hear about it

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -2068,6 +2068,28 @@ test-targets:
     # the host clippy did not previously enforce (the embedded one always did).
     cargo clippy --quiet --workspace --all-targets --no-default-features \
         {{HOST_UNCHECKABLE}} -- -D warnings
+    # Then each crate ALONE, under its own default features. `--workspace`
+    # UNIFIES features across members, so a crate's test target can compile
+    # only because a SIBLING turned on a feature it needs. nros-node is
+    # `#![no_std]` with empty defaults; its `cancel_tests` used `std` and
+    # `alloc`-gated methods with neither in its gate, which the line above passed
+    # (some member unifies `nros-node/std`) while `cargo test -p nros-node`
+    # and `cargo clippy -p nros-node --all-targets` failed with 20 errors.
+    # Same exclusions as above, for the same reason. Every failing crate is
+    # named, not just the first.
+    excl=" {{HOST_UNCHECKABLE}} "
+    members="$(cargo metadata --no-deps --format-version 1 \
+        | python3 -c 'import json,sys; print(" ".join(sorted(p["name"] for p in json.load(sys.stdin)["packages"])))')"
+    failed=""
+    for p in $members; do
+        case "$excl" in *" --exclude $p "*) continue ;; esac
+        cargo clippy --quiet -p "$p" --all-targets -- -D warnings || failed="$failed $p"
+    done
+    if [ -n "$failed" ]; then
+        echo "per-crate clippy (own default features, --all-targets) failed:$failed"
+        echo "  reproduce: cargo clippy -p <crate> --all-targets -- -D warnings"
+        exit 1
+    fi
     # The CLI is its own workspace (own manifest + lock) and its exclusions have
     # a single home in `check-cli-clippy` — call it rather than restate them.
     just check cli-clippy
@@ -2084,13 +2106,17 @@ test-targets:
 # can't resolve its type parameter. Real consumers always specify
 # a platform; the per-feature combinations are covered by
 # `check-workspace-features` further down.
-# Kept as a name others may invoke. Both of its former jobs moved to the FAST
-# tier, where they catch a mistake before a build tier nobody runs per task:
-# host clippy -> `check-test-targets` (now `--all-targets`, `-D warnings`),
-# `fmt --check` -> `check-workspace-fmt`.
+# Kept as a name others may invoke. Its former jobs moved: `fmt --check` ->
+# `check-workspace-fmt` (fast tier), host clippy -> `check-test-targets`.
+# That second move was to the fast tier, then (issue 0466) OUT of it into
+# `build-serial`, which runs on schedule only — and this recipe kept echoing
+# "clippy now run[s] in the fast tier". `workspace-all` called it as its HOST
+# half, so from then until 2026-09-11 no merge-gating lane ran a host clippy at
+# all: 20 errors in nros-node's own test target and a `needless_borrow` in
+# nros-tests reached main. `workspace-all` now calls `test-targets` directly.
 [private]
 workspace: workspace-fmt
-    @echo "check-workspace: fmt + clippy now run in the fast tier."
+    @echo "check-workspace: fmt only; host clippy is check-test-targets."
 
 # Run the host + embedded workspace clippy CONCURRENTLY. They share no
 # target-dir (host = `target/`, embedded = `target-embedded/`), so cargo's
@@ -2104,7 +2130,10 @@ workspace-all:
     set -uo pipefail
     jobs="${NROS_BUILD_JOBS:-$(nproc 2>/dev/null || echo 8)}"
     half=$(( jobs / 2 )); [ "$half" -lt 1 ] && half=1
-    CARGO_BUILD_JOBS="$half" just check workspace &
+    # The HOST half is the real host clippy (`--workspace --all-targets`,
+    # `-D warnings`, then per crate). It was `just check workspace`, an echo —
+    # see that recipe for what that cost.
+    CARGO_BUILD_JOBS="$half" just check test-targets &
     host=$!
     CARGO_BUILD_JOBS="$half" just check workspace-embedded &
     emb=$!

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -1894,8 +1894,10 @@ fn report_typed_deserialize_failure(rc: i32, len: usize) {
 /// `#[cfg(test)]`: the test module is `not(feature = "rmw-cffi")` too, so under
 /// `test + rmw-cffi` a bare gate leaves this compiled with its only caller
 /// gone, and `-D warnings` turns that into a build failure rather than a lint.
-/// An accessor's gate has to be the gate of the thing that reads it.
-#[cfg(all(test, not(feature = "rmw-cffi")))]
+/// An accessor's gate has to be the gate of the thing that reads it — and
+/// that gate gained `alloc` after this one was written, so under default
+/// features this was compiled with no caller at all.
+#[cfg(all(test, feature = "alloc", not(feature = "rmw-cffi")))]
 pub(crate) fn typed_deserialize_failures() -> u32 {
     TYPED_DESERIALIZE_FAILURES.load(portable_atomic::Ordering::Relaxed)
 }

--- a/packages/core/nros-node/src/executor/mod.rs
+++ b/packages/core/nros-node/src/executor/mod.rs
@@ -102,9 +102,10 @@ pub mod action;
 // feature unification under `cargo test --workspace` flips `ConcreteSession`
 // to a real backend handle (e.g. UorbSession when rmw-uorb is on transitively
 // via the workspace), breaking the type signatures the tests expect.
-// `feature = "std"` is part of the gate, not decoration. The crate is
-// `#![no_std]`; `tests.rs` uses `std::` in 155 places and calls
-// `from_session`, which is itself `#[cfg(feature = "alloc")]`. Without the
+// `feature = "alloc"` is part of the gate, not decoration. The crate is
+// `#![no_std]`; `tests.rs` uses `std::` in 155 places (in scope because
+// `lib.rs` brings `std` in under `cfg(test)`) and calls `from_session`, which
+// is itself `#[cfg(feature = "alloc")]`. Without the
 // feature in the gate, a plain `cargo test -p nros-node` compiles this module
 // into a no_std crate and produces 252 errors, 192 of them "cannot find module
 // or crate `std`" — an incomprehensible wall for anyone running the obvious

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -10551,10 +10551,12 @@ impl<'s> Executor<'s> {
 // ============================================================================
 //
 // Same gate as `executor::tests`, exactly: `ConcreteSession` is `MockSession`
-// only while no rmw-* feature is unified in (see `executor/mod.rs`). No `std`
-// gate — `cfg(test)` already means a hosted harness, and adding one would be a
-// census site phase-359 is spending effort removing.
-#[cfg(all(test, not(feature = "rmw-cffi")))]
+// only while no rmw-* feature is unified in (see `executor/mod.rs`), and
+// `from_session_with` / `halt_flag` are `alloc`. No `std` gate — `cfg(test)`
+// already means a hosted harness, which is why `lib.rs` brings `std` in under
+// `test` as well. (It said "exactly" while missing `alloc`, and `std` was not in
+// scope: 20 errors, hidden by feature unification under `--workspace`.)
+#[cfg(all(test, feature = "alloc", not(feature = "rmw-cffi")))]
 mod cancel_tests {
     use super::Executor;
     use crate::{executor::types::ExecutorConfig, mock::MockSession};

--- a/packages/core/nros-node/src/lib.rs
+++ b/packages/core/nros-node/src/lib.rs
@@ -81,6 +81,19 @@ extern crate nros_platform_cffi as _;
 #[cfg(feature = "std")]
 extern crate std;
 
+// And under `test` without the feature: a test build is a hosted harness, so
+// `std` exists there whatever the features say. Without this a test module's
+// `std::` resolved only when some OTHER workspace member unified
+// `nros-node/std` in — so `--workspace` clippy was green while
+// `cargo clippy -p nros-node --all-targets` (and plain `cargo test -p
+// nros-node`) failed to compile the test target at all.
+//
+// Two items, not `any(feature = "std", test)`: `check-std-census` reads any
+// cfg naming `test` as a test gate and stops counting it, and the line above
+// IS a non-test std site — folding them hid it and read as progress.
+#[cfg(all(test, not(feature = "std")))]
+extern crate std;
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/packages/testing/nros-tests/tests/pubsub_freertos_ros2_interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/pubsub_freertos_ros2_interop_e2e.rs
@@ -124,7 +124,7 @@ fn nros_freertos_mps2_publisher_reaches_ros2_topic_echo() {
         .unwrap_or_else(|e| skip!("zenohd failed to start on {FREERTOS_C_ENTRY_PORT}: {e}"));
     let peer_locator = format!("tcp/127.0.0.1:{FREERTOS_C_ENTRY_PORT}");
 
-    let mut guest = QemuProcess::start_mps2_an385_freertos_slirp(&entry)
+    let mut guest = QemuProcess::start_mps2_an385_freertos_slirp(entry)
         .unwrap_or_else(|e| panic!("boot freertos QEMU (mps2-an385): {e}"));
 
     // Poll `ros2 topic echo --once` until a sample lands. Each attempt pays


### PR DESCRIPTION
On `main`, `cargo clippy -p nros-node --all-targets -- -D warnings` fails with 20 errors. None of them are lints: nros-node's test target doesn't compile under the crate's own default features. This PR fixes the errors and closes the two lane gaps that let them through.

## The errors

| count | error | cause |
|---|---|---|
| 12 | cannot find `std` | `cancel_tests` uses `std`, and `lib.rs` brought `std` in only with the `std` feature |
| 7 | no method `spin` / `halt_flag` / `spin_period` / `from_session_with` | those methods need `alloc`. `cancel_tests`' comment said "same gate as `executor::tests`, exactly", but `tests` has `alloc` and `cancel_tests` didn't |
| +1 | `typed_deserialize_failures` never used | a test-only accessor gated like `tests` was before `tests` gained `alloc`. It only appeared once the first 19 were fixed |

**The fix:**
- `lib.rs` also brings `std` in for test builds that don't have the `std` feature, since test builds always run on a host.
- The two gates gain `alloc`.
- `lib.rs` keeps two separate `extern crate std` declarations rather than one `any(feature = "std", test)`. `check-std-census` treats any cfg that mentions `test` as a test gate and stops counting it. A combined line would have hidden a real non-test `std` site; the first draft took the count from 3 to 2.

## Why nothing caught it

1. **Workspace clippy pools features across crates.** Some crate enables `nros-node/std`, so the tests compiled under `--workspace`. They didn't under `-p nros-node`, or under plain `cargo test -p nros-node`.
2. **No PR or merge batch ran host clippy at all.**
   - `check-test-targets` is the host clippy. Issue 0466 moved it to `build-serial`, which only runs on schedule.
   - `workspace-all` runs on PRs and merge batches. Its host half called `just check workspace`, which had become an `echo` saying clippy runs in the fast tier. Only the embedded half ran.
   - That's why #825 measured `workspace-all` at 28 s. It's also how #835's `needless_borrow` (`fc234aba5`) landed yesterday. That lint is fixed here too.

## The lane

- `workspace-all`'s host half now runs `check-test-targets`: `--workspace --all-targets` with `-D warnings`.
- `check-test-targets` then runs clippy on **each workspace crate alone**, with its own default features, skipping `HOST_UNCHECKABLE`. It names every crate that fails.
- The echo, the `gate.yml` step name ("feature combinations"; it's host + embedded clippy), the 28 s rationale in `gate.yml`, and `CLAUDE.md` now describe what actually runs.

**Cost:** `check-test-targets` took **113 s locally with a warm target dir**, covering workspace + per-crate + CLI. A cold runner will take longer; this PR's first run gives the real CI number.

## Sweep: every workspace crate, alone, with `--all-targets`, on main

| result | crates |
|---|---|
| real errors, fixed here | `nros-node` (20), `nros-tests` (1) |
| fail without submodule sources; pass once the recorded pins are checked out | zpico-sys, nros-rmw-zenoh, both cyclonedds-sys crates, nros-rmw-xrce-cffi, nros-board-linux |
| already in `HOST_UNCHECKABLE` | both `-staticlib` crates (need `#[panic_handler]`), nros-c, nros-cpp |
| clean | the other 45 |

## Verified

- nros-node `--all-targets` clippy is clean under default features, `alloc` and `std`.
- `check-test-targets` passes.
- `node-std-tests` passes: 404 + 159 tests.
- `check-lane-contracts`, `check-gate-lists` and `check-std-census` pass.
- fmt is clean.
- `just check fast` passes all **293** gates (this worktree has the submodule sources checked out at their recorded pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
