### PR TITLE
docs(issues): triage eight issues that looked left behind — four archived, four still open

### DIFF
--- a/docs/issues/0865-no-example-registers-parameter-services.md
+++ b/docs/issues/0865-no-example-registers-parameter-services.md
@@ -80,3 +80,39 @@ and nothing says so.
 Do not add the call to an example to "demonstrate" it. That is what phase-277
 W3.a deliberately undid, and it would make the example's build feature-dependent
 again.
+
+## Status 2026-09-11
+
+**Still open — no fix for this issue has landed.** An audit flagged it as
+"fixed but left open" because `61817418f` is titled `fix(#0865): ...`. That
+commit is not about this issue: it fixes nuttx e2e throttling, and
+`715cf359f` (same minute) renumbered that branch's 0865 to 0891 after this file
+took the id. The subject line was never corrected.
+
+Measured against the three fix directions on `main`:
+
+- **Header — not done.** `nros_generated.h:3445-3452` still declares
+  `nros_executor_register_parameter_services` with no guard and no capability
+  note, while the definition is still
+  `#[cfg(all(feature = "param-services", feature = "rmw-cffi"))]`
+  (`nros-c/src/parameter.rs:769`, fn at `:860`). A caller without the feature
+  still learns it from `ld`. The hand-written `parameter.h:371` banner says
+  "requires NROS_PARAM_SERVICES feature" — a name defined nowhere in the tree
+  (`git grep NROS_PARAM_SERVICES` finds only that comment), so the one hint
+  that exists points at nothing.
+- **Docs — not done.** No page in `book/`, `docs/guides/` or
+  `docs/reference/c-api-cmake.md` says how a CMake consumer requests the
+  `param_services` capability.
+- **Silent absence — only the Rust half of a neighbouring case.** The
+  `nros::main!` const-assert (`nros/src/lib.rs` `PARAM_SERVICES_ENABLED`,
+  `nros-macros/src/main_macro.rs` phase-314 guard) fails the build when a
+  system DECLARES `[param_services]` but `nros` lacks the feature. It predates
+  this issue and does not reach it: a node that never asked for the capability
+  still answers `ros2 param list` with silence, and C entries have no such
+  assert. (C++ `ComponentNode` answers `ErrorCode::Unsupported` without a
+  store, per the `param.json` ledger — the one place absence already explains
+  itself.)
+
+What would close it: the header note at the declaration (and the banner
+corrected to the real capability name), one doc line for the CMake
+`param_services` capability, and a decision on the startup line.

--- a/docs/issues/0902-action-goal-completion-is-variable.md
+++ b/docs/issues/0902-action-goal-completion-is-variable.md
@@ -5,7 +5,7 @@ title: "action goals complete between 20 % and 90 % of the time on the same buil
 status: open
 type: bug
 area: rmw
-related: [issue-0882, issue-0879, issue-0852]
+related: [issue-0912, issue-0882, issue-0879, issue-0852, phase-444]
 ---
 
 ## Measurement
@@ -249,3 +249,52 @@ created in order and none is destroyed — `NEXT_SERVICE_BUFFER_INDEX` never
 decrements, but `Queryable::drop` (`zpico.rs:218`) frees the C slot for reuse.
 One dropped service server desynchronises the two permanently. Not reachable in
 this image; one lifecycle transition away.
+
+## Status 2026-09-11 — both leak arms fixed, the symptom never re-measured
+
+Checked against the code on `main`, not against the commit messages.
+
+**Fixed: the reply-slot leak, both arms.** Every release now goes through ONE
+helper, `_zpico_release_reply_slot` (`zpico.c:4083`):
+
+* declined query: `1a032a10b`. `zpico_queryable_take_reply_seq` clears the
+  seq, and `query_handler` releases any clone whose seq is still set when the
+  callback returns (`zpico.c:990`). This covers the empty-payload probe and the
+  ring-full drop.
+* failed reply: `b56e3d50a`. Every error return in `zpico_query_reply`
+  releases the slot, and so does the success path (`zpico.c:4112`, `:4119`,
+  `:4137`).
+
+**What remains, and why this stays open:**
+
+1. **The symptom was never re-measured.** No run after the fixes records a goal
+   completion rate, so nobody knows whether the leak was the whole cause or
+   only part of it. The 09-04 section's "second candidate" (a per-reply
+   transport failure) does not explain the idle soak, but nothing has ruled it
+   out either. `phase-444-rmw-fix-up.md` W2 carries this as its acceptance: the
+   completion rate on a freshly built image, over enough runs to separate it
+   from 20–90 %. That run needs a router and a live peer.
+2. **The two free checks were never recorded.** One: did any goal ever succeed
+   after an earlier failure in the same boot? Two: is there a ~15 B
+   `REPLY_FINAL` between the 82 B query and the 78 B status? Both read data
+   that already exists. They would confirm the MECHANISM on the pre-fix
+   captures, independent of item 1.
+3. **No regression test.** Both fix commits say why: reaching either arm needs
+   a query delivered to a queryable, which needs a router. No test under
+   `packages/testing` references the reply-slot table.
+4. **The latent desync is unchanged.** `shim/service.rs:402` builds
+   `buffer_index` from the Rust counter, and `:246` passes it to
+   `zpico_queryable_take_reply_seq` as the C queryable handle. The comment at
+   `:241` asserts they are equal, and nothing enforces that. Still unreachable
+   in this image; still one dropped server away.
+5. **A correction to the 09-04 section.** `ZPICO_MAX_PENDING_REPLIES` is
+   `#ifndef`-guarded (`zpico.c:265`), so a raw `-D` does override it. No
+   Kconfig, cmake or env knob sets it, which is what the leak analysis relied
+   on.
+
+Also done here: `related:` gains issue 0912, as the 09-04 section asked,
+together with phase-444.
+
+**What would close it:** item 1's measurement at or near 10/10 on a fresh image
+closes the issue. A residual failure rate reopens the second candidate, and
+items 2 and 3 are what would make that residual diagnosable.

--- a/docs/issues/1177-no-alloc-nros-c-lane-runs-only-on-schedule.md
+++ b/docs/issues/1177-no-alloc-nros-c-lane-runs-only-on-schedule.md
@@ -9,6 +9,37 @@ severity: high
 related: [issue-0196, issue-0952, issue-0993, issue-1175, phase-395, phase-417]
 ---
 
+## Status 2026-09-11
+
+Re-triaged against `origin/main` because three `fix(#1177)` commits
+(`9fd7e3457`, `04e597288`, `8fdb9631a`) read as if they closed it. They closed
+the BREAK half only — the coverage half is still open, and nothing since has
+decided the tier question:
+
+* No workflow step runs `workspace-features` on a merge-gating event. Its only
+  caller is `check build`, and `no-std` is its own step guarded
+  `contains(fromJSON('["schedule","workflow_dispatch"]'), …)`
+  (`.github/workflows/gate.yml:983-984`).
+* Option B was not taken: `compile-smoke`'s `nros-c` row is still
+  `C_API_SHIPPED_FEATURES` (`std,…`), with no `panic-platform,rmw-cffi,lending`
+  row (`just/check/lanes.just`, `compile-smoke`).
+* `workspace-all` MOVED since this was written — #825 put it on
+  `pull_request` as well as `merge_group`, so the table row below reading
+  "merge_group" is now "pull_request, merge_group". It still does not cover
+  this row: `nros-c` declares `host-only = true` (`packages/api/nros-c/
+  Cargo.toml:258-260`), so its embedded arm passes `--exclude nros-c`.
+  (#875, queued, gives `workspace-all` a real host clippy; it runs `-p nros-c`
+  never, because `nros-c` is in `HOST_UNCHECKABLE`, so it does not bear on
+  this either.)
+* The rows are green today, re-measured on this tree — both `lending`
+  clippies with `-D warnings` (`panic-platform,rmw-cffi,lending` and
+  `std,rmw-cffi,lending,platform-posix`) and the default-features
+  `cargo test --no-run -p nros-c` that was red at `f0f97de42`: rc=0 all three.
+
+So the status is unchanged: a maintainer's choice among A / A-narrow / B / C
+below. Green rows are not coverage — the next break in this class still
+reaches `main` the same way the first two did.
+
 ## Where this stands
 
 Two halves, and only one of them is still open.

--- a/docs/issues/1225-capability-probe-changes-sizeof-timer-and-guard-condition.md
+++ b/docs/issues/1225-capability-probe-changes-sizeof-timer-and-guard-condition.md
@@ -204,6 +204,33 @@ caller-owned, the shape `rclcpp::detail::WallTimer` uses — is not needed to
 reach a stable layout under this decision, and it is a bigger change to the
 `std_compat.hpp` surface than an unconditional 8-byte member.
 
+## Status 2026-09-11 — still open; the wave it was handed to had already merged
+
+A triage of open issues whose fix commits had landed found this one. The GATE
+half is done (`d93cc31e6`); the three types are **not**, and nothing is carrying
+them:
+
+* **The divergence is unchanged.** `check-cpp-capability-layout --report` on
+  `origin/main` today: `::nros::Timer` 32 vs 24, `::nros::GuardCondition` 40 vs 32,
+  `::nros::ComponentNode` 496 vs 432 (still exactly 8 × 8 — it shrank from 55784
+  with phase-427, the delta did not), and `rclcpp::Timer` / `TimerBase` with
+  `Timer`. `timer.hpp:160-167` and `guard_condition.hpp:122-123` still carry
+  `closure_` under `#ifdef NROS_CPP_STD`.
+* **The five `diverges` lines are still in the baseline**, and the gate is green —
+  which, because its selftest proves a `diverges` entry on a subject that no
+  longer diverges FAILS, is itself the measurement that all five still diverge.
+* **"For PR #755's wave" cannot happen as written.** #755 merged at
+  2026-09-08 18:25 UTC, 55 minutes BEFORE `d93cc31e6` / `6b1886104` handed it
+  this work. Nothing open cites 1225.
+
+What closes it is unchanged and fully decided above: make `closure_` an
+UNCONDITIONAL member of `nros::Timer` and `nros::GuardCondition` (the
+`std::unique_ptr<std::function<void()>>` needs a freestanding-safe spelling —
+an opaque pointer plus destroyer, the `rclcpp::Node` W1 shape — since the
+freestanding arm has no `<functional>`), then delete the five `diverges` lines
+in the same commit. `ComponentNode` follows. The gate is the acceptance: a
+stale line fails.
+
 ## Repro
 
 ```sh

--- a/docs/issues/archived/1099-cpp-trigger-transition-crosses-lifecycle-ids.md
+++ b/docs/issues/archived/1099-cpp-trigger-transition-crosses-lifecycle-ids.md
@@ -2,7 +2,8 @@
 id: 1099
 title: "`LifecycleNode::trigger_transition(uint8_t)` takes upstream's exact
   signature over a DIFFERENT id space — `2` activates where ROS 2 cleans up"
-status: open
+status: resolved
+resolved: 2026-09-06
 type: bug
 area: api, cpp
 related: [phase-428, rfc-0089]
@@ -65,3 +66,32 @@ API and the wire agree, and resolve `shutdown()` from the current state. Then
 decide whether our enum's discriminants should simply become upstream's —
 nothing in a fixed arena requires a different numbering, so this looks like a
 preference recorded as a divergence (RFC-0036).
+
+## Resolution
+
+Fixed 2026-09-06 by `0747a4c34`, by renumbering rather than translating: the
+core enum takes `lifecycle_msgs/msg/Transition` ids, because the C side carried
+the same latent defect and a boundary translation would have left
+`NROS_LIFECYCLE_TRANSITION_ACTIVATE` and `trigger_transition(2)` meaning
+different things inside one image. `c1db3a752` (2026-09-10) discharged the
+prose-ratchet rows that cited this issue as in flight. The file itself was
+never archived — the ledger row `cpp:LifecycleNode::trigger_transition` has said
+"issue 1099 archived" since the fix; it is now true. Re-verified on `main`
+2026-09-11:
+
+* Ids are upstream's: `packages/core/nros-core/src/lifecycle.rs:92-101`
+  (`Cleanup = 2`, `Activate = 3`, `Deactivate = 4`); `ErrorRecovery = 60`
+  (`TRANSITION_ON_ERROR_SUCCESS`, `:114`), not upstream's 8 (DESTROY, which we
+  do not implement); `from_u8` rejects the rest (`:44-51`).
+* `shutdown()` resolves from the current state through
+  `shutdown_transition_for(LifecycleState)`
+  (`packages/api/nros-cpp/include/nros/lifecycle.hpp:105`).
+* Pinned: `packages/api/nros-cpp/tests/compile/lifecycle_transition_ids.cpp`
+  static-asserts the C literals against UPSTREAM values, run by `check-cpp`
+  (`just/check/lanes.just:646`); nros-core's lifecycle tests pass (15/15).
+* The dangling cross-reference is gone: `cpp:LifecycleNode::trigger_transition`
+  exists in `lifecycle.json`, and no `.config` baseline row cites 1099.
+
+State ids stay a deliberate divergence (`ErrorProcessing = 5` vs upstream 15;
+5 is unassigned upstream, so it cannot silently mean another state) — recorded
+with a test by the same commit.

--- a/docs/issues/archived/1183-node-std-tests-latch-test-red-in-shared-process.md
+++ b/docs/issues/archived/1183-node-std-tests-latch-test-red-in-shared-process.md
@@ -1,7 +1,8 @@
 ---
 id: 1183
 title: "`check node-std-tests` is red on main — the executor-backing latch test asserts a process-global that 367 sibling tests share"
-status: open
+status: resolved
+resolved: 2026-09-07
 type: bug
 area: testing
 related: [phase-392, issue-1145]
@@ -68,3 +69,23 @@ documents.
 A lane that is red for every input has no signal capacity — a regression landing
 in it looks exactly like this failure. `node-std-tests` is in the derived
 fast-serial gate list, so that is the whole lane.
+
+## Resolution
+
+Fixed by `605d667eb` ("fix(#1183, #1186): the backing latch test needs a virgin
+process"), the second option above: the test is `#[ignore]`d with its reason in
+the attribute (`packages/core/nros-node/src/executor/backing.rs:237-240`) and
+`node-std-tests` runs it in its OWN cargo invocation, through the `ran_tests`
+guard that fails if the filter matches nothing
+(`just/check/lanes.just:1707-1710`). Same issue as 1186, filed independently.
+
+This file was ADDED eleven minutes after that fix landed (`a0435e5db`, 17:14 vs
+17:03 UTC on 2026-09-06), by a parallel session that had not seen it — it was
+never deliberately kept open, just never closed.
+
+Re-measured on `origin/main` 2026-09-11, features `std,sim-time,param-services`:
+the isolated invocation passes 5/5 (`1 passed`); the full `--lib` suite is
+439 passed, 0 failed, 2 ignored; and the negative control — the same test pulled
+back INTO the shared process with `--include-ignored` — still fails at
+`backing.rs:247`, 2/2. So the isolation is load-bearing and the positive control
+is intact.

--- a/docs/issues/archived/1186-executor-backing-latch-test-races-siblings.md
+++ b/docs/issues/archived/1186-executor-backing-latch-test-races-siblings.md
@@ -1,11 +1,12 @@
 ---
 id: 1186
 title: "`the_static_is_handed_out_once_and_only_once` reads a latch its sibling tests have already claimed"
-status: open
+status: resolved
 type: bug
 area: core, testing
 severity: medium
 found: 2026-09-07
+resolved: 2026-09-07
 related: [1145]
 ---
 
@@ -64,3 +65,22 @@ vacuous test the doc-comment is trying to avoid. Either give this test its own
 process (a `#[test]` in a dedicated integration binary, or a nextest
 `test-group` of one), or make the latch injectable so the test drives its own
 instance and the process-global one is exercised once, deliberately.
+
+## Resolution
+
+Fixed by `605d667eb` ("fix(#1183, #1186): the backing latch test needs a virgin
+process") — the "own process" shape above, without making the latch injectable:
+the test is `#[ignore]`d with its reason in the attribute
+(`packages/core/nros-node/src/executor/backing.rs:237-240`) and `node-std-tests`
+runs it in a dedicated cargo invocation, guarded by `ran_tests` so a renamed
+filter fails instead of running nothing (`just/check/lanes.just:1707-1710`).
+Issue 1183 is the same defect, filed independently.
+
+Re-measured on `origin/main` 2026-09-11, features `std,sim-time,param-services`:
+isolated 5/5 `1 passed`; full `--lib` suite 439 passed, 0 failed, 2 ignored;
+negative control (`--include-ignored`, i.e. back in the shared process) still
+fails at `backing.rs:247`, 2/2 — so it is the isolation, not a changed
+scheduler, that keeps it green.
+
+The "Why it stayed" half is closed separately: `node-std-tests` now runs in the
+`check` job on `pull_request`, not only in schedule-only `check-build`.

--- a/docs/issues/archived/1242-park-granularity-is-hardcoded-not-queried.md
+++ b/docs/issues/archived/1242-park-granularity-is-hardcoded-not-queried.md
@@ -1,9 +1,11 @@
 ---
 id: 1242
 title: "`park_granularity_us()` is a hardcoded 1 ms — wrong high on ThreadX, wrong low on POSIX, and never asks the primitive"
-status: open
+status: resolved
 type: bug
 area: executor
+resolved: 2026-09-10
+resolved_in: "78569eb66 fix(#1242): the park granularity comes from the primitive, not a constant"
 related: [issue-1193, issue-1194, phase-436]
 ---
 
@@ -92,3 +94,34 @@ same time, which is the whole point.
 
 Found by parallel port surveys during phase-436 W6, verified against the
 sources cited above rather than inferred from the ABI.
+
+## Resolution
+
+Resolved by `78569eb66` (2026-09-10); verified against `main` on 2026-09-11.
+Fix-direction items 1 and 2 hold; item 3 was never this issue's to close.
+
+1. **The granularity is the primitive's.** `set_park_primitive(park, ctx,
+   granularity_us)` stores what the port declares
+   (`packages/core/nros-node/src/executor/spin.rs:2546-2554`), and
+   `park_granularity_us()` returns it, falling back to 1 ms only when nothing
+   is installed (`spin.rs:2685-2691`) — the honest floor of the `wake_wait_ms`
+   ABI. No hardcoded `1_000` remains outside that fallback.
+2. **Each port states its tick.** ThreadX derives it from
+   `TX_TIMER_TICKS_PER_SECOND` — 10 ms on both shipped boards
+   (`packages/platform/nros-platform-threadx/src/platform.c:811-815`); Zephyr
+   from `CONFIG_SYS_CLOCK_TICKS_PER_SEC` (`nros-platform-zephyr/src/platform.c:1096`).
+   The board entries hand it to the executor
+   (`nros-board-threadx/src/entry.rs:115`, `nros-board-zephyr/src/entry_tiers.rs:111`,
+   `nros-board-zephyr/c/zephyr_run_tiers.c:199`).
+3. **POSIX / NuttX / FreeRTOS** install no `ParkUntilFn`, so they report the
+   1 ms fallback, which is exactly what their `uint32_t timeout_ms` primitive
+   delivers — no longer an over- or under-claim. Their sub-millisecond park
+   needs the ABI unit change this issue named as a precondition, and that is
+   issue 1193's `wake_wait_us` slot (still open), not a residue here. The cffi
+   shim deliberately forwards neither optional symbol
+   (`nros-platform-cffi/src/lib.rs:416-427`).
+
+Tests from the fix commit, in `executor/tests.rs`: fallback with no primitive
+(`:2085`), a coarser 10 ms port honoured (`:2099`), a finer 1 µs port honoured
+(`:2118`), and the jitter granularity following the port rather than the
+constant (`:2130`).

--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -420,7 +420,7 @@ Each is a filed issue; the issue holds the evidence.
     insertion that anchors on the `pub fn` line and walks back past attributes
     without knowing doc comments are attributes.
 
-  * **W7.b — [issue 1242](../issues/1242-park-granularity-is-hardcoded-not-queried.md).
+  * **W7.b — [issue 1242](../issues/archived/1242-park-granularity-is-hardcoded-not-queried.md).
     DONE.** `park_granularity_us()` now reports what the INSTALLED primitive
     declares (`park_granularity_declared_us`), and the port states it because
     only the port knows: ThreadX's 100 Hz tick is 10 ms, coarser than the ABI


### PR DESCRIPTION
This PR triages the open issues that looked left behind. For each open issue, the audit checked whether a commit on main says `fix/resolve #N` and whether the issue file was left untouched after it. Seven matched. Each one was checked against the current code, with file:line evidence and tests where they were cheap, and either archived as resolved or given a dated status saying what's left.

## Resolved and archived (4)

| issue | fixed by | evidence on main |
|---|---|---|
| 1099: `trigger_transition` took the wrong lifecycle ids | `0747a4c34` (2026-09-06) | every point of the issue's Fix section holds; nros-core lifecycle tests 15/15 |
| 1183: `node-std-tests` red on the backing latch test | `605d667eb` | the latch test is `#[ignore]` and runs in its own process; 5/5 solo, and the full lib passes (439). **Control:** put back in the shared process, it fails 2/2, so the isolation is what keeps it green |
| 1186: the latch test races its siblings | `605d667eb` | same evidence. 1183 wasn't kept open on purpose: a parallel session filed it 11 min after the fix landed |
| 1242: `park_granularity_us()` hardcoded to 1 ms | `78569eb66` | the granularity comes from the installed park primitive (ThreadX tick, Zephyr tick). POSIX/NuttX/FreeRTOS report 1 ms, which is their real wait granularity; going below that is issue 1193's job, as the issue itself said |

## Still open, with a dated status (4)

| issue | why the audit flagged it | what's actually left |
|---|---|---|
| 0865: parameter services undiscoverable | its only `fix(#0865)` commit belongs to **0891**. The issue was renumbered in the same minute and the commit subject kept the old id | all three fix directions are unmet: the header declaration is ungated, no CMake doc, no assert for nodes that never asked |
| 0902: action goals complete 20–90 % | both reply-slot leak fixes landed | nobody has re-measured the completion rate since; the leak was only the leading suspect |
| 1177: no-alloc `nros-c` lane runs only on schedule | three fixes closed the build break | no merge-gating lane runs `workspace-features`/`no-std`. The rows pass today, but nothing enforces them; which tier should carry them is the maintainer's call |
| 1225: `sizeof(nros::Timer)` follows `NROS_CPP_STD` | `d93cc31e6` fixed the **gate** | the layout difference itself is still there (Timer 32 vs 24, GuardCondition 40 vs 32). The issue handed the rest to PR #755, which had already merged 55 minutes before that note was written |

## Notes

- **Four of seven were false positives** for "left behind", and each for a different reason: a renumbered id, an unverified symptom, a partial fix, and a same-second edit the audit counted as "before". So a `fix(#N)` subject alone isn't evidence an issue is done.
- **Also changed:** a stale baseline row is removed (the same line #844 removes, so they merge in either order), and one roadmap link now points at 1242's archived path.
- **Checks on the combined branch:** `check-prose-issue-refs`, `gen-issue-index`, `check-archived-issue-status` and `check-doc-refs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
