### PR TITLE
fix(ci): the doctor called a correctly provisioned host broken — three probes and three stores

### DIFF
--- a/just/xrce.just
+++ b/just/xrce.just
@@ -27,6 +27,21 @@ setup:
     # The recipe must not re-implement that decision: build.sh prints
     # "already built" itself when the stamp matches, so the fast path is
     # preserved without a second, weaker copy of the rule.
+    #
+    # PROVISION FIRST. build.sh prefers the prebuilt agent from the nros store
+    # and, finding neither that nor a checked-out submodule, exits 1 with
+    # "Micro-XRCE-DDS Agent not provisioned. Run: nros setup native --rmw xrce".
+    # It is right to refuse — provisioning is `nros setup`'s job and it says so
+    # — but a verb named "install XRCE prerequisites" that stops to tell you to
+    # run the install command is a step, not a verb. So run it: three packages,
+    # all XRCE (the agent plus the two client submodules a Zephyr XRCE build
+    # needs anyway), idempotent, and it prints "present (skip)" when the store
+    # already has them.
+    #
+    # Found by `just setup zephyr` on a fresh host: it calls this recipe last,
+    # after `west update` and the whole patch set, so a clean provisioning run
+    # failed at the final step with an error naming a command nothing had run.
+    nros setup native --rmw xrce
     ./scripts/xrce-agent/build.sh
 
 # Diagnose XRCE install status (read-only).

--- a/scripts/ci/runner-bootstrap.sh
+++ b/scripts/ci/runner-bootstrap.sh
@@ -175,6 +175,7 @@ docker run --rm \
     -v "nros-runner-cargo:/home/runner/.cargo" \
     -v "nros-runner-rustup:/home/runner/.rustup" \
     -v "nros-runner-local:/home/runner/.local" \
+    -v "nros-runner-cmake:/home/runner/.cmake" \
     -v "nros-runner-sccache:/home/runner/.cache/sccache" \
     -v "nros-runner-nros:/home/runner/.nros" \
     -v "nros-runner-src:/home/runner/src" \

--- a/scripts/ci/runner-bootstrap.sh
+++ b/scripts/ci/runner-bootstrap.sh
@@ -118,7 +118,29 @@ echo "  installing the Python packages the image owes its interpreter"
 python3 -m pip install --user --quiet --disable-pip-version-check \
     tomli PyYAML jsonschema packaging pyelftools pykwalify west
 
-./scripts/ci/runner-provision.sh "$LABELS"
+# PROVISIONING AND LABEL TRUTH ARE DIFFERENT QUESTIONS, and the second one is
+# the contract. A provisioning step can fail for a reason that has nothing to do
+# with the labels this runner claims — issue 1276 is exactly that: a panic in
+# `nros setup rv-virt-threadx --rmw cyclonedds` on the SEVENTH package, after
+# the toolchain and QEMU the `nros-qemu` label actually names were already
+# installed and reported `present (skip)`.
+#
+# So the failure is reported LOUDLY and then the doctor is asked anyway. What it
+# must never do is launder the failure: an unread non-zero here is the bug this
+# repo keeps paying for, so the status is captured explicitly (issue 1249 — a
+# status meant for inspection dies at the assignment under `set -e`) and printed
+# whatever the doctor says.
+provision_rc=0
+./scripts/ci/runner-provision.sh "$LABELS" || provision_rc=$?
+if [ "$provision_rc" -ne 0 ]; then
+    echo ""
+    echo "runner-bootstrap: PROVISIONING REPORTED FAILURES (exit $provision_rc)." >&2
+    echo "  Asking runner-doctor anyway — the labels are the contract, and a" >&2
+    echo "  step can fail for a reason none of them depend on. If the doctor" >&2
+    echo "  passes, this runner is honest about what it can build; the failure" >&2
+    echo "  above is still real and still wants fixing." >&2
+    echo ""
+fi
 
 # The verification is the point of the whole script. `runner-provision` ends
 # with the same check, which is deliberate duplication of the CHEAP half: this
@@ -126,6 +148,12 @@ python3 -m pip install --user --quiet --disable-pip-version-check \
 # check the entrypoint runs before registering, so "provisioned" and "actually
 # has it" cannot be different answers at any of the three points.
 ./scripts/ci/runner-doctor.sh "$LABELS"
+
+if [ "$provision_rc" -ne 0 ]; then
+    echo ""
+    echo "runner-bootstrap: the labels hold, but provisioning exited $provision_rc."
+    echo "  Read the failure above — it is not about these labels, and it is not fixed."
+fi
 '
 
 if [ "$CHECK" -eq 1 ]; then

--- a/scripts/ci/runner-container.sh
+++ b/scripts/ci/runner-container.sh
@@ -120,7 +120,7 @@ mkdir -p "$CONTEXT"
 PREREQ_KEYS=(cmake unzip curl zstd python3-dev python3-venv
              python3-pip clang libclang-dev libglib2-dev libpixman-dev
              libgcrypt-dev socat genromfs kconfig-frontends libmbedtls
-             aria2 doxygen graphviz libz3 gnu-parallel wget)
+             aria2 doxygen graphviz libz3 gnu-parallel wget qemu-system-misc)
 if ! PREREQ_PACKAGES="$(python3 "$REPO_ROOT/scripts/sdk/prereq-packages.py" \
         --manager apt "${PREREQ_KEYS[@]}")"; then
     echo "runner-container: could not resolve the prereq packages from the index." >&2

--- a/scripts/ci/runner-container.sh
+++ b/scripts/ci/runner-container.sh
@@ -354,6 +354,7 @@ if [ "$DO_RUN" -eq 1 ]; then
         -v "nros-runner-nros:/home/runner/.nros" \
         -v "nros-runner-rustup:/home/runner/.rustup" \
         -v "nros-runner-local:/home/runner/.local" \
+        -v "nros-runner-cmake:/home/runner/.cmake" \
         -v "nros-runner-src:/home/runner/src" \
         -e NROS_RUNNER_LABELS="$LABELS" \
         -e GH_REPO="${GH_REPO:-NEWSLabNTU/nano-ros}" \

--- a/scripts/ci/runner-container.sh
+++ b/scripts/ci/runner-container.sh
@@ -203,6 +203,20 @@ set -euo pipefail
 # `safe.directory` in ~/.gitconfig dies with the writable layer every job.
 NROS_SRC="${NROS_SRC:-/home/runner/src/nano-ros}"
 
+# The store's own tools go on PATH, here, BEFORE anything reads them.
+#
+# `just`, `west` and the cargo-installed tools live in the persistent volumes —
+# `~/.local/bin` and `~/.cargo/bin` — because they are installable as the runner
+# user (the rule the `.local`, `.rustup` and `.cmake` stores all follow). The
+# image does not put those on PATH, so without this line the label gate asks a
+# correctly provisioned store whether it has `west` and is told no.
+#
+# It matters twice over: `run.sh` inherits this environment and hands it to
+# every job, so a workflow's `run: just …` resolves the same tools the gate
+# just verified. A runner whose PATH differs from the one its labels were
+# checked against is a runner whose labels were checked against nothing.
+export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+
 # --ephemeral: one job, then the registration is spent. A job cannot leave state
 # for the next one, which is also what stops the orphan/disk rot a long-lived
 # runner accumulates (the design doc records 71 orphaned processes, oldest 10

--- a/scripts/ci/runner-doctor.sh
+++ b/scripts/ci/runner-doctor.sh
@@ -221,20 +221,42 @@ _nros_runner_check_sdk_zephyr() {
         fail=1
     fi
 
-    # Mirrors `ZEPHYR_WORKSPACE` in just/zephyr.just. Restated rather than
-    # imported because that derivation lives in a `just` variable, which no
-    # shell can read without invoking `just` — and this script must work on a
-    # machine where `just` is not yet installed.
+    # ASK THE ONE RESOLVER. This used to restate `ZEPHYR_WORKSPACE` from
+    # just/zephyr.just, with a comment saying the derivation could not be
+    # imported "because it lives in a `just` variable, which no shell can read".
+    # That stopped being true: the recipe itself shells out to
+    # `scripts/lib/zephyr-workspace.sh`, which is plain shell and needs no
+    # `just` — so the reason for the copy is gone, and the copy had drifted.
+    #
+    # It drifted in the direction that matters. The resolver puts the STORE
+    # location FIRST (`~/.nros/workspaces/zephyr/<version>`, RFC-0095), which is
+    # where `just setup zephyr` installs; the copy did not know that location
+    # exists, so it fell through to `$root/zephyr-workspace` and reported
+    # MISSING for a host that had just provisioned successfully. Measured on a
+    # contained runner: `west update` and the whole patch set completed into
+    # `/home/runner/.nros/workspaces/zephyr/3.7`, and this probe called it
+    # absent.
+    #
+    # A doctor that reports a correct host as broken is worse than no doctor:
+    # it is the failure mode this file exists to prevent, pointed the other way.
     local ws="${NROS_ZEPHYR_WORKSPACE:-}"
     if [ -z "$ws" ]; then
-        if [ "${NROS_ZEPHYR_VERSION:-3.7}" = "4.4" ]; then
-            ws="$root/../nano-ros-workspace-4.4"
-        elif [ -d "$root/zephyr-workspace" ]; then
-            ws="$root/zephyr-workspace"
-        elif [ -d "$root/../nano-ros-workspace" ]; then
-            ws="$root/../nano-ros-workspace"
-        else
-            ws="$root/zephyr-workspace"
+        local _zws_resolver="$root/scripts/lib/zephyr-workspace.sh"
+        if [ -x "$_zws_resolver" ]; then
+            ws="$("$_zws_resolver" --version "${NROS_ZEPHYR_VERSION:-3.7}" resolve-or-default 2>/dev/null || true)"
+        fi
+        # Only if the resolver is absent or silent — a checkout too old to have
+        # it. Never as a second opinion about where the workspace is.
+        if [ -z "$ws" ]; then
+            if [ "${NROS_ZEPHYR_VERSION:-3.7}" = "4.4" ]; then
+                ws="$root/../nano-ros-workspace-4.4"
+            elif [ -d "$root/zephyr-workspace" ]; then
+                ws="$root/zephyr-workspace"
+            elif [ -d "$root/../nano-ros-workspace" ]; then
+                ws="$root/../nano-ros-workspace"
+            else
+                ws="$root/zephyr-workspace"
+            fi
         fi
     fi
 

--- a/scripts/ci/runner-store.sh
+++ b/scripts/ci/runner-store.sh
@@ -52,7 +52,7 @@
 # fail somewhere less obvious than here.
 set -euo pipefail
 
-STORES=(work cargo rustup local sccache nros src)
+STORES=(work cargo rustup local cmake sccache nros src)
 ROOT="${NROS_RUNNER_STORE_ROOT:-$HOME/nros-runner}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 IMAGE="${NROS_RUNNER_IMAGE:-nano-ros-runner:local}"


### PR DESCRIPTION
Follow-up to #842, which is in the merge queue and therefore frozen. Everything
here was found by bootstrapping the contained runner from an empty store and
reading what it said.

**One shape, four times.** A probe exists, is authored, is correct about the
question it asks — and something else decides the answer:

* `runner-doctor`'s Zephyr probe restated `ZEPHYR_WORKSPACE` from
  just/zephyr.just, with a comment saying the derivation "lives in a `just`
  variable, which no shell can read". That stopped being true — the recipe
  shells out to `scripts/lib/zephyr-workspace.sh`, plain shell — so the copy's
  reason was gone and the copy had drifted past the STORE location the resolver
  puts first. It reported MISSING for a host that had just completed
  `west update` and the whole patch set. It asks the resolver now.
* `west is not on PATH`, on a store that had west. `~/.local/bin` and
  `~/.cargo/bin` are volumes precisely because they are installable as the
  runner user, and the image put neither on PATH. Exported in the entrypoint,
  which also hands it to every job — a runner whose PATH differs from the one
  its labels were checked against is a runner whose labels were checked against
  nothing.
* the Zephyr SDK, complete and unpacked, unregistered with cmake because
  `~/.cmake` was not a volume — so `find_package(Zephyr-sdk)` would have failed
  at configure, not at download, which is what the doctor's message warns about
  by name.
* `just setup zephyr` stopping to tell you to run `nros setup native --rmw
  xrce`. Fixed in the verb rather than in the runner's label map: the map would
  have made this runner work and left every contributor the same wall on their
  first setup.

**Three more stores** (`.cmake`, plus `.local` and `.rustup` from #842) and two
more baked prereqs (`qemu-system-misc` for the `qemu-system-riscv64` the
`nros-qemu` label claims; `wget`, now declared in the index because the Zephyr
SDK's own setup.sh requires it by name and exits 91 after a 1.4 GB download).

**The bootstrap asks the doctor even when provisioning failed**, because
"provisioned" and "has it" are different questions and the labels are the
contract. Issue #1276 is the case: `nros setup rv-virt-threadx --rmw cyclonedds`
panics on its seventh package, after the toolchain and QEMU that `nros-qemu`
names are already installed. The failure is reported loudly before and after,
and the status captured explicitly rather than left to `set -e` (issue 1249).

Verified end to end:

```
runner-doctor: OK — all 3 label(s) verified.
√ Runner successfully added
Listening for Jobs

nano-ros-runner  online  busy=true  [self-hosted,Linux,X64,nros-qemu,nros-sdk-zephyr,nros-big]
```

It registered only after passing, and the PATH bug is why that ordering is worth
having: the first attempt refused rather than winning `L3` and failing inside it.

The baseline row for issue 1276 goes when #870 lands and its file arrives.