### PR TITLE
fix(phase-441 W4): the live-peer lane's first verdict could not be read — four defects under it

### DIFF
--- a/.github/workflows/live-peer.yml
+++ b/.github/workflows/live-peer.yml
@@ -202,6 +202,27 @@ jobs:
           source ./activate.sh
           nros setup --system --sudo
 
+      # issue 0741 — the XRCE Agent, built against the SOURCED ROS's own
+      # Fast-DDS. Nothing provisioned one here: the probe took whichever Agent
+      # resolved first (build dir, SDK store, PATH), and the store prebuilt carries
+      # a Jazzy-era Fast-DDS whose Fast-CDR 2.x mis-frames a Humble bus's service
+      # replies. `scripts/xrce-agent/build.sh` reads the tag off the installed
+      # libfastcdr and shallow-clones it — no submodule — but only when it can SEE
+      # a sourced ROS. Asserted first: without one, the script would quietly
+      # publish the skewed store Agent instead, which is the bug it exists for.
+      - name: Build the XRCE Agent against the sourced ROS (issue 0741)
+        id: agent
+        run: |
+          source ./activate.sh
+          if [ -z "${AMENT_PREFIX_PATH:-}" ]; then
+              echo "no sourced ROS (AMENT_PREFIX_PATH is empty) — refusing to build an" >&2
+              echo "Agent that would not be ROS-paired (issue 0741)." >&2
+              exit 1
+          fi
+          # The DISPATCHER, not `just xrce setup`: the module spelling skips
+          # `_setup-common` (check-workflow-setup-spelling).
+          just setup xrce
+
       # NOT "the fixtures those CELLS resolve", which is what this said until
       # 2026-09-09. `lane-stage.py` classifies a step by keyword, `cells` is the
       # marker for the runtime stage, and the classifier takes the most specific
@@ -218,8 +239,19 @@ jobs:
           # fixture built before it — then the rows. Building rows first cost a
           # whole box batch on 2026-09-06.
           NROS_CARGO_FLAGS= just native build-workspace-fixtures
-          bash scripts/build/fixtures-build.sh linux rust zenoh
-          bash scripts/build/fixtures-build.sh linux rust cyclonedds
+          # DERIVED, not written: one `fixtures-build.sh linux <lang> <rmw>` per
+          # pair the host cells with a recorded PASS run on. The two builds this
+          # step used to name by hand never included C Cyclone or Rust XRCE, so
+          # those cells skipped for fixtures nothing built (run 34497290149).
+          builds="$(python3 scripts/check-interop-verdicts.py --list-passing --runner host --host-builds)"
+          echo "host fixture builds (derived from the ledger):"
+          printf '  %s\n' "$builds"
+          while IFS= read -r b; do
+              [ -n "$b" ] || continue
+              echo "=== fixtures-build.sh $b ==="
+              # `$b` is `linux <lang> <rmw>`: unquoted on purpose, three args.
+              bash scripts/build/fixtures-build.sh $b
+          done <<< "$builds"
 
       # `host`, not everything — phase-441 W4. A board cell's image is built by
       # an SDK this container does not carry, so running one here resolves no
@@ -243,6 +275,19 @@ jobs:
           printf 'cells_ran=%s\n' "$ran" >> "$GITHUB_OUTPUT"
           exit $rc
 
+      # Keep the evidence. `test-live-peer-regression` writes one junit per test
+      # binary under tmp/live-peer-junit/, and it is the only record of WHY a cell
+      # failed or which precondition a skip named. Run 34497290149 printed seven
+      # real failures and kept nothing to read them from.
+      - name: Upload the cells' junit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-peer-junit-host
+          path: tmp/live-peer-junit/host/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Ledger after the run
         if: always()
         run: |
@@ -263,6 +308,7 @@ jobs:
              {"name": "Report what the ledger claims, before running anything", "conclusion": "${{ steps.ledger.outcome }}"},
              {"name": "Check out the submodules the fixtures vendor", "conclusion": "${{ steps.submodules.outcome }}"},
              {"name": "Provision the declared system closure (phase-413 W3)", "conclusion": "${{ steps.system.outcome }}"},
+             {"name": "Build the XRCE Agent against the sourced ROS (issue 0741)", "conclusion": "${{ steps.agent.outcome }}"},
              {"name": "Build the fixtures those rows resolve", "conclusion": "${{ steps.fixtures.outcome }}"},
              {"name": "Run the cells with a recorded PASS", "conclusion": "${{ steps.cells.outcome }}"}]
           # The fourth axis (phase-441 W4): the cells step FAILED tells you the
@@ -445,6 +491,19 @@ jobs:
           [ "$rc" -le 1 ] && ran=true
           printf 'cells_ran=%s\n' "$ran" >> "$GITHUB_OUTPUT"
           exit $rc
+
+      # Keep the evidence. `test-live-peer-regression` writes one junit per test
+      # binary under tmp/live-peer-junit/, and it is the only record of WHY a cell
+      # failed or which precondition a skip named. Run 34497290149 printed seven
+      # real failures and kept nothing to read them from.
+      - name: Upload the cells' junit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-peer-junit-board
+          path: tmp/live-peer-junit/board/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Ledger after the run
         if: always()

--- a/just/native.just
+++ b/just/native.just
@@ -1188,6 +1188,10 @@ test-live-peer-regression runner="all" verbose="":
     junit_dir="tmp/live-peer-junit/$runner"
     rm -rf "$junit_dir"
     mkdir -p "$junit_dir"
+    # Failure output ON for this lane: a real failure must print why, and a
+    # `skip!` (a panic) must print its reason, or a red here cannot be read
+    # without a rerun. `final` puts it at the end of each binary's run.
+    export NROS_TEST_FAILURE_OUTPUT="${NROS_TEST_FAILURE_OUTPUT:-final}"
     source scripts/test/nextest-profile.sh
     failed=0
     broken=0

--- a/just/zephyr-ci.just
+++ b/just/zephyr-ci.just
@@ -352,10 +352,24 @@ build-fixtures:
     # Kept until the end: the tier-priority check below judges exactly the
     # images THESE records build (field 12 is each leaf's build dir).
     probe_records="$log_dir/records-$$.tsv"
-    if scripts/build/zephyr-fixture-leaves.sh --emit records "${zephyr_leaf_args[@]}" >"$probe_records" 2>/dev/null; then
-        if [ -s "$probe_records" ]; then
-            normal_records=1
-        fi
+    # A probe that FAILED is not a probe that found nothing. This was
+    # `2>/dev/null` with the status read only as a truth value, so a failing
+    # leaves script and a filter selecting nothing printed the same line — "no
+    # Zephyr fixtures matched" — and live-peer run 34497290149's board job died
+    # on it with no way to tell which. Locally the same filter emits its record;
+    # whatever failed in CI now says so here, in its own words.
+    probe_err="$log_dir/records-$$.err"
+    probe_rc=0
+    scripts/build/zephyr-fixture-leaves.sh --emit records "${zephyr_leaf_args[@]}" \
+        >"$probe_records" 2>"$probe_err" || probe_rc=$?
+    if [ "$probe_rc" -ne 0 ]; then
+        echo "  ✗ the Zephyr records probe FAILED (exit $probe_rc) — NOT 'no fixtures" >&2
+        echo "    matched'. Its stderr:" >&2
+        sed 's/^/      /' "$probe_err" | head -30 >&2
+        exit 1
+    fi
+    if [ -s "$probe_records" ]; then
+        normal_records=1
     fi
 
     failures=()

--- a/justfile
+++ b/justfile
@@ -952,7 +952,8 @@ test-unit verbose="":
         --exclude nros-build-paths \
           --no-fail-fast)
     if [ -z "{{verbose}}" ]; then
-        args+=(--success-output never --failure-output never)
+        # NROS_TEST_FAILURE_OUTPUT (default `never`) — see `_test-focused`.
+        args+=(--success-output never --failure-output "${NROS_TEST_FAILURE_OUTPUT:-never}")
     fi
     # issue 0388 — `nros_tests::skip!` panics with `[SKIPPED]` for an unmet
     # precondition, and nextest has no native skip, so those land as FAILURES and
@@ -1085,7 +1086,14 @@ _test-focused filter verbose="":
     cargo_nextest_args=($(nros_cargo_nextest_args))
     args=(-p nros-tests --no-fail-fast -E '{{filter}}')
     if [ -z "{{verbose}}" ]; then
-        args+=(--success-output never --failure-output never)
+        # `--failure-output` honours NROS_TEST_FAILURE_OUTPUT, default `never` —
+        # unchanged for every caller that does not set it. The live-peer lane
+        # sets `final`: with `never`, run 34497290149 reported "7 real failures"
+        # without one line of WHY, and because `nros_tests::skip!` is a panic the
+        # skip REASONS were suppressed too, so the lane's red could not be read
+        # without a rerun. The five sibling recipes take the same hook, so the
+        # knob means one thing wherever it is set.
+        args+=(--success-output never --failure-output "${NROS_TEST_FAILURE_OUTPUT:-never}")
     fi
     nros_nextest_junit_reset
     set +e
@@ -1141,7 +1149,8 @@ test-integration verbose="":
     exclude='not (group(=qemu-baremetal) or group(=qemu-freertos) or group(=qemu-nuttx) or group(=qemu-threadx-riscv) or binary(esp32_emulator) or group(=threadx-linux) or group(=qemu-zephyr) or group(=qemu-zephyr-xrce) or group(=zephyr-fvp) or group(=ros2-interop) or binary(xrce_ros2_interop) or binary(rtos_e2e) or binary(zephyr))'
     args=(-p nros-tests --no-fail-fast -E "$exclude")
     if [ -z "{{verbose}}" ]; then
-        args+=(--success-output never --failure-output never)
+        # NROS_TEST_FAILURE_OUTPUT (default `never`) — see `_test-focused`.
+        args+=(--success-output never --failure-output "${NROS_TEST_FAILURE_OUTPUT:-never}")
     fi
     # `nros_tests::skip!` panics with `[SKIPPED]` for unmet preconditions
     # (missing fixture/binary/emulator/agent/SDK) — nextest has no native skip,
@@ -1292,7 +1301,8 @@ _nextest-platform test_name verbose="" feature_args="" filter="":
         args+=({{feature_args}})
     fi
     if [ -z "{{verbose}}" ]; then
-        args+=(--success-output never --failure-output never)
+        # NROS_TEST_FAILURE_OUTPUT (default `never`) — see `_test-focused`.
+        args+=(--success-output never --failure-output "${NROS_TEST_FAILURE_OUTPUT:-never}")
     fi
     just _nextest-tolerant "${args[@]}"
 
@@ -1444,7 +1454,8 @@ test-zpico-multisession verbose="":
     args=(-p nros-rmw-zenoh --features platform-posix --test zenoh_integration
           two_sessions --no-fail-fast)
     if [ -z "{{verbose}}" ]; then
-        args+=(--success-output never --failure-output never)
+        # NROS_TEST_FAILURE_OUTPUT (default `never`) — see `_test-focused`.
+        args+=(--success-output never --failure-output "${NROS_TEST_FAILURE_OUTPUT:-never}")
     fi
     just _nextest-tolerant "${args[@]}"
     # issue 0652 — `loan_e2e` for the same reason, and it is why the feature is
@@ -2339,7 +2350,8 @@ test-all verbose="": _require-fixtures-ready test-zpico-multisession
     just _nextest-platform custom_transport_loopback "{{verbose}}" "--features rmw" || failed=1
     args=(--workspace "${nextest_run_profile_args[@]}" "${nextest_fail_fast_args[@]}")
     if [ -z "{{verbose}}" ]; then
-        args+=(--success-output never --failure-output never)
+        # NROS_TEST_FAILURE_OUTPUT (default `never`) — see `_test-focused`.
+        args+=(--success-output never --failure-output "${NROS_TEST_FAILURE_OUTPUT:-never}")
     fi
     # Phase 185.2 / 186.4 — toolchain-gated exclusion of embedded-RTOS Cyclone
     # tests. Since Phase 186 the embedded Cyclone backend self-provisions from

--- a/packages/testing/nros-tests/src/fixtures/xrce_agent.rs
+++ b/packages/testing/nros-tests/src/fixtures/xrce_agent.rs
@@ -383,14 +383,21 @@ pub fn xrce_agent_binary_path() -> std::path::PathBuf {
     xrce_agent_binary_with_provenance().0
 }
 
-/// Check if the XRCE Agent binary is available (local build or system PATH).
+/// Check that the XRCE Agent is present AND runs (local build, store, or PATH).
+///
+/// Through [`crate::probe_ran`], not `.status().is_ok()`: that is true for any
+/// binary that SPAWNS, so an Agent that exists and dies on launch passed this
+/// probe, went past the caller's `skip!`, and turned an environment gap into a
+/// real failure (live-peer run 34497290149). `--help` exits 1 on a healthy
+/// Agent, which is why the helper is not `.success()`.
 pub fn is_xrce_agent_available() -> bool {
-    std::process::Command::new(xrce_agent_binary_path())
-        .arg("--help")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok()
+    crate::probe_ran(
+        std::process::Command::new(xrce_agent_binary_path())
+            .arg("--help")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status(),
+    )
 }
 
 /// Skip test if the XRCE Agent is not available.
@@ -597,13 +604,17 @@ impl Drop for XrceSerialAgent {
 }
 
 /// Check if `socat` is available on the system PATH.
+///
+/// Same flaw as the Agent probe had, fixed through the same helper
+/// ([`crate::probe_ran`]).
 pub fn is_socat_available() -> bool {
-    std::process::Command::new("socat")
-        .arg("-V")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok()
+    crate::probe_ran(
+        std::process::Command::new("socat")
+            .arg("-V")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status(),
+    )
 }
 
 /// Skip test if socat is not available.

--- a/packages/testing/nros-tests/src/lib.rs
+++ b/packages/testing/nros-tests/src/lib.rs
@@ -821,6 +821,70 @@ pub fn host_python_available() -> bool {
         .is_ok_and(|s| s.success())
 }
 
+/// Did a probe invocation show that a tool can RUN — not merely that it exists?
+///
+/// `Command::status()` is `Err` only when the process cannot be SPAWNED, so a
+/// bare `.status().is_ok()` answers "present" for a binary that exists and
+/// cannot run: a missing shared library (the loader exits 127), an exec failure
+/// (126), a crash on start (a signal). Live-peer run 34497290149 had that shape:
+/// the XRCE Agent probe said "available", the tests went past their `skip!`, and
+/// seven live cells scored REAL failures 0.15 s in — an environment gap reported
+/// as a regression.
+///
+/// Any other exit status counts as "runs": plenty of tools answer a probe with a
+/// non-zero USAGE exit, and `MicroXRCEAgent --help` exits 1 on a HEALTHY agent
+/// (measured on both the ROS-paired build and the SDK-store copy). So this is
+/// deliberately not `.success()`, which would skip every XRCE cell forever.
+#[must_use]
+pub fn probe_ran(result: std::io::Result<std::process::ExitStatus>) -> bool {
+    match result {
+        Err(_) => false,
+        Ok(status) => !matches!(status.code(), None | Some(126) | Some(127)),
+    }
+}
+
+#[cfg(test)]
+mod probe_ran_tests {
+    use super::probe_ran;
+    use std::process::Command;
+
+    fn sh(script: &str) -> bool {
+        probe_ran(Command::new("sh").arg("-c").arg(script).status())
+    }
+
+    #[test]
+    fn a_clean_exit_runs() {
+        assert!(sh("exit 0"));
+    }
+
+    #[test]
+    fn a_usage_exit_still_runs() {
+        assert!(sh("exit 1"), "a healthy `MicroXRCEAgent --help` exits 1");
+    }
+
+    #[test]
+    fn a_loader_failure_does_not_run() {
+        assert!(!sh("exit 127"));
+    }
+
+    #[test]
+    fn an_exec_failure_does_not_run() {
+        assert!(!sh("exit 126"));
+    }
+
+    #[test]
+    fn death_by_signal_does_not_run() {
+        assert!(!sh("kill -9 $$"));
+    }
+
+    #[test]
+    fn a_binary_that_cannot_be_spawned_does_not_run() {
+        assert!(!probe_ran(
+            Command::new("nros-tests-no-such-binary-xyzzy").status()
+        ));
+    }
+}
+
 /// The `nros-launch-resolve` helper, by ABSOLUTE path (issue 0285 — never
 /// `$PATH`, where a stale `~/.nros/bin` copy shadows the in-tree one).
 /// `just setup-launch-resolve` builds it; `None` means it has not been built.

--- a/scripts/check-interop-cell-runners.py
+++ b/scripts/check-interop-cell-runners.py
@@ -256,7 +256,7 @@ def parse_cells(src: str) -> list[dict]:
 
 
 def _parse_cell(arg: str, line: int) -> dict:
-    """The platform and tier out of `c(platform, lang, rmw, workload, kind, tier)`.
+    """Platform, lang, rmw and tier out of `c(platform, lang, rmw, workload, kind, tier)`.
 
     The PLATFORM is here for phase-441 W4: which runner a cell needs is a
     property of its coordinate and of nothing else. `.config/interop-verdicts.
@@ -290,7 +290,12 @@ def _parse_cell(arg: str, line: int) -> dict:
         raise ParseError(
             f"{INTEROP_RS.name}:{line}: `c(...)` has an empty platform token"
         )
-    return {"platform": platform, "tier": tier}
+    # lang + rmw for the host lane's fixture builds, which are DERIVED from what
+    # its cells run on rather than written by hand (the hand-written list never
+    # followed the C Cyclone cells in) — same reason the platform is read here.
+    lang = re.split(r"[\s(]", inner[1].strip(), maxsplit=1)[0]
+    rmw = re.split(r"[\s(]", inner[2].strip(), maxsplit=1)[0]
+    return {"platform": platform, "tier": tier, "lang": lang, "rmw": rmw}
 
 
 def _parse_test(arg: str, line: int) -> dict:

--- a/scripts/check-interop-verdicts.py
+++ b/scripts/check-interop-verdicts.py
@@ -90,6 +90,7 @@ import datetime
 import importlib.util
 import io
 import re
+import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
@@ -320,6 +321,65 @@ def narrowing_for(ids) -> list[str]:
             )
         merged.setdefault(key, []).append(value)
     return [f"{k}={'|'.join(sorted(set(v)))}" for k, v in sorted(merged.items())]
+
+
+# Which `fixtures-build.sh linux <lang> <rmw>` the HOST cells need, DERIVED from
+# their coordinates. The lane used to name three builds by hand; the C Cyclone
+# cells joined the ledger when phase-433 W3 corrected that half to C and the list
+# never followed, so they skipped for fixtures no step built — and the XRCE cells
+# would have been next, once their Agent ran (run 34497290149). Only pairs the
+# manifest has rows for are emitted, read through the ONE row-coordinate
+# computation (`fixtures-manifest.py coords` / `row_coord()`), never re-derived.
+HOST_BUILD_LANG = {"Rust": "rust", "C": "c", "Cpp": "cpp"}
+HOST_BUILD_RMW = {"Zenoh": "zenoh", "Cyclonedds": "cyclonedds", "Xrce": "xrce"}
+MANIFEST_PY = ROOT / "scripts" / "build" / "fixtures-manifest.py"
+
+
+def _linux_fixture_pairs() -> set:
+    """(lang, rmw) of every `fixture` row on `linux`, from the manifest itself."""
+    out = subprocess.run(
+        [sys.executable, str(MANIFEST_PY), "coords"], capture_output=True, text=True
+    )
+    if out.returncode != 0:
+        raise LedgerError(
+            f"{_rel(MANIFEST_PY)} coords failed (exit {out.returncode}): "
+            f"{out.stderr.strip()[:200]}"
+        )
+    pairs = set()
+    for line in out.stdout.splitlines():
+        f = line.split("\x1f")
+        if len(f) >= 4 and f[0] == "fixture" and f[1] == "linux":
+            pairs.add((f[2], f[3]))
+    if not pairs:
+        raise LedgerError(
+            f"{_rel(MANIFEST_PY)} coords listed no linux fixture rows — refusing "
+            f"to derive an empty build set, which would build nothing and read "
+            f"as done"
+        )
+    return pairs
+
+
+def host_builds_for(cells, ids) -> list[str]:
+    """`linux <lang> <rmw>` lines, one per pair these HOST cells run on."""
+    by_id = {c["id"]: c for c in cells}
+    have = _linux_fixture_pairs()
+    out: set[str] = set()
+    for cid in sorted(set(ids)):
+        c = by_id[cid]
+        if runner_of(c["platform"]) != "host":
+            continue
+        lang = HOST_BUILD_LANG.get(c["lang"])
+        rmw = HOST_BUILD_RMW.get(c["rmw"])
+        if lang is None or rmw is None:
+            raise LedgerError(
+                f"`{cid}` is a host cell on ({c['lang']}, {c['rmw']}), which "
+                f"HOST_BUILD_LANG / HOST_BUILD_RMW do not map to a fixtures-build.sh "
+                f"token — add it; an unmapped pair would build nothing and the "
+                f"cell would skip"
+            )
+        if (lang, rmw) in have:
+            out.add(f"linux {lang} {rmw}")
+    return sorted(out)
 
 
 def in_runner(cells: list[dict], ids, runner: str) -> list[str]:
@@ -1410,6 +1470,27 @@ def _self_test_runner_split(
     )
     assert scopes_for([HOST_PLATFORM]) == [], "selftest: the host board asked for a scope"
 
+    # The host-build derivation: mapped, deduplicated, board cells ignored, and
+    # an unmapped language a LOUD error rather than a silently dropped build.
+    _hc = [
+        {"id": "a", "platform": HOST_PLATFORM, "lang": "C", "rmw": "Cyclonedds"},
+        {"id": "b", "platform": HOST_PLATFORM, "lang": "C", "rmw": "Cyclonedds"},
+        {"id": "c", "platform": HOST_PLATFORM, "lang": "Rust", "rmw": "Xrce"},
+        {"id": "d", "platform": "ZephyrQemuCortexM", "lang": "C", "rmw": "Zenoh"},
+    ]
+    assert host_builds_for(_hc, ["a", "b", "c", "d"]) == [
+        "linux c cyclonedds", "linux rust xrce"
+    ], host_builds_for(_hc, ["a", "b", "c", "d"])
+    try:
+        host_builds_for(
+            [{"id": "x", "platform": HOST_PLATFORM, "lang": "Cobol", "rmw": "Zenoh"}],
+            ["x"],
+        )
+    except LedgerError as e:
+        assert "Cobol" in str(e), e
+    else:
+        raise AssertionError("selftest: an unmapped language was silently dropped")
+
     # The narrowing map: present, and pointing at something that exists.
     assert narrowing_for(["zephyr-qos-rust-zenoh"]) == [
         "NROS_ZEPHYR_FIXTURE_FILTER=build-ws-rs-qos-entry-zenoh"
@@ -1740,6 +1821,13 @@ def main(argv: list[str]) -> int:
         "resolve",
     )
     ap.add_argument(
+        "--host-builds",
+        action="store_true",
+        help="with --list-passing --runner host, emit the `linux <lang> <rmw>` "
+        "fixture builds those cells need, derived from their coordinates and "
+        "narrowed to pairs the manifest has rows for",
+    )
+    ap.add_argument(
         "--assert-ran",
         metavar="DIR",
         help="phase-441 W4 — every junit in DIR, together: exit 3 naming the "
@@ -1813,6 +1901,13 @@ def main(argv: list[str]) -> int:
 
     if args.list_passing:
         by_id = {c["id"]: c for c in cells}
+        if args.host_builds:
+            try:
+                print("\n".join(host_builds_for(cells, passing)))
+            except LedgerError as e:
+                print(f"check-interop-verdicts: {e}", file=sys.stderr)
+                return 1
+            return 0
         if args.scopes or args.narrowing:
             try:
                 if args.scopes:

--- a/scripts/ci/lane-stage.py
+++ b/scripts/ci/lane-stage.py
@@ -491,6 +491,7 @@ LANES = (
         "Report what the ledger claims, before running anything": PROVISIONING,
         "Check out the submodules the fixtures vendor": PROVISIONING,
         "Provision the declared system closure (phase-413 W3)": PROVISIONING,
+        "Build the XRCE Agent against the sourced ROS (issue 0741)": BUILD,
         "Build the fixtures those rows resolve": BUILD,
         "Run the cells with a recorded PASS": CELLS,
     }),


### PR DESCRIPTION
Run [34497290149](https://github.com/NEWSLabNTU/nano-ros/actions/runs/34497290149) was the first live-peer run to get past its builds and run cells. The host job reported **`VERDICT: cells ran and FAILED`**: 7 real failures, all in `xrce_ros2_interop`. The board job reported **`NO VERDICT: stopped in the build`**. Reading that verdict turned up four defects underneath it. None of them is an RMW regression, as far as the evidence goes.

## 1. The lane kept no evidence

When not in verbose mode, `_test-focused` runs with `--failure-output never`, and the workflow uploaded nothing. So the run printed seven real failures without a single line of *why*. And because `skip!` is implemented as a panic, the skip *reasons* were suppressed too.

- `--failure-output` now reads `NROS_TEST_FAILURE_OUTPUT`. The default stays `never`, so behaviour is unchanged for every other caller. The five sibling recipes use the same hook, so the setting means the same thing everywhere.
- `test-live-peer-regression` sets it to `final`.
- Both jobs upload `tmp/live-peer-junit/<runner>/` with `if: always()`.

## 2. The Agent probe could not fail for a broken Agent

`is_xrce_agent_available` was `Command::status().is_ok()`. `status()` only returns an error when the process can't be **spawned**. So an Agent that exists but dies on launch looked present, the tests went past their `skip!`, and a failure 0.15 s in was counted as real. The seven failures fit that pattern, but because of defect 1 I can't prove that's what happened.

There's now one helper, `nros_tests::probe_ran`. A spawn error, exit code 126 or 127, or death by signal means "can't run". Any other exit means "runs".

**It deliberately does not use `.success()`.** I measured that `MicroXRCEAgent --help` exits 1 on a *healthy* Agent, both the ROS-paired build and the store copy. With `.success()`, every XRCE cell would have been skipped permanently. `is_socat_available` had the same flaw and now uses the helper too. It comes with six unit tests.

## 3. A failed probe was reported as "nothing matched"

My first diagnosis of the board failure was **wrong**. Workspace entries *are* counted, and locally the same filter emits its record, including with CI's full argument set. What actually happened: the records probe ran with `2>/dev/null` and only its exit status was checked, so a failing probe and an empty one printed the same line. It now keeps its stderr and exit code and fails with `the Zephyr records probe FAILED (exit N)` plus its own output. This does not fix whatever failed in CI. It makes the next run tell us what that was.

## 4. The host build list was hand-written and had drifted

The list was `linux rust zenoh` and `linux rust cyclonedds`. The C Cyclone cells never made it in, so they were skipped for fixtures nothing built.

The list is now **derived**, the same way #833 derives the board narrowing:
- `_parse_cell` now also reads lang and rmw.
- `--host-builds` emits one `linux <lang> <rmw>` per pair the host cells run on, filtered through `fixtures-manifest.py coords`, the single source for row coordinates.
- On today's ledger that gives five builds, two more than the hand-written list: `c cyclonedds` and `rust xrce`.

The host job also builds the XRCE Agent against the sourced ROS (issue 0741), using the `just setup xrce` dispatcher. If no ROS is sourced, the job stops rather than falling back to the store Agent, whose Fast-DDS version doesn't match.

## Verification

- `probe_ran` unit tests: 6/6 pass.
- `nros-tests --tests` compiles, and clippy `-D warnings` is clean.
- Both Python selftests pass, including new host-build cases: duplicates removed, board cells ignored, and an unmapped language raises an error.
- The derivation runs correctly on the real ledger.
- `lane-stage` selftest: 83/83.
- `workspace-fmt`, `workflow-setup-spelling`, `workflow-repo-env`, `lane-stage-reporting`, `set-e-bare-assignment` and `lane-contracts` all pass.
- `just check fast`: 293 of 294. The failing gate is `third-party-is-submodules`, tripped by two **untracked** directories on the machine I ran it on, not by this change.

**Not established:** why the seven XRCE cells failed, why the Rust Cyclone action cell was skipped, and what the Zephyr probe hit in CI. Fixes 1 and 3 are there so the next run can answer all three. After this merges, a single dispatch should tell us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lee2SrWhASryz9dd5F28mS
