### PR TITLE
docs(phase-446): landed notes, every-node and wildcard rules, follow-ups F1-F3

### DIFF
--- a/docs/roadmap/phase-446-contract-declares-parameters.md
+++ b/docs/roadmap/phase-446-contract-declares-parameters.md
@@ -45,10 +45,29 @@ states `pub`, `sub`, `srv` and `cli`.
 | slot count | derived: sum of contract params + one `use_sim_time` per node | the phase-430 W2 seed is per node |
 | max name length | derived: the longest contract name | platform-agnostic |
 | string / array / byte-array capacity | 0 when no node declares that type; otherwise the BOARD states it, and the build refuses when it does not | capacity is a board fact (an MCU and a PC want different ones), and a bound must exist before a buffer can be sized from it, the rule messages already follow |
-| service reply buffer | derived: the largest reply the declared names and types can produce (issue 1270) | follows from the declarations |
+| description capacity | today the string capacity (F2) | the descriptor's `description` is a `String<MAX_STRING_VALUE_LEN>`, so an all-scalar image has no room for any description |
+| service request/reply buffer | derived: the largest message the declared names and types can produce (F3); until then the configured `NROS_PARAM_SERVICE_BUFFER_SIZE`, one pair per executor (W5) | follows from the declarations and the board capacities |
 
 Size bounds deliberately do NOT go in the contract: the contract describes the
 node, and a capacity describes the board it is built for.
+
+**Every node or none.** The store holds every node's parameters, so a count
+over the nodes that declared is a count over a subset of the image. The
+derivation runs only when every node in the image has a `params:` entry; when
+some do and some do not, it refuses and the store knobs keep their configured
+values. That makes "declares no parameters" a statement a node must be able
+to make: `params: {}` means zero declared parameters (the node still gets its
+`use_sim_time` seed), and a missing `params:` means "not stated". The two must
+stay distinct all the way to the model (F1).
+
+**Undeclared launch values.** A launch value for a parameter the node's
+contract does not declare is an ERROR when it is addressed to the node by
+name (an inline `<param>`, a parameter-file key equal to the node's name, a
+launch-argument override), and a WARNING when it arrives through a wildcard
+key such as `/**`. rclcpp ignores undeclared overrides, and a shared file
+(Autoware's `vehicle_info.param.yaml`) is loaded into many nodes that each use
+a subset; a typo in a node's own section is still caught. A value of the wrong
+type is an error wherever it came from.
 
 The contract entry, in the map style of `sub:` / `pub:` so later fields
 (`read_only`, a description) are additive:
@@ -84,17 +103,28 @@ trips through serde, and a contract without `params:` parses exactly as before.
 *Acceptance:* schema tests for every type, an unknown type, a missing type,
 and an absent section; a release tag the other repos pin.
 
+**Landed** in ros-launch-manifest v0.1.34 (`1a50d32`). Gap found after: an
+explicitly empty `params: {}` parses the same as no `params:` (F1).
+
 ### W2 -- play_launch: the declared parameters reach the resolved model
 
 The resolver carries each node's contract `params:` into the SystemModel next
 to the node's other contract facts, keyed by the node's fully qualified name,
 and validates the launch's parameter values for that node against the declared
-types (a launch value for an undeclared name, or one that does not parse as
-the declared type, is an error naming the node, the parameter and the file).
+types, by the rule in the design section: a mistyped value, or an undeclared
+one addressed to the node by name, is an error naming the node, the parameter
+and the launch file; an undeclared value that arrived through a wildcard key
+is a warning. `use_sim_time`, `start_type_description_service` and
+`qos_overrides.*` are always accepted.
 
 *Acceptance:* a model built from a contract with `params:` carries them per
 node; a mistyped or undeclared launch parameter fails resolution with a
 message that names it.
+
+**Landed** in play_launch `155ed78b`, with the wildcard warning in `f5264bf0`.
+The messages name the parameter-file key and the launch file that loaded it,
+not the file's path: the model keeps parameter files as contents only, and
+naming the path needs a field in ros-launch-manifest's model.
 
 ### W3 -- launch parameters are seeded on their own node (issue 1272)
 
@@ -133,6 +163,13 @@ declared, so the RMW pools are sized for them.
 parameter services on, measured, and a reply past the derived size is
 refused with a log line naming the knob (issue 1271).
 
+**Landed** in #868: one pair per executor, allocated with the first node's
+services; six servers per node and five lifecycle servers per executor
+counted into the queryable pool; a dropped request logged once per service
+and failure kind. Host `size_of`, mock backend, 4,096 B buffers: a four-node
+image's service state went from 255,968 B to 68,096 B. The pair is still the
+configured size -- deriving it is F3 -- and the board measurement is W7's.
+
 ### W6 -- the code is checked against the contract at boot
 
 A generated per-node table of declared parameter names and types, consulted
@@ -155,10 +192,95 @@ the native and Zephyr islands.
 *Acceptance:* the demo's VERDICT PASS on both islands; the board image's heap
 use with parameter services measured and recorded.
 
+## Follow-ups
+
+### F1 -- `params: {}` survives to the model
+
+A node that declares no parameters cannot say so today, and the every-node
+rule then refuses the derivation for the whole image. The cause is the TYPE,
+which every layer after it follows; it is not a YAML problem (yaml-rust2
+yields an empty mapping for `{}`):
+
+- ros-launch-manifest: `NodeDecl.params` is a `BTreeMap` (`types/src/types.rs`),
+  so it has no third state. `parse_params` (`types/src/parse.rs`) returns the
+  empty map both for a missing key (`Yaml::BadValue => return Ok(out)`) and
+  for `{}`. Checked with a scratch program against v0.1.34: a node with no
+  `params:` and a node with `params: {}` both parse to an empty map.
+  `skip_serializing_if = "BTreeMap::is_empty"` drops it again on output.
+- play_launch: `model_builder.rs` skips a node whose map is empty
+  (`if node.params.is_empty() { continue; }`), so no `node_params` entry.
+- nano-ros: `ParamDeclarations::from_model` (`entity_inventory.rs`) sees a
+  node with no entry and refuses. It needs no change once the entry arrives:
+  an entry with no names counts as declared, with the `use_sim_time` seed.
+
+Fix: `params: Option<BTreeMap<String, ParamDecl>>` (`None` for no key,
+`Some(empty)` for `{}`), serialized only when `Some`; the model builder
+inserts `Some(empty)` as `/<fqn>: {}`, which `contracts.node_params` already
+serializes because only the outer map skips when empty. The launch check then
+treats every launch value for that node as undeclared, by the design rule.
+
+*Acceptance:* a contract with `params: {}` on one node and names on the rest
+resolves to a `node_params` entry for all of them, and the image derives its
+store; dropping the `{}` refuses again, naming the node.
+
+### F2 -- descriptions get their own capacity, and an overflow is not silent
+
+`ParameterDescriptor.description` is a `String<MAX_STRING_VALUE_LEN>`
+(`nros-params/src/types.rs`), so the description shares the capacity sized
+for string VALUES. W4 derives that capacity to 0 for an all-scalar image, and
+`with_description` then stores nothing: it clears the field and discards the
+`push_str` error (`let _ =`), so a description one byte too long is dropped
+whole rather than truncated, with no log. `ros2 param describe` then answers
+an empty description.
+
+Fix shape:
+
+- a knob of its own, `NROS_MAX_PARAM_DESCRIPTION_LEN`, on the same ladder as
+  the other per-slot knobs. A description is code-supplied text the contract
+  does not declare, so its capacity is a board fact; 0 is a legitimate board
+  choice meaning "no descriptions", stated rather than inherited;
+- an overflow truncates at a character boundary and logs once per parameter,
+  naming the knob, instead of emptying the field in silence;
+- the same for any other `let _ = push_str` on a parameter's metadata.
+
+Declaring description TEXT in the contract (it could then live in flash
+instead of every slot) stays under "Not in this phase".
+
+*Acceptance:* a scalar-only image with the description knob at 64 answers
+`describe` with the code's text; a longer description is truncated with one
+log line naming the knob.
+
+### F3 -- the parameter-service buffer is derived from the declarations
+
+W5 shares one request/reply pair per executor at the configured
+`NROS_PARAM_SERVICE_BUFFER_SIZE` (4,096 B default). Its size should follow
+from what can actually cross it:
+
+- the largest REPLY over one executor's declared parameters, at the board's
+  capacities: `describe_parameters` for every declared name (per descriptor:
+  name, type, description, the additional-constraints string, flags, one
+  range), `get_parameters` for every declared value, and `list_parameters`
+  (every name plus its prefixes);
+- the largest REQUEST a well-formed client can send for those parameters
+  (`set_parameters_atomically` of every declared value). A request for names
+  the image does not declare can be larger; it is refused and logged by the
+  W5 path rather than sized for;
+- CDR framing and alignment included, computed at build time by the entity
+  inventory into `NROS_PARAM_SERVICE_BUFFER_SIZE` on the derivable ladder, and
+  applied through `param_service_buffer_bytes()`
+  (`nros-node/src/parameter_services.rs`), the one place W5 left for it;
+- the configured constant stays the fallback when the declarations are absent
+  or refused.
+
+*Acceptance:* the downstream's image derives its buffer size and records it;
+a unit test serializes the worst describe reply for a declared set and
+asserts it fits the derived size and is within a small margin of it.
+
 ## Order
 
 W1 -> W2 -> W4 and W6; W3 and W5 do not depend on the schema and can start at
-once. W7 needs all of them.
+once. W7 needs all of them. F1 lands in ros-launch-manifest and play_launch
+and needs no nano-ros change beyond a pin; F2 is independent; F3 needs W4.
 
 ## Not in this phase
 


### PR DESCRIPTION
Updates the phase 446 doc after W1, W2 and W5 landed and W4/W6 went up.

## Design section
- **Every node or none.** The store is derived only when every node has a `params:` entry (what #872 implements), so `params: {}` has to mean "declares no parameters", distinct from a missing `params:`.
- **Undeclared launch values.** Addressed to the node by name: error. Through a wildcard key such as `/**`: warning, matching rclcpp, which ignores undeclared overrides. Wrong type: error either way. This is play_launch f5264bf0.
- Two new table rows: description capacity (F2) and the service buffer (W5 now, F3 derived).

## Landed notes
W1 (ros-launch-manifest v0.1.34), W2 (play_launch 155ed78b + f5264bf0), W5 (#868, with its host measurement).

## Follow-ups
- **F1:** `params: {}` is lost. Not a YAML problem: `NodeDecl.params` is a plain `BTreeMap`, so the hand-written parser returns the same empty map for no key and for `{}` (checked with a scratch program against v0.1.34), the serializer skips it, and play_launch's model builder skips an empty map. Fix: `Option<BTreeMap>` in ros-launch-manifest plus the model builder inserting the empty entry; nano-ros needs only a pin.
- **F2:** `ParameterDescriptor.description` is a `String<MAX_STRING_VALUE_LEN>`, which W4 derives to 0 for an all-scalar image, and `with_description` drops an overflow whole with `let _ =`. Own knob, logged truncation.
- **F3:** derive the shared parameter-service buffer from the declared parameters through `param_service_buffer_bytes()`.

The status line at the top is left alone: #872 and #878 each rewrite it, and this PR would only conflict with them.

`just check fast`: 292 of 294; the two failures are `capability-conditionals` and `xrce-vendored-versions`, which fail only because this bare worktree lacks the zenoh-pico submodule and the vendored XRCE trees. Pushed with `NROS_SKIP_PREPUSH_CHECKS=1` for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKY5TGsRzN9SVs1e4c8BoH