### PR TITLE
fix(#1276): the installer was the one consumer that never asked the one derivation

### DIFF
--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -29,8 +29,15 @@
 #         0319/0896 class — is still worth reading, and `refs/issue-ids/1110`
 #         is claimed either way.
 #
+#   1274  IN FLIGHT, both of them — issue 1279 cites its two siblings and
+#   1276  their files are in PR #870 (docs/provisioning-findings). Same
+#         provisioning study, split across PRs only because #842 was already
+#         queued and frozen. Both rows go when #870 lands.
+#
 docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
 docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
 docs/roadmap/archived/phase-431-ship-the-nros-binary.md:1110
 just/check/docs.just:1110
 scripts/build/rustdoc-set.sh:1110
+docs/issues/1279-zephyr-setup-skips-sdk-registration-when-workspace-exists.md:1274
+docs/issues/1279-zephyr-setup-skips-sdk-registration-when-workspace-exists.md:1276

--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -29,15 +29,8 @@
 #         0319/0896 class — is still worth reading, and `refs/issue-ids/1110`
 #         is claimed either way.
 #
-#   1274  IN FLIGHT, both of them — issue 1279 cites its two siblings and
-#   1276  their files are in PR #870 (docs/provisioning-findings). Same
-#         provisioning study, split across PRs only because #842 was already
-#         queued and frozen. Both rows go when #870 lands.
-#
 docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
 docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
 docs/roadmap/archived/phase-431-ship-the-nros-binary.md:1110
 just/check/docs.just:1110
 scripts/build/rustdoc-set.sh:1110
-docs/issues/1279-zephyr-setup-skips-sdk-registration-when-workspace-exists.md:1274
-docs/issues/1279-zephyr-setup-skips-sdk-registration-when-workspace-exists.md:1276

--- a/docs/issues/1279-zephyr-setup-skips-sdk-registration-when-workspace-exists.md
+++ b/docs/issues/1279-zephyr-setup-skips-sdk-registration-when-workspace-exists.md
@@ -1,0 +1,99 @@
+---
+id: 1279
+title: "`just setup zephyr` skips the whole SDK setup when the WORKSPACE
+  exists, but cmake registration is per-USER state — a host can hold a
+  complete, unpacked, unusable SDK that the verb cannot repair"
+status: open
+type: bug
+area: build, setup
+severity: medium
+found: 2026-09-11
+related: [issue-1274, issue-1276, rfc-0095]
+---
+
+## What this is
+
+`just/zephyr-setup.just`:
+
+```sh
+if [ -d "$WORKSPACE/zephyr" ] && [[ "$ARGS" != *--force* ]]; then
+    echo "Zephyr workspace already present at $WORKSPACE"
+    echo "To reinstall, run: just zephyr setup --force"
+else
+    NROS_ZEPHYR_MANIFEST=… ./scripts/zephyr/setup.sh $ARGS
+fi
+```
+
+`scripts/zephyr/setup.sh` does more than fill the workspace. Among other things
+it runs the Zephyr SDK's own `setup.sh -h -c`, whose `-c` writes the cmake
+package registry entry:
+
+```
+~/.cmake/packages/Zephyr-sdk
+```
+
+That is per-USER state, not per-workspace. The gate in front of it asks about
+the workspace. So a host whose workspace is present and whose registry entry is
+absent is a host `just setup zephyr` cannot fix — it prints "already present"
+and returns 0.
+
+## Why the state is reachable
+
+Two ways, and the second is not exotic:
+
+* the workspace is provisioned, and `~/.cmake` is later lost or cleared;
+* the workspace lives in a persistent store and `~/.cmake` does not. That is
+  exactly a contained CI runner: `~/.nros/workspaces/zephyr/3.7` is a volume,
+  and `~/.cmake` was in the container's writable layer, which `--ephemeral`
+  destroys after one job. Every container would have started with a complete,
+  unpacked SDK and no registration.
+
+## Why it matters more than it looks
+
+`runner-doctor` catches it and says what it costs:
+
+```
+[MISSING] Zephyr SDK 0.16.8 is not registered with cmake
+          find_package(Zephyr-sdk) reads ~/.cmake/packages/Zephyr-sdk/;
+          an unregistered SDK fails at configure, not at download.
+          Run the SDK's own registration:
+            (cd …/zephyr-sdk-0.16.8 && ./setup.sh -h -c)
+```
+
+"Fails at configure, not at download" is the whole point: the failure surfaces
+in a build, far from the provisioning step that should have prevented it. And
+the remedy the doctor prints is the SDK's own script, NOT a nano-ros verb —
+which is an admission that the verb cannot do it.
+
+## Fix
+
+Split the skip. The workspace check should gate the workspace work (`west init`
+/ `west update`), not the steps that are idempotent and cheap and about the
+user's own environment. SDK registration is one of those: it is a few
+milliseconds, it is safe to repeat, and it is the difference between an SDK that
+builds and one that does not.
+
+Concretely, one of:
+
+* run the SDK's `setup.sh -c` unconditionally near the end of the recipe (the
+  `-h` half, installing host tools, is the expensive part and can stay behind
+  the skip — note it FAILED in a container, so it wants its own look);
+* or give the registration its own verb the doctor can name, so its remedy line
+  points at nano-ros rather than at a vendor script.
+
+Prefer the first. A second verb is another thing to remember, and the reason
+this bug exists is that a step got attached to the wrong condition.
+
+## Worked around, not fixed
+
+The contained runner registers the SDK by hand once, and `~/.cmake` is now one
+of its persistent stores, so it survives (PR #882). Resetting that store would
+need the registration re-run by hand. That is a workaround at the wrong layer
+and is recorded here so it does not become the answer.
+
+## Note for whoever is revising provisioning
+
+This is the same shape as issue 1274 — a step gated on a condition that is not
+the one it depends on — and the same shape as issue 1276, where the installer
+read a field instead of asking the derivation. Worth fixing together with
+whatever else touches `scripts/zephyr/setup.sh`.

--- a/docs/issues/archived/1276-clone-mode-panics-on-store-located-source.md
+++ b/docs/issues/archived/1276-clone-mode-panics-on-store-located-source.md
@@ -1,0 +1,126 @@
+---
+id: 1276
+title: "`provision_source` panics on a `location = \"store\"` source — `nros
+  setup rv-virt-threadx --rmw cyclonedds` dies at `expect(\"clone mode has a
+  dest\")` on any host that does not already have rosidl"
+status: resolved
+type: bug
+area: cli, build
+severity: high
+found: 2026-09-11
+resolved: 2026-09-11
+related: [rfc-0095, issue-1264, issue-0628]
+---
+
+## What this is
+
+On `main`, `orchestration/sdk_store.rs`, `SourceProvision::Clone`:
+
+```rust
+let git     = src.git.as_deref().expect("clone mode has a git url");
+let git_ref = src.git_ref.as_deref().expect("clone mode has a ref");
+let dest    = src.dest.as_deref().expect("clone mode has a dest");   // line 980
+```
+
+And on `main`, `nros-sdk-index.toml`:
+
+```toml
+[source.rosidl]
+version = "humble-5621b26"
+git = "https://github.com/ros2/rosidl"
+ref = "5621b26eff54596a356ad8abd72c06e7650d21f7"
+location = "store"
+```
+
+No `dest`. Phase-440 / RFC-0095 D1/D2 introduced `location = "store"` and the
+`source_dir()` helper that derives `$NROS_STORE/sources/<name>/<version>` for
+exactly this case — but the `Clone` arm was never taught about it and still
+requires the workspace-relative `dest` that a store-located source no longer
+has.
+
+`rosidl` is in `[rmw.cyclonedds].packages`, so every board that provisions
+Cyclone reaches it.
+
+## Reproduction
+
+```
+nros setup rv-virt-threadx --rmw cyclonedds
+```
+
+on a host where rosidl is not already provisioned:
+
+```
+nros setup: rv-virt-threadx (rmw cyclonedds) needs 7 package(s):
+  riscv-none-elf-gcc     present 14.2-nros1 (skip)
+  qemu                   present 11.0.0-nros6 (skip)
+  threadx                source 6.4.1 — submodule … [provisioned]
+  threadx-netxduo        source 6.4.x — submodule … [provisioned]
+  cyclonedds             present 0.10.5-nros1 (skip)
+  cyclonedds-src         source 0.10.5-nros1 — submodule … [provisioned]
+
+thread 'main' (6583) panicked at nros-cli-core/src/orchestration/sdk_store.rs:980:44:
+clone mode has a dest
+error: recipe `setup` failed with exit code 1
+```
+
+Six of seven packages provision, then it panics on the seventh. `just setup
+threadx_riscv64` fails with it.
+
+## Why nobody has hit it
+
+A host that provisioned rosidl before the `location` change has the tree already,
+and the `present` check returns `AlreadyPresent` — but only AFTER the `expect`,
+so that is not what saves it. What saves an existing host is that the OLD index
+had `dest = "third-party/ros/rosidl"`; the panic needs the NEW index, which
+means a fresh provisioning run against current `main`.
+
+That is a contained self-hosted runner bootstrapping from an empty store, and
+nothing else here does it routinely. The same wall waits for any new contributor
+and any fresh CI image.
+
+## Fix
+
+In `Clone` mode, resolve the destination the way `source_dir()` already
+documents:
+
+* `location = "store"`  -> `source_dir(index, name)` — derived, never authored;
+* `location = "workspace"` (the default) -> `workspace.join(dest)`, as today.
+
+And replace the three `expect`s with errors that name the source and the missing
+key. A panic here reports a Rust invariant to a user who typed a provisioning
+command; the index is user-editable, so a malformed entry is an input error, not
+an unreachable state. Every neighbouring failure in this file already does that
+(`nros setup: {name} … has no prebuilt for {host} and no source recipe …`).
+
+Note `SourceProvision::Clone` is selected before location is consulted at all —
+check whether a store-located source should take the clone path in the first
+place, or whether the mode selection needs the same fix one level up.
+
+## Sweep
+
+`location` was added by phase-440; the `Clone` arm is one consumer of
+`SourceSpec` and there may be others that read `dest` unconditionally. Grep for
+`src.dest` / `\.dest` across the CLI and fix them together rather than only the
+site that panicked (the issue-0196 rule).
+
+## Resolution (2026-09-11)
+
+`provision_source`'s `Clone` arm asks `source_dir_of`, the derivation whose own
+doc comment already claimed the installer as one of its three consumers. The
+resolver MOVED from `cmd/setup.rs` to `orchestration/sdk_store.rs`, beside the
+store root it derives from — `orchestration` reaching up into `cmd` for a path
+is how the third consumer gets missed again. The two remaining `expect`s became
+errors naming the source and the missing key.
+
+The sweep found the display half: `describe_source` and the auto-setup notice
+read `dest` directly and printed `-` for a store source, so the line said rosidl
+would be provisioned to nowhere. Both take the derivation now. `sdk_index.rs`'s
+reads are the validator itself; `metadata_build.rs` and `sdk_path.rs` degrade
+rather than panic.
+
+Verified three ways: a regression test for the shape (store source, no dest,
+dry-run) that also asserts the path lands UNDER the store at
+`sources/<name>/<version>`, since a fix that invented a workspace path would
+pass a weaker assertion; a positive control, reverting the resolution line to
+watch that test panic at the reported site; and the command itself against the
+shipped index and an empty store, where all seven packages now resolve.

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -348,7 +348,11 @@ pub fn run(args: Args) -> Result<()> {
                 let disp =
                     provision_source(name, src, &workspace, args.dry_run, shallow_override(&args))
                         .wrap_err_with(|| format!("provision source {name}"))?;
-                eprintln!("  {:<22} {}", name, describe_source(src, &disp));
+                eprintln!(
+                    "  {:<22} {}",
+                    name,
+                    describe_source(name, src, &workspace, &disp)
+                );
                 if matches!(disp, SourceDisposition::Provisioned) {
                     installed = true;
                 }
@@ -902,7 +906,7 @@ fn provision_named_sources(
             .wrap_err_with(|| format!("provision source {name}"))?;
         eprintln!(
             "nros setup --source {name}: {}",
-            describe_source(src, &disp)
+            describe_source(name, src, &workspace, &disp)
         );
     }
     Ok(())
@@ -916,36 +920,12 @@ fn source_present(
     src: &crate::orchestration::sdk_index::SourcePackage,
     workspace: &Path,
 ) -> bool {
-    source_dir_of(name, src, workspace)
+    crate::orchestration::sdk_store::source_dir_of(name, src, workspace)
         .and_then(|d| std::fs::read_dir(d).ok())
         .map(|mut d| d.next().is_some())
         .unwrap_or(false)
 }
 
-/// The directory a `[source.*]` is provisioned into — phase-440, RFC-0095
-/// D1/D2. ONE derivation, so "where is it?" has one answer for the installer,
-/// the presence probe and `nros sdk-path --source`.
-///
-/// `location = "store"` derives `$NROS_STORE/sources/<name>/<version>` from the
-/// index rather than reading a path out of it; `workspace` (the default) keeps
-/// the historical workspace-relative `dest`, so every existing entry means what
-/// it meant.
-pub(crate) fn source_dir_of(
-    name: &str,
-    src: &crate::orchestration::sdk_index::SourcePackage,
-    workspace: &Path,
-) -> Option<std::path::PathBuf> {
-    use crate::orchestration::sdk_index::SourceLocation;
-    match src.location {
-        SourceLocation::Store => Some(
-            crate::orchestration::store::root()
-                .join("sources")
-                .join(name)
-                .join(&src.version),
-        ),
-        SourceLocation::Workspace => src.dest.as_deref().map(|d| workspace.join(d)),
-    }
-}
 
 /// RFC-0097 D12 — what a TARGET BUILD will need that no board provisions.
 ///
@@ -1103,7 +1083,9 @@ pub fn ensure_tools(board: &str, workspace: Option<&Path>) -> Result<Vec<PathBuf
                     Ok(SourceDisposition::Provisioned) => {
                         eprintln!(
                             "nros: provisioned source {name} → {}",
-                            src.dest.as_deref().unwrap_or("-")
+                            crate::orchestration::sdk_store::source_dir_of(name, src, &ws)
+                                .map(|d| d.display().to_string())
+                                .unwrap_or_else(|| "<no location>".to_string())
                         );
                         installed = true;
                     }
@@ -1448,8 +1430,16 @@ fn index_workspace(index: &Path) -> PathBuf {
 }
 
 /// One-line description of a source's provisioning outcome (Phase 195.B).
+///
+/// Takes `name` and `workspace` so the destination can come from
+/// `source_dir_of` — the same derivation the installer uses. Reading `dest`
+/// directly printed `-` for a `location = "store"` source, which has no `dest`
+/// by construction: the line said the tool would provision rosidl to nowhere
+/// (issue 1276, the display half).
 fn describe_source(
+    name: &str,
     src: &crate::orchestration::sdk_index::SourcePackage,
+    workspace: &Path,
     disp: &SourceDisposition,
 ) -> String {
     use crate::orchestration::sdk_index::SourceProvision;
@@ -1470,11 +1460,13 @@ fn describe_source(
         SourceDisposition::NoFetch => "no fetch step",
         SourceDisposition::Planned => "would provision (--dry-run)",
     };
-    format!(
-        "source {} — {mode} → {} [{outcome}]",
-        src.version,
-        src.dest.as_deref().unwrap_or("-")
-    )
+    let where_ = crate::orchestration::sdk_store::source_dir_of(name, src, workspace)
+        .map(|d| d.display().to_string())
+        // Only a malformed entry reaches this, and `SdkIndex::validate` refuses
+        // that shape — but a display helper must not be the thing that decides
+        // a run fails.
+        .unwrap_or_else(|| "<no location>".to_string());
+    format!("source {} — {mode} → {where_} [{outcome}]", src.version)
 }
 
 /// Names of the `[tool.*]` packages in `packages` that this host will BUILD

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -926,7 +926,6 @@ fn source_present(
         .unwrap_or(false)
 }
 
-
 /// RFC-0097 D12 — what a TARGET BUILD will need that no board provisions.
 ///
 /// `nros setup <board>` resolves a board's `[tool.*]`/`[source.*]` slice and

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -89,6 +89,36 @@ pub fn source_dir(index: &super::sdk_index::SdkIndex, source: &str) -> Option<Pa
     )
 }
 
+/// The directory a `[source.*]` is provisioned into — phase-440, RFC-0095
+/// D1/D2. ONE derivation, so "where is it?" has one answer for the installer,
+/// the presence probe and `nros sdk-path --source`.
+///
+/// It lives HERE, beside the store root it derives from, because the INSTALLER
+/// is in this file and was the one consumer that never called it — the sentence
+/// above was true of two of its three consumers (issue 1276). Moved rather than
+/// called across the layer: `orchestration` reaching up into `cmd` for a path
+/// derivation is how the third consumer gets missed again.
+///
+/// `location = "store"` derives `$NROS_STORE/sources/<name>/<version>` from the
+/// index rather than reading a path out of it; `workspace` (the default) keeps
+/// the historical workspace-relative `dest`, so every existing entry means what
+/// it meant.
+pub fn source_dir_of(
+    name: &str,
+    src: &SourcePackage,
+    workspace: &Path,
+) -> Option<std::path::PathBuf> {
+    match src.location {
+        SourceLocation::Store => Some(
+            super::store::root()
+                .join("sources")
+                .join(name)
+                .join(&src.version),
+        ),
+        SourceLocation::Workspace => src.dest.as_deref().map(|d| workspace.join(d)),
+    }
+}
+
 pub fn tool_dir(index: &super::sdk_index::SdkIndex, tool: &str) -> Option<PathBuf> {
     let version = &index.tool.get(tool)?.version;
     Some(tool_prefix(&store_root(), tool, version))
@@ -975,10 +1005,32 @@ pub fn provision_source(
             Ok(SourceDisposition::Provisioned)
         }
         SourceProvision::Clone => {
-            let git = src.git.as_deref().expect("clone mode has a git url");
-            let git_ref = src.git_ref.as_deref().expect("clone mode has a ref");
-            let dest = src.dest.as_deref().expect("clone mode has a dest");
-            let dest_abs = workspace.join(dest);
+            // The index is USER-EDITABLE, so a malformed entry is an input
+            // error reported to somebody who typed a provisioning command — not
+            // an unreachable state. `SdkIndex::validate` rejects both of these
+            // before we get here; if one ever arrives, say which source and
+            // which key, the way every other failure in this file does.
+            let git = src.git.as_deref().ok_or_else(|| {
+                eyre!("source '{name}' is in clone mode but has no `git` url")
+            })?;
+            let git_ref = src.git_ref.as_deref().ok_or_else(|| {
+                eyre!("source '{name}' is in clone mode but has no `ref`")
+            })?;
+            // ASK THE ONE DERIVATION. This read `dest` directly and panicked
+            // with `expect("clone mode has a dest")` — which is exactly what a
+            // `location = "store"` source has no `dest` to give, because
+            // phase-440 removed it so the store path could not be spelled
+            // twice, and `validate` REFUSES an authored one.
+            //
+            // `rosidl` is that source and rides `[rmw.cyclonedds]`, so
+            // `nros setup <board> --rmw cyclonedds` provisioned six packages
+            // and then aborted on the seventh, on any host that did not already
+            // have the tree (issue 1276).
+            let dest_abs = source_dir_of(name, src, workspace).ok_or_else(|| {
+                eyre!(
+                    "source '{name}' is in clone mode but nothing says where it                      lives: location = \"workspace\" needs a `dest`, and                      location = \"store\" derives one from name + version"
+                )
+            })?;
             // Idempotent: a present, non-empty dest is left as-is (don't clobber
             // a contributor checkout / in-progress work). `nros setup` on a
             // fresh tree provisions; a populated tree is a skip.
@@ -1661,6 +1713,44 @@ mod tests {
             provision_source("lwip", &empty, &ws, true, None).unwrap(),
             SourceDisposition::Planned
         );
+
+        // Clone mode, location = "store", NO dest — issue 1276.
+        //
+        // This is not a hypothetical shape: `SdkIndex::validate` REFUSES a
+        // store source that carries a `dest` (phase-440 removed it so the
+        // store path could not be spelled twice), so "store + no dest" is the
+        // only legal spelling and `[source.rosidl]` is it. This arm used to
+        // `expect("clone mode has a dest")` and panicked — after provisioning
+        // every earlier package in the plan.
+        //
+        // Dry-run, so the assertion is about REACHING the decision rather than
+        // about cloning: a panic cannot be dry-run past.
+        let store_src = SourcePackage {
+            dest: None,
+            location: SourceLocation::Store,
+            ..clone.clone()
+        };
+        assert_eq!(
+            provision_source("rosidl-ish", &store_src, &ws, true, None).unwrap(),
+            SourceDisposition::Planned
+        );
+
+        // And it resolves to the STORE, not to something under the workspace —
+        // a fix that stopped the panic by inventing a workspace path would pass
+        // the assertion above and put the tree in the wrong place.
+        let resolved = source_dir_of("rosidl-ish", &store_src, &ws)
+            .expect("a store source resolves without a dest");
+        assert!(
+            resolved.starts_with(crate::orchestration::store::root()),
+            "store source resolved outside the store: {}",
+            resolved.display()
+        );
+        assert!(
+            resolved.ends_with(Path::new("sources/rosidl-ish/2.2.0")),
+            "store source path is derived from name + version: {}",
+            resolved.display()
+        );
+
         std::fs::remove_dir_all(&ws).ok();
     }
 }

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -1010,12 +1010,14 @@ pub fn provision_source(
             // an unreachable state. `SdkIndex::validate` rejects both of these
             // before we get here; if one ever arrives, say which source and
             // which key, the way every other failure in this file does.
-            let git = src.git.as_deref().ok_or_else(|| {
-                eyre!("source '{name}' is in clone mode but has no `git` url")
-            })?;
-            let git_ref = src.git_ref.as_deref().ok_or_else(|| {
-                eyre!("source '{name}' is in clone mode but has no `ref`")
-            })?;
+            let git = src
+                .git
+                .as_deref()
+                .ok_or_else(|| eyre!("source '{name}' is in clone mode but has no `git` url"))?;
+            let git_ref = src
+                .git_ref
+                .as_deref()
+                .ok_or_else(|| eyre!("source '{name}' is in clone mode but has no `ref`"))?;
             // ASK THE ONE DERIVATION. This read `dest` directly and panicked
             // with `expect("clone mode has a dest")` — which is exactly what a
             // `location = "store"` source has no `dest` to give, because


### PR DESCRIPTION
`nros setup <board> --rmw cyclonedds` provisions six packages and then dies:

```
thread 'main' panicked at orchestration/sdk_store.rs:980:44:
clone mode has a dest
```

`rosidl` is that seventh package, it rides `[rmw.cyclonedds]`, and phase-440
(RFC-0095 D1/D2) moved it to `location = "store"` — which by construction has no
`dest`. Not optionally: `SdkIndex::validate` **refuses** a store source that
carries one, "so the two cannot disagree". So the only legal spelling of a store
source is the shape this arm panicked on.

`source_dir_of` already answers both shapes, and its doc comment already names
who asks it:

```rust
/// ONE derivation, so "where is it?" has one answer for the installer,
/// the presence probe and `nros sdk-path --source`.
```

True of two of the three. The installer — `provision_source`, the code that
actually puts the tree on disk — read `dest` directly. A declaration that exists,
is authored, is correct, while something else is load-bearing.

The resolver **moves** to `sdk_store.rs` beside the store root it derives from,
rather than being called across the layer: `orchestration` reaching up into `cmd`
for a path derivation is how the third consumer gets missed again. The two
remaining `expect`s become errors naming the source and the missing key — the
index is user-editable, so a malformed entry is an input error reported to
somebody who typed a provisioning command, which is what every other failure in
this file already does.

**Sweep.** Grepping `.dest` found the display half of the same bug:
`describe_source` and the auto-setup notice read `dest` directly and printed `-`
for a store source, so the line said rosidl would be provisioned to nowhere. Both
take the derivation now. `sdk_index.rs`'s reads are the validator itself and
correct; `metadata_build.rs` and `sdk_path.rs` are `?`/`unwrap_or` and degrade
rather than panic.

**Verified three ways:**

1. A regression test for the shape — store source, no dest, dry-run — plus an
   assertion that it resolves *under the store* to `sources/<name>/<version>`,
   because a fix that stopped the panic by inventing a workspace path would pass
   the first assertion and put the tree in the wrong place.
2. A positive control: reverting just the resolution line makes that test panic
   at the reported site, so the test is testing the fix and not the weather.
3. The command itself, against the shipped index and an empty store — all seven
   packages resolve, and rosidl's destination prints as
   `<store>/sources/rosidl/humble-5621b26` instead of `-`.

Also files **#1279**: `just setup zephyr` skips the whole SDK setup when the
*workspace* exists, but cmake registration is per-*user* state
(`~/.cmake/packages/Zephyr-sdk`) — so a host can hold a complete, unpacked,
unusable SDK that the verb cannot repair, and `find_package(Zephyr-sdk)` fails at
configure rather than at download. Worked around in the contained runner (#882)
by making `~/.cmake` a store; filed so the workaround does not become the answer.

Found provisioning a contained self-hosted runner from an empty store. Invisible
to any host that provisioned rosidl before the index changed — an existing tree
is `AlreadyPresent`, but that check is *after* the panic, so what saves such a
host is the old `dest`, not the skip.

The baseline rows for 1274/1276 go when #870 lands and their files arrive.