### PR TITLE
fix(#1264): a dead manifest parser is reported as one, not as a platform/id that does not exist

### DIFF
--- a/changelog.d/1264.fix.md
+++ b/changelog.d/1264.fix.md
@@ -1,0 +1,1 @@
+a manifest parser that fails to even start is reported as a parser failure, not as an unknown platform or fixture id

--- a/docs/issues/archived/1264-platform-rmws-swallows-parser-stderr.md
+++ b/docs/issues/archived/1264-platform-rmws-swallows-parser-stderr.md
@@ -3,11 +3,12 @@ id: 1264
 title: "`nros_platform_rmws` redirects the manifest parser's stderr to
   /dev/null, so an interpreter that cannot read `fixtures.toml` is reported
   as a platform that does not exist"
-status: open
+status: resolved
 type: bug
 area: build, testing
 severity: medium
 found: 2026-09-10
+resolved_in: "fix(#1264): a dead manifest parser is reported as one, not as a platform/id that does not exist"
 related: [phase-395]
 ---
 
@@ -93,3 +94,51 @@ That the runner image lacked `tomli` is a container-provisioning gap, fixed in
 `scripts/ci/runner-bootstrap.sh` (PR #842). This issue is that the failure was
 unreadable, which would have been just as true on any python3.10 host without
 `tomli` installed.
+
+## Resolution
+
+Added `scripts/lib/manifest-query.sh` — one shared `nros_manifest_query
+<python-script> [args...]` that runs `fixtures-manifest.py`, captures stderr
+into a temp file rather than discarding it, and checks the parser's exit
+status via the `rc=0; out="$(...)" || rc=$?` idiom (issue 1249) rather than a
+bare assignment. On failure it prints the parser's own stderr, indented, and
+returns the parser's status (never 0); on success it prints stdout, empty or
+not, unchanged.
+
+`nros_platform_rmws` (`scripts/build/platform-rmws.sh`) now calls it and
+reports "the manifest parser failed (above), so it is unknown whether
+'\<platform\>' has fixture rows — not that it doesn't" on a parser failure,
+leaving the original "no fixture rows for platform '\<platform\>'" message
+untouched for the genuine-emptiness case.
+
+**Sweep.** Grepping `scripts/` for `2>/dev/null` on a `fixtures-manifest.py`
+invocation found two closely related siblings in `scripts/build/
+fixture-id-guard.sh`, doing the identical thing for a different table:
+
+- `nros_fixture_id_no_match` read a dead parser's empty `describe-id` output
+  as "no row anywhere carries id '\<id\>'" — the exact misdiagnosis, one table
+  over.
+- `nros_fixture_require_known_platform` read a dead parser's empty
+  `list-platforms` output as `return 0` ("manifest unreadable — not this
+  guard's job"), silently disabling platform-typo validation on the same
+  failure that broke the parser — a quieter failure mode, but the same root
+  cause.
+
+Both now use `nros_manifest_query` and fail loud, naming the parser failure,
+with the genuine-typo and genuine-empty messages left exactly as they were.
+
+Other `2>/dev/null` sites against `fixtures-manifest.py` exist
+(`nuttx-libc-pin-guard.sh`, `drop-family-artifacts.sh`,
+`check-fixtures-stale.sh`, `measure-fixture-build.sh`) but read emptiness as
+"nothing to do" rather than emitting a confident wrong claim about a named
+entity — a quieter, lower-severity shape than this issue's title. Left alone
+here to keep the change scoped to the misdiagnosis class; worth a follow-up if
+the quieter shape turns out to matter in practice.
+
+**Tests.** `scripts/check-fixture-id-guard.sh` gained two cases exercising
+both `fixture-id-guard.sh` functions against a fake `python3` that dies the
+way a python3.10 host with no `tomllib`/`tomli` does. A new
+`scripts/check-platform-rmws.sh` (`just check platform-rmws`) does the same
+for `nros_platform_rmws`, plus the two pre-existing cases (real platform,
+typo'd platform). All four cases were verified by mutation: reverting the
+fix reproduces the original misdiagnosis and the new assertions catch it.

--- a/just/check/fixtures.just
+++ b/just/check/fixtures.just
@@ -131,6 +131,15 @@ fixture-groups:
 fixture-id-guard:
     @bash scripts/check-fixture-id-guard.sh
 
+# Issue 1264 — `nros_platform_rmws` (and the fixture-id-guard functions above,
+# which share its `nros_manifest_query` helper) must report a manifest parser
+# that failed to even START as a PARSER failure, never as "this platform/id
+# does not exist". Buildless: sources the library and calls its functions
+# directly, once against a fake `python3` that dies the way a python3.10 host
+# with no tomllib/tomli does.
+platform-rmws:
+    @bash scripts/check-platform-rmws.sh
+
 # Issue 0835 — a fixture staleness probe decides from the ARTIFACT's BYTES, not
 # from whether the build did work. Corrosion's cargo step is an always-dirty
 # edge and the phase-340 cargo groups evict rows nobody touched, so an

--- a/scripts/build/fixture-id-guard.sh
+++ b/scripts/build/fixture-id-guard.sh
@@ -26,6 +26,16 @@
 #
 # So the loudness is keyed on the spelling, and the spellings keep distinct
 # meanings instead of being merged into one that cannot express both.
+#
+# Issue 1264: both guards below used to run the manifest parser with
+# `2>/dev/null` and read empty output as a definitive "no such id" / "no such
+# platform" — which is also what a python3 with no `tomllib`/`tomli` prints,
+# having raised before reading a byte. `nros_manifest_query` tells the two
+# apart; see scripts/lib/manifest-query.sh.
+
+_nros_fixture_id_guard_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/manifest-query.sh
+source "$_nros_fixture_id_guard_dir/../lib/manifest-query.sh"
 
 # nros_fixture_id_out_of_lane <id> <coords_active> <unnarrowed_rows> <what>
 #
@@ -70,8 +80,14 @@ nros_fixture_id_no_match() {
     # cwd — the three builders run from different directories.
     guard_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     local guard_root="${guard_dir%/scripts/build}"
-    where="$(python3 "$guard_dir/fixtures-manifest.py" \
-        --manifest "$guard_root/examples/fixtures.toml" describe-id --id "$id" 2>/dev/null)"
+    local rc=0
+    where="$(nros_manifest_query "$guard_dir/fixtures-manifest.py" \
+        --manifest "$guard_root/examples/fixtures.toml" describe-id --id "$id")" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "fixtures: could not look up id '${id}' — the manifest parser failed" \
+            "(above), so this is not a claim that the id is wrong." >&2
+        exit 2
+    fi
 
     local other_platform="" other_lang=""
     while IFS=$'\x1f' read -r k p l r; do
@@ -142,12 +158,23 @@ nros_fixture_id_no_match() {
 # anywhere is a typo, and every platform the recipes pass is in the manifest,
 # so rejecting the rest costs nothing.
 nros_fixture_require_known_platform() {
-    local platform="$1" guard_dir guard_root known
+    local platform="$1" guard_dir guard_root known rc=0
     guard_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     guard_root="${guard_dir%/scripts/build}"
-    known="$(python3 "$guard_dir/fixtures-manifest.py" \
-        --manifest "$guard_root/examples/fixtures.toml" list-platforms 2>/dev/null)"
-    [ -n "$known" ] || return 0  # manifest unreadable — not this guard's job
+    known="$(nros_manifest_query "$guard_dir/fixtures-manifest.py" \
+        --manifest "$guard_root/examples/fixtures.toml" list-platforms)" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        # The parser itself failed (issue 1264) — distinct from a genuinely
+        # empty platform list, which `nros_manifest_query` would not produce
+        # for a real `examples/fixtures.toml`. Say so and stop, rather than
+        # silently skipping validation: a typo'd platform sliding past this
+        # guard on the SAME failure that broke the parser is exactly the
+        # confusion this issue was filed over.
+        echo "fixtures: could not check platform '${platform}' — the manifest" \
+            "parser failed (above)." >&2
+        exit 2
+    fi
+    [ -n "$known" ] || return 0  # a real, successfully-parsed empty list
     if ! grep -qxF "$platform" <<< "$known"; then
         {
             echo "fixtures: unknown platform '${platform}' — no row in examples/fixtures.toml declares it."

--- a/scripts/build/platform-rmws.sh
+++ b/scripts/build/platform-rmws.sh
@@ -30,23 +30,42 @@
 #
 # Deliberately NOT silent on failure: a platform with no rows is a caller error
 # (a typo'd name), and returning "nothing to provision" for it would reproduce
-# the bug this fixes one level up.
+# the bug this fixes one level up. Issue 1264: that reasoning only held for
+# failures where the PARSER ran — it was reached with `2>/dev/null` ahead of
+# it, so a python3 that cannot even import the manifest parser (no
+# `tomllib`/`tomli`) produced the identical empty `$out` and got the identical
+# confident-but-wrong message. `nros_manifest_query` (scripts/lib/manifest-
+# query.sh) is what now tells the two apart.
+
+_nros_platform_rmws_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/manifest-query.sh
+source "$_nros_platform_rmws_dir/../lib/manifest-query.sh"
 
 # nros_platform_rmws <platform>
 #
 # Echoes one backend per line, sorted and deduped. Exit 1 with a message if the
-# platform has no fixture rows at all.
+# platform has no fixture rows at all, or if the manifest parser itself failed.
 nros_platform_rmws() {
     local platform="${1:?nros_platform_rmws: platform}"
     local root
     root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
-    local out
     # `coords` is the same subcommand the lane filters use, so this reads the
     # manifest through the one parser rather than re-implementing TOML in awk.
+    local coords rc
+    rc=0
+    coords="$(nros_manifest_query "$root/scripts/build/fixtures-manifest.py" coords)" \
+        || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "nros_platform_rmws: the manifest parser failed (above), so it is unknown" >&2
+        echo "  whether '$platform' has fixture rows — not that it doesn't." >&2
+        return 1
+    fi
+
+    local out
     # Its fields are separated by 0x1f, NOT tab — a tab-split silently yields
     # one field and an empty answer, which looks exactly like "no rows".
-    out="$(python3 "$root/scripts/build/fixtures-manifest.py" coords 2>/dev/null \
+    out="$(printf '%s\n' "$coords" \
         | awk -F'\x1f' -v p="$platform" '$2 == p { print $4 }' \
         | grep -v '^$' \
         | sort -u)"

--- a/scripts/check-fixture-id-guard.sh
+++ b/scripts/check-fixture-id-guard.sh
@@ -101,6 +101,69 @@ echo "check-fixture-id-guard: platform vocabulary"
 expect_rc 2 "unknown platform is fatal" \
     bash -c 'source scripts/build/fixture-id-guard.sh; nros_fixture_require_known_platform natve'
 
+echo "check-fixture-id-guard: manifest parser failure (issue 1264)"
+
+# A parser that cannot even start (no tomllib/tomli — the real trigger, on a
+# python3.10 host with neither installed — or any other import-time failure)
+# must be reported as a PARSER failure, never folded into "no such id" / "no
+# such platform". Those are confident claims a dead parser has no evidence
+# for, and reading its empty output as one is exactly issue 1264.
+#
+# Faked with a `python3` shadowing PATH rather than by uninstalling tomllib:
+# the real failure is host-Python-version-dependent (this repo's own dev
+# hosts vary), and this gate must reproduce identically on any of them.
+fake_python_dir="$(mktemp -d)"
+cat >"$fake_python_dir/python3" <<'FAKE_PY'
+#!/usr/bin/env bash
+echo "Traceback (most recent call last):" >&2
+echo "ModuleNotFoundError: No module named 'tomllib'" >&2
+exit 1
+FAKE_PY
+chmod +x "$fake_python_dir/python3"
+
+# expect_dead_parser <label> <command...>
+#
+# Distinct from expect_rc: a dead parser's rc is the PARSER's exit status
+# (not a fixed fatal code), so this checks shape (non-zero, parser's own
+# traceback reached the caller, no "does not exist" claim) rather than one rc.
+expect_dead_parser() {
+    local label="$1"
+    shift
+    local out rc
+    out="$(PATH="$fake_python_dir:$PATH" "$@" 2>&1)"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "  FAIL  ${label}: a dead parser returned rc=0"
+        fails=$((fails + 1))
+        return
+    fi
+    case "$out" in
+        *ModuleNotFoundError*) ;;
+        *)
+            echo "  FAIL  ${label}: the parser's own traceback did not reach the caller"
+            echo "        output: ${out}"
+            fails=$((fails + 1))
+            return
+            ;;
+    esac
+    case "$out" in
+        *"no row anywhere carries id"* | *"unknown platform"* | *"no fixture rows for platform"*)
+            echo "  FAIL  ${label}: a dead parser was reported as a real 'does not exist'"
+            echo "        output: ${out}"
+            fails=$((fails + 1))
+            return
+            ;;
+    esac
+    echo "  ok    ${label} (rc=${rc})"
+}
+
+expect_dead_parser "require_known_platform on a dead parser names the parser, not a typo" \
+    bash -c 'source scripts/build/fixture-id-guard.sh; nros_fixture_require_known_platform threadx-linux'
+expect_dead_parser "id_no_match on a dead parser names the parser, not a typo" \
+    bash -c 'source scripts/build/fixture-id-guard.sh; nros_fixture_id_no_match some-id flag fixture linux rust'
+
+rm -rf "$fake_python_dir"
+
 echo "check-fixture-id-guard: wired into the builders"
 # End to end through a real builder — proves the guard is actually reached,
 # not merely present. fixtures-build.sh needs no CLI or SDK to get this far.

--- a/scripts/check-platform-rmws.sh
+++ b/scripts/check-platform-rmws.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Issue 1264 — `nros_platform_rmws` must tell a dead manifest parser apart
+# from a platform that genuinely has no fixture rows. It used to run the
+# parser with `2>/dev/null` and read empty output either way, so a python3
+# with no `tomllib`/`tomli` (stock on Ubuntu 22.04) produced the identical
+# confident-but-wrong "no fixture rows for platform 'threadx-riscv64'" — a
+# name the manifest carries 42 times.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# shellcheck source=scripts/build/platform-rmws.sh
+source scripts/build/platform-rmws.sh
+
+fails=0
+
+# _dead_parser_verdict <output> <rc>
+#
+# Pure predicate, separated from the real-function cases below so `self_test`
+# can drive it against SYNTHETIC output — a checker whose predicate always
+# says "ok" would pass every case with no code under test doing anything
+# right. 0 ("this correctly reports a parser failure") requires all three:
+# a non-zero rc, the parser's own text reaching the caller, and NONE of the
+# "does not exist" messages a genuine empty-but-successful parse would print.
+_dead_parser_verdict() {
+    local out="$1" rc="$2"
+    [ "$rc" -ne 0 ] || return 1
+    case "$out" in
+        *ModuleNotFoundError*) ;;
+        *) return 1 ;;
+    esac
+    case "$out" in
+        *"no row anywhere carries id"* | *"unknown platform"* | *"no fixture rows for platform"*)
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# self_test — negative control for `_dead_parser_verdict`, run unconditionally
+# on the normal path (never behind a flag): a negative control nobody runs
+# decays into a comment. Reproduces the exact pre-1264 message by hand rather
+# than by breaking real code, so it demonstrates the PREDICATE can fail
+# without depending on `platform-rmws.sh` staying broken to prove it.
+self_test() {
+    # The pre-1264 shape: `2>/dev/null` discarded the traceback and printed
+    # only the typo message. The predicate must REJECT this.
+    if _dead_parser_verdict \
+        "nros_platform_rmws: no fixture rows for platform 'threadx-riscv64'" 1; then
+        echo "[FAIL] self_test: predicate accepted the pre-1264 misdiagnosis" >&2
+        return 1
+    fi
+    # rc=0 is never a parser failure, however the message reads.
+    if _dead_parser_verdict "ModuleNotFoundError: No module named 'tomllib'" 0; then
+        echo "[FAIL] self_test: predicate accepted rc=0 as a parser failure" >&2
+        return 1
+    fi
+    # The traceback with neither typo message present — the fixed shape —
+    # must pass.
+    if ! _dead_parser_verdict \
+        "nros_manifest_query: ... failed (exit 1):
+  ModuleNotFoundError: No module named 'tomllib'" 1; then
+        echo "[FAIL] self_test: predicate rejected the correct fixed shape" >&2
+        return 1
+    fi
+    return 0
+}
+self_test || fails=$((fails + 1))
+
+echo "check-platform-rmws: a real platform resolves its backends"
+out="$(nros_platform_rmws linux)"
+rc=$?
+if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
+    echo "  FAIL  linux: expected rc=0 and non-empty output, got rc=${rc} out=${out}"
+    fails=$((fails + 1))
+else
+    echo "  ok    linux -> $(tr '\n' ' ' <<<"$out")"
+fi
+
+echo "check-platform-rmws: a typo'd platform is reported as one"
+out="$(nros_platform_rmws not-a-real-platform 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    echo "  FAIL  typo'd platform returned rc=0"
+    fails=$((fails + 1))
+elif [[ "$out" != *"no fixture rows for platform"* ]]; then
+    echo "  FAIL  typo'd platform: expected the 'no fixture rows' message, got: ${out}"
+    fails=$((fails + 1))
+else
+    echo "  ok    typo'd platform reports 'no fixture rows' (rc=${rc})"
+fi
+
+echo "check-platform-rmws: a dead parser is reported as one (issue 1264)"
+
+# Faked with a `python3` shadowing PATH rather than by uninstalling tomllib —
+# the real failure is host-Python-version-dependent, and this gate must
+# reproduce identically everywhere it runs.
+fake_python_dir="$(mktemp -d)"
+cat >"$fake_python_dir/python3" <<'FAKE_PY'
+#!/usr/bin/env bash
+echo "Traceback (most recent call last):" >&2
+echo "ModuleNotFoundError: No module named 'tomllib'" >&2
+exit 1
+FAKE_PY
+chmod +x "$fake_python_dir/python3"
+
+out="$(PATH="$fake_python_dir:$PATH" nros_platform_rmws threadx-riscv64 2>&1)"
+rc=$?
+rm -rf "$fake_python_dir"
+
+if _dead_parser_verdict "$out" "$rc"; then
+    echo "  ok    dead parser reported as a parser failure, not as a missing platform (rc=${rc})"
+else
+    echo "  FAIL  dead parser was misreported — see issue 1264"
+    echo "        rc: ${rc}"
+    echo "        output: ${out}"
+    fails=$((fails + 1))
+fi
+
+if [ "$fails" -ne 0 ]; then
+    echo "check-platform-rmws: ${fails} case(s) failed" >&2
+    exit 1
+fi
+echo "check-platform-rmws: OK"

--- a/scripts/lib/manifest-query.sh
+++ b/scripts/lib/manifest-query.sh
@@ -1,0 +1,48 @@
+# shellcheck shell=bash
+# Sourced, not executed — hence no shebang.
+#
+# nros_manifest_query — run `fixtures-manifest.py` and tell "parsed cleanly,
+# printed nothing" apart from "failed to parse" (issue 1264).
+#
+# Every caller of this used to run the parser with `2>/dev/null` and then read
+# an empty result as "this coordinate genuinely has no rows" — which is true
+# of exactly one of the two ways a python3/awk pipe can print nothing. A
+# python3 with no `tomllib`/`tomli` (stock on Ubuntu 22.04's python3.10) raises
+# `ModuleNotFoundError` before reading a byte of `examples/fixtures.toml`, and
+# that failure's output is ALSO empty — so a caller comparing `$out` to `""`
+# cannot tell a dead interpreter from a typo'd platform name, and reported a
+# confident, specific, WRONG diagnosis: "no fixture rows for platform
+# 'threadx-riscv64'", a name the manifest carries 42 times.
+#
+# nros_manifest_query <python-script> [args...]
+#
+# On success: prints the parser's stdout (which may legitimately be empty —
+#             that IS "no rows", the case callers are entitled to report as
+#             such), returns 0.
+# On failure: prints nothing to stdout; prints the parser's own stderr,
+#             indented, to THIS caller's stderr, headed by the command that
+#             produced it; returns the parser's exit status (never 0, so a
+#             caller can distinguish it from a clean empty result).
+#
+# Follows issue 1249's rule for a status meant to be INSPECTED: the capture is
+# `rc=0; out="$(...)" || rc=$?`, never a bare assignment a later `$?` cannot
+# reach under `set -e`.
+nros_manifest_query() {
+    local script="$1"
+    shift
+    local err_file out rc
+    err_file="$(mktemp)" || {
+        echo "nros_manifest_query: mktemp failed" >&2
+        return 1
+    }
+    rc=0
+    out="$(python3 "$script" "$@" 2>"$err_file")" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "nros_manifest_query: python3 $script $* failed (exit ${rc}):" >&2
+        sed 's/^/  /' "$err_file" >&2
+        rm -f "$err_file"
+        return "$rc"
+    fi
+    rm -f "$err_file"
+    printf '%s\n' "$out"
+}


### PR DESCRIPTION
## Summary

`nros_platform_rmws` (`scripts/build/platform-rmws.sh`) ran the manifest
parser with `2>/dev/null` and read empty output as "this platform has no
fixture rows" — true of exactly one of the two ways the pipe can print
nothing. A python3 with no `tomllib`/`tomli` (stock on Ubuntu 22.04's
python3.10) raises before reading a byte of `examples/fixtures.toml`, and
that failure's stdout is ALSO empty, so the function reported a confident,
specific, wrong diagnosis: "no fixture rows for platform 'threadx-riscv64'"
— a name the manifest carries 42 times.

- New `scripts/lib/manifest-query.sh`: `nros_manifest_query`, a shared
  helper that captures the parser's stderr instead of discarding it and
  checks its exit status separately from the emptiness of its output
  (issue 1249's `rc=0; out="$(...)" || rc=$?` rule, never a bare assignment
  `set -e` can outrun). Failure surfaces the parser's own stderr and returns
  non-zero; success behaves exactly as before, genuinely-empty output
  included.
- `nros_platform_rmws` now uses it.
- Same sweep found two siblings in `scripts/build/fixture-id-guard.sh`:
  `nros_fixture_id_no_match` read a dead parser's empty `describe-id` output
  as "no row anywhere carries id", and `nros_fixture_require_known_platform`
  read it as "manifest unreadable — not this guard's job", silently
  disabling platform-typo validation. Both fixed the same way.
- New gates: `scripts/check-platform-rmws.sh` (`just check platform-rmws`,
  runs its own selftest on the normal path) and two new cases in
  `scripts/check-fixture-id-guard.sh`, both driving a fake `python3` that
  fails the way a tomllib-less host does.
- Closes #1264 (archived, resolution recorded there).

## Test plan

- [x] Rebased onto current `main`.
- [x] `just check fast` green: 293 gates ran, 0 failed, 2 pre-existing
      environment skips (`ivc-fsp` — NVIDIA SPE tree not provisioned here;
      `leaf-lockfiles` — 2 nuttx-qemu leaves not synced), both unrelated to
      this change.
- [x] Reproduced the original symptom on this host (python3.10, no
      `tomllib`) by shadowing `python3` on `PATH` with a script that raises
      `ModuleNotFoundError`, confirming the pre-fix code reports "no fixture
      rows for platform 'threadx-riscv64'".
- [x] Mutation pass: reverted `scripts/build/platform-rmws.sh` and
      `scripts/build/fixture-id-guard.sh` to their pre-fix content in turn
      — `scripts/check-platform-rmws.sh` and `scripts/check-fixture-id-guard.sh`
      both went red on exactly the reintroduced cases, then green again once
      restored (clean `git diff`).
- [x] `python3 scripts/check-gate-selftests.py` — the new gate counted among
      those running a selftest on the normal path.
- [x] `git push` succeeded through the `pre-push` hook's own `just check fast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)