### PR TITLE
docs(claude-md): the queue ejections were mostly each PR's own defect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,11 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     the batch lane and onto the PR: it is 28 s against `test-unit`'s 3.5 min, so
     it never belonged under the same cost argument, and a feature-combination
     break there costs a batch rather than a PR — `grouping_strategy` is ALLGREEN
-    over 5 entries, so one `clippy::derivable_impls` error took #741, #768 and
-    #779 down 7-8 times each with no defect of their own. (That 28 s was the
+    over 5 entries, so one red entry ejects every entry behind it — though
+    measured, that was mostly not what happened: of 31 ejections of #741, #768
+    and #779, 27 carried the PR's OWN defect (#741's `result_unit_err`,
+    #768/#779's `declared-fact-carriers`) and `clippy::derivable_impls`
+    appeared in 3. (That 28 s was the
     EMBEDDED clippy alone: the host half was an `echo`, so until 2026-09-11 no
     merge-gating lane ran a host clippy. It now runs `check-test-targets`,
     workspace-wide AND per crate — `--workspace` unifies features, which hid


### PR DESCRIPTION
Corrects one sentence in CLAUDE.md that misattributed the merge-queue ejections of #741, #768 and #779.

The sentence said a single `clippy::derivable_impls` error took all three down "7-8 times each with no defect of their own". Measured against the ejection run logs (`gh pr view <n> --json comments` → `gh run view <id> --log-failed`), that is false for all three:

- **#741** — 8 ejections: 6 were its own `clippy::result_unit_err` (three `Result<(), ()>` returns in `nros-node/src/executor/spin.rs`), `derivable_impls` co-occurred in 1, and 2 were aggregator-only.
- **#768** — 18 ejections: 16 carried its own `declared-fact-carriers` failure (it edits that checker; its first ejection was tested against plain main with nothing queued ahead). 6 of those also inherited #741's lint from the batch.
- **#779** — 5 ejections: all 5 carried the same `declared-fact-carriers` failure.

In total, 27 of 31 ejections carried the PR's own defect, and `derivable_impls` appeared in 3. The surrounding point stands: `grouping_strategy` is ALLGREEN, so one red entry does eject every entry behind it, which is why moving `workspace-all` onto the pull-request lane was right.

The adjacent parenthetical that `2440745e8` added (host clippy, `check-test-targets`) is kept unchanged. This PR replaces only the sentence before it.

CLAUDE.md only. It was verified green in a full `just check fast` run on the branch it was cherry-picked from. The one red in that run, `third-party-is-submodules`, names untracked local directories, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zw1nseWJBSTRqVQzRAZcg
