### PR TITLE
docs(RFC-0098, RFC-0065): three facts phase-445 W4 measured, and the esp32 driver row

### DIFF
--- a/docs/design/0065-colcon-like-workspace-builder.md
+++ b/docs/design/0065-colcon-like-workspace-builder.md
@@ -197,7 +197,7 @@ naming the package and the manual step.
 | pure-Rust package set | **cargo** | the generated entry `build/<coord>/<entry>/Cargo.toml` as its own root, plus `build/<coord>/nros-cargo.toml` read through `--config` — **no workspace root** (RFC-0098 D9; the 2026-08-26 correction below is superseded) |
 | any C/C++ package in the set | **cmake** | `CMakeLists.txt` calling `nano_ros_workspace(…)` |
 | zephyr | **west** | nothing — sets env, `exec west build -b <board>` |
-| esp32 | **idf.py** | nothing — same shape |
+| esp32 on ESP-IDF (`framework = "espidf"`) | **idf.py** | nothing — same shape. **The esp-hal bare-metal esp32-c3 board is NOT this row: it is a cargo image.** The driver follows the board descriptor's kind, not the chip family (`plan::driver_for_board`, phase-445 W4 / PR #880 — `nros build esp32` had been exec'ing `idf.py` for an esp-hal image). |
 
 Mixed is not a fourth case. RFC-0024 §6.3 already settled it: *"cargo can be
 consumed as a cmake target (via Corrosion); cmake cannot be consumed as a cargo

--- a/docs/design/0098-generated-leaf-build-config.md
+++ b/docs/design/0098-generated-leaf-build-config.md
@@ -1,6 +1,6 @@
 # RFC-0098 — A leaf's build configuration is generated from one board choice
 
-**Status:** Draft (2026-09-10; revised 2026-09-10 — generated settings live under `build/`, and a workspace has no root build file)
+**Status:** Draft (2026-09-10; revised 2026-09-10 — generated settings live under `build/`, and a workspace has no root build file; 2026-09-11 — three facts measured by phase-445 W4)
 
 Home phase: [phase-445](../roadmap/phase-445-board-choice-generates-leaf-config.md).
 
@@ -53,7 +53,7 @@ commit that line") that has already been broken twice.
 
 **D1 — a leaf's generated build settings live under `build/`, never in the
 source tree.** `nros sync` / `nros build` write one file per image,
-`build/<image>/nros-cargo.toml`: the board's `cargo_config` (A, B) including a
+`build/<coord>/<entry>/nros-cargo.toml`: the board's `cargo_config` (A, B) including a
 per-image `target-dir`, the resolved `[env]` (D, E), and the in-repo
 `[patch.crates-io]` rows (H). Cargo reads it through `--config`, so nothing
 generated sits beside a package: no leaf `.cargo/config.toml`, no committed
@@ -63,8 +63,26 @@ DELETED, not gitignored. Measured 2026-09-10 (cargo 1.98.1): `cargo build
 the `[env]`, the `target-dir` and a `[patch.crates-io]` row from that file, and
 left the package's source directory with no `.cargo/` and no `target/`.
 
+**Measured while implementing it (phase-445 W4, PR #880), three facts the
+first revision did not have:**
+
+- **The file is per IMAGE, not per coordinate.** Several images share one
+  coordinate directory — nine native images share `build/posix-zenoh/` — and
+  their entity facts differ, so the file sits beside the image's generated
+  entry: `build/<coord>/<entry>/nros-cargo.toml`.
+- **A relative path inside a `--config` file resolves against the file's
+  GRANDPARENT directory** (cargo 1.98.1: for `build/<coord>/<entry>/nros-cargo.toml`,
+  against `build/<coord>/`), not against the file's own directory. The writer
+  emits paths relative to that base, or absolute.
+- **The working directory still matters for one thing.** Cargo still walks up
+  from the invocation directory for `.cargo/config.toml`, and the custom
+  `nros-*` profiles (`nros-relwithdebinfo`, …) live in the repo-root config. A
+  workspace OUTSIDE the checkout therefore loses them. Open: the profiles move
+  into the generated file (cargo accepts `[profile.*]` through `--config`), so
+  nothing depends on where cargo is run from.
+
 A single-package example builds the same way: `nros build`, or plain
-`cargo build --config build/<image>/nros-cargo.toml` for a user who drives
+`cargo build --config build/<coord>/<entry>/nros-cargo.toml` for a user who drives
 cargo themselves. A user's own Rust-toolchain preference goes where cargo's
 config hierarchy already looks — a parent directory or `$CARGO_HOME` — never in
 a generated file.
@@ -114,7 +132,7 @@ entity-facts` already answers that from the SystemModel's `execution.features`
 (`nros-zpico-build/src/runner.rs`) already computes the count from
 `NROS_DECLARED_SERVICE_SERVERS` + `NROS_DECLARED_INFRA_QUERYABLES` +
 `NROS_DECLARED_NODES`. So the facts are CARRIED, never the count (issue 0460),
-and they go in that image's own `build/<image>/nros-cargo.toml` `[env]`. This
+and they go in that image's own `build/<coord>/<entry>/nros-cargo.toml` `[env]`. This
 closes the question the first revision left open: today a workspace member's
 sidecar is the workspace root's, shared by every image, and cargo reads
 `.cargo/` from the invocation's working directory — so per-image facts could
@@ -138,6 +156,12 @@ cargo root is the generated entry itself, `build/<coord>/<entry>/Cargo.toml`
 root is `build/<coord>/CMakeLists.txt`, as RFC-0065 already has it. Each image
 therefore compiles its shared dependencies in its own `target-dir` — the cost
 the fixture lane already pays per group (phase-340).
+
+A workspace with NO bringup — a set of packages and nothing that declares a
+system, e.g. a message package beside its consumers — builds every package in
+dependency order, each with its own driver and its own `build/<pkg>/`: colcon's
+default. `nros build` gains that mode (phase-445 W5); until it does, such a
+workspace is the one shape that still needs a hand root.
 
 This supersedes RFC-0065 D3's "the cargo root is `<ws>/Cargo.toml` and nowhere
 else". That constraint is real only while a workspace EXISTS: a package finds


### PR DESCRIPTION
Records in the RFCs what phase-445 W4 (#880) measured against them:

- **Per IMAGE, not per coordinate** — nine native images share `build/posix-zenoh/` with different entity facts, so the file is `build/<coord>/<entry>/nros-cargo.toml`.
- **`--config` relative paths resolve against the file's GRANDPARENT** (cargo 1.98.1).
- **CWD still matters for one thing** — the custom `nros-*` profiles live in the repo-root `.cargo/config.toml`, so a workspace outside the checkout loses them. Open: move them into the generated file.
- RFC-0098 D9 states the **no-bringup** case (build every package in dependency order — colcon's default; W5 implements it).
- RFC-0065 D3: `idf.py` only for ESP-IDF boards; the **esp-hal esp32-c3 board is a cargo image** (driver follows the board descriptor, `plan::driver_for_board`).

Docs only; no open PR touches `docs/design/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK