### PR TITLE
feat(phase-447 A1+A2): a release ships what a build reads, and the ladder gains a store rung

### DIFF
--- a/.github/workflows/release-nros.yml
+++ b/.github/workflows/release-nros.yml
@@ -127,6 +127,30 @@ jobs:
         run: |
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
+          # phase-447 A1 — the launch resolver, the SECOND artifact a build
+          # needs and the one the SDK root cannot carry (it is a binary, its own
+          # cargo workspace, and it embeds CPython).
+          #
+          # Measured, not assumed: with `share/nano-ros` staged and no checkout
+          # present, `nros new my_robot --workspace` scaffolds and then dies at
+          # cmake configure with "`nros-launch-resolve` not found. Build it with
+          # ./scripts/bootstrap.sh" — a remedy naming a checkout the user does
+          # not have. Every workspace configure goes through it, because
+          # `nano_ros_entry` resolves the bringup's launch file into a
+          # SystemModel.
+          #
+          # `bootstrap.sh` builds exactly this for a contributor, one line below
+          # the CLI, and for the same reason: "a CLI without it fails the FIRST
+          # `nros new --workspace` build". `resolve_launch_resolver` rung 2 is
+          # already "a sibling of the running `nros` — the installed layout", so
+          # staging it into `bin/` beside the CLI needs no code.
+          #
+          # Its own workspace (own lock, own `ros-launch-manifest` pin), hence
+          # its own manifest path. `default-features = false` in that manifest
+          # drops z3/libclang, so this adds no system build dep beyond the
+          # CPython pyo3 already links.
+          cargo build --release \
+              --manifest-path packages/cli/nros-launch-resolve/Cargo.toml
           # phase-429 W5 — the binary must match the checkout it was built from.
           # A release is the one artifact where nobody downstream can re-check
           # this, so it is asserted here rather than assumed.
@@ -204,6 +228,14 @@ jobs:
           mkdir -p "$stage/bin" "$stage/share/nros"
           test -f "$stage/share/nros/manifest.toml"
           cp packages/cli/target/release/nros "$stage/bin/nros"
+          # phase-447 A1 — beside `nros`, which is `resolve_launch_resolver`
+          # rung 2 ("the installed layout"). It links `libpython3.10.so.1.0` as a
+          # hard DT_NEEDED — 22.04's interpreter, which is why the runner is
+          # pinned there — and a host without it gets `verify_resolver_pin`'s
+          # named diagnostic rather than a raw loader message. Declaring and
+          # PROBING that floor before download is RFC-0099 D1, not this line.
+          cp packages/cli/nros-launch-resolve/target/release/nros-launch-resolve \
+              "$stage/bin/nros-launch-resolve"
           printf '%s\n' '${{ inputs.version }}' >"$stage/share/nros/VERSION"
           cp nros-sdk-index.toml "$stage/share/nros/nros-sdk-index.toml"
           # phase-440 W7 / RFC-0095 D8 job 2: the launcher fetches a pinned
@@ -214,6 +246,20 @@ jobs:
           # asset predating this line does not carry it.
           cp scripts/install.sh "$stage/share/nros/install.sh"
           chmod +x "$stage/share/nros/install.sh"
+          # phase-447 A1 / RFC-0099 D2 — the SDK ROOT a build reads.
+          #
+          # Without it the installed journey dead-ends one step from the end:
+          # `nros build` resolves its board catalog from a nano-ros CHECKOUT and
+          # says so, so `install.sh` -> `nros setup` -> `nros new` -> `nros
+          # build` fails on the first release ever cut. It is INSIDE the
+          # toolchain rather than beside it because RFC-0097 D6 already decided
+          # codegen and the runtime are one unit.
+          #
+          # The path list and the reason for every entry live in the script, and
+          # the script VERIFIES what it staged — a set that only this workflow
+          # knew would be checked nowhere, and could not be run by a person
+          # asking "what does the asset carry?".
+          sh scripts/stage-sdk-root.sh "$stage"
           # Prefix-rooted, the mirror shape every other dist in the index uses,
           # so `sdk_store::execute`'s default unpack lands it unchanged.
           tar --zstd -cf "$RUNNER_TEMP/nros-linux-x86_64.tar.zst" -C "$stage" bin share
@@ -247,6 +293,23 @@ jobs:
           cd "$RUNNER_TEMP"
           "$installed" --codegen-version
           "$installed" setup --list >/dev/null
+          # phase-447 A1/A2 — the two things that make the installed journey
+          # reach a BUILD, asked of the INSTALLED prefix rather than of the
+          # staging dir. `sdk-root` walks the same four-rung ladder `nros build`
+          # does, from a directory that is not a checkout and with no
+          # NROS_REPO_DIR, so only the shipped rung can answer; and it prints the
+          # prefix's own `share/nano-ros`, which proves the asset unpacked where
+          # the binary looks rather than merely somewhere.
+          test "$(env -u NROS_REPO_DIR "$installed" sdk-root)" \
+               = "$(readlink -f "$RUNNER_TEMP/probe/sdk/nros/${{ inputs.version }}")/share/nano-ros"
+          # The launch resolver, asked of the FRONT dir — because that is the
+          # rung `model_location::launch_resolver_bin` reads
+          # (`$NROS_HOME/bin/nros-launch-resolve`), and a resolver sitting in the
+          # store that nothing fronted is a resolver no build finds. Run, not
+          # just present: it links libpython, so "the file is there" and "it
+          # starts" are different questions and the loader answers the second
+          # before `main`.
+          "$RUNNER_TEMP/probe/bin/nros-launch-resolve" --version
           # RFC-0097 D7 — the manifest must survive the install and be READ back
           # by the installed binary, from the file, at the prefix it landed in.
           # An asset whose manifest the CLI cannot read is an asset for which

--- a/examples/rv-virt-threadx/rust/action-client/CMakeLists.txt
+++ b/examples/rv-virt-threadx/rust/action-client/CMakeLists.txt
@@ -36,16 +36,54 @@ set(NROS_RMW "cyclonedds" CACHE STRING
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING
     "nano-ros root RMW backend" FORCE)
 set(NANO_ROS_BOARD rv-virt-threadx)
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 # phase-369 W2 — cyclone-only setup, guarded so the same CMakeLists serves both

--- a/examples/rv-virt-threadx/rust/action-server/CMakeLists.txt
+++ b/examples/rv-virt-threadx/rust/action-server/CMakeLists.txt
@@ -36,16 +36,54 @@ set(NROS_RMW "cyclonedds" CACHE STRING
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING
     "nano-ros root RMW backend" FORCE)
 set(NANO_ROS_BOARD rv-virt-threadx)
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 # phase-369 W2 — cyclone-only setup, guarded so the same CMakeLists serves both

--- a/examples/rv-virt-threadx/rust/listener/CMakeLists.txt
+++ b/examples/rv-virt-threadx/rust/listener/CMakeLists.txt
@@ -36,16 +36,54 @@ set(NROS_RMW "cyclonedds" CACHE STRING
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING
     "nano-ros root RMW backend" FORCE)
 set(NANO_ROS_BOARD rv-virt-threadx)
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 # phase-369 W2 — cyclone-only setup, guarded so the same CMakeLists serves both

--- a/examples/rv-virt-threadx/rust/service-client/CMakeLists.txt
+++ b/examples/rv-virt-threadx/rust/service-client/CMakeLists.txt
@@ -36,16 +36,54 @@ set(NROS_RMW "cyclonedds" CACHE STRING
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING
     "nano-ros root RMW backend" FORCE)
 set(NANO_ROS_BOARD rv-virt-threadx)
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 # phase-369 W2 — cyclone-only setup, guarded so the same CMakeLists serves both

--- a/examples/rv-virt-threadx/rust/service-server/CMakeLists.txt
+++ b/examples/rv-virt-threadx/rust/service-server/CMakeLists.txt
@@ -36,16 +36,54 @@ set(NROS_RMW "cyclonedds" CACHE STRING
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING
     "nano-ros root RMW backend" FORCE)
 set(NANO_ROS_BOARD rv-virt-threadx)
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 # phase-369 W2 — cyclone-only setup, guarded so the same CMakeLists serves both

--- a/examples/rv-virt-threadx/rust/talker/CMakeLists.txt
+++ b/examples/rv-virt-threadx/rust/talker/CMakeLists.txt
@@ -36,16 +36,54 @@ set(NROS_RMW "cyclonedds" CACHE STRING
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING
     "nano-ros root RMW backend" FORCE)
 set(NANO_ROS_BOARD rv-virt-threadx)
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 # phase-369 W2 — cyclone-only setup, guarded so the same CMakeLists serves both

--- a/examples/templates/c-and-cpp-mixed-workspace/CMakeLists.txt
+++ b/examples/templates/c-and-cpp-mixed-workspace/CMakeLists.txt
@@ -1,16 +1,54 @@
 cmake_minimum_required(VERSION 3.22)
 project(c_and_cpp_mixed_workspace LANGUAGES C CXX)
 
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 include("${NANO_ROS_ROOT}/cmake/NanoRosWorkspace.cmake")

--- a/examples/templates/cpp-port-minimal-publisher/CMakeLists.txt
+++ b/examples/templates/cpp-port-minimal-publisher/CMakeLists.txt
@@ -14,16 +14,54 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(NANO_ROS_PLATFORM posix)
 set(NROS_RMW "zenoh" CACHE STRING "Active RMW (zenoh|cyclonedds|xrce).")
 set(NANO_ROS_RMW "${NROS_RMW}")
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 add_subdirectory("${NANO_ROS_ROOT}" nano_ros)

--- a/examples/templates/local-msg-package/CMakeLists.txt
+++ b/examples/templates/local-msg-package/CMakeLists.txt
@@ -20,16 +20,54 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(NANO_ROS_PLATFORM posix)
 set(NROS_RMW "zenoh" CACHE STRING "Active RMW (zenoh|cyclonedds|xrce).")
 set(NANO_ROS_RMW "${NROS_RMW}")
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 add_subdirectory("${NANO_ROS_ROOT}" nano_ros)

--- a/examples/templates/multi-node-workspace-cpp/CMakeLists.txt
+++ b/examples/templates/multi-node-workspace-cpp/CMakeLists.txt
@@ -16,16 +16,54 @@ project(multi_node_workspace_cpp LANGUAGES C CXX)
 #
 # Workspace build (from this dir):
 #     cmake -S . -B build -DNANO_ROS_ROOT=/path/to/nano-ros && cmake --build build
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 include("${NANO_ROS_ROOT}/cmake/NanoRosWorkspace.cmake")

--- a/examples/templates/pure-c-workspace/CMakeLists.txt
+++ b/examples/templates/pure-c-workspace/CMakeLists.txt
@@ -1,16 +1,54 @@
 cmake_minimum_required(VERSION 3.22)
 project(pure_c_workspace LANGUAGES C CXX)
 
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 include("${NANO_ROS_ROOT}/cmake/NanoRosWorkspace.cmake")

--- a/examples/templates/rclcpp-compat-smoke/CMakeLists.txt
+++ b/examples/templates/rclcpp-compat-smoke/CMakeLists.txt
@@ -17,16 +17,54 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(NANO_ROS_PLATFORM posix)
 set(NROS_RMW "zenoh" CACHE STRING "Active RMW (zenoh|cyclonedds|xrce).")
 set(NANO_ROS_RMW "${NROS_RMW}")
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 add_subdirectory("${NANO_ROS_ROOT}" nano_ros)

--- a/examples/templates/topic-state-monitor-port/CMakeLists.txt
+++ b/examples/templates/topic-state-monitor-port/CMakeLists.txt
@@ -7,16 +7,54 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(NANO_ROS_PLATFORM posix)
 set(NROS_RMW "zenoh" CACHE STRING "Active RMW (zenoh|cyclonedds|xrce).")
 set(NANO_ROS_RMW "${NROS_RMW}")
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 add_subdirectory("${NANO_ROS_ROOT}" nano_ros)

--- a/examples/templates/workspace-shadowing/CMakeLists.txt
+++ b/examples/templates/workspace-shadowing/CMakeLists.txt
@@ -29,16 +29,54 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(NANO_ROS_PLATFORM posix)
 set(NROS_RMW "zenoh" CACHE STRING "Active RMW (zenoh|cyclonedds|xrce).")
 set(NANO_ROS_RMW "${NROS_RMW}")
-# Resolve the nano-ros checkout root once (phase-277 W6 standard guard):
+# Resolve the nano-ros SDK root once (phase-277 W6 standard guard; 4th rung
+# phase-447 A2 / RFC-0099 D3):
 #   1. -DNANO_ROS_ROOT=<path> cache var (explicit, e.g. a copied-out example),
 #   2. NROS_REPO_DIR env var (exported by nano-ros's activate.sh),
-#   3. in-repo relative walk-up (this example inside the nano-ros tree).
+#   3. in-repo relative walk-up (this example inside the nano-ros tree),
+#   4. ask the installed toolchain: `nros sdk-root`. A release carries its own
+#      SDK root at <prefix>/share/nano-ros, which is the only rung a copied-out
+#      project on a machine with no checkout can reach — before it this guard
+#      resolved three ways and all three were a checkout.
+# LAST is a decision, not an ordering detail: a store rung placed earlier would
+# answer a contributor with a store copy of the tree they are editing, which is
+# the ownership guard's own failure mode (phase-431 W1). And the answer is ASKED
+# for rather than baked in — a store moves, `nros pin` swaps a toolchain under a
+# project, and a project is committed and then built on another machine.
 if(NOT DEFINED NANO_ROS_ROOT)
+    set(_nros_walk_up "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
     if(DEFINED ENV{NROS_REPO_DIR} AND NOT "$ENV{NROS_REPO_DIR}" STREQUAL "")
         set(NANO_ROS_ROOT "$ENV{NROS_REPO_DIR}")
+    elseif(EXISTS "${_nros_walk_up}/packages/core/nros-core/Cargo.toml")
+        # The marker `nros_launcher::checkout::MONOREPO_MARKER` names, so "is
+        # this a nano-ros root" has one answer whichever language asks. The walk
+        # used to be UNCONDITIONAL, which gave a copied-out project a confident
+        # wrong path that failed one line later at the include — and left rung 4
+        # unreachable, since rung 3 never declined.
+        get_filename_component(NANO_ROS_ROOT "${_nros_walk_up}" ABSOLUTE)
     else()
-        get_filename_component(NANO_ROS_ROOT
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+        find_program(NROS_TOOLCHAIN_EXECUTABLE nros)
+        if(NROS_TOOLCHAIN_EXECUTABLE)
+            execute_process(
+                COMMAND "${NROS_TOOLCHAIN_EXECUTABLE}" sdk-root
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                OUTPUT_VARIABLE NANO_ROS_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _nros_sdk_root_rc)
+            if(NOT _nros_sdk_root_rc EQUAL 0)
+                # An `nros` too old to know the verb exits non-zero. Treat that
+                # as "no answer" rather than letting clap's usage text become a
+                # path.
+                set(NANO_ROS_ROOT "")
+            endif()
+        endif()
+    endif()
+    if(NOT NANO_ROS_ROOT)
+        message(FATAL_ERROR
+            "nano-ros: cannot locate the nano-ros SDK root.\n"
+            "  Pass -DNANO_ROS_ROOT=<path>, or export NROS_REPO_DIR, or put an\n"
+            "  installed toolchain's `nros` on PATH — `nros sdk-root` answers\n"
+            "  this, and a released toolchain answers it out of itself.")
     endif()
 endif()
 add_subdirectory("${NANO_ROS_ROOT}" nano_ros)

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "clap",
  "eyre",
  "indicatif",
+ "nros-launcher",
  "nros-msg-to-idl",
  "quick-xml",
  "rayon",

--- a/packages/cli/cargo-nano-ros/Cargo.toml
+++ b/packages/cli/cargo-nano-ros/Cargo.toml
@@ -29,6 +29,11 @@ rosidl-bindgen = { path = "../rosidl-bindgen" }
 rosidl-codegen = { path = "../rosidl-codegen" }
 rosidl-parser = { path = "../rosidl-parser" }
 nros-msg-to-idl = { workspace = true }
+# phase-447 A1/A2 — `checkout::shipped_sdk_root`, so the bundled `.msg` share
+# dirs resolve for an INSTALLED binary too. The launcher owns "where is a
+# nano-ros root" (it holds `MONOREPO_MARKER`), and asking it is what keeps this
+# from becoming a second derivation of `<prefix>/share/nano-ros`.
+nros-launcher = { workspace = true }
 rayon = "1.10"
 indicatif = "0.17"
 quick-xml = "0.37"

--- a/packages/cli/cargo-nano-ros/src/lib.rs
+++ b/packages/cli/cargo-nano-ros/src/lib.rs
@@ -686,7 +686,22 @@ fn bundled_interfaces_dir() -> Option<PathBuf> {
         }
     }
 
-    None
+    // phase-447 A1/A2 — and LAST, this toolchain's own shipped SDK root.
+    //
+    // The walk above starts at the binary and expects it to sit inside a
+    // checkout (`packages/cli/target/{release,debug}/nros`). An INSTALLED
+    // binary is at `<prefix>/bin/nros`, so every ancestor it visits is a store
+    // directory and the walk answers `None` — which means a scaffolded project
+    // depending on `std_msgs`, as the shipped C++ workspace template does,
+    // could not resolve it on a machine with no checkout.
+    //
+    // Same rung, same reason and same LAST placement as
+    // `orchestration::nano_ros_root`: reached only when the checkout arms found
+    // nothing, so a contributor's resolution is untouched.
+    let dir = nros_launcher::checkout::shipped_sdk_root()?
+        .join("packages/cli")
+        .join(BUNDLED_INTERFACES_DIR);
+    dir.join("std_msgs").is_dir().then_some(dir)
 }
 
 /// Load the ament index, merging bundled interfaces as fallback.

--- a/packages/cli/nros-cli-core/src/cmd/board_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/board_facts.rs
@@ -476,11 +476,9 @@ pub fn run(args: BoardFactsArgs) -> Result<()> {
         .path
         .canonicalize()
         .map_err(|e| eyre!("{}: {e}", args.path.display()))?;
-    let root = args
-        .nano_ros_path
-        .or_else(|| std::env::var_os("NROS_REPO_DIR").map(PathBuf::from))
-        .or_else(|| crate::cmd::ws::autodetect_nano_ros_path(&ws))
-        .ok_or_else(|| eyre!("no nano-ros checkout found (pass --nano-ros-path)"))?;
+    // phase-447 A2 — the shared four-rung ladder (RFC-0099 D3).
+    let root = crate::orchestration::nano_ros_root::resolve(args.nano_ros_path, &ws)
+        .ok_or_else(|| eyre!("{}", crate::orchestration::nano_ros_root::not_found_help()))?;
 
     let facts = resolve(
         &ws,

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -222,11 +222,14 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
     // Zephyr board is spelled `native_sim/native/64`, which says nothing about
     // being Zephyr. Resolving it needs the board catalog, which lives in a
     // nano-ros checkout, NOT in the user's workspace.
-    let nano_ros_root = args
-        .nano_ros_path
-        .clone()
-        .or_else(|| std::env::var_os("NROS_REPO_DIR").map(PathBuf::from))
-        .or_else(|| crate::cmd::ws::autodetect_nano_ros_path(&root));
+    //
+    // phase-447 A2 (RFC-0099 D3) — the ladder moved to
+    // `orchestration::nano_ros_root`, and gained a fourth rung LAST: this
+    // toolchain's own `share/nano-ros`. Before it, all three rungs were a
+    // CHECKOUT, so a released `nros` reached the bail below on the first
+    // release ever cut.
+    let nano_ros_root =
+        crate::orchestration::nano_ros_root::resolve(args.nano_ros_path.clone(), &root);
     // phase-398 W3 — every `<depend>` resolves, or the build stops.
     //
     // Runs once per invocation, before anything is generated, because an
@@ -252,10 +255,7 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
             crate::orchestration::board_descriptor::BoardCatalog::load_with_packages(r, &pkg_dirs)
                 .map_err(|e| eyre::eyre!("loading board descriptors from {}: {e}", r.display()))?
         }
-        None => eyre::bail!(
-            "no nano-ros checkout found, so board ids cannot be resolved. \
-             Pass --nano-ros-path, or set NROS_REPO_DIR."
-        ),
+        None => eyre::bail!("{}", crate::orchestration::nano_ros_root::not_found_help()),
     };
 
     // Does the package graph cross languages? A CMakeLists is the signal — but

--- a/packages/cli/nros-cli-core/src/cmd/mod.rs
+++ b/packages/cli/nros-cli-core/src/cmd/mod.rs
@@ -45,6 +45,7 @@ pub mod profile;
 pub mod scaffold_deploy;
 pub mod sdk_front;
 pub mod sdk_path;
+pub mod sdk_root;
 pub mod setup;
 /// phase-440 W6 — `nros store list|gc` (RFC-0095 D11).
 pub mod store;
@@ -149,6 +150,13 @@ pub enum Cmd {
     /// the CLI itself and has no `nros setup` to run until it has.
     #[command(name = "sdk-front")]
     SdkFront(sdk_front::Args),
+
+    /// phase-447 A2 — print the nano-ros SDK root this toolchain resolves
+    /// (RFC-0099 D3). The cmake/shell bridge to the four-rung ladder, so a
+    /// scaffolded project ASKS where the runtime is instead of baking in an
+    /// absolute path that is right on exactly one machine.
+    #[command(name = "sdk-root")]
+    SdkRoot(sdk_root::Args),
 
     /// phase-440 W6 — inspect and shrink the SDK store (RFC-0095 D11). The
     /// store is additive by design, so `list` says what is in it and `gc`

--- a/packages/cli/nros-cli-core/src/cmd/sdk_root.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sdk_root.rs
@@ -1,0 +1,76 @@
+//! `nros sdk-root` — print the nano-ros SDK root this toolchain resolves
+//! (phase-447 A2, RFC-0099 D3).
+//!
+//! The bridge for cmake and shell, exactly as `nros sdk-path` is the bridge to
+//! `sdk_store::tool_dir` and `nros model-path` to the SystemModel rule: the
+//! ladder lives ONCE, in [`crate::orchestration::nano_ros_root`], and everyone
+//! else asks.
+//!
+//! ## Why a scaffolded `CMakeLists.txt` must ask rather than remember
+//!
+//! The scaffold cannot bake the answer in. A store moves — `$NROS_HOME` is a
+//! variable, `nros pin` swaps a toolchain under a project, and a project is
+//! committed and then built on another machine that has neither the same store
+//! nor the same version. A baked absolute path is right exactly once, on the
+//! machine that ran `nros new`, and wrong silently everywhere else. Asking the
+//! `nros` that is on `PATH` is right by construction, because the toolchain
+//! answering is the toolchain that would do the codegen.
+//!
+//! ## Why this needs no index, and no network
+//!
+//! `nros sdk-path` loads `nros-sdk-index.toml` (and may fetch it) because a
+//! tool's prefix is a function of the PIN. The SDK root is not — it is a
+//! function of where this binary lives — so this command reads no index, opens
+//! no socket, and answers in a directory that is not a workspace. That matters:
+//! a configure-time `execute_process` that could block on the network would be
+//! a new failure mode in every scaffolded project.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use eyre::{Result, bail};
+
+use crate::orchestration::nano_ros_root;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Where to start the walk-up rung. Defaults to the current directory —
+    /// which is what a cmake caller wants, since `execute_process` runs in the
+    /// project being configured.
+    #[arg(long)]
+    pub workspace: Option<PathBuf>,
+
+    /// An explicit root, taking precedence over everything. Present so a caller
+    /// forwarding a user's `-DNANO_ROS_ROOT` uses ONE ladder rather than
+    /// branching around it.
+    #[arg(long)]
+    pub nano_ros_path: Option<PathBuf>,
+
+    /// Print which rung answered, on stderr. stdout stays the bare path, so a
+    /// cmake `execute_process` can keep capturing it unchanged.
+    #[arg(long)]
+    pub explain: bool,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let workspace = match args.workspace {
+        Some(w) => w,
+        None => std::env::current_dir()?,
+    };
+    let Some(root) = nano_ros_root::resolve(args.nano_ros_path, &workspace) else {
+        bail!("{}", nano_ros_root::not_found_help());
+    };
+    if args.explain {
+        // Named by comparison, not by re-walking: `shipped()` is the only rung
+        // whose answer is a property of the BINARY, and it is the one a reader
+        // is surprised by.
+        let via = if nano_ros_root::shipped().as_deref() == Some(root.as_path()) {
+            "this toolchain's own share/nano-ros"
+        } else {
+            "a nano-ros checkout"
+        };
+        eprintln!("nros sdk-root: {} — via {via}", root.display());
+    }
+    println!("{}", root.display());
+    Ok(())
+}

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -800,11 +800,19 @@ pub fn provider_index_path(ws_root: &Path) -> PathBuf {
 /// the two ambient sources, so that function stays a pure one and every test of
 /// it can name its inputs.
 pub fn provider_search_path(workspace: &Path) -> Result<provider_scan::SearchPath> {
-    let nano_ros_root = crate::abi_guard::find_monorepo_root(workspace).or_else(|| {
-        let exe = std::env::current_exe().ok()?;
-        let exe = exe.canonicalize().unwrap_or(exe);
-        crate::abi_guard::find_monorepo_root(&exe)
-    });
+    let nano_ros_root = crate::abi_guard::find_monorepo_root(workspace)
+        .or_else(|| {
+            let exe = std::env::current_exe().ok()?;
+            let exe = exe.canonicalize().unwrap_or(exe);
+            crate::abi_guard::find_monorepo_root(&exe)
+        })
+        // phase-447 A2 — and LAST, this toolchain's own shipped SDK root. The
+        // providers under `packages/interfaces/` are what let `std_msgs` and
+        // friends resolve, so without this rung a released `nros` finds no
+        // message packages at all: the arm above walks up from the binary, and
+        // a store prefix has no checkout above it (that is exactly the case
+        // `runtime_root`'s doc calls "falls through to `None`").
+        .or_else(crate::orchestration::nano_ros_root::shipped);
     provider_search_path_with(nano_ros_root.as_deref(), workspace)
 }
 
@@ -3056,10 +3064,8 @@ pub fn run_sync(args: SyncArgs) -> Result<()> {
             .or_default()
             .push(c.dir.clone());
     }
-    let nano_ros_path = args
-        .nano_ros_path
-        .or_else(|| std::env::var_os("NROS_REPO_DIR").map(PathBuf::from))
-        .or_else(|| autodetect_nano_ros_path(&ws_root));
+    // phase-447 A2 — the shared four-rung ladder (RFC-0099 D3).
+    let nano_ros_path = crate::orchestration::nano_ros_root::resolve(args.nano_ros_path, &ws_root);
 
     // Phase 220.E — collect the union of `nros-*` (+ `nros` + `cyclonedds-sys`)
     // registry-style deps across every Rust consumer pointing at this
@@ -3566,15 +3572,13 @@ fn extract_cargo_path_deps(body: &str) -> Vec<String> {
 /// In-tree fixtures + examples sit several levels below the nano-ros
 /// root, so this turns the most common "I forgot to set NROS_REPO_DIR"
 /// case into a no-op — patches still flow.
+///
+/// phase-447 A2 — the walk was written out here and identically in
+/// `nros_launcher::checkout`, against the same marker file. One spelling now:
+/// this is rung 3 of `orchestration::nano_ros_root`, and the marker it looks
+/// for has a single definition (`MONOREPO_MARKER`).
 pub(crate) fn autodetect_nano_ros_path(ws_root: &Path) -> Option<PathBuf> {
-    let mut cur: Option<&Path> = Some(ws_root);
-    while let Some(p) = cur {
-        if p.join("packages/core/nros-core/Cargo.toml").is_file() {
-            return Some(p.to_path_buf());
-        }
-        cur = p.parent();
-    }
-    None
+    nros_launcher::checkout::find_monorepo_root(ws_root)
 }
 
 fn extract_pkg_deps(body: &str) -> Vec<String> {
@@ -3988,9 +3992,9 @@ fn run_check_board_projections(args: CheckBoardProjectionsArgs) -> Result<()> {
             ws_root.display()
         ));
     }
-    let nano_ros_path = std::env::var_os("NROS_REPO_DIR")
-        .map(PathBuf::from)
-        .or_else(|| autodetect_nano_ros_path(&ws_root));
+    // phase-447 A2 — the shared four-rung ladder (RFC-0099 D3). This site has
+    // no `--nano-ros-path`, so the first rung is simply absent.
+    let nano_ros_path = crate::orchestration::nano_ros_root::resolve(None, &ws_root);
 
     if args.write {
         // phase-351 W3 — sync's board-projection pass, alone. Writing with the

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -147,6 +147,7 @@ fn cmd_name(cmd: &cmd::Cmd) -> &'static str {
         cmd::Cmd::ModelPath(_) => "model-path",
         cmd::Cmd::SdkPath(_) => "sdk-path",
         cmd::Cmd::SdkFront(_) => "sdk-front",
+        cmd::Cmd::SdkRoot(_) => "sdk-root",
         cmd::Cmd::GenerateRust(_) => "generate-rust",
         cmd::Cmd::Setup(_) => "setup",
         // Everything else stays runnable on a stale binary ON PURPOSE —
@@ -196,6 +197,7 @@ pub fn run(cmd: cmd::Cmd) -> Result<()> {
         cmd::Cmd::ModelPath(args) => cmd::model_path::run(args),
         cmd::Cmd::SdkPath(args) => cmd::sdk_path::run(args),
         cmd::Cmd::SdkFront(args) => cmd::sdk_front::run(args),
+        cmd::Cmd::SdkRoot(args) => cmd::sdk_root::run(args),
         // phase-440 W6 — deliberately NOT in `cmd_name`'s guarded set. These
         // report on and repair the STORE, which is not a fact about any
         // checkout, and a store verb has to work on the day the binary is stale

--- a/packages/cli/nros-cli-core/src/orchestration/mod.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/mod.rs
@@ -38,6 +38,10 @@ pub mod metadata_probe_cmake;
 pub mod metadata_refresh;
 pub mod model_ingest;
 pub mod names;
+// phase-447 A2 (RFC-0099 D3) — the four-rung ladder to the SDK root. One
+// spelling, so a released toolchain's own `share/nano-ros` is reachable from
+// every site that used to bail with "no nano-ros checkout found".
+pub mod nano_ros_root;
 pub mod nros_config;
 pub mod params;
 // phase-440 W7 (RFC-0095 D7/D9) — `nros-toolchain.toml`, the per-project pin.

--- a/packages/cli/nros-cli-core/src/orchestration/nano_ros_root.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/nano_ros_root.rs
@@ -207,7 +207,6 @@ mod tests {
             repo_dir: Some(tmp.path().to_path_buf()),
             workspace: Some(tmp.path()),
             exe: Some(exe),
-            ..Rungs::default()
         });
         assert_eq!(
             got,

--- a/packages/cli/nros-cli-core/src/orchestration/nano_ros_root.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/nano_ros_root.rs
@@ -1,0 +1,254 @@
+//! Where the nano-ros SDK root is — one ladder, four rungs (RFC-0099 D3,
+//! phase-447 A2).
+//!
+//! The SDK root is the directory a BUILD reads from: `cmake/` (the modules a
+//! workspace includes), `config/` and `packages/` (the board descriptors and
+//! the runtime crates a user's project compiles against). Until this module
+//! there was no such concept — every site resolved "a nano-ros CHECKOUT", three
+//! ways, in three separately-written `or_else` chains:
+//!
+//! ```text
+//! --nano-ros-path / -DNANO_ROS_ROOT   ->  $NROS_REPO_DIR  ->  a walk-up
+//! ```
+//!
+//! All three are a checkout, so the released `nros` could resolve none of them
+//! and `nros build` bailed with "no nano-ros checkout found". That is RFC-0099
+//! D1: the journey `install.sh` -> `nros setup` -> `nros new` -> `nros build`
+//! dead-ends one step from the end, and it breaks nobody today only because
+//! every contributor has `$NROS_REPO_DIR` from `activate.sh`.
+//!
+//! ## The fourth rung, and why it is LAST
+//!
+//! A release now carries its own SDK root at `<prefix>/share/nano-ros/`
+//! (phase-447 A1), so a toolchain can answer the question out of itself.
+//!
+//! It is consulted **last**, and that is a decision rather than an ordering
+//! detail. The ownership guard ([`crate::stale_guard`], phase-431 W1) requires
+//! that an `nros` running inside a checkout be that checkout's own build,
+//! because a foreign binary emits with emitters nobody in that tree can see. A
+//! store rung placed EARLIER would answer with a store copy of the very tree a
+//! contributor is editing — the same class of silent substitution, one layer
+//! down, and it would be invisible because a store copy compiles perfectly
+//! well. Placed last it changes no existing behaviour: it is reached only when
+//! the three checkout rungs found nothing, which today is the case that has no
+//! answer at all.
+//!
+//! ## One ladder, spelled once
+//!
+//! Five call sites carried the three-rung chain by hand (`cmd::build`,
+//! `cmd::board_facts`, `orchestration::planner`, and two in `cmd::ws`). Adding
+//! a fourth spelling at one of them is how the sizes-header mirror was fixed
+//! five times, so the chain moved here and the sites ask. `nros sdk-root` is
+//! the same ladder exposed for cmake and shell — the bridge shape
+//! `nros sdk-path` and `nros model-path` already use, for the same reason: the
+//! derivation lives once and everyone else asks rather than re-deriving.
+//!
+//! ## Where the pieces live
+//!
+//! The RUNG itself is in [`nros_launcher::checkout`], not here, and that is
+//! layering rather than accident: the launcher already owns
+//! [`MONOREPO_MARKER`](nros_launcher::checkout::MONOREPO_MARKER) — the tree's
+//! one answer to "is this a nano-ros root" — and `cargo-nano-ros` needs the
+//! same rung for the bundled `.msg` share dirs while sitting BELOW this crate.
+//! Putting it in the shared leaf is what stops `<prefix>/share/nano-ros` being
+//! derived in two places. What lives HERE is the ladder: the order, and what to
+//! say when no rung answers.
+//!
+//! A shipped SDK root satisfies the marker because `packages/` is staged whole
+//! (`scripts/stage-sdk-root.sh`) — the asset is not a different SHAPE of root,
+//! it IS a root, which is what lets every consumer downstream of this module
+//! stay unchanged.
+
+use std::path::{Path, PathBuf};
+
+pub use nros_launcher::checkout::{
+    SHIPPED_SUBDIR, is_monorepo_root as is_root, shipped_sdk_root as shipped,
+    shipped_sdk_root_beside as shipped_beside,
+};
+
+/// The four rungs, as data — so [`resolve_from`] is a pure function and the
+/// ORDER can be tested without touching the environment or `current_exe`.
+#[derive(Debug, Default)]
+pub struct Rungs<'a> {
+    /// `--nano-ros-path` / `-DNANO_ROS_ROOT`, whatever the caller was told.
+    pub explicit: Option<PathBuf>,
+    /// `$NROS_REPO_DIR`, as `activate.sh` exports it.
+    pub repo_dir: Option<PathBuf>,
+    /// Where the walk-up starts — the workspace root.
+    pub workspace: Option<&'a Path>,
+    /// `current_exe()`, for the shipped rung.
+    pub exe: Option<PathBuf>,
+}
+
+/// Walk the ladder. `None` means no rung answered.
+#[must_use]
+pub fn resolve_from(rungs: Rungs<'_>) -> Option<PathBuf> {
+    rungs
+        .explicit
+        .or(rungs.repo_dir)
+        .or_else(|| {
+            rungs
+                .workspace
+                .and_then(crate::cmd::ws::autodetect_nano_ros_path)
+        })
+        // LAST. See the module header — earlier would redirect a contributor to
+        // a store copy of the tree they are editing.
+        .or_else(|| rungs.exe.as_deref().and_then(shipped_beside))
+}
+
+/// The ladder with the process environment read for it, once, here.
+///
+/// The shape every call site used to spell by hand, plus the rung a released
+/// toolchain can actually reach.
+#[must_use]
+pub fn resolve(explicit: Option<PathBuf>, workspace: &Path) -> Option<PathBuf> {
+    resolve_from(Rungs {
+        explicit,
+        repo_dir: std::env::var_os("NROS_REPO_DIR").map(PathBuf::from),
+        workspace: Some(workspace),
+        exe: std::env::current_exe()
+            .ok()
+            .map(|e| e.canonicalize().unwrap_or(e)),
+    })
+}
+
+/// What to tell someone when no rung answered.
+///
+/// Names all four, because before A2 it named two and the reader had no way to
+/// learn that an installed toolchain is supposed to answer this by itself.
+#[must_use]
+pub fn not_found_help() -> String {
+    "no nano-ros SDK root found, so board ids cannot be resolved. Resolved in \
+     order: --nano-ros-path, $NROS_REPO_DIR, a walk-up from the workspace, then \
+     this toolchain's own share/nano-ros (present in a released `nros`, absent \
+     from a `cargo build` of the CLI). Inside a checkout, `source ./activate.sh`."
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MARKER: &str = nros_launcher::checkout::MONOREPO_MARKER;
+
+    /// A prefix that looks like an installed release: `<p>/bin/nros` beside
+    /// `<p>/share/nano-ros/<MARKER>`.
+    fn staged_prefix(dir: &Path) -> PathBuf {
+        let root = dir.join(SHIPPED_SUBDIR);
+        std::fs::create_dir_all(root.join("packages/core/nros-core")).unwrap();
+        std::fs::write(root.join(MARKER), "[package]\nname = \"nros-core\"\n").unwrap();
+        std::fs::create_dir_all(dir.join("bin")).unwrap();
+        let exe = dir.join("bin/nros");
+        std::fs::write(&exe, "").unwrap();
+        exe
+    }
+
+    /// A1 — an `nros` installed from a release answers out of its own asset.
+    /// This is the arm that has no answer at all before phase-447.
+    #[test]
+    fn an_installed_toolchain_resolves_its_own_shipped_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = staged_prefix(tmp.path());
+        let elsewhere = tmp.path().join("some/users/project");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+
+        let got = resolve_from(Rungs {
+            workspace: Some(&elsewhere),
+            exe: Some(exe),
+            ..Rungs::default()
+        });
+        assert_eq!(got, Some(tmp.path().join(SHIPPED_SUBDIR)));
+    }
+
+    /// The OTHER arm of the guard: a contributor inside a checkout still
+    /// resolves to their tree even though a shipped root is also reachable.
+    ///
+    /// This is the test the LAST placement exists for. With the rung moved
+    /// first it goes red; with the rung absent entirely it stays green, which
+    /// is why the test above is its pair rather than its substitute.
+    #[test]
+    fn a_checkout_still_wins_over_a_reachable_shipped_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = staged_prefix(tmp.path());
+
+        // A checkout, and a workspace nested inside it.
+        let checkout = tmp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join("packages/core/nros-core")).unwrap();
+        std::fs::write(checkout.join(MARKER), "").unwrap();
+        let ws = checkout.join("examples/workspaces/mixed");
+        std::fs::create_dir_all(&ws).unwrap();
+
+        let got = resolve_from(Rungs {
+            workspace: Some(&ws),
+            exe: Some(exe.clone()),
+            ..Rungs::default()
+        });
+        assert_eq!(
+            got,
+            Some(checkout.clone()),
+            "the walk-up must outrank the store"
+        );
+
+        // …and so must the two rungs above it.
+        let got = resolve_from(Rungs {
+            repo_dir: Some(checkout.clone()),
+            workspace: Some(tmp.path()),
+            exe: Some(exe.clone()),
+            ..Rungs::default()
+        });
+        assert_eq!(
+            got,
+            Some(checkout.clone()),
+            "$NROS_REPO_DIR must outrank the store"
+        );
+
+        let got = resolve_from(Rungs {
+            explicit: Some(checkout.clone()),
+            repo_dir: Some(tmp.path().to_path_buf()),
+            workspace: Some(tmp.path()),
+            exe: Some(exe),
+            ..Rungs::default()
+        });
+        assert_eq!(
+            got,
+            Some(checkout),
+            "--nano-ros-path must outrank everything"
+        );
+    }
+
+    /// A `cargo build` of the CLI is not an install: `target/release/nros` has
+    /// no `share/nano-ros` two levels up, and inventing one would be worse than
+    /// answering nothing.
+    #[test]
+    fn a_binary_with_no_staged_root_answers_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp.path().join("target/release/nros");
+        std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        std::fs::write(&exe, "").unwrap();
+        assert_eq!(shipped_beside(&exe), None);
+
+        let empty = tmp.path().join("empty");
+        std::fs::create_dir_all(&empty).unwrap();
+        assert_eq!(
+            resolve_from(Rungs {
+                workspace: Some(&empty),
+                exe: Some(exe),
+                ..Rungs::default()
+            }),
+            None
+        );
+    }
+
+    /// A directory at the right PATH that is not a root is not an answer —
+    /// the marker is checked, not the directory's existence. A half-unpacked
+    /// asset would otherwise resolve and fail much later, naming nothing.
+    #[test]
+    fn a_staged_directory_without_the_marker_is_not_a_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(SHIPPED_SUBDIR).join("cmake")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("bin")).unwrap();
+        let exe = tmp.path().join("bin/nros");
+        std::fs::write(&exe, "").unwrap();
+        assert_eq!(shipped_beside(&exe), None);
+    }
+}

--- a/packages/cli/nros-cli-core/src/orchestration/planner.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/planner.rs
@@ -187,18 +187,17 @@ pub fn plan_system(options: PlanOptions) -> Result<PlanningOutput> {
     // from the selected image's board rather than copied from a `[deploy.*]`
     // field that is going away.
     //
-    // Resolved exactly as `nros build` resolves it (`--nano-ros-path` →
-    // `NROS_REPO_DIR` → an autodetect walk), because the two must agree about
-    // which descriptors exist. Unlike `build`, a MISSING checkout is not fatal
-    // here: `nros plan` legitimately runs outside a nano-ros tree, and every
-    // plan that needs no triple still works. What is fatal is an image naming a
+    // Resolved exactly as `nros build` resolves it — literally the same
+    // function since phase-447 A2 (`--nano-ros-path` → `NROS_REPO_DIR` → an
+    // autodetect walk → this toolchain's own `share/nano-ros`) — because the
+    // two must agree about which descriptors exist. Unlike `build`, a MISSING
+    // checkout is not fatal here: `nros plan` legitimately runs outside a
+    // nano-ros tree, and every plan that needs no triple still works. What is
+    // fatal is an image naming a
     // board the catalog HAS and cannot resolve — that is a wrong plan, not an
     // absent one, and `schema_build_json` refuses it.
-    let nano_ros_root = options
-        .nano_ros_path
-        .clone()
-        .or_else(|| std::env::var_os("NROS_REPO_DIR").map(PathBuf::from))
-        .or_else(|| crate::cmd::ws::autodetect_nano_ros_path(&options.workspace_root));
+    let nano_ros_root =
+        super::nano_ros_root::resolve(options.nano_ros_path.clone(), &options.workspace_root);
     let catalog = nano_ros_root
         .as_deref()
         .and_then(|r| super::board_descriptor::BoardCatalog::load(r).ok());

--- a/packages/cli/nros-launcher/src/checkout.rs
+++ b/packages/cli/nros-launcher/src/checkout.rs
@@ -24,10 +24,59 @@ pub fn find_monorepo_root(start: &Path) -> Option<PathBuf> {
         Some(start)
     };
     while let Some(dir) = cur {
-        if dir.join(MONOREPO_MARKER).is_file() {
+        if is_monorepo_root(dir) {
             return Some(dir.to_path_buf());
         }
         cur = dir.parent();
     }
     None
+}
+
+/// Does `dir` itself carry [`MONOREPO_MARKER`]?
+///
+/// The walk-up's per-step predicate, named because [`shipped_sdk_root_beside`]
+/// asks the same question about ONE directory rather than a chain — and a
+/// second `join(MARKER).is_file()` written out somewhere else is how a tree
+/// ends up with two answers to "is this a nano-ros root".
+#[must_use]
+pub fn is_monorepo_root(dir: &Path) -> bool {
+    dir.join(MONOREPO_MARKER).is_file()
+}
+
+/// Where a release stages its SDK root, relative to the install prefix —
+/// phase-447 A1, RFC-0099 D2.
+///
+/// `share/nano-ros`, beside `share/nros`. The two are deliberately different
+/// directories: `share/nros/` is about the TOOLCHAIN (its manifest, its
+/// `VERSION`, the index it was released with, the installer), while
+/// `share/nano-ros/` is the project a build compiles against, and it uses the
+/// project's prose spelling because that is what `NANO_ROS_ROOT` has always
+/// named. `scripts/stage-sdk-root.sh` writes it; this constant is what reads it.
+pub const SHIPPED_SUBDIR: &str = "share/nano-ros";
+
+/// The SDK root shipped inside the release asset an `exe` belongs to, if any.
+///
+/// A pure function of the path, so its callers' tests need no `current_exe`.
+/// `None` for a `cargo build` of the CLI — `target/release/nros` has no
+/// `share/nano-ros` two levels up, and inventing one would be worse than
+/// answering nothing.
+#[must_use]
+pub fn shipped_sdk_root_beside(exe: &Path) -> Option<PathBuf> {
+    let prefix = exe.parent()?.parent()?; // <prefix>/bin/nros -> <prefix>
+    let candidate = prefix.join(SHIPPED_SUBDIR);
+    is_monorepo_root(&candidate).then_some(candidate)
+}
+
+/// [`shipped_sdk_root_beside`] for the running executable.
+///
+/// Resolved from the binary rather than from `$NROS_HOME`, exactly as the
+/// shipped SDK index is: two versions in the store each answer with their own,
+/// which is what makes them independently installable. `$NROS_HOME/bin/nros` is
+/// a symlink into the store, and this canonicalizes, so the answer is the
+/// prefix the binary really lives in rather than the front's parent.
+#[must_use]
+pub fn shipped_sdk_root() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let exe = exe.canonicalize().unwrap_or(exe);
+    shipped_sdk_root_beside(&exe)
 }

--- a/packages/core/nros-orchestration-ir/src/model_location.rs
+++ b/packages/core/nros-orchestration-ir/src/model_location.rs
@@ -446,9 +446,16 @@ pub fn ensure_model(
         ));
     }
     let resolver = launch_resolver_bin().ok_or_else(|| {
-        "cannot resolve the SystemModel: `nros-launch-resolve` not found. Build it with \
-         `./scripts/bootstrap.sh` (contributors: `just setup-launch-resolve`), or point \
-         $NROS_LAUNCH_RESOLVE at one. (Never resolved \
+        // phase-447 A1 — the INSTALLED remedy comes first. Both remedies used to
+        // name a checkout, which is exactly the audience that cannot act on
+        // them: a release now ships this binary beside `nros` and fronts it at
+        // `$NROS_HOME/bin`, so a toolchain missing it is one that predates that
+        // or was installed by hand, and reinstalling is the fix.
+        "cannot resolve the SystemModel: `nros-launch-resolve` not found. A released \
+         toolchain ships it beside `nros` and fronts it at `$NROS_HOME/bin`, so \
+         re-running the installer gets you one. From a checkout: \
+         `./scripts/bootstrap.sh` (contributors: `just setup-launch-resolve`). Either \
+         way, `$NROS_LAUNCH_RESOLVE` points at one explicitly. (Never resolved \
          through $PATH — a stale copy there resolves with an older schema, issue 0285.)"
             .to_string()
     })?;

--- a/scripts/check-release-manifest.py
+++ b/scripts/check-release-manifest.py
@@ -15,9 +15,9 @@ existing generated code wrong, so only the last may block anything.
 D7 replaces asserting with RECORDING, in `share/nros/manifest.toml`. That change
 is easy to make and easy to un-make: the retired assertions are each two lines
 and each looks prudent in isolation, which is exactly how a coupling comes back.
-So the four properties below are gated rather than remembered.
+So the properties below are gated rather than remembered.
 
-## The four rules
+## The five rules
 
 * **R1 — the asset carries the manifest.** The staged prefix must contain
   `share/nros/<FILE_NAME>`, where FILE_NAME is READ OUT of the Rust module that
@@ -36,10 +36,28 @@ So the four properties below are gated rather than remembered.
   property of the fatal paths rather than as a ban on the two old wordings,
   because a reintroduction would be written in new words — the shape the
   2026-07-28 audit found in four gates whose reach was narrower than their rule.
+* **R5 — the asset carries what a BUILD reads** (phase-447 A1, RFC-0099 D2).
+  Two artifacts, both measured absent before phase-447 and each fatal on its
+  own:
+
+  - the **SDK root**, staged by `scripts/stage-sdk-root.sh` — that script owns
+    the path list and VERIFIES what it wrote, so the rule here is that the
+    workflow calls it, not a second copy of its inventory. Without it
+    `nros build` bails "no nano-ros SDK root found, so board ids cannot be
+    resolved."
+  - the **launch resolver** binary, copied into the asset's `bin/`. It is not
+    part of the SDK root (its own cargo workspace, embeds CPython) and every
+    workspace configure goes through it: with the SDK root staged and this
+    missing, `cmake -S . -B build` on a scaffolded project dies at
+    `nros codegen entry` with a remedy naming a checkout the user does not have.
+
+  Both NAMES are read out of the Rust that resolves them — `SHIPPED_SUBDIR` in
+  `nros_launcher::checkout`, `LAUNCH_RESOLVER` in `cmd::ws` — for R1's reason: a
+  gate that spells a path itself goes green while the reader looks elsewhere.
 
 ## Buildless
 
-Pure text over one YAML file and one Rust file. No CLI, no network, no store —
+Pure text over one YAML file, three Rust files and one shell script. No CLI, no network, no store —
 it passes in a pristine worktree, which is the bar for the fast lane.
 
 Run: python3 scripts/check-release-manifest.py [--self-test]
@@ -56,9 +74,18 @@ READER = os.path.join(
     ROOT, "packages", "cli", "nros-cli-core", "src", "orchestration", "release_manifest.rs"
 )
 CODEGEN_SRC = "packages/core/nros-core/src/codegen_version.rs"
+# R5 — the two Rust files that decide where a build looks for what the asset
+# must carry. Read, never spelled here (R1's reason).
+LAUNCHER = os.path.join(ROOT, "packages", "cli", "nros-launcher", "src", "checkout.rs")
+WS = os.path.join(ROOT, "packages", "cli", "nros-cli-core", "src", "cmd", "ws.rs")
+# The script that owns the SDK root's path list and verifies what it staged.
+STAGE_SCRIPT = "scripts/stage-sdk-root.sh"
+STAGE_PATH = os.path.join(ROOT, "scripts", "stage-sdk-root.sh")
 
 # The Rust reader's own name for the file. Read, never spelled here.
 FILE_NAME_RE = re.compile(r'pub const FILE_NAME: &str = "([^"]+)"')
+SHIPPED_SUBDIR_RE = re.compile(r'pub const SHIPPED_SUBDIR: &str = "([^"]+)"')
+LAUNCH_RESOLVER_RE = re.compile(r'const LAUNCH_RESOLVER: &str = "([^"]+)"')
 
 # A shell line that composes the manifest by hand instead of asking the binary.
 HAND_WRITTEN_RE = re.compile(
@@ -71,6 +98,70 @@ def manifest_file_name(reader_text):
     """FILE_NAME as the Rust reader declares it."""
     m = FILE_NAME_RE.search(reader_text)
     return m.group(1) if m else None
+
+
+def sdk_root_violations(workflow_text, launcher_text, ws_text, stage_text):
+    """R5 — the asset carries what a build reads (phase-447 A1, RFC-0099 D2).
+
+    Every clause below is about the STAGED PREFIX (`"$stage"`), never about the
+    bare name appearing somewhere in the file. The first version of this rule
+    asked `f"bin/{resolver}" in workflow_text` and stayed GREEN when the staging
+    `cp` was deleted, because the install probe two steps later mentions the same
+    path — a gate satisfied by the sentence that checks the thing rather than by
+    the thing.
+    """
+    bad = []
+
+    m = SHIPPED_SUBDIR_RE.search(launcher_text)
+    if not m:
+        bad.append(
+            ("R5", f"{LAUNCHER} declares no `pub const SHIPPED_SUBDIR` — nothing "
+                   "says where an installed toolchain's SDK root lives")
+        )
+    else:
+        subdir = m.group(1)
+        # The script owns the path list AND verifies what it wrote, so the
+        # workflow's job is to CALL it against the staged prefix.
+        if f'{STAGE_SCRIPT} "$stage"' not in workflow_text:
+            bad.append(
+                ("R5", f'the release does not run `{STAGE_SCRIPT} "$stage"` — without '
+                       "the SDK root in the asset a released `nros` resolves its board "
+                       "catalog from a checkout it does not have, and `nros build` "
+                       "bails on the first release ever cut")
+            )
+        # …and the script must write where the CLI looks. This is the pair that
+        # can drift silently: both sides are correct in isolation and the asset
+        # lands one directory away from `shipped_sdk_root_beside`.
+        sm = re.search(r'^SHIPPED_SUBDIR="([^"]+)"', stage_text, re.M)
+        if not sm:
+            bad.append(
+                ("R5", f"{STAGE_SCRIPT} declares no SHIPPED_SUBDIR — it and "
+                       f"{LAUNCHER} must name one directory")
+            )
+        elif sm.group(1) != subdir:
+            bad.append(
+                ("R5", f"{STAGE_SCRIPT} stages into {sm.group(1)} but the CLI looks in "
+                       f"{subdir} — the asset would land one directory away from "
+                       "`shipped_sdk_root_beside`, which answers None and reads as "
+                       "'no SDK root found'")
+            )
+
+    m = LAUNCH_RESOLVER_RE.search(ws_text)
+    if not m:
+        bad.append(
+            ("R5", f"{WS} declares no `const LAUNCH_RESOLVER` — nothing names the "
+                   "launch resolver binary")
+        )
+    else:
+        resolver = m.group(1)
+        if f'"$stage/bin/{resolver}"' not in workflow_text:
+            bad.append(
+                ("R5", f'the release copies nothing to "$stage/bin/{resolver}" — it is '
+                       "not part of the SDK root (own workspace, embeds CPython), and "
+                       "every workspace configure resolves its launch file through it, "
+                       "so a scaffolded project dies at `nros codegen entry`")
+            )
+    return bad
 
 
 def fatal_paragraphs(text):
@@ -92,9 +183,10 @@ def fatal_paragraphs(text):
     return out
 
 
-def violations(workflow_text, reader_text):
+def violations(workflow_text, reader_text, launcher_text, ws_text, stage_text):
     """Every rule broken, as (rule, message) pairs."""
     bad = []
+    bad += sdk_root_violations(workflow_text, launcher_text, ws_text, stage_text)
     name = manifest_file_name(reader_text)
     if not name:
         bad.append(("R1", f"{READER} declares no `pub const FILE_NAME` to read the asset path from"))
@@ -205,25 +297,101 @@ NO_EQUALITY = """
 """
 
 READER_STUB = 'pub const FILE_NAME: &str = "manifest.toml";'
+LAUNCHER_STUB = 'pub const SHIPPED_SUBDIR: &str = "share/nano-ros";'
+WS_STUB = 'const LAUNCH_RESOLVER: &str = "nros-launch-resolve";'
+
+# R5's half of the workflow, appended to whichever body a case is about, so the
+# R1–R4 cases keep asserting exactly what they always did.
+STAGES_WHAT_A_BUILD_READS = """
+          sh scripts/stage-sdk-root.sh "$stage"
+          cp packages/cli/nros-launch-resolve/target/release/nros-launch-resolve \\
+              "$stage/bin/nros-launch-resolve"
+"""
+
+# The staging script's half of the R5 pair.
+STAGE_STUB = 'SHIPPED_SUBDIR="share/nano-ros"\n'
+
+# The shape that fooled R5's first version: the staging `cp` is GONE, and the
+# install probe still names the path. A substring rule reads this as OK.
+PROBE_ONLY = """
+          sh scripts/stage-sdk-root.sh "$stage"
+      - name: Prove the asset installs
+        run: |
+          "$RUNNER_TEMP/probe/bin/nros-launch-resolve" --version
+"""
 
 
 def self_test():
+    G = GOOD + STAGES_WHAT_A_BUILD_READS
+    S = STAGE_STUB
     cases = [
-        ("the shipped shape passes", GOOD, READER_STUB, set()),
-        ("a reintroduced index assertion", REINTRODUCED_INDEX_ASSERT, READER_STUB, {"R4"}),
-        ("a reintroduced crate-prefix assertion", REINTRODUCED_CRATE_ASSERT, READER_STUB, {"R4"}),
-        ("a hand-composed manifest", HAND_WRITTEN, READER_STUB, {"R2"}),
-        ("no surviving codegen equality", NO_EQUALITY, READER_STUB, {"R3"}),
+        ("the shipped shape passes", G, READER_STUB, LAUNCHER_STUB, WS_STUB, S, set()),
+        (
+            "a reintroduced index assertion",
+            REINTRODUCED_INDEX_ASSERT + STAGES_WHAT_A_BUILD_READS,
+            READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R4"},
+        ),
+        (
+            "a reintroduced crate-prefix assertion",
+            REINTRODUCED_CRATE_ASSERT + STAGES_WHAT_A_BUILD_READS,
+            READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R4"},
+        ),
+        (
+            "a hand-composed manifest",
+            HAND_WRITTEN + STAGES_WHAT_A_BUILD_READS,
+            READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R2"},
+        ),
+        (
+            "no surviving codegen equality",
+            NO_EQUALITY + STAGES_WHAT_A_BUILD_READS,
+            READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R3"},
+        ),
         (
             "a renamed manifest file the workflow did not follow",
-            GOOD,
+            G,
             'pub const FILE_NAME: &str = "components.toml";',
-            {"R1"},
+            LAUNCHER_STUB, WS_STUB, S, {"R1"},
+        ),
+        # R5 — one case per artifact, because they fail independently and a
+        # rule written for one of them would have caught only that one.
+        ("no SDK root staged", GOOD, READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R5"}),
+        (
+            "the SDK root staged but no launch resolver",
+            GOOD + '\n          sh scripts/stage-sdk-root.sh "$stage"\n',
+            READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R5"},
+        ),
+        # The mutant that beat R5's first version: staging deleted, the install
+        # probe still naming the path. A bare-substring rule reads this as OK.
+        (
+            "only the install probe names the resolver",
+            GOOD + PROBE_ONLY,
+            READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R5"},
+        ),
+        (
+            "the resolver copied but the SDK root inlined instead of scripted",
+            GOOD + '\n          cp -r cmake config packages "$stage/share/nano-ros/"\n'
+                 + '          cp a/nros-launch-resolve "$stage/bin/nros-launch-resolve"\n',
+            READER_STUB, LAUNCHER_STUB, WS_STUB, S, {"R5"},
+        ),
+        (
+            "the shipped subdir renamed and the workflow left behind",
+            G, READER_STUB,
+            'pub const SHIPPED_SUBDIR: &str = "share/nros-sdk";', WS_STUB, S, {"R5"},
+        ),
+        (
+            "the resolver renamed and the workflow left behind",
+            G, READER_STUB, LAUNCHER_STUB,
+            'const LAUNCH_RESOLVER: &str = "nros-resolve-launch";', S, {"R5"},
+        ),
+        (
+            "the staging script and the CLI name different directories",
+            G, READER_STUB, LAUNCHER_STUB, WS_STUB,
+            'SHIPPED_SUBDIR="share/nros/sdk"\n', {"R5"},
         ),
     ]
     failures = 0
-    for label, wf, reader, want in cases:
-        got = {rule for rule, _ in violations(wf, reader)}
+    for label, wf, reader, launcher, ws, stage, want in cases:
+        got = {rule for rule, _ in violations(wf, reader, launcher, ws, stage)}
         if got != want:
             print(f"  self-test FAIL [{label}]: expected {sorted(want) or 'no violations'}, got {sorted(got)}")
             failures += 1
@@ -243,7 +411,7 @@ def main():
     if self_test() != 0:
         return 1
 
-    for path in (WORKFLOW, READER):
+    for path in (WORKFLOW, READER, LAUNCHER, WS, STAGE_PATH):
         if not os.path.isfile(path):
             print(f"check-release-manifest: {path} is missing — nothing records the release")
             return 1
@@ -251,8 +419,14 @@ def main():
         workflow_text = fh.read()
     with open(READER, encoding="utf-8") as fh:
         reader_text = fh.read()
+    with open(LAUNCHER, encoding="utf-8") as fh:
+        launcher_text = fh.read()
+    with open(WS, encoding="utf-8") as fh:
+        ws_text = fh.read()
+    with open(STAGE_PATH, encoding="utf-8") as fh:
+        stage_text = fh.read()
 
-    bad = violations(workflow_text, reader_text)
+    bad = violations(workflow_text, reader_text, launcher_text, ws_text, stage_text)
     if bad:
         print("check-release-manifest: the release does not record its components (RFC-0097 D7):")
         for rule, msg in bad:
@@ -265,9 +439,12 @@ def main():
 
     name = manifest_file_name(reader_text)
     fatal = len(fatal_paragraphs(workflow_text))
+    subdir = SHIPPED_SUBDIR_RE.search(launcher_text).group(1)
+    resolver = LAUNCH_RESOLVER_RE.search(ws_text).group(1)
     print(
         f"check-release-manifest: OK — the asset records share/nros/{name}, "
-        f"stamped by the binary; {fatal} release-blocking path(s), all about codegen."
+        f"stamped by the binary; {fatal} release-blocking path(s), all about codegen; "
+        f"it carries {subdir} and bin/{resolver}."
     )
     return 0
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -232,7 +232,25 @@ EOF
 # checkout has no `nros-sdk-index.toml` until this install finishes. The path is
 # the one input the binary cannot supply itself; WHICH version gets linked is
 # still `front_newest`'s decision, reading the store.
-"$prefix/bin/nros" sdk-front nros --front bin/nros >/dev/null \
+#
+# phase-447 A1 — `bin/nros-launch-resolve` is fronted TOO, when the asset
+# carries one. It is a second binary, not part of the SDK root, and
+# `model_location::launch_resolver_bin`'s installed rung is literally
+# `$NROS_HOME/bin/nros-launch-resolve` — so without this link every workspace
+# configure dies at `nros codegen entry` with a remedy naming a checkout the
+# user does not have. Measured against a staged prefix: the SDK root resolves,
+# cmake gets as far as the entry package, and stops there.
+#
+# CONDITIONAL because `front_newest` refuses a declared path that is absent, and
+# an asset predating this line has no resolver — fronting it unconditionally
+# would turn "an older release, installed" into "an older release, uninstallable".
+front_args="--front bin/nros"
+if [ -x "$prefix/bin/nros-launch-resolve" ]; then
+    front_args="$front_args --front bin/nros-launch-resolve"
+fi
+# shellcheck disable=SC2086
+# Word-splitting is intended: $front_args is a flag list built above.
+"$prefix/bin/nros" sdk-front nros $front_args >/dev/null \
     || die "installed $ver at $prefix, but could not front it at $BIN/nros (see above)."
 
 echo "nros-install: installed $ver"

--- a/scripts/stage-sdk-root.sh
+++ b/scripts/stage-sdk-root.sh
@@ -1,0 +1,269 @@
+#!/bin/sh
+# Stage the nano-ros SDK root into a release prefix — phase-447 A1, RFC-0099 D2.
+#
+# The SDK root is what a BUILD reads: the cmake modules a workspace includes,
+# the board and platform descriptors, and the runtime crates a user's project
+# compiles against. Until phase-447 a release staged `bin/nros`, the index and
+# `install.sh`, so the journey `install.sh` -> `nros setup <board>` -> `nros new`
+# -> `nros build` dead-ended at the last step with "no nano-ros checkout found"
+# (RFC-0099 D1). This is the missing member.
+#
+# It goes INSIDE the toolchain asset, at `<prefix>/share/nano-ros`, because
+# RFC-0097 D6 already decided codegen and the runtime are ONE unit — a
+# separately-versioned SDK would split exactly that unit and reopen the
+# acceptance-range question D6 closed.
+#
+# WHY `git archive` AND NOT `cp -r`
+#
+# The working tree carries ~20 G of build output; `git ls-files` is this repo's
+# rule for enumerating the tree, and `git archive HEAD` is that rule with the
+# copy attached. It also pins the payload to the COMMIT — the same commit
+# `share/nros/manifest.toml` records as `nano_ros` — rather than to whatever a
+# runner's working tree happens to hold. Submodule gitlinks are skipped, which
+# is correct: `packages/cli/third-party/play_launch` is a build-time dep of the
+# CLI, not of a user's project.
+#
+# WHAT IS STAGED, AND WHY EACH PART IS NOT OPTIONAL
+#
+# Measured against what a build actually reads, not assumed. RFC-0099 D2 named
+# `{cmake,config,packages}`; that set is REAL but not sufficient, and the four
+# additions below each have a reader:
+#
+#   cmake/              every module a workspace includes, the platform and
+#                       board overlays, and the cross-toolchain files a board
+#                       descriptor names.
+#   config/            `config/rust-targets.txt` (stage-3 preflight: `rustup
+#                       target add` vs `-Zbuild-std`) and the platform
+#                       descriptors `nros-platform-config` resolves.
+#   packages/          `BoardCatalog::load_with_packages` reads
+#                       `packages/boards/**/nros-board.toml`; a generated entry
+#                       path-deps `packages/api/nros`,
+#                       `packages/platform/nros-platform` and its board crate;
+#                       `packages/interfaces/` is where `std_msgs` and friends
+#                       resolve from. Staged WHOLE apart from `packages/cli`,
+#                       because 58 of its subdirectories are members of the root
+#                       `Cargo.toml` — including `packages/testing` and
+#                       `packages/verification`, which no build reads but whose
+#                       absence makes the workspace manifest unloadable, and
+#                       therefore every Rust user project unbuildable.
+#   packages/cli       EXCLUDED, then four paths carved back. The directory is
+#                       75.9 MB tracked and mostly ships as a binary, so the
+#                       exclusion is worth having — but "nothing in a user's
+#                       graph reaches it" was FALSE, and staging is the only
+#                       place that could have found out. What is carved back,
+#                       each MEASURED by building a scaffolded workspace against
+#                       a staged prefix rather than read off a manifest:
+#                         nros-entry-lower, nros-pkg-index — `packages/core/
+#                           nros-macros` PATH-DEPS both (`../../cli/…`), and
+#                           every Rust user project compiles `nros-macros`. Their
+#                           absence is not a missing feature: cargo cannot LOAD
+#                           the graph, so `_cargo-build_nros_c` and
+#                           `_cargo-build_nros_cpp` fail before compiling
+#                           anything — i.e. the C++ quick start too, not just
+#                           Rust.
+#                         Cargo.toml — both carry `version.workspace = true`, so
+#                           cargo must find the CLI workspace manifest above them
+#                           to parse either one.
+#                         interfaces/ — the bundled ROS `.msg` share dirs
+#                           `bundled_interfaces_dir` resolves, which the shipped
+#                           C++ workspace template needs for its
+#                           `<depend>std_msgs</depend>`.
+#                       Anything else under `packages/cli` is the CLI's own
+#                       source or its test workspaces; a user's graph reaches
+#                       none of it, and `test ! -d nros-cli-core` below keeps
+#                       that true.
+#   Cargo.lock         The root workspace's lock. The SDK root IS a cargo
+#                       workspace — corrosion builds `packages/api/nros-c` and
+#                       `nros-cpp` out of it — so without the lock the first
+#                       build either re-resolves every dependency (a version set
+#                       nobody tested, WRITTEN INTO the install prefix) or, under
+#                       this repo's project-wide `--locked`, fails with `cannot
+#                       create the lock file … because --locked was passed`.
+#                       Shipping it is the same promise a lock always makes:
+#                       someone else's build resolves what ours did.
+#   zephyr/            NOT just the Zephyr lane. `NanoRosSharedCargoDir.cmake`
+#                       reads `zephyr/cmake/nros_cargo_build.cmake` as the
+#                       AUTHORED knob-name inventory on every C/C++ configure
+#                       and FATAL_ERRORs when it is absent — its own comment
+#                       says "nano-ros is consumed only as a source distribution
+#                       … its absence is a real breakage rather than a reason to
+#                       degrade". This line is what keeps that true for a
+#                       release.
+#   scripts/           `scripts/nuttx/build-nuttx.sh` (NuttX kernel
+#                       provisioning, invoked by the board overlay) and
+#                       `scripts/check-shared-cargo-dir-used.sh` (build-time
+#                       assertion when NROS_SHARED_CARGO_ROOT is set).
+#   CMakeLists.txt     `_nros_import_once` does `add_subdirectory("${root}")`,
+#                       so the root listfile IS executed by every workspace.
+#   nano_rosConfig.cmake
+#                      the `find_package(nano_ros)` entry point every generated
+#                       cmake root uses.
+#   Cargo.toml         REQUIRED by every Rust build: all 58 workspace members
+#                       are under `packages/` and inherit `version.workspace`
+#                       and `[lints] workspace = true`, so cargo must find this
+#                       manifest by walking up from a path-dep'd crate. Without
+#                       it a Rust user project fails at manifest parse.
+#   nros-sdk-index.toml
+#                      read FROM THE SDK ROOT by cmake modules that derive it
+#                       from their own location — `NanoRosCorrosion.cmake`
+#                       (`…/../nros-sdk-index.toml`, the Corrosion pin) and
+#                       `NanoRosCrossToolchain.cmake`
+#                       (`…/../../nros-sdk-index.toml`, the toolchain pins).
+#                       This is a SECOND copy: `share/nros/nros-sdk-index.toml`
+#                       is the one `setup::shipped_index` reads, resolved from
+#                       the BINARY. Both are written from the same file here, so
+#                       they cannot disagree.
+#   examples/qemu-armv7a-nuttx/rust-toolchain.toml
+#                      the NuttX nightly-channel SSoT, read as DATA by both
+#                       NuttX board overlays. It degrades silently when absent
+#                       (an `if(EXISTS)`), and the degradation is `E0463: can't
+#                       find crate for core` several minutes into a build.
+#
+# NOT staged, each on purpose:
+#
+#   tools/             `cmake/bootstrap.cmake` treats `tools/setup.sh` PLUS the
+#                       index as its "am I in a nano-ros source tree?" signal
+#                       and returns early when either is missing. Staging the
+#                       index without `tools/` is what makes an installed prefix
+#                       read as "consumed from an install prefix — nothing to
+#                       bootstrap", which is exactly right.
+#   third-party/       gitignored; provisioned by `nros setup`, never shipped.
+#   docs/ book/ tests/ just/ ci/ .github/ changelog.d/
+#                      development surfaces with no build reader.
+#   examples/ (rest)   copy-out projects, not inputs to a user's build. Only the
+#                       one file above has a reader.
+#
+# Usage: scripts/stage-sdk-root.sh <prefix>
+#   Stages into <prefix>/share/nano-ros and verifies the result.
+
+set -eu
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 <prefix>" >&2
+    exit 2
+fi
+prefix="$1"
+
+# The repo this script lives in, so the caller's cwd does not decide the payload.
+repo="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+
+# The subdirectory of the prefix. Kept in step with
+# `orchestration::nano_ros_root::SHIPPED_SUBDIR`, which is where the CLI looks.
+SHIPPED_SUBDIR="share/nano-ros"
+root="$prefix/$SHIPPED_SUBDIR"
+
+# One list, read by the archive below and by `--list`. Every entry is documented
+# in the header; a new one belongs there too.
+PATHS="cmake
+config
+packages
+zephyr
+scripts
+CMakeLists.txt
+nano_rosConfig.cmake
+Cargo.toml
+Cargo.lock
+examples/qemu-armv7a-nuttx/rust-toolchain.toml
+:(exclude)packages/cli"
+
+# The `packages/cli` paths carved back IN. They need their own archive
+# invocation: git applies every `:(exclude)` pathspec LAST, so listing them
+# beside the exclusion drops them anyway (measured — the first version of this
+# script staged nothing under `packages/cli`).
+#
+# Each is justified in the header. The two crates are reached by a PATH DEP from
+# `packages/core/nros-macros`, which every Rust user project compiles and which
+# both the C and C++ quick starts reach through `nros-c` / `nros-cpp`; the
+# manifest is what their `version.workspace = true` inherits from.
+CARVED="packages/cli/interfaces
+packages/cli/Cargo.toml
+packages/cli/nros-entry-lower
+packages/cli/nros-pkg-index"
+
+if [ "$prefix" = "--list" ]; then
+    printf '%s\n' "$PATHS" "$CARVED"
+    exit 0
+fi
+
+mkdir -p "$root"
+# shellcheck disable=SC2086
+# Word-splitting is intended: these are newline-separated pathspecs and none
+# contains whitespace.
+git -C "$repo" archive HEAD -- $PATHS | tar -x -C "$root"
+# shellcheck disable=SC2086
+git -C "$repo" archive HEAD -- $CARVED | tar -x -C "$root"
+
+# The index, from the SDK root's own position. See the header — this is a second
+# copy of `share/nros/nros-sdk-index.toml`, written from one source so the two
+# cannot drift.
+cp "$repo/nros-sdk-index.toml" "$root/nros-sdk-index.toml"
+
+# VERIFY, here rather than in the caller: a staging step that produced an
+# incomplete root would otherwise be discovered by a user, several minutes into
+# their first build, with an error about a missing include. Each path below is
+# an entry point named in the header, so this fails on the thing it is about.
+#
+# No `exit 1` — `set -e` carries these, which keeps `check-release-manifest`'s
+# R4 (every release-blocking `exit 1` must be about `codegen`) meaning what it
+# says. Same idiom the workflow's own install probe already uses.
+#
+# Each assertion SAYS what it is about. A bare `test -f` under `set -e` fails
+# with NO OUTPUT, so an incomplete staging read as "the script died" and the
+# operator had to bisect this block to learn which path was missing (measured
+# while mutation-testing it: two mutants went red in silence).
+need() {  # need <flag> <rel-path> <what it is for>
+    if [ ! "$1" "$root/$2" ]; then
+        echo "nano-ros: the staged SDK root is INCOMPLETE — missing $2" >&2
+        echo "  ($3)" >&2
+        echo "  The path list is at the top of this script; its header says why each entry is there." >&2
+        return 1
+    fi
+}
+refuse() {  # refuse <flag> <rel-path> <why it must not be here>
+    if [ "$1" "$root/$2" ]; then
+        echo "nano-ros: the staged SDK root carries $2, which it must not." >&2
+        echo "  ($3)" >&2
+        return 1
+    fi
+}
+need -f packages/core/nros-core/Cargo.toml \
+    "the root MARKER — without it nothing recognises this directory as a nano-ros root"
+need -f cmake/NanoRosWorkspace.cmake "the workspace modules every user CMakeLists includes"
+need -f nano_rosConfig.cmake "the find_package(nano_ros) entry point"
+need -f CMakeLists.txt "the listfile _nros_import_once add_subdirectory()s"
+need -f Cargo.toml "the workspace manifest every member inherits from"
+need -f Cargo.lock "the resolution this release was built on"
+need -f zephyr/cmake/nros_cargo_build.cmake \
+    "the authored knob inventory NanoRosSharedCargoDir reads on EVERY C/C++ configure"
+need -f config/rust-targets.txt "the stage-3 preflight's rustup-target-vs-build-std list"
+need -d packages/boards "the board catalog BoardCatalog::load_with_packages reads"
+need -d packages/interfaces "the pre-generated msg packages core crates need before codegen runs"
+need -d packages/cli/interfaces/std_msgs "the bundled ROS .msg share dirs"
+need -f packages/cli/Cargo.toml "the CLI workspace the carved-back crates inherit their version from"
+refuse -d packages/cli/nros-cli-core "the CLI's own source ships as a binary"
+need -f nros-sdk-index.toml "the Corrosion + cross-toolchain pins, read from the SDK root's own position"
+
+# The carve-back set is DERIVED and re-checked, never trusted. A new path dep
+# from a runtime crate into `packages/cli` reads as an ordinary manifest edit and
+# would ship a root cargo cannot LOAD — the build fails before compiling
+# anything, in every language, and the message names a path inside the asset. So
+# every relative `path = "../../cli/<crate>"` in a tracked manifest OUTSIDE
+# `packages/cli` must resolve to something staged. Read from HEAD, which is what
+# `git archive` above staged. (Fixture templates spell it
+# `@NANO_ROS_ROOT@/packages/cli/...`; that is not a cargo path dep and belongs to
+# no workspace, so the relative form is the right pattern to key on.)
+missing=""
+for dep in $(git -C "$repo" grep -h -o -E 'path = "(\.\./)+cli/[A-Za-z0-9_.-]+"' HEAD \
+        -- '*Cargo.toml' ':(exclude)packages/cli' | sed -e 's|.*/cli/||' -e 's|"$||' | sort -u); do
+    [ -e "$root/packages/cli/$dep" ] || missing="$missing packages/cli/$dep"
+done
+if [ -n "$missing" ]; then
+    echo "nano-ros: a runtime crate path-deps into packages/cli, but staging omits:$missing" >&2
+    echo "  Carve it back in CARVED above and say why in the header." >&2
+    false
+fi
+refuse -e tools "with it, cmake/bootstrap.cmake would provision submodules inside an install prefix instead of returning early"
+
+files="$(find "$root" -type f | wc -l)"
+bytes="$(du -sb "$root" | cut -f1)"
+echo "nano-ros: staged the SDK root -> $root ($files files, $bytes bytes)"


### PR DESCRIPTION
Implements **phase-447 A1 + A2** (RFC-0099 D1/D2/D3). Base for the phase doc is PR #883, which is not merged yet — A1/A2's boxes are ticked there, not here.

## What was broken

`install.sh` → `nros setup` → `nros new` → `nros build` dead-ends one step from the end. `nros build` resolves its board catalog from a CHECKOUT and says so in its own bail; the release asset stages `bin/nros`, the index and `install.sh`. It hurts nobody today, which is the trap: the only people who could notice have `$NROS_REPO_DIR` from `activate.sh`.

## A2 — one ladder, and the store rung is LAST

Five call sites carried a three-rung chain by hand, all three rungs a checkout. They ask `orchestration::nano_ros_root::resolve` now, and the scaffolded/template `CMakeLists.txt` asks the new `nros sdk-root`. The fourth rung is this toolchain's own `<prefix>/share/nano-ros`, consulted **last** — the ownership guard (phase-431 W1) requires an `nros` inside a checkout to be that checkout's build, so an earlier store rung would answer a contributor with a store copy of the tree they are editing. A scaffold **asks** rather than baking a path that is right on exactly one machine.

## A1 — the SDK root ships, and measuring it moved the set three times

`scripts/stage-sdk-root.sh` owns the path list and verifies what it wrote. RFC-0099 named `{cmake,config,packages}`; that set is real and not sufficient, and no manifest-reading sweep would have found the rest. Built against a staged prefix with no checkout:

1. **`packages/cli` excluded whole is wrong.** `packages/core/nros-macros` — compiled by every Rust user project and reached by both the C and C++ quick starts — path-deps `packages/cli/nros-pkg-index` and `nros-entry-lower`. Cargo cannot **load** the graph without them, so the build fails before compiling anything, in every language. Carved back (plus `packages/cli/Cargo.toml` for their `version.workspace`); the exclusion still earns its keep at 75.9 MB tracked. The carve-back set is now **derived and re-checked** at staging time from every relative `path = "../../cli/<crate>"` outside `packages/cli`.
2. **The root `Cargo.lock` must ship.** The SDK root *is* a cargo workspace — corrosion builds `nros-c`/`nros-cpp` out of it — so without it a first build either re-resolves everything into the install prefix or, under this repo's project-wide `--locked`, fails outright.
3. **The SDK root is not enough.** See below.

## The separate missing artifact: `nros-launch-resolve`

The previous `wip` commit reported a blocker it could not name. It is the launch resolver. With `share/nano-ros` staged and no checkout, `nros new my_robot --workspace` scaffolds and then dies at cmake configure:

```
`nros-launch-resolve` not found. Build it with `./scripts/bootstrap.sh`
```

— a remedy naming a checkout the user does not have. Every workspace configure goes through it, because `nano_ros_entry` resolves the bringup's launch file into a SystemModel. It cannot live in the SDK root: own cargo workspace, own lock, embeds CPython. So the release builds it (one line, exactly as `bootstrap.sh` already does for a contributor), stages it beside `nros`, and `install.sh` fronts it — `model_location::launch_resolver_bin`'s installed rung is literally `$NROS_HOME/bin/nros-launch-resolve` and had never had anything to find. Fronting is **conditional**, because `front_newest` refuses a declared path that is absent and an older asset must stay installable.

## Acceptance — measured end to end

A real asset built by `stage-sdk-root.sh`, installed by `scripts/install.sh` into a scratch `$NROS_HOME`, then `nros new my_robot --workspace` → `cmake -S . -B build` → `cmake --build` → the binary prints `Published: 0…`. No checkout, `$NROS_REPO_DIR` unset, `$NROS_LAUNCH_RESOLVE` unset. The other arm is unchanged: inside a checkout `nros sdk-root --explain` still answers *via a nano-ros checkout*.

## Gate

`check-release-manifest` gains R5. Every clause is about the **staged prefix**, never the bare name — R5's first version asked `"bin/nros-launch-resolve" in workflow_text`, stayed **green** when the staging `cp` was deleted (the install probe two steps later mentions the same path), and is now a self-test case. R5 also pairs the script's own `SHIPPED_SUBDIR` against `nros_launcher::checkout::SHIPPED_SUBDIR` — the drift where both sides are correct in isolation and the asset lands one directory from where the CLI looks.

## Mutation pass

| fix | mutation | red |
| --- | --- | --- |
| store rung placed LAST | move it first | `a_checkout_still_wins_over_a_reachable_shipped_root` |
| store rung exists | delete it | `an_installed_toolchain_resolves_its_own_shipped_root` |
| marker checked, not just the path | `Some(candidate)` always | `a_staged_directory_without_the_marker_is_not_a_root` + `a_binary_with_no_staged_root_answers_nothing` |
| workflow stages the SDK root | drop the script call | `check-release-manifest` R5 |
| workflow stages the resolver | drop the `cp`, keep the probe | R5 — **stayed green first**; the gate was the defect |
| script and CLI agree on the subdir | rename the script's | `check-release-manifest` R5 |
| `nros-entry-lower` carved back | drop it from `CARVED` | the script's derived cli-path-dep check |
| `packages/cli/Cargo.toml` carved back | drop it | `stage-sdk-root.sh` verification |
| root `Cargo.lock` staged | drop it from `PATHS` | `stage-sdk-root.sh` verification |
| `tools/` refused | stage it | `stage-sdk-root.sh` verification |
| `install.sh` fronts the resolver | drop the conditional front | cmake configure of a scaffolded project |

Two of those went red in **silence** — a bare `test -f` under `set -e` prints nothing — so the staging assertions now name the missing path and what it is for.

## Not done here

The resolver links `libpython3.10.so.1.0` as a hard `DT_NEEDED`, so the asset now carries an ABI floor the `nros` binary does not. `[prereq.libpython310]` exists in the index and `verify_resolver_pin` already names the failure; **declaring and probing** that floor before download is RFC-0099 D1 / phase-447 D1.

A3 (a clean-host probe through `first-project.md`) is the item that would have caught all of this, and is still open.

## Verification

`just check fast` green (293 gates, 2 skipped for unprovisioned host trees) · `just check cli-tests` green · `cargo test -p nros-cli-core --lib nano_ros_root` 4/4. No fixture-tier or matrix run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
