### PR TITLE
docs(phase-448, 392, 394, 412): every open memory and exact-size issue has a home

### DIFF
--- a/docs/issues/1010-zephyr-xrce-executor-arena-exceeds-heap.md
+++ b/docs/issues/1010-zephyr-xrce-executor-arena-exceeds-heap.md
@@ -7,7 +7,7 @@ type: bug
 area: zephyr, platform, examples
 severity: high
 found: 2026-09-03
-related: [issue-0968, issue-1003]
+related: [issue-0968, issue-1003, phase-448]
 ---
 
 ## Measured

--- a/docs/issues/1130-derive-cell-entity-bounds-from-the-declaration.md
+++ b/docs/issues/1130-derive-cell-entity-bounds-from-the-declaration.md
@@ -6,7 +6,7 @@ type: enhancement
 area: api, cli
 severity: medium
 found: 2026-09-06
-related: [0857, 0827, 0900, 0965, 1061]
+related: [0857, 0827, 0900, 0965, 1061, phase-412]
 ---
 
 # The number is derivable and is still hand-written

--- a/docs/issues/1142-nuttx-standalone-example-has-no-entity-declaration.md
+++ b/docs/issues/1142-nuttx-standalone-example-has-no-entity-declaration.md
@@ -5,7 +5,7 @@ title: "A standalone (non-workspace) example declares no entities, so the guesse
 status: open
 type: tech-debt
 area: [rmw, memory, build]
-related: [1028, 0827, 1061, 0460]
+related: [1028, 0827, 1061, 0460, phase-412]
 ---
 
 ## What

--- a/docs/issues/1145-executor-backing-static-unpaired-with-rtos-heap.md
+++ b/docs/issues/1145-executor-backing-static-unpaired-with-rtos-heap.md
@@ -6,7 +6,7 @@ title: "The executor backing is a `.bss` static now, but on an RTOS the allocato
 status: open
 type: tech-debt
 area: core
-related: [phase-392, RFC-0002, 0163, 0880]
+related: [phase-392, RFC-0002, 0163, 0880, phase-448]
 ---
 
 ## Problem

--- a/docs/issues/1146-freertos-app-task-stack-never-derived.md
+++ b/docs/issues/1146-freertos-app-task-stack-never-derived.md
@@ -6,7 +6,7 @@ title: "The FreeRTOS app-task stack is 384 KiB by bisection, its C/C++ mirror sa
 status: open
 type: tech-debt
 area: boards
-related: [phase-392, phase-76, 0271, 0739, 1145, 1187]
+related: [phase-392, phase-76, 0271, 0739, 1145, 1187, phase-448]
 ---
 
 ## Problem

--- a/docs/issues/1181-stale-zpico-subscriber-buffer-size-name.md
+++ b/docs/issues/1181-stale-zpico-subscriber-buffer-size-name.md
@@ -6,7 +6,7 @@ type: bug
 area: docs, rmw-zenoh, memory
 severity: low
 found: 2026-09-07
-related: [1125, 0940]
+related: [1125, 0940, phase-412]
 ---
 
 ## What

--- a/docs/issues/1189-xrce-leaf-sets-an-arena-knob-its-image-lacks.md
+++ b/docs/issues/1189-xrce-leaf-sets-an-arena-knob-its-image-lacks.md
@@ -8,7 +8,7 @@ type: bug
 area: [embedded, build]
 severity: low
 found: 2026-09-06
-related: [1145, 1171, 0876, 0163]
+related: [1145, 1171, 0876, 0163, phase-448]
 ---
 
 ## What

--- a/docs/issues/1197-freertos-heap-cannot-learn-the-backing-size.md
+++ b/docs/issues/1197-freertos-heap-cannot-learn-the-backing-size.md
@@ -7,7 +7,7 @@ title: "FreeRTOS still budgets `configTOTAL_HEAP_SIZE` for an executor backing t
 status: open
 type: tech-debt
 area: [embedded, core, build]
-related: [1145, 1171, 1146, 0827, 1061, phase-392]
+related: [1145, 1171, 1146, 0827, 1061, phase-392, phase-448]
 ---
 
 ## What

--- a/docs/issues/1198-executor-node-and-sc-slots-are-undeclared-defaults.md
+++ b/docs/issues/1198-executor-node-and-sc-slots-are-undeclared-defaults.md
@@ -6,7 +6,7 @@ title: "`MAX_NODES` and `MAX_SC` are undeclared defaults, so every executor back
 status: open
 type: tech-debt
 area: [core, embedded]
-related: [1145, 1171, 0827, 0857, 0900, 1061, phase-392]
+related: [1145, 1171, 0827, 0857, 0900, 1061, phase-392, phase-448]
 ---
 
 ## What

--- a/docs/issues/1255-arena-prices-every-subscription-slot-at-one-global-type-bound.md
+++ b/docs/issues/1255-arena-prices-every-subscription-slot-at-one-global-type-bound.md
@@ -6,7 +6,7 @@ status: open
 type: enhancement
 area: executor, build
 severity: medium
-related: [issue-1227, issue-1179, issue-1190]
+related: [issue-1227, issue-1179, issue-1190, phase-448]
 ---
 
 ## What is true today

--- a/docs/issues/archived/1183-node-std-tests-latch-test-red-in-shared-process.md
+++ b/docs/issues/archived/1183-node-std-tests-latch-test-red-in-shared-process.md
@@ -2,7 +2,7 @@
 id: 1183
 title: "`check node-std-tests` is red on main — the executor-backing latch test asserts a process-global that 367 sibling tests share"
 status: resolved
-resolved: 2026-09-07
+resolved_in: "605d667eb"
 type: bug
 area: testing
 related: [phase-392, issue-1145]
@@ -70,22 +70,23 @@ A lane that is red for every input has no signal capacity — a regression landi
 in it looks exactly like this failure. `node-std-tests` is in the derived
 fast-serial gate list, so that is the whole lane.
 
-## Resolution
+## RESOLVED 2026-09-11 — fixed by `605d667eb`; one defect, three ids
 
-Fixed by `605d667eb` ("fix(#1183, #1186): the backing latch test needs a virgin
-process"), the second option above: the test is `#[ignore]`d with its reason in
-the attribute (`packages/core/nros-node/src/executor/backing.rs:237-240`) and
-`node-std-tests` runs it in its OWN cargo invocation, through the `ran_tests`
-guard that fails if the filter matches nothing
-(`just/check/lanes.just:1707-1710`). Same issue as 1186, filed independently.
+`605d667eb fix(#1183, #1186): the backing latch test needs a virgin process`
+(2026-09-06) marks `the_static_is_handed_out_once_and_only_once` `#[ignore]` and
+runs it alone, in its own process, from the lane:
+`just/check/lanes.just:1709` —
+`cargo test … -- --ignored --exact executor::backing::tests::the_static_is_handed_out_once_and_only_once`.
+The latch is process-global, and in a separate process no sibling test can take
+it first.
 
-This file was ADDED eleven minutes after that fix landed (`a0435e5db`, 17:14 vs
-17:03 UTC on 2026-09-06), by a parallel session that had not seen it — it was
-never deliberately kept open, just never closed.
+Checked before archiving, because an ignored test is dead coverage until the
+lane that is meant to run it is shown to run it:
 
-Re-measured on `origin/main` 2026-09-11, features `std,sim-time,param-services`:
-the isolated invocation passes 5/5 (`1 passed`); the full `--lib` suite is
-439 passed, 0 failed, 2 ignored; and the negative control — the same test pulled
-back INTO the shared process with `--include-ignored` — still fails at
-`backing.rs:247`, 2/2. So the isolation is load-bearing and the positive control
-is intact.
+* the test still exists — `packages/core/nros-node/src/executor/backing.rs:240`;
+* `just check node-std-tests` passes, and its dedicated invocation reports
+  `1 passed; 0 failed; … 447 filtered out` — exactly that one test.
+
+Issues 1183, 1185 and 1186 are the same defect filed three times. The fix commit
+named 1183 and 1186 and missed 1185, and it archived none of them, so all three
+stayed open for five days after the fix landed.

--- a/docs/issues/archived/1185-backing-latch-test-order-dependent.md
+++ b/docs/issues/archived/1185-backing-latch-test-order-dependent.md
@@ -2,7 +2,8 @@
 id: 1185
 title: "`the_static_is_handed_out_once_and_only_once` fails IN SUITE and passes
   solo — the latch it asserts on is process-global and another test takes it first"
-status: open
+status: resolved
+resolved_in: "605d667eb"
 type: bug
 area: [core, testing]
 related: [1171, phase-392]
@@ -71,3 +72,24 @@ binary's parallelism for one test. The shapes worth considering:
 The positive control (`take` actually succeeds once) genuinely needs a fresh
 process, so it cannot be made order-independent — which is the argument for the
 first shape.
+
+## RESOLVED 2026-09-11 — fixed by `605d667eb`; one defect, three ids
+
+`605d667eb fix(#1183, #1186): the backing latch test needs a virgin process`
+(2026-09-06) marks `the_static_is_handed_out_once_and_only_once` `#[ignore]` and
+runs it alone, in its own process, from the lane:
+`just/check/lanes.just:1709` —
+`cargo test … -- --ignored --exact executor::backing::tests::the_static_is_handed_out_once_and_only_once`.
+The latch is process-global, and in a separate process no sibling test can take
+it first.
+
+Checked before archiving, because an ignored test is dead coverage until the
+lane that is meant to run it is shown to run it:
+
+* the test still exists — `packages/core/nros-node/src/executor/backing.rs:240`;
+* `just check node-std-tests` passes, and its dedicated invocation reports
+  `1 passed; 0 failed; … 447 filtered out` — exactly that one test.
+
+Issues 1183, 1185 and 1186 are the same defect filed three times. The fix commit
+named 1183 and 1186 and missed 1185, and it archived none of them, so all three
+stayed open for five days after the fix landed.

--- a/docs/issues/archived/1186-executor-backing-latch-test-races-siblings.md
+++ b/docs/issues/archived/1186-executor-backing-latch-test-races-siblings.md
@@ -2,11 +2,11 @@
 id: 1186
 title: "`the_static_is_handed_out_once_and_only_once` reads a latch its sibling tests have already claimed"
 status: resolved
+resolved_in: "605d667eb"
 type: bug
 area: core, testing
 severity: medium
 found: 2026-09-07
-resolved: 2026-09-07
 related: [1145]
 ---
 
@@ -66,21 +66,23 @@ process (a `#[test]` in a dedicated integration binary, or a nextest
 `test-group` of one), or make the latch injectable so the test drives its own
 instance and the process-global one is exercised once, deliberately.
 
-## Resolution
+## RESOLVED 2026-09-11 — fixed by `605d667eb`; one defect, three ids
 
-Fixed by `605d667eb` ("fix(#1183, #1186): the backing latch test needs a virgin
-process") — the "own process" shape above, without making the latch injectable:
-the test is `#[ignore]`d with its reason in the attribute
-(`packages/core/nros-node/src/executor/backing.rs:237-240`) and `node-std-tests`
-runs it in a dedicated cargo invocation, guarded by `ran_tests` so a renamed
-filter fails instead of running nothing (`just/check/lanes.just:1707-1710`).
-Issue 1183 is the same defect, filed independently.
+`605d667eb fix(#1183, #1186): the backing latch test needs a virgin process`
+(2026-09-06) marks `the_static_is_handed_out_once_and_only_once` `#[ignore]` and
+runs it alone, in its own process, from the lane:
+`just/check/lanes.just:1709` —
+`cargo test … -- --ignored --exact executor::backing::tests::the_static_is_handed_out_once_and_only_once`.
+The latch is process-global, and in a separate process no sibling test can take
+it first.
 
-Re-measured on `origin/main` 2026-09-11, features `std,sim-time,param-services`:
-isolated 5/5 `1 passed`; full `--lib` suite 439 passed, 0 failed, 2 ignored;
-negative control (`--include-ignored`, i.e. back in the shared process) still
-fails at `backing.rs:247`, 2/2 — so it is the isolation, not a changed
-scheduler, that keeps it green.
+Checked before archiving, because an ignored test is dead coverage until the
+lane that is meant to run it is shown to run it:
 
-The "Why it stayed" half is closed separately: `node-std-tests` now runs in the
-`check` job on `pull_request`, not only in schedule-only `check-build`.
+* the test still exists — `packages/core/nros-node/src/executor/backing.rs:240`;
+* `just check node-std-tests` passes, and its dedicated invocation reports
+  `1 passed; 0 failed; … 447 filtered out` — exactly that one test.
+
+Issues 1183, 1185 and 1186 are the same defect filed three times. The fix commit
+named 1183 and 1186 and missed 1185, and it archived none of them, so all three
+stayed open for five days after the fix landed.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1,9 +1,12 @@
 # Phase 392 — 27% of a safety-island image is message buffers nobody can price
 
-**Status (2026-09-07). W1, W2, W3, W4 and W5.a-W5.g landed. W3a/W3b/W3c landed
-here, W3d landed as phase-408 W1, W3g as phase-403 W0/W6, W3e is superseded by
-phase 408 and W3f was delivered as a recorded refusal. W2 IS issue 0900, which
-is RESOLVED. Open: W6, and amendment B's wave.**
+**Status (2026-09-11). W1, W2, W3, W4, W5.a-W5.g and W6 landed. W3a/W3b/W3c
+landed here, W3d landed as phase-408 W1, W3g as phase-403 W0/W6, W3e is
+superseded by phase 408 and W3f was delivered as a recorded refusal. W2 IS issue
+0900, which is RESOLVED. W6 landed 2026-09-06 (the backing is a named `.bss`
+static); its per-port follow-through — pairing that static with each RTOS's
+allocator arena — is now [phase 448](phase-448-exact-executor-backing-on-every-port.md).
+Open: amendment B's wave, and the issues homed at the end of this doc.**
 
 **W3c landed with its acceptance NOT met, and the reason is a finding rather
 than an omission — read its wave entry before quoting it.** The default now
@@ -1591,6 +1594,11 @@ holds the evidence, the item is *close it*.
 | [#0852](../issues/0852-zephyr-serial-rx-is-polled-and-overruns.md) | the zenoh read task inherits the executor's priority on Zephyr |
 | [#0880](../issues/0880-tcm-unused-while-sram-exhausted.md) | 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted |
 | [#0969](../issues/archived/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a full round trip. **Round trip removed; cost measured** — ~46 ns/message floor (176 ns at 16 KB). The allocation saving this row assumed did NOT appear: count unchanged, bytes a crossover at ~6 KB. Remaining: the third site, per 0976 |
+| [#0810](../issues/0810-executor-arena-sized-by-worst-case-shape.md) | the executor arena was sized at `MAX_CBS x sizeof(ActionClient)` whatever the entity mix. Lever 3 cites it. It predates phase-412 W3, which now derives the arena per KIND — so re-measure against that before working it; what is left may be only the worst-case SHAPE, or nothing |
+| [#0815](../issues/0815-pool-inventory-prices-3-of-46-knobs.md) | the inventory prices 3 of 46 sizing knobs. The W1 amendment answered the ANNOTATION half (measure, do not declare); pricing the remaining knobs is the work |
+| [#1147](../issues/1147-mem-report-cannot-attribute-cpp-executor-storage.md) | `mem-report` counts the C and C++ executor storage but files it under the wrong crate — the third of W6's hand-offs, and the only one without another home |
+| [#1179](../issues/1179-derived-rx-default-unreachable-without-schema.md) | W3c's residue: on zenoh and XRCE the derived RX default is unreachable, because a type-erased registration site sees only `MessageForRmw`. The issue records two designs — the bound carried on `RosMessage`, or a split typed entry point — and asks for a deliberate choice between them |
+| [#1180](../issues/1180-mem-report-baseline-cannot-match-llvm-suffixed-symbols.md) | `mem-report --baseline` reports no delta for LLVM-internalised symbols, so a real saving can read as zero — the instrument this phase measures everything with |
 
 
 ## Adopted issue (2026-09-04)

--- a/docs/roadmap/phase-394-memory-campaign-ledger.md
+++ b/docs/roadmap/phase-394-memory-campaign-ledger.md
@@ -1,9 +1,11 @@
 # Phase 394 — memory unification and optimization: the campaign ledger
 
-**Status (2026-09-06). Ledger open. 390 and 391 are done through W5; 392 has
-W1, W2, W3 (except W3c), W4 and W5 landed, with W6 in flight. Of the eighteen issues on
-the ledger, nine are resolved and nine open — two of those claimed today, plus
-the W6 wave.** This doc
+**Status (2026-09-11). Ledger open. 390 is done through W5 (W6, the emitter's
+own vocabulary, is not started); 391 is done through W5; 392 has W1-W6 landed
+with amendment B's wave open. The per-port exact-size work that followed 392 W6
+has its own phase now, [448](phase-448-exact-executor-backing-on-every-port.md).
+As of this date every open issue on the ledger names a HOME phase — see the
+2026-09-11 amendment.** This doc
 coordinates work that already had three phase docs and eight issues but no single
 place saying who is doing what. It owns no design of its own — every decision
 lives in the phase it belongs to.
@@ -122,28 +124,43 @@ decision, never this doc.
 | 392 W3g | — | **landed, under another phase** | 0896 layers 5-6, delivered as phase-403 W0/W6. The split is `_TX_/_RX_MAX_SERIALIZED_SIZE` (TX is XCDR1, RX is `max(XCDR1, XCDR2)`), and the unbounded diagnostic is a POISON TOKEN — `NROS_UNBOUNDED__<type>__field_<name>`, an undefined identifier that names the offending field at the compile error |
 | 392 W4 net stack | — | **landed and MEASURED** | 38,334 B of `.bss`+`.data` and 78,696 B of flash on mps2/an385, two images from one tree differing only in networking. Larger than this row's original 27,760 B estimate, because that counted `net_*` symbols and missed four stacks |
 | 392 W5.a-W5.g | — | **landed; NO SHIPPED SAVING** | the mechanism, the diagnostic, the checked override and the measurement all exist. The figure reaches one of six compiled cargo units and carries the infra half only. Do not quote 143,456 B as shipped |
-| 392 W6 arena static | **claimed 2026-09-06** | in flight | the executor arena becomes a named static, so the campaign's largest allocation stops being invisible to the campaign's own instrument |
+| 392 W6 arena static | — | **landed 2026-09-06** | the executor arena is a named `.bss` static (`EXECUTOR_BACKING`). Its per-port follow-through — pairing it with each RTOS allocator arena — is [phase 448](phase-448-exact-executor-backing-on-every-port.md) |
 | 390 W1-W5 | — | **landed** | the `inline`/`heap`/`view` rename shipped; this row said "open" for nine days |
 | 390 W6 | unclaimed | open | the emitter's OWN vocabulary; found while rebasing W5, never started |
 | 391 W1-W5 | — | **landed** | one funnel, the tier model, rlsf, and the tier is gated |
-| issue 0810 | unclaimed | open | executor arena at `MAX_CBS * sizeof(ActionClient)`. Overlaps W6 — read that wave first |
+| issue 0810 | home: phase-392 | open | executor arena at `MAX_CBS * sizeof(ActionClient)`. Predates phase-412 W3's per-kind derivation — re-measure before working it |
 | issue 0811 | — | **resolved** | five ports; a real cross-allocator use-after-free |
 | issue 0812 | — | **resolved** | TWO mallocs, not one; removed with zero new state |
 | issue 0813 | — | **resolved** | now the `ZPICO_PUBLISHER_TX_BUFFER_SIZE` knob; pool row deliberately NOT added (see below) |
-| issue 0814 | unclaimed | open | zero-copy surface behind a feature only a posix test crate enables — `nm` on a built zenoh example finds zero |
-| issue 0815 | unclaimed | **open, superseded in part** | 3-of-46 pricing — the W1 amendment answers the annotation half, not the rest |
-| issue 0816 | unclaimed | **gate landed, claims still unbacked** | the missing thing is a FIXTURE, not a gate |
+| issue 0814 | home: phase-433 | open | zero-copy surface behind a feature only a posix test crate enables. Phase-391 disowns it ("related, not owned here"); phase-433's **loans** row is the live-verification work |
+| issue 0815 | home: phase-392 | **open, superseded in part** | 3-of-46 pricing — the W1 amendment answers the annotation half, not the rest |
+| issue 0816 | home: phase-391 | **gate landed, claims still unbacked** | the missing thing is a FIXTURE, not a gate |
 | issue 0817 | — | resolved | sixteen Zephyr funnel bypasses (391 prerequisite) |
 | issue 0827 | — | **resolved** | pools sized at the backend, not the image. `nros sync` now writes the derived budget — 176,720 B off a talker. The ledger carried it as "filed" |
 | issue 0857 | — | **resolved, in the merge queue** | `Node::ENTITY_BOUNDS` defaulted to the knob caps and 81 of 99 in-tree classes declared nothing. Measured −50,256 B on one slot store, −14.1 % of image `.bss` |
-| issue 0880 | unclaimed | open | 192 KiB of TCM at 0 % while SRAM is exhausted; stacks moved, 80 KiB of DTCM still free |
-| issue 0973 | **claimed 2026-09-06** | in flight | no resolved model describes endpoint wiring, so W5's application half never arrives. Answered (wiring is authored, nobody authors it); what remains is writing that down |
+| issue 0880 | home: phase-392 | open | 192 KiB of TCM at 0 % while SRAM is exhausted; stacks moved, 80 KiB of DTCM still free |
+| issue 0973 | — | **resolved** | wiring is AUTHORED, and nobody authored it; the answer is written down. Ledger carried it as "in flight" |
 | issue 1015 | — | **resolved** | the pool floor was in the wrong LAYER — applied at the shared derivation, where XRCE legitimately wants zero |
-| issue 1028 | **claimed 2026-09-06** | in flight | NuttX classified `hosted` because `target_os != "none"`, so an RTOS takes the 32-slot host budget: **106,752 B** measured waste |
+| issue 1028 | — | **resolved** | NuttX was classified `hosted`, taking the 32-slot host budget: **106,752 B** measured waste. Fixed and gated (`check-rtos-target-os`) |
 | issue 1033 | — | **resolved** | 62 % of the XRCE session struct is slots the image does not have. Also fixed six zephyr C++ leaves that could not CONFIGURE at all |
 | issue 1061 | — | **resolved** | a leaf declares what the probe cannot read |
-| issue 1125 | unclaimed | open | `ZPICO_MAX_LARGE_SUBSCRIBERS` is never derived; `LARGE_PAYLOADS` is the biggest symbol left in the esp32 image |
-| issue 1131 | unclaimed | open | fifteen knob-sized C arrays with no ruling on whether zero is a legal size |
+| issue 1125 | — | **resolved** | `ZPICO_MAX_LARGE_SUBSCRIBERS` is derived now |
+| issue 1131 | — | **resolved** | every knob-sized C array is ruled; `UNCLASSIFIED_CEILING` is 0 |
+| issue 1010 | home: phase-448 W2 | open | every Zephyr XRCE image dies at boot; the allocation is `xrce_session_state`, not the arena |
+| issue 1036 | home: phase-412 | open | arena exhaustion: no cell exercises the target-side path |
+| issue 1130 | home: phase-412 | open | cell registries sized by an authored const; the inventory already knows the figure |
+| issue 1142 | home: phase-412 (W5) | open | a standalone example reaches no declaration channel |
+| issue 1145 | home: phase-448 W4/W5 | **Zephyr landed**; FreeRTOS, NuttX, ThreadX, ESP32 open | the backing reserved twice on every RTOS but Zephyr |
+| issue 1146 | home: phase-448 W3 | **part 1 landed**; part 2 open | the C/C++ carrier's 512 KiB — unblocked now that issue 1187 is resolved |
+| issue 1147 | home: phase-392 | open | `mem-report` misattributes C/C++ executor storage |
+| issue 1179 | home: phase-392 | open | W3c residue: derived RX default unreachable on zenoh and XRCE |
+| issue 1180 | home: phase-392 | open | `mem-report --baseline` misses LLVM-suffixed symbols |
+| issue 1181 | home: phase-412 | open | a knob documented in four places and read by nothing |
+| issue 1183 / 1185 / 1186 | — | **resolved** | ONE defect filed three times: the backing latch test shared a process-global with its siblings. Fixed by `605d667eb` (a virgin-process run the lane really performs, `lanes.just:1709`); that commit named 1183 and 1186, missed 1185, and archived none |
+| issue 1189 | home: phase-448 W1 | open | the XRCE leaves set a picolibc knob their images lack — which allocator SHOULD they have? |
+| issue 1197 | home: phase-448 W4 | open | FreeRTOS heap cannot learn the backing size; the board cannot be the consumer |
+| issue 1198 | home: phase-448 W6 | open | `MAX_NODES`/`MAX_SC` undeclared: a constant 12,416 B per FreeRTOS backing |
+| issue 1255 | home: phase-448 W7 | open | the arena prices every subscription at one global type bound |
 
 ## Amendment 2026-09-06 — the ledger had drifted, and drift is the failure this doc exists to prevent
 
@@ -204,3 +221,38 @@ with removing the symbol.
 Recorded because the lesson generalises past this row: a status nobody can
 confirm is usually not unknowable, it is filed somewhere the question did not
 look.
+
+## Amendment 2026-09-11 — every open issue has a home, and the ledger drifted a third time
+
+A survey of every open issue this ledger touches found two things.
+
+**The ledger had drifted again, in the same direction as before.** It carried
+392 W6 as "in flight" five days after it landed, issues 0973 and 1028 as "in
+flight" after both were resolved, and 1125 and 1131 as "open" after both were
+resolved and archived. Every one of those errors made work look available that
+was not. The 2026-09-06 amendment already recorded that shape; recording it again
+is the evidence that a ledger nobody reconciles against the tree decays at the
+rate work lands.
+
+**A third of the open issues had no owner.** Seven issues continued phase-392 W6
+across the RTOS ports — the backing reserved twice, the heap that cannot learn
+its size, undeclared table counts, per-type arena pricing, and two Zephyr XRCE
+failures — and no phase carried any of them as a work item. They are
+[phase 448](phase-448-exact-executor-backing-on-every-port.md) now. Four more went
+into phase-412's homed table and five into phase-392's. The rule applied is
+phase-412's own: *a mention is not an owner.* An issue cited in a wave's
+hand-off list ("→ issue 1146") is a hand-off, not a work item. 1145, 1146 and
+1147 were each in that state.
+
+**Three issue ids were one defect.** 1183, 1185 and 1186 each reported the backing
+latch test red in the shared test process. `605d667eb` fixed it, naming two of
+the three, and archived none of them. Before archiving, the fix was checked in two
+ways: the test still exists (`backing.rs:240`), and the lane that claims to run
+it really does (`lanes.just:1709`, `--ignored --exact`, "1 passed" in a live
+run). An `#[ignore]` whose reason says "run via the lane" is dead coverage until
+someone confirms the lane runs it.
+
+Homes, for the record: 0814 → phase-433 (the loans row; phase-391 disowns it);
+0816 → phase-391; 0880 → phase-392; 1228 and 1252 → phase-439 (W2's named
+remainder).
+

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -530,4 +530,8 @@ holds the evidence, the item is *close it*.
 | issue | why it belongs here |
 | --- | --- |
 | [#0991](../issues/archived/0991-a-clean-build-of-an-entity-declaring-image-does-not-link.md) | a clean build of an entity-declaring image derived the WRONG payload basis and did not link — **RESOLVED 2026-09-03**; the recovery every reader relied on had never fired |
+| [#1036](../issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md) | arena exhaustion was half silent, and on the island wholly unreachable. The host half is fixed. What is left is a CELL that exhausts a real image's arena on purpose and asserts the boot record names the shortfall, plus a sweep of the other diagnostics that assume a sink. It lives here because of this phase's second rule: a derived count is safe only where exhaustion NAMES the knob |
+| [#1130](../issues/1130-derive-cell-entity-bounds-from-the-declaration.md) | a component's cell registries are sized by a const the author must write. The inventory already knows the figure: `max_cell_entities` goes in `DerivedEntityKnobs`, composed across entries by MAX, abstaining when any entry refuses. An explicit `ENTITY_BOUNDS` keeps winning, being per-class |
+| [#1142](../issues/1142-nuttx-standalone-example-has-no-entity-declaration.md) | a standalone copy-out example reaches none of the three declaration channels, so the guessed budget is the only one it can get. This is W5's open design question in its most concrete form; answering W5 closes it |
+| [#1181](../issues/1181-stale-zpico-subscriber-buffer-size-name.md) | `ZPICO_SUBSCRIBER_BUFFER_SIZE` is documented in four places and read by nothing. A knob that sizes nothing is deleted from the docs, not derived — the census is this phase's |
 

--- a/docs/roadmap/phase-448-exact-executor-backing-on-every-port.md
+++ b/docs/roadmap/phase-448-exact-executor-backing-on-every-port.md
@@ -1,0 +1,184 @@
+# Phase 448 — the executor backing, sized exactly and paid for once, on every port
+
+**Status (2026-09-11). Opened to give the exact-size work a home. Nothing in
+this phase has landed; W1–W7 are open. Zephyr's pairing (issue 1145, landed
+2026-09-06) predates the phase and is the template the other ports follow.**
+
+## Why this phase exists
+
+[Phase 392 W6](phase-392-static-memory-space-campaign.md) moved the executor
+arena into a named `.bss` static, `EXECUTOR_BACKING`, so the campaign's largest
+allocation stopped being invisible to its own instrument. On a host that move is
+free. On an RTOS it is not: the allocator arena the backing used to come out of
+is itself a fixed static, and unless it is lowered by the same amount the image
+reserves the bytes TWICE.
+
+Zephyr was fixed within a day — twelve confs paired, the knob
+`CONFIG_NROS_EXECUTOR_BACKING_U64S`, the gate
+`check-executor-backing-arena-pairing`, and the subtrahend DERIVED rather than
+copied from `nm` ([issue 1171](../issues/archived/1171-arena-backing-pairing-is-hand-maintained.md)).
+Every other port is untouched, and sizing the backing exposed three more costs
+along the way.
+
+That work then continued as seven loose issues. No phase owned any of them,
+which is the state phase-412 names as the failure: *a mention is not an owner —
+an issue with no work item is an issue nobody is accountable for.* This doc is
+the owner.
+
+## What "exact" means here
+
+The backing is the arena plus a set of fixed tables, and its size depends on the
+knobs AND the target: **87,256 B on mps2_an385 against 88,328 B on
+native_sim/native/64 for one conf.** So the number is always derived per target
+(`nros-executor-layout` computes the offsets for a target's padding and
+alignment), and a subtrahend is always the derivation, never a literal. A figure
+copied from one board's `nm` is wrong on the next board and drifts on the next
+knob move.
+
+## Work items
+
+### W1 — answer which allocator a Zephyr XRCE image has
+
+[Issue 1189](../issues/1189-xrce-leaf-sets-an-arena-knob-its-image-lacks.md).
+The six Zephyr XRCE Rust leaves set `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE`, and
+their images do not select picolibc, so the knob never reaches the resolved
+`.config` and the comment above it describes another image. The issue refuses
+the one-line fix on purpose: *should* an XRCE image be on picolibc like its
+zenoh siblings? A silent libc difference between RMW variants of one example is
+a bigger finding than a dead config line.
+
+It comes first because it decides which heap W2 has to size.
+
+- [ ] The question answered, with the reason recorded in the issue.
+- [ ] Either the dead line removed and its comment corrected, or picolibc
+      selected and the knob kept — and one XRCE leaf's resolved `.config` shows
+      whichever was chosen.
+
+### W2 — every Zephyr XRCE image boots
+
+[Issue 1010](../issues/1010-zephyr-xrce-executor-arena-exceeds-heap.md). The
+only item in this phase where an image does not run: every Zephyr XRCE example
+dies at boot. The 2026-09-04 correction located the allocation — it is not the
+executor arena but `xrce_session_state`, dominated by
+`subscriber_slots[MAX_SUBSCRIBERS]` at `RING_DEPTH x (BUFFER_SIZE + 16)`.
+
+- [ ] Size the session (or the heap it comes from) so it fits — the issue
+      measured that ring depth alone does not.
+- [ ] The nine Zephyr XRCE cells boot, confirmed by running them.
+
+### W3 — the FreeRTOS C/C++ carrier's stack is measured
+
+[Issue 1146](../issues/1146-freertos-app-task-stack-never-derived.md), part 2.
+`cmake/templates/freertos_app_config.c.in` keeps `.app_stack_bytes = 524288u`
+for both typed carriers. Its C half measures 18,176 B at worst. Its C++ half was
+unmeasurable because no embedded C++ FreeRTOS image built; that blocker
+([issue 1187](../issues/archived/1187-freertos-embedded-cpp-freestanding-string.md))
+is resolved, so the number can now be taken and has not been.
+
+Part 1 (the Rust app task, 384 KiB → 128 KiB, measured on 14 running images) is
+done.
+
+- [ ] A `examples/mps2-an385-freertos/cpp/*` image measured the way part 1 was:
+      `uxTaskGetStackHighWaterMark` at the end of the register pass, on a running
+      image against a live router.
+- [ ] The carrier default set from both halves, and the image's boot print
+      confirming the peak.
+
+### W4 — FreeRTOS reserves the backing once
+
+[Issue 1197](../issues/1197-freertos-heap-cannot-learn-the-backing-size.md), and
+the FreeRTOS half of [issue 1145](../issues/1145-executor-backing-static-unpaired-with-rtos-heap.md).
+Measured: every FreeRTOS Rust image reserves its 20,608–32,512 B backing twice,
+because `configTOTAL_HEAP_SIZE` is still budgeted for an arena that moved to
+`.bss`. Neither Zephyr mechanism transfers. The 2026-09-07 attempt established
+that the board crate cannot be the consumer: it cannot see the size, and stating
+the size would fight the per-leaf derivation. `nros-node` now publishes the
+backing size for probing (`936064f25`), and the board still cannot read it.
+
+W3 comes first, for the reason the issue gives: the app stack and the backing
+both come out of the SAME heap budget, so re-deriving that budget twice in two
+PRs is how it ends up wrong.
+
+- [ ] The layering decided — route the backing size to whatever computes
+      `configTOTAL_HEAP_SIZE`, or move that computation to a layer that can see
+      it — and the decision recorded in issue 1197.
+- [ ] The heap default re-derived ONCE, against both W3's and this item's
+      reductions, as a derivation that tracks the backing rather than a literal
+      (so W6 cannot re-stale it).
+- [ ] Every affected FreeRTOS image RUN on QEMU against a live router. A too-small
+      heap is a runtime allocation failure, and running is the only bar that
+      catches it.
+
+### W5 — NuttX, ThreadX, ESP32
+
+The rest of [issue 1145](../issues/1145-executor-backing-static-unpaired-with-rtos-heap.md).
+Untouched. **One platform per commit**, as the issue specifies: the failure mode
+is a runtime allocation failure, and a three-platform diff makes it
+unattributable. The knob is Zephyr-only so far; on the other ports it is spelled
+through the `NROS_*` build environment.
+
+- [ ] NuttX paired, measured, and a running image.
+- [ ] ThreadX paired, measured, and a running image.
+- [ ] ESP32 paired, measured, and a running image.
+- [ ] `check-executor-backing-arena-pairing` covers each paired port, or records
+      why that port cannot be checked.
+
+### W6 — the fixed tables shrink to what the image declares
+
+[Issue 1198](../issues/1198-executor-node-and-sc-slots-are-undeclared-defaults.md).
+`MAX_NODES` and `MAX_SC` are undeclared defaults. Every FreeRTOS backing carries
+a constant **12,416 B** of tables, identical to the byte across leaves with
+different declarations. `MAX_NODES` is the heavier of the two: it multiplies
+seven tables.
+
+This is a design question before it is code, and the issue lists it:
+
+- [ ] Find which artifact already states the node count — the model, the
+      contract sidecar, or the entry. An entry may create several `Node`s, and
+      tiered boot opens one executor per tier. This is close to issue 0973's
+      answer: wiring is authored.
+- [ ] Decide where `MAX_SC` comes from. Scheduling contexts are the tier model's
+      (RFC-0016), not the entity inventory's, so they may belong to a different
+      declaration than `MAX_CBS`.
+- [ ] Both derived, with a FreeRTOS `nm -S` before and after.
+
+### W7 — each subscription priced at its own type
+
+[Issue 1255](../issues/1255-arena-prices-every-subscription-slot-at-one-global-type-bound.md).
+`subs_arena()` bills every declared subscription at one image-wide bound — 880 B
+on the reference island — although the per-type bound is generated and reaches
+the build script: the declared-depth triples are `type|topic=depth`, and the
+parse keeps only the depth. Headroom, not a blocker (DTCM is at 74.8 %). It
+becomes a blocker when the next subscription is added to a part with 128 KB of
+DTCM.
+
+- [ ] `subs_arena()` sums `buffered_region(depth_i, bound(type_i)) + entry_struct`,
+      and falls back to the global bound when a type's bound is absent (absent
+      is not zero).
+- [ ] The host oracle (`cargo:arena_size`) and the island's linked
+      `EXECUTOR_BACKING` agree, measured before and after.
+
+## Order
+
+W1 and then W2 first, because an image that does not boot outranks one that
+wastes bytes. Then W3 and then W4, together, because they reduce one budget.
+W5 is one port at a time, in any order. W6 and W7 are tightness work and can go
+in parallel with the rest.
+
+## Not owned here
+
+- **Arena exhaustion diagnostics** — issue 1036, homed in
+  [phase 412](phase-412-derived-counts-and-sizes.md), whose second rule is that a
+  derived count is safe only where exhaustion names the knob.
+- **The runtime stack-headroom rule** — phase 436.
+- **Main-stack and Zephyr-heap derivation** — phase 412 W2's table, which records
+  the blocker for each.
+
+## Acceptance
+
+1. On every port, `nm -S` shows `EXECUTOR_BACKING` and an allocator arena that no
+   longer also budgets for it. Each is reported as a before/after pair, and the
+   subtrahend is a derivation, never a copied literal.
+2. Every Zephyr XRCE cell boots.
+3. No executor table is sized by a default the image did not declare, unless the
+   phase records why that count cannot be known.


### PR DESCRIPTION
Docs only. Remaining memory and exact-size work sat in issues that no phase owned, which phase-412 names as the failure: *"a mention is not an owner — an issue with no work item is an issue nobody is accountable for."*

Surveyed every open issue the memory ledger touches, **against `main` rather than against the ledger's own claims**.

## New: phase 448 — the executor backing, sized exactly and paid for once, on every port

Phase-392 W6 made the executor backing a named `.bss` static. On an RTOS that is only half a saving until the allocator arena it used to come from is lowered by the same amount — otherwise the image reserves the bytes twice. Zephyr was paired the next day; everything after became loose issues:

| W | issue | what |
|---|---|---|
| W1 | 1189 | which allocator a Zephyr XRCE image *should* have — decides which heap W2 sizes |
| W2 | 1010 | **every Zephyr XRCE image dies at boot** (`xrce_session_state`, not the arena) |
| W3 | 1146 pt 2 | the FreeRTOS C/C++ carrier's 512 KiB stack — now measurable, its blocker #1187 is resolved |
| W4 | 1197 + 1145 | FreeRTOS reserves the backing twice; the board cannot be the consumer |
| W5 | 1145 | NuttX, ThreadX, ESP32 — one port per commit |
| W6 | 1198 | `MAX_NODES`/`MAX_SC` undeclared: a constant 12,416 B per FreeRTOS backing |
| W7 | 1255 | the arena prices every subscription at one global type bound |

Ordered by consequence: images that do not boot first; then W3+W4 together, because they reduce one heap budget and re-deriving it in two PRs is how it ends up wrong.

## Homed in existing phases
- **phase-412**: 1036, 1130, 1142, 1181
- **phase-392**: 0810, 0815, 1147, 1179, 1180
- already homed, now named in the ledger: 0814 (433), 0816 (391), 0880 (392), 1228/1252 (439)

Three of these were in phase-392 only as W6 hand-offs ("→ issue 1146") — a hand-off, not a work item. Each homed issue gains its phase in `related:`.

## Ledger drift, corrected (third time)
392 W6 "in flight" five days after landing; 0973 and 1028 "in flight" after resolution; 1125 and 1131 "open" after archiving. Phase-392's own status still read "Open: W6". Every error made finished work look available.

## Three ids, one defect, already fixed — archived
1183 / 1185 / 1186 all report the backing-latch test red in the shared process. `605d667eb` fixed it 2026-09-06, naming two of the three and archiving none. Verified before archiving, because an `#[ignore]` whose reason says "run via the lane" is dead coverage until the lane is shown to run it:
- the test still exists — `backing.rs:240`;
- `just check node-std-tests` runs it alone (`lanes.just:1709`, `--ignored --exact`) and passed it live: `1 passed; … 447 filtered out`.

## Gates
roadmap-status, roadmap-claims, roadmap-boxes, prose-issue-refs, doc-recipe-refs, issue-ids, archived-issue-status — all green.

**Heads-up:** #820 also inserts into phase-412's homed-table region. Whichever lands second may need a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2SAAWku4WZWQwpkt8qNxk