### PR TITLE
feat(phase-436 A3): per-window jitter readout for C entries, and what the idle A/B measured

### DIFF
--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -496,11 +496,56 @@ watched run.
     loop can declare its cadence without over-claiming.
   * **Left for A3:** the ASI side printing these on a cadence.
 
-* **A3 — a loaded FVP cross-check.** Run the control loop under load and
-  compare `release_jitter()` and `last_park()` against an independent CTF
-  capture of the same run. **Exit:** the probe's maximum and the trace's agree
-  within the declared `release_jitter_granularity_us()`, and a disagreement
-  is explained, not averaged away.
+* **A3 — a loaded FVP cross-check. IN PROGRESS: the readout is live on ASI,
+  an idle A/B is measured, and the loaded run is next.** ASI's
+  `controller_pkg::Controller` wrapper prints one `rt-probe:` line per
+  window, behind `CONFIG_ASI_RT_PROBE_REPORT`, which `tracing_stats.conf`
+  turns on. Four things were established before the loaded run, each changing
+  what it can claim:
+
+  * **The probe and the trace share a clock, so the comparison is
+    self-consistent and not absolute.** With
+    `CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER=y` on the ARM arch timer, the
+    executor's clock is `k_cycle_get_64()` and CTF stamps events with
+    `k_cycle_get_32()` (`ctf_top.h:55`), both CNTVCT. ASI's
+    `rt_evaluation_zephyr.rst` records that the FVP advances that counter
+    during WFI at a rate unrelated to elapsed time, and that the image is SMP
+    while CTF events carry no CPU id. So A3 on FVP can check that the probe
+    measures the right thing in the right place. Absolute latency needs
+    silicon (S32Z), or a short, low-idle capture under the 4.295 s wrap.
+  * **E4 measured.** Same painted image, idle boot, with and without E4:
+
+    | | without E4 | with E4 |
+    |---|---|---|
+    | wakes per second (declared cadence 5 ms) | ~26.7 | ~162 |
+    | `timer-overrun-runtime` | ~6.5/s | ~0.2/s |
+    | `main` CPU (thread analyzer) | 15-19 % | 1 % |
+    | `main` average frame (counter ticks) | ~747 k | ~40 k |
+
+    The analyzer reports 458 992 unused bytes on `main`'s stack, which is the
+    length of every pre-E4 scan. Painted builds on any pin between #529
+    (which arms the bound) and E4 run this way. That includes ASI's pinned
+    `--trace-stats` / `--trace` lanes at the time of writing.
+  * **The since-boot maximum is pinned by boot.** Both runs report
+    `jitter_max_us` of about 34 ms, set at ~10 s and never exceeded, so the
+    cumulative figure describes startup and hides the steady state.
+    `nros_cpp_executor_clear_release_jitter_stats` exposes the existing Rust
+    `clear_release_jitter_stats`, and the ASI readout clears after every
+    report, so each line covers its own `window_ms`.
+  * **A2c — open: `late_wakes` ignores the granularity it reports.** A wake
+    counts as late at `interval - nominal > 0`, one microsecond over. On a
+    loop paced by a relative `spin_once` timeout, every interval is nominal
+    plus work plus tick rounding, so about 99 % of wakes count as late with E4
+    in. A captured example: `park_bound_us=27 park_achieved_us=1000` is a
+    timer 27 us away rounded up to the 1 ms tick by design. The executor
+    already says the figure is worth `granularity_us=1000`; the count should
+    agree with it (for example, a separate count of wakes late beyond one
+    granule). This is A2b's coupling, showing in a number.
+
+  **Exit:** a loaded `--drive` run on an E4 build, with the windowed readout
+  and a CTF capture of the same run. The probe's per-window maximum and the
+  trace's activation lateness must agree within `granularity_us` on the shared
+  counter, and any disagreement must be explained, not averaged away.
 
 ### Path B — Deadline sources: the unused half of the seam.
 

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -1639,6 +1639,20 @@ nros_cpp_ret_t nros_cpp_executor_last_park(void *handle,
                                            uint8_t *platform_index);
 
 /**
+ * phase-436 A3 — reset the release-jitter statistics from a C or C++ entry.
+ *
+ * The executor's maximum, late count and total are since the executor opened,
+ * so a single startup outlier pins the maximum for the life of the process.
+ * Measured on ASI's FVP image: a ~34 ms wake during boot, and nothing in the
+ * steady state could ever show above it. A readout that reports per window
+ * calls this after each report, so every report covers its own window.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL.
+ */
+nros_cpp_ret_t nros_cpp_executor_clear_release_jitter_stats(void *handle);
+
+/**
  * Get current monotonic time in nanoseconds.
  *
  * Used by `nros::Future::wait()` (header-side) to budget its spin loop by

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3981,6 +3981,28 @@ pub unsafe extern "C" fn nros_cpp_executor_last_park(
     NROS_CPP_RET_OK
 }
 
+/// phase-436 A3 — reset the release-jitter statistics from a C or C++ entry.
+///
+/// The executor's maximum, late count and total are since the executor opened,
+/// so a single startup outlier pins the maximum for the life of the process.
+/// Measured on ASI's FVP image: a ~34 ms wake during boot, and nothing in the
+/// steady state could ever show above it. A readout that reports per window
+/// calls this after each report, so every report covers its own window.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_clear_release_jitter_stats(
+    handle: *mut c_void,
+) -> nros_cpp_ret_t {
+    let Some(ctx) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    ctx.executor.clear_release_jitter_stats();
+    NROS_CPP_RET_OK
+}
+
 /// Phase 274.W2 (RFC-0015 Model 1) — run a native multi-tier entry over one
 /// shared RMW session.
 ///
@@ -4763,5 +4785,13 @@ mod jitter_readout_tests {
             (7, 7, 7, 7),
             "a refused call wrote its outputs"
         );
+    }
+
+    /// phase-436 A3 — a readout that reports per window must be able to reset
+    /// the statistics, or one boot-time outlier pins the maximum forever.
+    #[test]
+    fn clearing_the_jitter_stats_refuses_a_null_handle() {
+        let rc = unsafe { nros_cpp_executor_clear_release_jitter_stats(core::ptr::null_mut()) };
+        assert_eq!(rc, NROS_CPP_RET_INVALID_ARGUMENT);
     }
 }


### PR DESCRIPTION
Based on #881 (E3 + E4). Until #881 merges, this diff includes its 4 commits; **review only the top two**. The queue drops the carried commits by patch-id. Do not queue this while #881 is in the queue: the duplicated patches would make it unmergeable, as happened with #879 and #871.

## A3: a per-window jitter readout, and what the idle A/B on ASI established

**Code:** `nros_cpp_executor_clear_release_jitter_stats(handle)` exposes the existing Rust `clear_release_jitter_stats()` in the A2 accessors' shape. The executor's release-jitter figures are counted since it opened. On ASI's FVP image a ~34 ms wake at boot pinned the maximum for the whole run, and nothing in the steady state could show above it. ASI's readout now clears after each report, so every `rt-probe:` line covers its own window.

**Doc:** A3 now records four things:
- The probe and the CTF trace share CNTVCT on FVP (`k_cycle_get_64` / `_32`). So A3 there is a self-consistent check, not absolute latency.
- **E4 measured** on the same painted image, idle, with and without it: ~26.7 → ~162 wakes/s, timer overruns ~6.5/s → ~0.2/s, `main` CPU 15–19 % → 1 %. Each pre-E4 query scanned 458 992 unused bytes.
- The since-boot maximum was pinned by boot, which is the reason for this PR.
- **A2c (open):** `late_wakes` counts any overshoot of 1 µs or more, while the executor reports `granularity_us=1000`. So a wait-paced loop reads ~99 % late. For example, a 27 µs timer park is rounded up to the 1 ms tick by design.

## Verified locally

- Test-first: the null-handle test failed to compile on exactly the missing function, then passed (3/3 readout tests).
- `just regen-c-headers` → `check-cbindgen-headers` OK: one new declaration, nothing else.
- clippy `-D warnings`, nightly fmt, `check-api-parity` rc 0, roadmap gates OK.
- The E4 A/B figures come from two 150 s idle FVP boots of ASI's `--trace-stats` image, built fresh on `30293e5c8` (main, no E4) and on `248d75f66` (#881, E4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
