### PR TITLE
fix(#1287): the Zephyr C++ feature string spells alloc with param-services

### DIFF
--- a/changelog.d/1287.fix.md
+++ b/changelog.d/1287.fix.md
@@ -1,0 +1,4 @@
+A Zephyr C++ image on zenoh that declares `param_services` builds again. The
+C++ feature string now spells `alloc` next to `param-services`, so the nros-c
+library built for C++ gets both, instead of stopping at "`param-services`
+allocates: add \"alloc\" to this crate's features".

--- a/docs/issues/archived/1287-zephyr-cpp-param-services-without-alloc.md
+++ b/docs/issues/archived/1287-zephyr-cpp-param-services-without-alloc.md
@@ -1,0 +1,48 @@
+---
+id: 1287
+title: "A Zephyr C++ image on zenoh with param_services fails to compile: nros-c
+  is built with param-services and without alloc"
+status: resolved
+type: bug
+area: build, zephyr
+severity: medium
+resolved_in: "fix(#1287): the Zephyr C++ feature string spells alloc with param-services"
+related: [issue-0730, issue-0745]
+---
+
+## What happens
+
+A Zephyr C++ image on the zenoh backend that declares `param_services` stops
+at:
+
+```
+compile_error!("`param-services` allocates: add \"alloc\" to this crate's features");
+```
+
+(`nros-node/src/lib.rs`). Measured on Autoware Safety Island's MR-CANHUBK344
+image (zenoh, four C++ component nodes, `param_services` declared): it fails
+with this error without the change below and builds with it.
+
+## Why
+
+`zephyr/CMakeLists.txt` builds the C++ feature string per backend. The xrce
+and cyclonedds strings spell `alloc`; the zenoh string does not, because
+nros-rmw-zenoh carries it transitively (the shape issue 0730 warned about).
+The issue 0745 mirror then appends `param-services` when the consumer passes
+`param_services` in `NANO_ROS_FEATURES`.
+
+The nros-c library built for C++ does not inherit that transitive `alloc`: it
+copies `alloc` and `param-services` into its own feature string only when the
+C++ string SPELLS them (`if(_nros_cpp_features MATCHES "(^|,)alloc(,|$)")`).
+So on zenoh it got `param-services` and no `alloc`, and nros-node's
+requirement check refused.
+
+## Fix
+
+Append `alloc` together with `param-services`, where the capability is
+added. That is the phase-361 W8.e rule: a capability names its requirement,
+it never relies on something else having switched it on.
+
+The Rust facade's own param-services compile failure (the discarded
+`declare_parameter` result) is a different defect, fixed on main by
+`eb8111ad1`.

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -625,8 +625,17 @@ if(CONFIG_NROS_CPP_API)
     # launch-param seeds link) + the directory-wide define ComponentNode's
     # seed-adoption gates on. Follow-up: resolve from the entry's BRINGUP
     # like nano_ros_workspace(SYSTEM ...) does.
+    #
+    # Issue 1287 -- `alloc` goes WITH it. `param-services` requires alloc
+    # (nros-node/src/lib.rs `compile_error!`; phase-361 W8.e: a capability
+    # names its requirement, it never switches it on), and the zenoh string
+    # above carries alloc only TRANSITIVELY, through nros-rmw-zenoh -- the
+    # shape the xrce and cyclonedds notes above warn about. The C-for-C++
+    # nros-c build below copies `alloc` only when THIS string spells it, so
+    # a Zephyr zenoh C++ image with param_services built nros-c with
+    # param-services and without alloc, and stopped at that compile_error.
     if("param_services" IN_LIST NANO_ROS_FEATURES)
-        string(APPEND _nros_cpp_features ",param-services")
+        string(APPEND _nros_cpp_features ",alloc,param-services")
         add_compile_definitions(NROS_SYSTEM_PARAM_SERVICES)
     endif()
 


### PR DESCRIPTION
A Zephyr C++ image on zenoh that declares `param_services` fails to compile at nros-node's requirement check:

```
compile_error!("`param-services` allocates: add \"alloc\" to this crate's features");
```

## Why
- The zenoh C++ feature string in `zephyr/CMakeLists.txt` does not spell `alloc`; it gets it transitively through nros-rmw-zenoh. The xrce and cyclonedds strings spell it.
- The issue 0745 mirror appends `param-services` to that string.
- The nros-c library built for C++ copies `alloc` and `param-services` into its own features only when the C++ string spells them. So on zenoh it got `param-services` without `alloc`.

## Fix
One line: append `alloc` together with `param-services` (phase-361 W8.e: a capability names its requirement). Issue 1287 is filed in `archived/` with this PR, plus a changelog fragment.

## Evidence
Autoware Safety Island's MR-CANHUBK344 image (zenoh, four C++ component nodes, `param_services`) fails with the error above without this line and builds with it. The island has been carrying this exact line as a local submodule patch.

## Relation to PR 843
Split out of PR 843, which is held. The Rust half of 843's original problem was fixed on main by eb8111ad1. After this lands, 843's `zephyr/CMakeLists.txt` hunk is redundant.

`just check fast`: 293 of 295. The two failures, `capability-conditionals` and `xrce-vendored-versions`, happen only because this bare worktree lacks the zenoh-pico submodule and the vendored XRCE trees. Pushed with `NROS_SKIP_PREPUSH_CHECKS=1` for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKY5TGsRzN9SVs1e4c8BoH