### PR TITLE
docs(phase-426, phase-428): the status lines said Planned over landed work

### DIFF
--- a/docs/roadmap/phase-426-parameters-rust-ssot.md
+++ b/docs/roadmap/phase-426-parameters-rust-ssot.md
@@ -1,6 +1,23 @@
 # Phase 426 — parameters get a Rust SSoT, and `ros2 param list` works
 
-**Status (2026-09-05). Planned.** Implements RFC-0089 §"Parameters:
+**Status (2026-09-11). W1–W6 each LANDED on main; per-item acceptance not
+re-audited here.** The line read "Planned" for six days after the work went in, so
+the evidence is the commits:
+- W1: 4 commits.
+- W2: `30f5e9f941`.
+- W3: 6 commits.
+- W4: `3bf30405f1` deleted both C++ stores, and `98f0f5de7e` taught the parameter FFI which node is asking.
+- W5: `1505290ecd`.
+- W6: `3e3f1ef2db`.
+
+Run `git log --grep='phase-426 W'` for the full list. There is one known hole in the
+promise this phase makes. On Cyclone, the parameter services never start, so
+`ros2 param list` sees the parameters on zenoh only. That is issue 1268, owned by
+[phase-444](phase-444-rmw-fix-up.md) W6. The remaining user-API parameter gaps (27
+ledger rows: descriptors, callbacks, undeclare) are listed in phase-444 § "The ROS 2
+gap list".
+
+Implements RFC-0089 §"Parameters:
 feature-complete, Rust-side SSoT" and RFC-0019/0020's rule that behaviour lives
 in Rust and the C/C++ APIs are thin wrappers. Closes the C++ half of issue 0793.
 

--- a/docs/roadmap/phase-428-api-porting-principle-sweep.md
+++ b/docs/roadmap/phase-428-api-porting-principle-sweep.md
@@ -1,6 +1,17 @@
 # Phase 428 — sweep the C, C++ and Rust APIs against the porting principle
 
-**Status (2026-09-05). RMW sweep DONE; findings below. User-API sweep planned.** Audits all three user APIs against RFC-0089's
+**Status (2026-09-11). Both sweeps DONE. The findings are ledgered and the checkable
+ones are gated; the fixes live elsewhere.** The user-API sweep was not "planned"; it
+ran:
+- W1–W4: `f018804434`. The extractor now sees our adopted names, and four audits were filed.
+- W5: `86792f9ead`, 82 ledger rows. Six of the recorded findings were wrong and corrected there.
+- W6's gates landed: the return-type verdict, `--require-disposition`, `#[must_use]` where a bool reports failure, and the orphan-citation gate.
+- W10 (one QoS SSoT) and W13.a/b/d landed.
+
+What is left is FIXING the findings. That work is not this phase's. The 22 behaviour
+defects still live under shared names (re-read in code on 2026-09-11) are listed in
+[phase-444](phase-444-rmw-fix-up.md) § "The ROS 2 gap list", group 1, and belong to
+phase-417 stage 3. Audits all three user APIs against RFC-0089's
 governing principle. Not a rename pass — a conformance review that produces
 findings, each of which becomes a work item somewhere else.
 


### PR DESCRIPTION
Phase-426 read **Planned** while all six work items had commits on main. Phase-428 read **User-API sweep planned** while W1–W6 had landed. Both status lines now cite the commits and name the one known hole: #1268, Cyclone parameter services, owned by phase-444 W6. Both point to phase-444's gap list (PR #901) for what is left. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lee2SrWhASryz9dd5F28mS