### PR TITLE
fix(#1285): one board key -> family table; an unknown key is an error

### DIFF
--- a/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
+++ b/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
@@ -637,6 +637,14 @@ pack today does not (it calls `nros_board_native_run_components_named`). The
 NEUTRAL fact is the board IDENTITY plus its boot shape; how that becomes a call
 is a pack's business — a class path in C++, a function symbol in C and Zig.
 
+**Status: fixed.** `LoweredEntry` carries only the board KEY. Each pack spells
+the call: C++ `board_cpp_path`, and Rust `nros_orchestration_ir::BOARD_PATHS`.
+C reads `BoardFamily::c_abi_runners`, because a C symbol name is part of the C
+ABI, not of any one template. The fact underneath, key → family, was still
+derived four times after that fix, and the four disagreed. Issue 1285 made it
+one table, `nros_entry_lower::BOARD_KEYS`, and an unknown key is now an error
+rather than the host.
+
 ### Defect 2 — escaping cannot be done in Stage 2
 
 §4 says Stage 2 escapes every literal, on the grounds that quoting is a

--- a/docs/issues/archived/1285-board-key-family-mapped-four-times.md
+++ b/docs/issues/archived/1285-board-key-family-mapped-four-times.md
@@ -1,0 +1,210 @@
+---
+id: 1285
+title: "The board key -> board family mapping is spelled four times, and the four
+  disagree"
+status: resolved
+type: tech-debt
+area: cli, codegen
+severity: low
+resolved_in: "fix(#1285): one board key -> family table; an unknown key is an error"
+related: [issue-1283, issue-1286, phase-432, rfc-0091]
+---
+
+## What happens
+
+RFC-0091 §8b Defect 1, as written, is fixed. It was a C++ path spelling in a
+view every pack shared. `LoweredEntry` now carries only the board key, and each
+language's spelling lives in its own pack: C++ `board_cpp_path`, Rust
+`board_path_for`, C `c_runner_names`.
+
+The fact underneath, "which family is this board key?", is still derived four
+times:
+
+| site | how | unknown key |
+| --- | --- | --- |
+| `nros-entry-lower` `board_family` | match on key | falls to `Native` |
+| Rust pack `board_path_for` | its own key set | refuses (proc-macro) |
+| `nros-cli-core` `codegen/entry/mod.rs` `board_to_rtos` | SUBSTRING match | `posix` |
+| `known_boards_csv` | its own list | n/a |
+
+They disagree. `board_to_rtos` sends `s32z270`, `an536`, `armfvp` and
+`fvp-aemv8r-smp` to `posix`, and `board_family`'s fallback turns ANY unknown key
+into `Native`. That makes an embedded key a C entry does not know look like a
+host build.
+
+Second defect on the same seam: `emit_c.rs`'s `c_runner_names` has a ThreadX arm
+naming two runner symbols that do not exist, and nothing ties the table to
+`BoardFamily::has_c_run_components()`. The table and the routing predicate can
+disagree, and today they only agree by accident.
+
+## Why it is latent, not live
+
+Audited 2026-09-11: no in-tree C or C++ entry passes a key the four disagree on.
+- CMake (`NanoRosEntry.cmake` around lines 180–200) passes only `native` or
+  `zephyr`.
+- The multi_pkg fixtures with keys `board_family` does not know are Rust-only
+  (`freertos`, which the proc-macro refuses on an unknown key) or declare no
+  entry (`nuttx`, `esp_idf`).
+
+So nothing is wrong today. It becomes wrong the first time someone copies a Rust
+board key into a C workspace.
+
+## Fix
+
+- ONE table, key -> `BoardFamily`. `board_family`, `board_to_rtos` and
+  `known_boards_csv` derive from it. The Rust pack's key set is checked against
+  it, or derives from it too.
+- An unknown key is an ERROR naming the known keys, never `Native`.
+- `BoardFamily::c_abi_runners() -> Option<CAbiRunners>`, with `run_components`
+  and `run_tiers` each their own `Option` (ThreadX will have the first and not
+  the second, issue 1286). `has_c_run_components()` becomes
+  `c_abi_runners().is_some()`, and `c_runner_names` is deleted, taking the
+  invented ThreadX symbols with it.
+
+## Acceptance
+
+- A test that every key in the table maps to the same family through every
+  consumer, and that an unknown key errors.
+- Regression cases for the four substring victims above.
+
+## Resolution
+
+### The measured table, before the fix
+
+Every key any of the four sites knew, and what each site answered. Bold marks a
+wrong answer. The ZST column is the Rust pack's `board_path_for`. "csv" is
+whether the proc-macro's hand-written `known_boards_csv` listed the key.
+
+| key | `board_family` | `board_to_rtos` | Rust ZST (its family) | csv |
+| --- | --- | --- | --- | --- |
+| `native` | Native | posix | `LinuxBoard` (native) | yes |
+| `posix` | Native | posix | `LinuxBoard` (native) | **no** |
+| `zephyr` | Zephyr | zephyr | `ZephyrBoard` (zephyr) | yes |
+| `fvp-aemv8r-smp` | Zephyr | **posix** | — | — |
+| `armfvp` | Zephyr | **posix** | — | — |
+| `nuttx` | Nuttx | nuttx | `NuttxQemu` (nuttx) | yes |
+| `qemu-armv7a-nuttx` | Nuttx | nuttx | `NuttxQemu` (nuttx) | **no** |
+| `rv-virt-nuttx` | Nuttx | nuttx | `NuttxQemu` (nuttx) | **no** |
+| `nuttx-riscv` | **Native** (fallback) | nuttx | `NuttxQemu` (nuttx) | yes |
+| `freertos` | Freertos | freertos | `Mps2An385` (freertos) | yes |
+| `mps2-an385-freertos` | Freertos | freertos | `Mps2An385` (freertos) | **no** |
+| `freertos-qemu-mps2-an385` | **Native** (fallback) | freertos | `Mps2An385` (freertos) | **no** |
+| `freertos-posix` | Freertos | freertos | — | — |
+| `s32z270-freertos` | Freertos | freertos | — | — |
+| `s32z270` | Freertos | **posix** | — | — |
+| `mps3-an536-freertos` | Freertos | freertos | — | — |
+| `an536` | Freertos | **posix** | — | — |
+| `threadx` | Threadx | threadx | — | — |
+| `threadx-linux` | Threadx | threadx | `ThreadxLinux` (threadx) | yes |
+| `threadx-qemu-riscv64` | Threadx | threadx | `ThreadxQemuRiscv64` (threadx) | yes |
+| `rv-virt-threadx` | Threadx | threadx | `ThreadxQemuRiscv64` (threadx) | **no** |
+| `esp32-qemu` | **Native** (fallback) | posix | `Esp32QemuEntry` (no RTOS) | yes |
+| `esp32-c3-baremetal` | **Native** (fallback) | posix | `Esp32QemuEntry` (no RTOS) | **no** |
+| `rtic-mps2-an385` | **Native** (fallback) | posix | `RticMps2An385` (no RTOS) | yes |
+| `qemu-rtic-mps2-an385` | **Native** (fallback) | posix | `RticMps2An385` (no RTOS) | **no** |
+| `qemu-mps2-an385` | **Native** (fallback) | posix | `Mps2An385` bare (no RTOS) | yes |
+| `mps2-an385` | **Native** (fallback) | posix | `Mps2An385` bare (no RTOS) | yes |
+
+Three things the table shows that the issue text did not:
+
+- Two real RTOS keys were known only to the Rust pack: `nuttx-riscv` and
+  `freertos-qemu-mps2-an385`. `board_family` sent them to `Native`, while
+  `board_to_rtos` got them right, and only because its substring match happened
+  to fit.
+- `known_boards_csv`, the message printed when the macro REFUSES a key, listed
+  11 of the 19 keys the macro ACCEPTS. The 8 it omitted all resolved.
+- The old ThreadX arm of `c_runner_names` named `nros_board_threadx_run_tiers`,
+  which is defined nowhere, and `nros_board_rtos_run_components`, which exists
+  but is linked only by the FreeRTOS, NuttX and Zephyr boards (`build.rs` / board
+  cmake). No ThreadX image has either symbol.
+
+### What changed
+
+- **One table.** It is `nros_entry_lower::BOARD_KEYS: &[(&str, BoardFamily)]`,
+  21 rows: the 19 the C++ emitter knew plus `nuttx-riscv` and
+  `freertos-qemu-mps2-an385`. It lives in `nros-entry-lower` because that is the
+  lowest crate every consumer already depends on. Both `nros-cli-core` and
+  `nros-macros` do, and the crate is serde-only, so the proc-macro can afford
+  it. `known_board_keys()` iterates the table.
+  - `board_family(key) -> Result<BoardFamily, UnknownBoard>` reads the table.
+    `UnknownBoard`'s `Display` names every known key.
+  - `board_to_rtos(key)` is now
+    `board_family(key).map(BoardFamily::tier_rtos_key)`, which gives `posix` for
+    the host and `as_str()` for the rest. The substring match is gone.
+- **The Rust pack keeps its own key set, and a test checks it against the
+  table.**
+  - `nros_orchestration_ir::board_path_for` is now a lookup in
+    `pub const BOARD_PATHS: &[(&str, &str)]`. The ZST paths are Rust-pack
+    spelling and stay in their own crate.
+  - `known_boards_csv` is derived from `BOARD_PATHS`. It is NOT derived from the
+    family table, which would list keys the macro refuses (`s32z270`,
+    `freertos-posix`) and drop keys it accepts (`esp32-qemu`,
+    `rtic-mps2-an385`).
+  - `nros-cli-core/tests/board_key_table.rs` gives each Rust ZST a family, and
+    `None` for the three no-RTOS boards. It asserts that every Rust key naming
+    an RTOS board is in `BOARD_KEYS` with that family, that every no-RTOS key is
+    absent, and that the family-only keys are exactly the 8 C/C++ spellings.
+- **An unknown key is an error at every family consumer. Each one was traced:**
+  - `pack::entry_pack_for` returns `Err(message)`. `nros codegen entry-pack`
+    prints it, and `NanoRosEntry.cmake` raises it as a FATAL_ERROR.
+  - `cmd/codegen.rs`, the typed `nros codegen entry`, resolves the family once
+    before tier resolution and before the C/C++ dispatch.
+  - `emit_c::emit_typed` refuses with the known-keys message.
+  - `emit_cpp::emit_typed_with_tail` refuses first. Every public entry point
+    funnels through it, so the private `board_*` helpers can rely on a key that
+    has already been validated.
+  - `LoweredEntry::family()` returns the `Result`.
+  - `plan_from_model` is the one DELIBERATE non-refuser, and the comment there
+    says why. It is shared with `nros build`'s Rust entry generation, where the
+    key is any Rust or out-of-tree board (`esp32-c3-baremetal`, `stm32f4` in its
+    own test) and only the node list is read. Refusing there would stop
+    generating those entries. So an unknown key resolves each tier from its
+    platform-neutral head, via `TierDef::platform("")`, which selects no
+    sub-table, rather than from `posix`'s sub-table. Every path that needs the
+    family refuses the key itself.
+- **In-tree callers still resolve.**
+  - CMake passes `native` or `zephyr` to `entry-pack` and `codegen entry`
+    (`BOARD native`/`BOARD zephyr` are the only literals, and the derived value
+    is `zephyr`).
+  - `_nros_node_register_entry_tu` passes the five family names.
+  - `nros build` reaches `plan_from_model` only for Cargo-driven images, and the
+    `native_sim/native/64` images all have a hand-written `zephyr_entry`.
+- **`BoardFamily::c_abi_runners() -> Option<CAbiRunners>`**, where
+  `CAbiRunners { run_components: Option<&'static str>, run_tiers: Option<&'static str> }`.
+  Native, FreeRTOS, Zephyr and NuttX name the symbols defined in
+  `nros-cpp/src/lib.rs` (native), `nros-board-common/c/nros_rtos_run_components.c`
+  and `nros-board-{freertos,zephyr,nuttx-qemu}/c/*_run_tiers.c`. ThreadX is
+  `None`, which is unchanged behaviour: a ThreadX C entry is still routed to C++.
+  - `has_c_run_components()` is derived as "`run_components` is `Some`".
+  - `c_runner_names` is deleted, and `emit_c` reads `c_abi_runners`. A tiered C
+    entry on a family with `run_components` but no `run_tiers` is refused. That
+    is the shape issue 1286 will create.
+  - A test greps the board C sources and `nros-cpp` for a definition of every
+    named symbol. Its negative control asserts that the scan does NOT find
+    `nros_board_threadx_run_tiers`.
+
+No golden changed: `every_emitter_matches_its_golden` and
+`every_parity_case_matches_its_golden` pass on the unchanged files, because
+every emitted name is the same string the deleted table produced.
+
+### Siblings found by the sweep, not fixed here
+
+`grep -rnE 'contains\("(freertos|zephyr|nuttx|threadx)"\)|=> "posix"' packages/cli packages/core`
+finds the same substring shape in three more places. None of them reads a key
+from the ENTRY namespace this table models:
+
+- `nros-macros` `derive_target_rtos`: it takes the Rust deploy key and falls
+  back to `posix`. For every in-tree Rust key it now gives the answer the table
+  gives. Making it read the table would change the answer for an OUT-OF-TREE key
+  whose name contains an RTOS name, and that key has no row to move to. This is
+  worth doing with an explicit out-of-tree story.
+- `orchestration/tier_resolver.rs` `derive_target_rtos` reads the IMAGE board,
+  which is the board-catalog namespace (`native_sim/native/64` is a Zephyr
+  board id there). It answers `posix` for that key, and
+  `examples/workspaces/realtime-{c,cpp}` declare Zephyr tiers on such an image.
+  It is latent today: the in-tree `codegen-system` invocations pass no
+  `--target`. Its own doc names the right fix, which is
+  `BoardDescriptor::platform` from the catalog, not this table.
+- `emit_rust::emit` falls back to `LinuxBoard` for a key `board_path_for` does
+  not know. Only the golden harness reaches it, because the Rust entry verb is
+  retired (phase-432 W2.4).

--- a/packages/cli/nros-cli-core/src/cmd/codegen.rs
+++ b/packages/cli/nros-cli-core/src/cmd/codegen.rs
@@ -96,9 +96,11 @@ pub enum Sub {
     ///
     /// This exists so `NanoRosEntry.cmake` stops re-deriving them. It used to
     /// key on `NANO_ROS_PLATFORM != "posix"` while the dispatch keyed on the
-    /// BOARD, and `board_family()` answers `native` for any key it does not
-    /// know — so an unlearned board is embedded to one and native to the
-    /// other, and the CLI writes a C TU into a file CMake named `.cpp`.
+    /// BOARD, and `board_family()` answered `native` for any key it did not
+    /// know — so an unlearned board was embedded to one and native to the
+    /// other, and the CLI wrote a C TU into a file CMake named `.cpp`. An
+    /// unknown key is now an error naming the known ones (issue 1285), which
+    /// CMake reports as a FATAL_ERROR at configure.
     #[command(name = "entry-pack")]
     EntryPack(EntryPackArgs),
 }
@@ -362,8 +364,11 @@ fn run_entry(args: EntryArgs) -> Result<()> {
         entry_codegen::metadata::enrich_plan(&mut plan, &index)?;
         // Phase 269 (W4) — resolve tiers + stamp PlanNode.sched_context after
         // enrich_plan has populated PlanNode.callback_groups from cmake metadata.
-        let target_rtos = entry_codegen::board_to_rtos(&plan.board).to_string();
-        entry_codegen::resolve_plan_sched(&mut plan, &target_rtos)?;
+        // Issue 1285 — a typed C/C++ entry needs the board's FAMILY (its
+        // runner, its boot shape, its tier sub-table), so an unknown key stops
+        // here, naming the known ones, instead of reading as `posix`/`native`.
+        let family = nros_entry_lower::board_family(&plan.board).map_err(|e| eyre!("{e}"))?;
+        entry_codegen::resolve_plan_sched(&mut plan, family.tier_rtos_key())?;
         match lang {
             // phase-263 C2 (issue 0097) — the C emitter is native-only (it emits a
             // pure-`.c` TU calling the C `nros_board_native_run_components`). The
@@ -373,9 +378,7 @@ fn run_entry(args: EntryArgs) -> Result<()> {
             // — exactly the single-node `threadx_entry_main_c_typed.cpp.in` shape). The
             // cmake side (`nano_ros_entry`) gives the `.out` a `.cpp` extension + links
             // `NanoRosCpp` for an embedded C entry.
-            entry_codegen::Lang::C
-                if nros_entry_lower::board_family(&plan.board).has_c_run_components() =>
-            {
+            entry_codegen::Lang::C if family.has_c_run_components() => {
                 entry_codegen::emit_c::emit_typed(&plan).map_err(|e| eyre!("{e}"))?
             }
             // phase-432 W3.1 — SAY that the routing fired.

--- a/packages/cli/nros-cli-core/src/codegen/entry/emit_c.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/emit_c.rs
@@ -69,56 +69,21 @@ struct CEntryView {
 /// native-only — `int main(argc, argv)` calling `nros_board_native_*` — because
 /// an embedded C entry was routed to the C++ pack before it reached here.
 ///
-/// The runner names are carried rather than derived from a prefix: the C ABI
-/// does not name them uniformly (`native` keeps the `_named` suffix its
-/// two-overload history left behind; the RTOS runners have no such pair), so a
-/// prefix rule would be a second, guessing spelling of a fact this module
-/// already holds exactly.
+/// The runner names come from `BoardFamily::c_abi_runners` in
+/// `nros-entry-lower` (issue 1285), which is also where the routing predicate
+/// reads them from. Each is `Option` because a family may ship one runner and
+/// not the other (issue 1286). The template names `run_tiers_fn` only inside
+/// its `boot.tiers` branch, and the emitter refuses a tiered plan whose family
+/// has none, so a `None` is never rendered.
 #[derive(serde::Serialize)]
 struct CBootView {
     /// `"kernel"` | `"app"` | `"host"` — `BootShape`'s single derivation,
     /// the same one the C++ pack reads.
     shape: &'static str,
-    run_components_fn: &'static str,
-    run_tiers_fn: &'static str,
+    run_components_fn: Option<&'static str>,
+    run_tiers_fn: Option<&'static str>,
     tiers: bool,
     n_tiers: usize,
-}
-
-/// The C-ABI runner names for a board family.
-///
-/// Only families whose `has_c_run_components()` is true can reach here with a
-/// C entry — the emitter refuses the rest above — so the arms for the others
-/// exist to keep this total, not because they are reachable. They name the
-/// symbol each family WOULD export, so adding a board's runner is a one-line
-/// change here and in the predicate rather than a new match.
-fn c_runner_names(board: &str) -> (&'static str, &'static str) {
-    match nros_entry_lower::board_family(board) {
-        nros_entry_lower::BoardFamily::Native => (
-            "nros_board_native_run_components_named",
-            "nros_board_native_run_tiers",
-        ),
-        // Every RTOS shares ONE `run_components` — the single-executor path
-        // differs only in a per-tick yield — while `run_tiers` is genuinely
-        // per-board, because a FreeRTOS task, a Zephyr `k_thread` and a NuttX
-        // pthread are three different things.
-        nros_entry_lower::BoardFamily::Freertos => (
-            "nros_board_rtos_run_components",
-            "nros_board_freertos_run_tiers",
-        ),
-        nros_entry_lower::BoardFamily::Zephyr => (
-            "nros_board_rtos_run_components",
-            "nros_board_zephyr_run_tiers",
-        ),
-        nros_entry_lower::BoardFamily::Nuttx => (
-            "nros_board_rtos_run_components",
-            "nros_board_nuttx_run_tiers",
-        ),
-        nros_entry_lower::BoardFamily::Threadx => (
-            "nros_board_rtos_run_components",
-            "nros_board_threadx_run_tiers",
-        ),
-    }
 }
 
 #[derive(serde::Serialize)]
@@ -194,7 +159,12 @@ pub fn emit_typed(plan: &Plan) -> Result<String, String> {
     //
     // W3.1 is the item that lifts this: give each RTOS board a C-ABI
     // `run_components` and the refusal narrows to what still lacks one.
-    if !nros_entry_lower::board_family(&plan.board).has_c_run_components() {
+    let family = nros_entry_lower::board_family(&plan.board)
+        .map_err(|e| format!("typed C entry emit: {e}"))?;
+    let Some(runners) = family
+        .c_abi_runners()
+        .filter(|r| r.run_components.is_some())
+    else {
         return Err(format!(
             "typed C entry emit: board `{}` has no C-ABI `run_components` — the C \
              board surface is native-only, so this emitter would name \
@@ -205,7 +175,7 @@ pub fn emit_typed(plan: &Plan) -> Result<String, String> {
              W3.1 is the item that would give this board a C runner.",
             plan.board, plan.board,
         ));
-    }
+    };
 
     for n in &plan.nodes {
         if !is_c_node(n) {
@@ -326,20 +296,23 @@ pub fn emit_typed(plan: &Plan) -> Result<String, String> {
             _ => None,
         },
         services: services_view(plan),
-        app_main_include: matches!(
-            nros_entry_lower::board_family(&plan.board).boot_shape(),
-            nros_entry_lower::BootShape::App
-        ),
+        app_main_include: matches!(family.boot_shape(), nros_entry_lower::BootShape::App),
         boot: {
-            let (run_components_fn, run_tiers_fn) = c_runner_names(&plan.board);
+            if tiers_view.is_some() && runners.run_tiers.is_none() {
+                return Err(format!(
+                    "typed C entry emit: board `{}` has a C-ABI `run_components` but no \
+                     C-ABI `run_tiers`, so a tiered C entry has no runner to call",
+                    plan.board
+                ));
+            }
             CBootView {
-                shape: match nros_entry_lower::board_family(&plan.board).boot_shape() {
+                shape: match family.boot_shape() {
                     nros_entry_lower::BootShape::Kernel => "kernel",
                     nros_entry_lower::BootShape::App => "app",
                     nros_entry_lower::BootShape::Host => "host",
                 },
-                run_components_fn,
-                run_tiers_fn,
+                run_components_fn: runners.run_components,
+                run_tiers_fn: runners.run_tiers,
                 tiers: tiers_view.is_some(),
                 n_tiers: tiers_view.as_ref().map(|t| t.n).unwrap_or(0),
             }

--- a/packages/cli/nros-cli-core/src/codegen/entry/emit_cpp.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/emit_cpp.rs
@@ -40,7 +40,7 @@ use super::{
 /// in the lowering. RFC-0091 §8b found the first draft leaking exactly this
 /// string into the IR, where a pure-C or Zig pack could not use it.
 fn board_cpp_path(board: &str) -> &'static str {
-    match nros_entry_lower::board_family(board) {
+    match family(board) {
         nros_entry_lower::BoardFamily::Native => "::nros::board::LinuxBoard",
         nros_entry_lower::BoardFamily::Zephyr => "::nros::board::ZephyrBoard",
         nros_entry_lower::BoardFamily::Nuttx => "::nros::board::NuttxBoard",
@@ -57,13 +57,24 @@ fn board_cpp_path(board: &str) -> &'static str {
 /// afford is what lets both stop.
 pub(crate) use nros_entry_lower::BootShape;
 
+/// The family of a board key this emitter has already VALIDATED.
+///
+/// Issue 1285 — `board_family` refuses an unknown key rather than answering
+/// `Native`. Every public entry point funnels through `emit_typed_with_tail`,
+/// which refuses an unknown `plan.board` with the known-keys message before
+/// any helper below runs, so a miss here is a broken invariant, not user input.
+fn family(board: &str) -> nros_entry_lower::BoardFamily {
+    nros_entry_lower::board_family(board)
+        .unwrap_or_else(|e| panic!("emit_cpp: board not validated at entry: {e}"))
+}
+
 /// The boot shape for a board key.
 pub(crate) fn boot_shape(board: &str) -> BootShape {
-    nros_entry_lower::board_family(board).boot_shape()
+    family(board).boot_shape()
 }
 
 pub(crate) fn board_is_embedded(board: &str) -> bool {
-    nros_entry_lower::board_family(board).is_embedded()
+    family(board).is_embedded()
 }
 
 /// phase-263 C2d — Zephyr is the exception among embedded boards: the Zephyr kernel
@@ -75,7 +86,7 @@ pub(crate) fn board_is_embedded(board: &str) -> bool {
 /// in via the compile-time `CONFIG_NROS_ZENOH_LOCATOR` Kconfig (read through the
 /// `NROS_ENTRY_LOCATOR` default in `<nros/main.hpp>`), not a baked `-D`.
 pub(crate) fn board_is_zephyr(board: &str) -> bool {
-    nros_entry_lower::board_family(board) == nros_entry_lower::BoardFamily::Zephyr
+    family(board) == nros_entry_lower::BoardFamily::Zephyr
 }
 
 // issue 1283 — `board_is_freertos_embedded` / `board_is_nuttx` existed only to
@@ -298,6 +309,9 @@ fn node_view(n: &super::PlanNode, i: usize, on_executor: usize, tiered: bool) ->
 }
 
 pub fn emit_typed_with_tail(plan: &Plan, tail: &EntryTail<'_>) -> Result<String, String> {
+    // Issue 1285 — refuse an unknown board key HERE, naming the known ones.
+    // Every board helper in this module relies on it (see `family`).
+    nros_entry_lower::board_family(&plan.board).map_err(|e| format!("typed entry emit: {e}"))?;
     for n in &plan.nodes {
         // phase-432 W2.6 — the exemption is the SAME one the `class_header`
         // guard below already applies, and it was missing here alone.

--- a/packages/cli/nros-cli-core/src/codegen/entry/golden.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/golden.rs
@@ -169,7 +169,9 @@ fn c_default_tier_plan(board: &str) -> Plan {
     let mut telem = c_node("telem_pkg", "telem");
     telem.callback_groups = vec!["telem_grp".into()];
     let mut p = plan(board, vec![ctrl, telem]);
-    let rtos = super::board_to_rtos(board).to_string();
+    let rtos = super::board_to_rtos(board)
+        .expect("the golden matrix names only board keys in the family table")
+        .to_string();
     super::resolve_plan_sched(&mut p, &rtos).expect("default-tier resolution");
     assert!(
         p.resolved_tiers

--- a/packages/cli/nros-cli-core/src/codegen/entry/mod.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/mod.rs
@@ -254,8 +254,21 @@ impl Plan {
 
 /// Whether the board family has a `run_tiers` runner. ThreadX does not
 /// (issue 1286), so a tiered ThreadX plan keeps the sched-context path.
+///
+/// Issue 1285: this reads the `run_tiers` half of
+/// `BoardFamily::c_abi_runners`, the one record of which runners each family
+/// exports. It no longer names ThreadX. When issue 1286 gives ThreadX a
+/// `run_components` and no `run_tiers`, this stays `false` without an edit.
+/// Both packs' `run_tiers` sit on those C-ABI symbols.
+///
+/// An unknown key answers `false` here rather than guessing a family. Every
+/// emitter refuses such a key, naming the known ones, before it renders
+/// anything, so this answer is never used.
 fn board_has_run_tiers(board: &str) -> bool {
-    nros_entry_lower::board_family(board) != nros_entry_lower::BoardFamily::Threadx
+    nros_entry_lower::board_family(board)
+        .ok()
+        .and_then(nros_entry_lower::BoardFamily::c_abi_runners)
+        .is_some_and(|r| r.run_tiers.is_some())
 }
 
 /// The param-services and lifecycle registrations that close a setup function.
@@ -741,7 +754,17 @@ pub fn plan_from_model(model_path: &Path, board: Option<String>) -> Result<Plan>
 
     let model = model_ingest::load_model(model_path)?;
     let board = board.unwrap_or_else(|| "native".to_string());
-    let target_rtos = board_to_rtos(&board).to_string();
+    // Issue 1285 — only a key the entry table knows HAS a tier sub-table.
+    //
+    // This function is shared: `nros codegen entry` (C/C++, where the key must
+    // name a family) and `nros build`'s Rust entry generation, where the key is
+    // any Rust board — `esp32-c3-baremetal`, an out-of-tree board — and only
+    // the node list is read. So an unknown key is NOT refused here; its tiers
+    // are resolved from their platform-neutral head (`TierDef::platform("")`
+    // selects no sub-table) rather than from `posix`'s, which the old substring
+    // fallback silently picked. Every consumer that needs the family asks
+    // `board_family`/`board_to_rtos` itself and refuses the key there.
+    let target_rtos = board_to_rtos(&board).unwrap_or("");
 
     // phase-315 / issue 0288 — does the model place ANYTHING on this board?
     //
@@ -880,7 +903,7 @@ pub fn plan_from_model(model_path: &Path, board: Option<String>) -> Result<Plan>
         .map(|(name, t)| {
             (
                 name.clone(),
-                crate::orchestration::model_ingest::tier_from_model(t, &target_rtos),
+                crate::orchestration::model_ingest::tier_from_model(t, target_rtos),
             )
         })
         .collect();
@@ -917,18 +940,17 @@ pub fn plan_from_model(model_path: &Path, board: Option<String>) -> Result<Plan>
     })
 }
 
-/// Phase 269 (W4) — derive the RTOS key recognised by [`resolve_tiers`] from a
-/// board deploy key. The mapping mirrors the `rtos_spec` function in
-/// `nros-orchestration-ir` (`"posix" | "native"`, `"freertos"`, …).
-pub fn board_to_rtos(board: &str) -> &str {
-    match board {
-        "native" | "posix" => "posix",
-        b if b.starts_with("freertos") || b.contains("freertos") => "freertos",
-        b if b.starts_with("zephyr") || b.contains("zephyr") => "zephyr",
-        b if b.starts_with("nuttx") || b.contains("nuttx") => "nuttx",
-        b if b.starts_with("threadx") || b.contains("threadx") => "threadx",
-        _ => "posix",
-    }
+/// Phase 269 (W4): the RTOS key [`resolve_tiers`] recognises, derived from a
+/// board deploy key. It is the key `rtos_spec` in `nros-orchestration-ir`
+/// reads (`"posix"`, `"freertos"`, …).
+///
+/// Issue 1285: read from `nros_entry_lower::BOARD_KEYS`, the one key →
+/// family table. This used to be a SUBSTRING match with a `posix` fallback,
+/// so `s32z270`, `an536` (FreeRTOS) and `armfvp`, `fvp-aemv8r-smp` (Zephyr)
+/// all silently got the POSIX tier sub-table. An unknown key is now an error
+/// naming the known ones.
+pub fn board_to_rtos(board: &str) -> Result<&'static str, nros_entry_lower::UnknownBoard> {
+    nros_entry_lower::board_family(board).map(nros_entry_lower::BoardFamily::tier_rtos_key)
 }
 
 /// Phase 269 (W4) — resolve `[tiers.*]` + `[[node_overrides]]` + per-node

--- a/packages/cli/nros-cli-core/src/codegen/entry/pack.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/pack.rs
@@ -29,12 +29,14 @@
 //! not, because its fixture rows set `NANO_ROS_PLATFORM = "freertos"`, so both
 //! sides say embedded.
 //!
-//! What is wrong is structural: nothing MAKES them agree. They read different
-//! inputs, `board_family` answers `Native` for any key it has not learned, and
+//! What was wrong is structural: nothing MADE them agree. They read different
+//! inputs, `board_family` answered `Native` for any key it had not learned, and
 //! the failure if they ever diverged is a C++ TU written into a `.c` file — a
 //! compile error at best, and at worst a `.c` file that happens to compile.
-//! The `freertos-posix` comment in `board_family` records that this table has
-//! already produced one silent wrong answer of exactly that kind.
+//! The `freertos-posix` row in `nros_entry_lower::BOARD_KEYS` records that the
+//! fallback already produced one silent wrong answer of exactly that kind.
+//! Issue 1285 removed the fallback: an unknown key is now an error naming the
+//! known keys, which `nros codegen entry-pack` returns and CMake reports.
 //!
 //! So the manifest holds the DATA and this module holds the DECISION, and both
 //! answers are served to CMake through `nros codegen entry-pack` — one
@@ -131,7 +133,9 @@ pub fn entry_pack_for(language: Language, board: &str) -> Result<EntryPackInfo, 
     // family-wide assumption would route a C entry to C++ on a board that no
     // longer needs it. One predicate, in `nros-entry-lower`, because four
     // sites must give the same answer.
-    let has_c_runner = nros_entry_lower::board_family(board).has_c_run_components();
+    let has_c_runner = nros_entry_lower::board_family(board)
+        .map_err(|e| e.to_string())?
+        .has_c_run_components();
     let pack = match language {
         Language::C if !has_c_runner => "cpp",
         Language::C => "c",
@@ -237,7 +241,9 @@ mod tests {
     #[test]
     fn a_c_entry_renders_as_c_exactly_where_the_board_has_a_c_runner() {
         for board in ["native", "zephyr", "nuttx", "freertos", "threadx"] {
-            let has_runner = nros_entry_lower::board_family(board).has_c_run_components();
+            let has_runner = nros_entry_lower::board_family(board)
+                .unwrap()
+                .has_c_run_components();
             let got = entry_pack_for(Language::C, board).unwrap();
             if has_runner {
                 assert_eq!(

--- a/packages/cli/nros-cli-core/src/codegen/entry/packs/entry/c/boot_wrapper.jinja
+++ b/packages/cli/nros-cli-core/src/codegen/entry/packs/entry/c/boot_wrapper.jinja
@@ -22,8 +22,9 @@
   The runner NAMES are carried rather than assembled from the board key: the C
   ABI does not name them uniformly (`native` has the `_named` suffix that its
   two-overload history left behind, the RTOS ones do not), so deriving them
-  from a prefix here would be a second, guessing spelling of a fact `emit_c`
-  already holds exactly.
+  from a prefix here would be a second, guessing spelling of a fact
+  `BoardFamily::c_abi_runners` in `nros-entry-lower` already holds exactly
+  (issue 1285).
 -#}
 {%- set call -%}
 {%- if boot.tiers -%}

--- a/packages/cli/nros-cli-core/tests/board_key_table.rs
+++ b/packages/cli/nros-cli-core/tests/board_key_table.rs
@@ -1,0 +1,243 @@
+//! Issue 1285: the board key → board family mapping has ONE table
+//! (`nros_entry_lower::BOARD_KEYS`), and every consumer answers from it.
+//!
+//! The mapping used to be derived four times, and the four disagreed:
+//! - `board_family` fell back to `Native`.
+//! - `board_to_rtos` was a substring match that fell back to `posix`.
+//! - The proc-macro's `known_boards_csv` was hand-written.
+//! - The Rust pack's `board_path_for` had its own key set.
+//!
+//! These tests pin the agreement, so a new key cannot land in one place only.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
+
+use nros_cli_core::codegen::entry::{board_to_rtos, pack::entry_pack_for};
+use nros_entry_lower::{BOARD_KEYS, BoardFamily, LoweredEntry, board_family, known_board_keys};
+use nros_lang::Language;
+
+/// Every consumer, asked about every key in the table, gives the table's answer.
+#[test]
+fn every_table_key_maps_to_its_family_through_every_consumer() {
+    for &(key, family) in BOARD_KEYS {
+        assert_eq!(board_family(key), Ok(family), "board_family(`{key}`)");
+        assert_eq!(
+            board_to_rtos(key),
+            Ok(family.tier_rtos_key()),
+            "board_to_rtos(`{key}`)"
+        );
+        let entry = LoweredEntry {
+            board: key.into(),
+            ..Default::default()
+        };
+        assert_eq!(entry.family(), Ok(family), "LoweredEntry::family(`{key}`)");
+
+        let routed = entry_pack_for(Language::C, key).expect("known key routes");
+        let want = if family.has_c_run_components() {
+            "c"
+        } else {
+            "cpp"
+        };
+        assert_eq!(routed.pack, want, "entry_pack_for(C, `{key}`)");
+    }
+}
+
+/// An unknown key is an error at every consumer: never `Native`, never
+/// `posix`. The error names the known keys.
+#[test]
+fn an_unknown_key_errors_at_every_consumer() {
+    for key in ["zigos", "esp32-qemu", "mps2-an385", "native_sim/native/64"] {
+        let err = board_family(key).expect_err(key).to_string();
+        for known in known_board_keys() {
+            assert!(
+                err.contains(known),
+                "`{key}`: message omits `{known}`: {err}"
+            );
+        }
+        assert!(board_to_rtos(key).is_err(), "board_to_rtos(`{key}`)");
+        let pack_err = entry_pack_for(Language::C, key).expect_err(key);
+        assert!(pack_err.contains(key), "{pack_err}");
+    }
+}
+
+/// The four keys the old SUBSTRING match sent to `posix`, because none of them
+/// contains its RTOS's name.
+#[test]
+fn substring_victims_get_their_real_rtos() {
+    for (key, rtos) in [
+        ("s32z270", "freertos"),
+        ("an536", "freertos"),
+        ("armfvp", "zephyr"),
+        ("fvp-aemv8r-smp", "zephyr"),
+    ] {
+        assert_eq!(board_to_rtos(key), Ok(rtos), "`{key}`");
+    }
+}
+
+/// The board family each Rust board ZST belongs to. `None` means the board has
+/// no RTOS, so no C or C++ entry family: ESP32, RTIC and bare-metal MPS2.
+///
+/// This oracle is the test's own statement, which is the point. A new ZST in
+/// `BOARD_PATHS` fails here until someone says which family it is.
+fn rust_zst_family() -> BTreeMap<&'static str, Option<BoardFamily>> {
+    BTreeMap::from([
+        ("::nros_board_linux::LinuxBoard", Some(BoardFamily::Native)),
+        (
+            "::nros_board_mps2_an385_freertos::Mps2An385",
+            Some(BoardFamily::Freertos),
+        ),
+        (
+            "::nros_board_threadx_linux::ThreadxLinux",
+            Some(BoardFamily::Threadx),
+        ),
+        (
+            "::nros_board_threadx_qemu_riscv64::ThreadxQemuRiscv64",
+            Some(BoardFamily::Threadx),
+        ),
+        (
+            "::nros_board_nuttx_qemu::NuttxQemu",
+            Some(BoardFamily::Nuttx),
+        ),
+        (
+            "::nros_board_zephyr::ZephyrBoard",
+            Some(BoardFamily::Zephyr),
+        ),
+        ("::nros_board_esp32_qemu::Esp32QemuEntry", None),
+        ("::nros_board_mps2_an385::RticMps2An385", None),
+        ("::nros_board_mps2_an385::Mps2An385", None),
+    ])
+}
+
+/// The Rust pack's key set and the family table agree. A key the Rust pack
+/// resolves to an RTOS board must be in the family table with THAT family. A
+/// key it resolves to a no-RTOS board must NOT be there, or a C entry would get
+/// a runner for a board that has none.
+#[test]
+fn the_rust_pack_key_set_agrees_with_the_family_table() {
+    let zst_family = rust_zst_family();
+    let mut used = BTreeSet::new();
+    for &(key, path) in nros_orchestration_ir::BOARD_PATHS {
+        let want = *zst_family.get(path).unwrap_or_else(|| {
+            panic!("`{key}` names ZST `{path}`, which this test has no family for")
+        });
+        used.insert(path);
+        match want {
+            Some(family) => assert_eq!(
+                board_family(key),
+                Ok(family),
+                "Rust key `{key}` names a {} board (`{path}`)",
+                family.as_str()
+            ),
+            None => assert!(
+                board_family(key).is_err(),
+                "Rust key `{key}` names a no-RTOS board (`{path}`) but the family table \
+                 claims it"
+            ),
+        }
+    }
+    let stale: Vec<_> = zst_family.keys().filter(|p| !used.contains(*p)).collect();
+    assert!(
+        stale.is_empty(),
+        "oracle names ZSTs no key reaches: {stale:?}"
+    );
+}
+
+/// Keys the family table has and the Rust pack does not. Each is a C/C++-only
+/// spelling. Pinned so that adding a key to one table and not the other is a
+/// deliberate edit here, not drift.
+#[test]
+fn family_keys_without_a_rust_board_are_exactly_these() {
+    let rust: BTreeSet<&str> = nros_orchestration_ir::board_path_keys().collect();
+    let c_cpp_only: BTreeSet<&str> = known_board_keys().filter(|k| !rust.contains(k)).collect();
+    assert_eq!(
+        c_cpp_only,
+        BTreeSet::from([
+            "an536",
+            "armfvp",
+            "freertos-posix",
+            "fvp-aemv8r-smp",
+            "mps3-an536-freertos",
+            "s32z270",
+            "s32z270-freertos",
+            "threadx",
+        ]),
+    );
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..")
+}
+
+/// Every runner symbol `c_abi_runners` names is DEFINED in the tree. The table
+/// it replaced named `nros_board_threadx_run_tiers`, a symbol that exists
+/// nowhere.
+///
+/// A C definition is a line starting `int32_t <sym>(` in a board crate's `c/`.
+/// A Rust one is `extern "C" fn <sym>(` in `nros-cpp`, where the native runners
+/// live.
+#[test]
+fn c_abi_runners_name_only_symbols_that_exist() {
+    let root = repo_root();
+    let mut sources: Vec<(PathBuf, String)> = Vec::new();
+    let boards = root.join("packages/boards");
+    for board in std::fs::read_dir(&boards).expect("read packages/boards") {
+        let c_dir = board.expect("dir entry").path().join("c");
+        let Ok(files) = std::fs::read_dir(&c_dir) else {
+            continue;
+        };
+        for f in files {
+            let p = f.expect("dir entry").path();
+            if p.extension().is_some_and(|e| e == "c") {
+                let text = std::fs::read_to_string(&p).expect("read C source");
+                sources.push((p, text));
+            }
+        }
+    }
+    let nros_cpp = root.join("packages/api/nros-cpp/src/lib.rs");
+    let nros_cpp_text = std::fs::read_to_string(&nros_cpp).expect("read nros-cpp lib.rs");
+    assert!(
+        sources.len() >= 4,
+        "found only {} board C sources under {} — the scan is looking in the wrong place",
+        sources.len(),
+        boards.display()
+    );
+
+    let defined = |sym: &str| -> bool {
+        let c_def = format!("int32_t {sym}(");
+        let rust_def = format!("extern \"C\" fn {sym}(");
+        sources
+            .iter()
+            .any(|(_, t)| t.lines().any(|l| l.starts_with(&c_def)))
+            || nros_cpp_text.contains(&rust_def)
+    };
+
+    let mut named = 0;
+    for family in BoardFamily::ALL {
+        let Some(runners) = family.c_abi_runners() else {
+            continue;
+        };
+        for sym in [runners.run_components, runners.run_tiers]
+            .into_iter()
+            .flatten()
+        {
+            named += 1;
+            assert!(
+                defined(sym),
+                "{}: c_abi_runners names `{sym}`, which no board C source or nros-cpp defines",
+                family.as_str()
+            );
+        }
+    }
+    assert!(named >= 5, "only {named} runner names checked");
+
+    // The negative control: the name the old table invented is absent, so
+    // the scan can fail. A scan that finds everything proves nothing.
+    assert!(
+        !defined("nros_board_threadx_run_tiers"),
+        "the scan found a definition of the symbol issue 1285 says does not exist \
+         — either ThreadX gained a C runner (update c_abi_runners and this test) or \
+         the scan is too loose"
+    );
+}

--- a/packages/cli/nros-entry-lower/src/lib.rs
+++ b/packages/cli/nros-entry-lower/src/lib.rs
@@ -34,16 +34,15 @@ pub use node::{LoweredEntry, LoweredNode, NodeIdentity, QosOverride, sanitize_pk
 
 /// The board families the entry pipeline distinguishes.
 ///
-/// Nineteen board keys collapse onto five families. The KEY is what a user
-/// writes and what cmake passes; the FAMILY is what the lowering reasons
-/// about, and what a pack turns into a call.
+/// Every key in [`BOARD_KEYS`] collapses onto one of five families. The KEY is
+/// what a user writes and what cmake passes; the FAMILY is what the lowering
+/// reasons about, and what a pack turns into a call.
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum BoardFamily {
-    /// The host build (`native`, `posix`) — and the fallback for an
-    /// unrecognised key, see [`board_family`].
+    /// The host build (`native`, `posix`).
     Native,
     Zephyr,
     Nuttx,
@@ -90,47 +89,99 @@ impl BoardFamily {
         self != BoardFamily::Native
     }
 
+    /// The C-ABI runners this family exports, or `None` when it has no C
+    /// board surface at all.
+    ///
+    /// Issue 1285. This is the ONE record of which symbol a C entry calls.
+    /// The runner names used to live in `emit_c`'s own table, while this
+    /// predicate lived here, and nothing tied the two. The table's ThreadX arm
+    /// named `nros_board_threadx_run_tiers`, a symbol that exists nowhere. Now
+    /// the predicate is derived from the names, so the two cannot disagree.
+    ///
+    /// The names are carried, not assembled from a prefix. The C ABI does not
+    /// name them uniformly: `native` keeps the `_named` suffix its
+    /// two-overload history left behind, and the RTOS runners have no such
+    /// pair. Where each is DEFINED:
+    ///
+    /// - `Native` — `nros_board_native_run_components_named` and
+    ///   `nros_board_native_run_tiers`, both `extern "C"` in Rust
+    ///   (`packages/api/nros-cpp/src/lib.rs`).
+    /// - `Freertos`, `Zephyr`, `Nuttx` — ONE `run_components`,
+    ///   `nros_board_rtos_run_components`
+    ///   (`packages/boards/nros-board-common/c/nros_rtos_run_components.c`),
+    ///   because the single-executor path differs only in a per-tick yield.
+    ///   `run_tiers` is per-board: a FreeRTOS task, a Zephyr `k_thread` and a
+    ///   NuttX pthread are three different things. The three are
+    ///   `nros_board_{freertos,zephyr,nuttx}_run_tiers`, in each board crate's
+    ///   `c/<rtos>_run_tiers.c`.
+    /// - `Threadx` — none. It has no `run_tiers` either, so it stays
+    ///   C++-entry-only, and the routing is REPORTED rather than refused.
+    ///
+    /// Each half is its own `Option` because the two land independently.
+    /// Issue 1286 gives ThreadX a `run_components` with no `run_tiers`, and
+    /// that is a `Some` with one `None` in it, not a lie in either direction.
+    ///
+    /// `nros-cli-core/tests/board_key_table.rs` checks that every name here is
+    /// defined in the tree.
+    pub fn c_abi_runners(self) -> Option<CAbiRunners> {
+        match self {
+            BoardFamily::Native => Some(CAbiRunners {
+                run_components: Some("nros_board_native_run_components_named"),
+                run_tiers: Some("nros_board_native_run_tiers"),
+            }),
+            BoardFamily::Freertos => Some(CAbiRunners {
+                run_components: Some("nros_board_rtos_run_components"),
+                run_tiers: Some("nros_board_freertos_run_tiers"),
+            }),
+            BoardFamily::Zephyr => Some(CAbiRunners {
+                run_components: Some("nros_board_rtos_run_components"),
+                run_tiers: Some("nros_board_zephyr_run_tiers"),
+            }),
+            BoardFamily::Nuttx => Some(CAbiRunners {
+                run_components: Some("nros_board_rtos_run_components"),
+                run_tiers: Some("nros_board_nuttx_run_tiers"),
+            }),
+            BoardFamily::Threadx => None,
+        }
+    }
+
     /// Whether this family ships a C-ABI `run_components`, i.e. whether a
     /// `--lang c` entry can be rendered by the C pack instead of being routed
     /// to the C++ one.
     ///
     /// phase-432 W3.1. This is the predicate the routing rule needs, and it is
     /// NOT `is_embedded()`, which is what it used to ask. The two agreed only
-    /// while `native` was the sole family with a C runner; they are different
+    /// while `native` was the sole family with a C runner. They are different
     /// questions, and conflating them made a family-wide assumption out of a
-    /// per-board fact. The fact is now measurable per family and moves as each
-    /// board's runner lands.
+    /// per-board fact.
     ///
     /// One home, because four sites consume it: the pack router
     /// (`entry_pack_for`), the emitter's own refusal, the CLI's emit dispatch,
-    /// and the CMake extension/`LANGUAGES` decision. They must agree, and when
-    /// they asked `is_embedded()` separately there was nothing making them.
+    /// and the CMake extension/`LANGUAGES` decision. It is DERIVED from
+    /// [`c_abi_runners`](Self::c_abi_runners) (issue 1285), so the routing
+    /// and the symbol the C pack names come from one record.
     ///
-    /// What is true today:
-    ///
-    /// - `Native` — the C-ABI `nros_board_native_run_components{,_named}`,
-    ///   implemented in Rust in `nros-cpp`.
-    /// - `Freertos` — `nros_board_freertos_run_components`, C, in the board
-    ///   crate's glue (`c/freertos_run_components.c`).
-    /// - `Zephyr`, `Nuttx` — the SAME runner. `run_components` is the
-    ///   single-executor path, identical on every RTOS but for a per-tick
-    ///   yield, so all three link one `nros_board_rtos_run_components`.
-    /// - `Threadx` — deliberately none, and not merely unwritten. It has no
-    ///   `run_tiers` either, so there is nothing to copy, and it stays
-    ///   C++-entry-only with the routing REPORTED rather than refused.
-    ///
-    /// The benefit is RMW-CONDITIONAL and this predicate does not encode that:
-    /// a C runner drops the C++ toolchain requirement for zenoh and XRCE, and
+    /// The benefit is RMW-CONDITIONAL and this predicate does not encode that.
+    /// A C runner drops the C++ toolchain requirement for zenoh and XRCE, but
     /// not for cyclonedds or uORB, whose RMW libraries are themselves C++. The
     /// entry language and the RMW's own language are separate facts, so the
     /// routing answers only the first.
     pub fn has_c_run_components(self) -> bool {
+        self.c_abi_runners()
+            .is_some_and(|r| r.run_components.is_some())
+    }
+
+    /// The key a tier's per-RTOS sub-table is read under:
+    /// `[tiers.<name>.<rtos>]`, rlm's `TierDef::platform`, and
+    /// `nros-orchestration-ir`'s `rtos_spec`.
+    ///
+    /// This is `as_str()` for every family but the host, which is spelled
+    /// `posix` there. That is the platform the host build runs on, not the
+    /// board it names.
+    pub fn tier_rtos_key(self) -> &'static str {
         match self {
-            BoardFamily::Native
-            | BoardFamily::Freertos
-            | BoardFamily::Zephyr
-            | BoardFamily::Nuttx => true,
-            BoardFamily::Threadx => false,
+            BoardFamily::Native => "posix",
+            other => other.as_str(),
         }
     }
 
@@ -155,79 +206,184 @@ impl BoardFamily {
     }
 }
 
+/// The C-ABI runners a board family exports. See
+/// [`BoardFamily::c_abi_runners`].
+///
+/// Each half is independently optional. A family may ship `run_components`
+/// without `run_tiers`: ThreadX will, issue 1286.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CAbiRunners {
+    /// The single-executor runner: `(…, setup) -> int32_t`.
+    pub run_components: Option<&'static str>,
+    /// The one-task-per-tier runner: `(…, tiers, n_tiers) -> int32_t`.
+    pub run_tiers: Option<&'static str>,
+}
+
+/// Every board key the entry pipeline knows, and the family it names. This is
+/// the ONE table (issue 1285).
+///
+/// It used to be derived four times, and the four disagreed:
+/// - `board_family` here was a `match` whose `_ => Native` turned any unknown
+///   key into a host build.
+/// - `nros-cli-core`'s `board_to_rtos` was a SUBSTRING match, so `s32z270`,
+///   `an536`, `armfvp` and `fvp-aemv8r-smp` read as `posix`.
+/// - The proc-macro's `known_boards_csv` was a hand-written list.
+/// - The Rust pack's `board_path_for` had its own key set.
+///
+/// [`board_family`] and `board_to_rtos` now read this table. The Rust pack's
+/// key set, `nros_orchestration_ir::BOARD_PATHS`, is Rust-pack-local spelling
+/// and stays in its own crate. `nros-cli-core/tests/board_key_table.rs`
+/// checks it against this table.
+///
+/// Rows, by family:
+/// - Zephyr: every Phase 215 board (FVP, qemu-zephyr, …) compiles with
+///   `__ZEPHYR__` and shares the one metadata-driven adapter.
+/// - NuttX (phase 238): the network is up at kernel boot, so these share the
+///   lifecycle adapter. `nuttx-riscv` is the Rust spelling of `rv-virt-nuttx`
+///   (phase-337 W3).
+/// - FreeRTOS: phase 240.6 / phase-263 C2b, plus phase-370's
+///   `freertos-posix` and phase-372/385's S32Z270 and MPS3-AN536.
+///   `freertos-posix` is a HOST process whose nodes still run as FreeRTOS
+///   TASKS, so it belongs here and not with `native`. It once fell through to
+///   the host default, a silent wrong answer that surfaced only at link, when
+///   `app_main` came up undefined.
+/// - ThreadX (phase 246): the host sim and bare-metal qemu-riscv64.
+///
+/// Board keys with no RTOS are NOT here: `esp32-qemu`, `rtic-mps2-an385` and
+/// the bare-metal `mps2-an385`. A C or C++ entry has no runner for them, so
+/// asking for their family is an error, not a guess.
+pub const BOARD_KEYS: &[(&str, BoardFamily)] = &[
+    ("native", BoardFamily::Native),
+    ("posix", BoardFamily::Native),
+    ("zephyr", BoardFamily::Zephyr),
+    ("fvp-aemv8r-smp", BoardFamily::Zephyr),
+    ("armfvp", BoardFamily::Zephyr),
+    ("nuttx", BoardFamily::Nuttx),
+    ("qemu-armv7a-nuttx", BoardFamily::Nuttx),
+    ("rv-virt-nuttx", BoardFamily::Nuttx),
+    ("nuttx-riscv", BoardFamily::Nuttx),
+    ("freertos", BoardFamily::Freertos),
+    ("mps2-an385-freertos", BoardFamily::Freertos),
+    ("freertos-qemu-mps2-an385", BoardFamily::Freertos),
+    ("freertos-posix", BoardFamily::Freertos),
+    ("s32z270-freertos", BoardFamily::Freertos),
+    ("s32z270", BoardFamily::Freertos),
+    ("mps3-an536-freertos", BoardFamily::Freertos),
+    ("an536", BoardFamily::Freertos),
+    ("threadx", BoardFamily::Threadx),
+    ("threadx-linux", BoardFamily::Threadx),
+    ("threadx-qemu-riscv64", BoardFamily::Threadx),
+    ("rv-virt-threadx", BoardFamily::Threadx),
+];
+
+/// A board key that is not in [`BOARD_KEYS`].
+///
+/// Its `Display` names every known key, so the person who wrote the key can
+/// fix it without reading this crate.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnknownBoard {
+    pub key: alloc::string::String,
+}
+
+impl core::fmt::Display for UnknownBoard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "unknown board key `{}` — the entry pipeline knows: ",
+            self.key
+        )?;
+        for (i, key) in known_board_keys().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            f.write_str(key)?;
+        }
+        Ok(())
+    }
+}
+
+impl core::error::Error for UnknownBoard {}
+
+/// The keys of [`BOARD_KEYS`], in table order.
+pub fn known_board_keys() -> impl Iterator<Item = &'static str> {
+    BOARD_KEYS.iter().map(|(key, _)| *key)
+}
+
 /// Which family a board key names.
 ///
-/// An unrecognised key falls back to [`BoardFamily::Native`], preserving the
-/// behaviour the C++ emitter had: cmake has already errored on a missing
-/// `BOARD` for a non-native `DEPLOY` by the time codegen runs, so this
-/// fallback exists to let unit tests cover the unhappy path without teaching
-/// the lowering every embedded board prematurely. It is a deliberate choice
-/// and not a silent default — a NEW board key that reaches production without
-/// a row here builds as a host image, which fails loudly at link.
-pub fn board_family(board: &str) -> BoardFamily {
-    match board {
-        "native" | "posix" => BoardFamily::Native,
-        // Every Phase 215 Zephyr board (FVP, qemu-zephyr, …) compiles with
-        // `__ZEPHYR__` and shares the one metadata-driven adapter.
-        "zephyr" | "fvp-aemv8r-smp" | "armfvp" => BoardFamily::Zephyr,
-        // Phase 238 — network is up at kernel boot; shares the lifecycle
-        // adapter.
-        "nuttx" | "qemu-armv7a-nuttx" | "rv-virt-nuttx" => BoardFamily::Nuttx,
-        // Phase 240.6 / phase-263 C2b, plus phase-370's `freertos-posix` and
-        // phase-372/385's S32Z270 and MPS3-AN536. `freertos-posix` is a HOST
-        // process whose nodes still run as FreeRTOS TASKS, so it belongs here
-        // and not with `native`: it once fell through to the host default,
-        // which is a silent wrong answer that only surfaced at link when
-        // `app_main` came up undefined.
-        "freertos"
-        | "mps2-an385-freertos"
-        | "freertos-posix"
-        | "s32z270-freertos"
-        | "s32z270"
-        | "mps3-an536-freertos"
-        | "an536" => BoardFamily::Freertos,
-        // Phase 246 — Azure RTOS ThreadX (host sim + bare-metal qemu-riscv64).
-        "threadx" | "threadx-linux" | "threadx-qemu-riscv64" | "rv-virt-threadx" => {
-            BoardFamily::Threadx
-        }
-        _ => BoardFamily::Native,
-    }
+/// An unknown key is an ERROR that names the known keys (issue 1285). This
+/// used to fall back to [`BoardFamily::Native`], which made an embedded key
+/// the table had not learned look exactly like a host build. The failure then
+/// arrived minutes later, at link, as an undefined `app_main`.
+pub fn board_family(board: &str) -> Result<BoardFamily, UnknownBoard> {
+    BOARD_KEYS
+        .iter()
+        .find(|(key, _)| *key == board)
+        .map(|(_, family)| *family)
+        .ok_or_else(|| UnknownBoard { key: board.into() })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Every key the C++ emitter recognised, and the family it must land in.
-    /// This is the table the emitters used to each carry a copy of.
-    const KEYS: &[(&str, BoardFamily)] = &[
-        ("native", BoardFamily::Native),
-        ("posix", BoardFamily::Native),
-        ("zephyr", BoardFamily::Zephyr),
-        ("fvp-aemv8r-smp", BoardFamily::Zephyr),
-        ("armfvp", BoardFamily::Zephyr),
-        ("nuttx", BoardFamily::Nuttx),
-        ("qemu-armv7a-nuttx", BoardFamily::Nuttx),
-        ("rv-virt-nuttx", BoardFamily::Nuttx),
-        ("freertos", BoardFamily::Freertos),
-        ("mps2-an385-freertos", BoardFamily::Freertos),
-        ("freertos-posix", BoardFamily::Freertos),
-        ("s32z270-freertos", BoardFamily::Freertos),
-        ("s32z270", BoardFamily::Freertos),
-        ("mps3-an536-freertos", BoardFamily::Freertos),
-        ("an536", BoardFamily::Freertos),
-        ("threadx", BoardFamily::Threadx),
-        ("threadx-linux", BoardFamily::Threadx),
-        ("threadx-qemu-riscv64", BoardFamily::Threadx),
-        ("rv-virt-threadx", BoardFamily::Threadx),
-    ];
-
     #[test]
     fn every_known_board_key_lands_in_its_family() {
-        for (key, want) in KEYS {
-            assert_eq!(board_family(key), *want, "board key `{key}`");
+        for (key, want) in BOARD_KEYS {
+            assert_eq!(board_family(key), Ok(*want), "board key `{key}`");
         }
-        assert_eq!(KEYS.len(), 19, "a key was added or removed without a row");
+        // 19 keys the C++ emitter knew, plus the two RTOS keys only the Rust
+        // pack knew (`nuttx-riscv`, `freertos-qemu-mps2-an385`, issue 1285).
+        assert_eq!(
+            BOARD_KEYS.len(),
+            21,
+            "a key was added or removed without a row"
+        );
+    }
+
+    #[test]
+    fn no_board_key_is_listed_twice() {
+        for (i, (key, _)) in BOARD_KEYS.iter().enumerate() {
+            assert!(
+                !BOARD_KEYS[..i].iter().any(|(k, _)| k == key),
+                "board key `{key}` has two rows — the first would shadow the second"
+            );
+        }
+    }
+
+    /// Each tier-key spelling is what rlm's `TierDef::platform` matches. The
+    /// host is `posix` there, not `native`.
+    #[test]
+    fn tier_rtos_key_is_the_spelling_the_tier_tables_use() {
+        assert_eq!(BoardFamily::Native.tier_rtos_key(), "posix");
+        for f in BoardFamily::ALL {
+            if f != BoardFamily::Native {
+                assert_eq!(f.tier_rtos_key(), f.as_str());
+            }
+        }
+    }
+
+    /// The routing predicate is DERIVED from the runner names. The two used to
+    /// be separate tables that agreed by accident.
+    #[test]
+    fn has_c_run_components_is_the_runner_table_read_one_way() {
+        for f in BoardFamily::ALL {
+            assert_eq!(
+                f.has_c_run_components(),
+                f.c_abi_runners().and_then(|r| r.run_components).is_some(),
+                "{}",
+                f.as_str()
+            );
+        }
+    }
+
+    /// Where issue 1285 left the surface. ThreadX has NO C-ABI runner, so a C
+    /// entry for it is still routed to the C++ pack. Issue 1286 is the change
+    /// that moves it, and it must edit this test to do so.
+    #[test]
+    fn threadx_has_no_c_abi_runner_yet() {
+        assert_eq!(BoardFamily::Threadx.c_abi_runners(), None);
+        assert!(!BoardFamily::Threadx.has_c_run_components());
     }
 
     /// `freertos-posix` is the trap this table exists to hold. It is a host
@@ -236,9 +392,9 @@ mod tests {
     /// and then fails at link on an undefined `app_main`.
     #[test]
     fn freertos_posix_is_freertos_not_native() {
-        assert_eq!(board_family("freertos-posix"), BoardFamily::Freertos);
+        assert_eq!(board_family("freertos-posix"), Ok(BoardFamily::Freertos));
         assert_eq!(
-            board_family("freertos-posix").boot_shape(),
+            board_family("freertos-posix").unwrap().boot_shape(),
             BootShape::App,
             "a host `int main` here is a second main"
         );
@@ -265,10 +421,20 @@ mod tests {
         );
     }
 
+    /// Issue 1285 — an unknown key is an error, never the host. The message
+    /// names every known key, so the fix is visible from the failure.
     #[test]
-    fn an_unknown_key_falls_back_to_native() {
-        assert_eq!(board_family("zigos"), BoardFamily::Native);
-        assert_eq!(board_family(""), BoardFamily::Native);
+    fn an_unknown_key_is_an_error_naming_the_known_keys() {
+        use alloc::string::ToString;
+        for key in ["zigos", "", "esp32-qemu", "mps2-an385", "NATIVE"] {
+            let err = board_family(key).expect_err(key);
+            assert_eq!(err.key, key);
+            let msg = err.to_string();
+            assert!(msg.contains(&alloc::format!("`{key}`")), "{msg}");
+            for known in known_board_keys() {
+                assert!(msg.contains(known), "message omits `{known}`: {msg}");
+            }
+        }
     }
 
     #[test]

--- a/packages/cli/nros-entry-lower/src/node.rs
+++ b/packages/cli/nros-entry-lower/src/node.rs
@@ -121,8 +121,9 @@ pub struct LoweredEntry {
 }
 
 impl LoweredEntry {
-    /// The family this entry's board key names.
-    pub fn family(&self) -> crate::BoardFamily {
+    /// The family this entry's board key names, or an error naming the known
+    /// keys (issue 1285).
+    pub fn family(&self) -> Result<crate::BoardFamily, crate::UnknownBoard> {
         crate::board_family(&self.board)
     }
 }
@@ -236,6 +237,6 @@ mod tests {
             nodes: vec![LoweredNode::bare("talker_pkg")],
             ..Default::default()
         };
-        assert_eq!(e.family(), crate::BoardFamily::Freertos);
+        assert_eq!(e.family(), Ok(crate::BoardFamily::Freertos));
     }
 }

--- a/packages/core/nros-macros/src/main_macro.rs
+++ b/packages/core/nros-macros/src/main_macro.rs
@@ -3118,9 +3118,16 @@ fn board_path_for(deploy: &str) -> Option<SynPath> {
     syn::parse_str::<SynPath>(path_str).ok()
 }
 
-fn known_boards_csv() -> &'static str {
-    "native, freertos, threadx-linux, threadx-qemu-riscv64, nuttx, nuttx-riscv, esp32-qemu, \
-     zephyr, rtic-mps2-an385, qemu-mps2-an385, mps2-an385"
+/// The keys [`board_path_for`] accepts, for the "unknown board" diagnostic.
+///
+/// Issue 1285 — DERIVED from `nros_orchestration_ir::BOARD_PATHS`, the table
+/// the lookup itself reads. It was a hand-written list of eleven, which named
+/// keys the lookup accepted and silently omitted eight it also accepted, so the
+/// message could not be trusted as the answer to "what may I write here?".
+fn known_boards_csv() -> String {
+    nros_orchestration_ir::board_path_keys()
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Phase 244.D1 — does this deploy key name a pure bare-metal Cortex-M

--- a/packages/core/nros-orchestration-ir/src/lib.rs
+++ b/packages/core/nros-orchestration-ir/src/lib.rs
@@ -123,50 +123,94 @@ pub fn framework_for_board_key(key: &str) -> Option<&'static str> {
     })
 }
 
+/// Every board key the Rust pack resolves, and the board ZST it names.
+///
+/// Issue 1285 — a TABLE rather than a `match`, so the key set is data: the
+/// proc-macro's "Known boards" message is derived from it rather than
+/// hand-written beside it, and `nros-cli-core/tests/board_key_table.rs` checks
+/// every key here against `nros_entry_lower::BOARD_KEYS` (the key → family
+/// table) so the two cannot disagree about which RTOS a key names. The ZST
+/// PATH stays here: it is Rust-pack spelling, not a neutral fact.
+///
+/// Rows, grouped:
+/// - FreeRTOS — MPS2-AN385 Cortex-M3 (the only FreeRTOS board today). The RTOS
+///   calls `main()`; the board ZST impls `BoardEntry`.
+/// - NuttX — phase-337 W3: ONE crate, two witnesses. Both keys resolve to the
+///   SAME ZST: the board marker only selects trait impls, and those never
+///   differed between arm virt and rv-virt (the arch delta is defconfig +
+///   toolchain DATA). The keys stay distinct because they select the
+///   `[[board]]` descriptor — and therefore the target triple — not the type.
+/// - ESP32 — Phase 225.O: CI-runnable ESP32-C3 QEMU (OpenETH) board, routed
+///   through `Framework::Esp32` emit shape in the proc-macro.
+/// - Zephyr — Phase 225.P: Zephyr owns `main`; the board ZST impls
+///   `NetworkWait` only (NOT `BoardEntry`). The proc-macro routes through
+///   `Framework::Zephyr` and emits a `rust_main` staticlib export.
+/// - RTIC — phase-337 W6.a: the RTIC entry surface moved INTO
+///   `nros-board-mps2-an385` (its `rtic` feature); the ZST kept its name. The
+///   deploy key stays distinct because the two entry shapes are distinct — this
+///   one routes through the RTIC framework emit.
+/// - Bare metal — Phase 244.D1: pure (no-RTOS) MPS2-AN385 direct-exec board.
+///   Board ZST impls `nros_platform::BoardEntry`. Distinct from
+///   `rtic-mps2-an385`, which routes through the RTIC framework emit.
+///
+/// phase-337 W7.a — the three STM32F4 keys (`stm32f4`, `rtic-stm32f4`,
+/// `embassy-stm32f4`) left with their board crates. Unlike W6.a's
+/// `rtic-mps2-an385`, no key survives: the ZSTs are gone, not moved, so an
+/// entry naming one must fail to resolve rather than silently pick another
+/// board. Out-of-tree replacements supply their own `board_crate` — see
+/// `book/src/porting/stm32f4-out-of-tree.md`.
+pub const BOARD_PATHS: &[(&str, &str)] = &[
+    ("native", "::nros_board_linux::LinuxBoard"),
+    ("posix", "::nros_board_linux::LinuxBoard"),
+    ("freertos", "::nros_board_mps2_an385_freertos::Mps2An385"),
+    (
+        "freertos-qemu-mps2-an385",
+        "::nros_board_mps2_an385_freertos::Mps2An385",
+    ),
+    (
+        "mps2-an385-freertos",
+        "::nros_board_mps2_an385_freertos::Mps2An385",
+    ),
+    ("threadx-linux", "::nros_board_threadx_linux::ThreadxLinux"),
+    (
+        "threadx-qemu-riscv64",
+        "::nros_board_threadx_qemu_riscv64::ThreadxQemuRiscv64",
+    ),
+    (
+        "rv-virt-threadx",
+        "::nros_board_threadx_qemu_riscv64::ThreadxQemuRiscv64",
+    ),
+    ("nuttx", "::nros_board_nuttx_qemu::NuttxQemu"),
+    ("qemu-armv7a-nuttx", "::nros_board_nuttx_qemu::NuttxQemu"),
+    ("nuttx-riscv", "::nros_board_nuttx_qemu::NuttxQemu"),
+    ("rv-virt-nuttx", "::nros_board_nuttx_qemu::NuttxQemu"),
+    ("esp32-qemu", "::nros_board_esp32_qemu::Esp32QemuEntry"),
+    (
+        "esp32-c3-baremetal",
+        "::nros_board_esp32_qemu::Esp32QemuEntry",
+    ),
+    ("zephyr", "::nros_board_zephyr::ZephyrBoard"),
+    ("rtic-mps2-an385", "::nros_board_mps2_an385::RticMps2An385"),
+    (
+        "qemu-rtic-mps2-an385",
+        "::nros_board_mps2_an385::RticMps2An385",
+    ),
+    ("qemu-mps2-an385", "::nros_board_mps2_an385::Mps2An385"),
+    ("mps2-an385", "::nros_board_mps2_an385::Mps2An385"),
+];
+
+/// The board ZST the Rust pack names for `key`, or `None` for a key it does
+/// not know. See [`BOARD_PATHS`].
 pub fn board_path_for(key: &str) -> Option<&'static str> {
-    Some(match key {
-        "native" | "posix" => "::nros_board_linux::LinuxBoard",
-        // FreeRTOS — MPS2-AN385 Cortex-M3 (the only FreeRTOS board today).
-        // The RTOS calls `main()`; the board ZST impls `BoardEntry`.
-        "freertos" | "freertos-qemu-mps2-an385" | "mps2-an385-freertos" => {
-            "::nros_board_mps2_an385_freertos::Mps2An385"
-        }
-        "threadx-linux" => "::nros_board_threadx_linux::ThreadxLinux",
-        "threadx-qemu-riscv64" | "rv-virt-threadx" => {
-            "::nros_board_threadx_qemu_riscv64::ThreadxQemuRiscv64"
-        }
-        // phase-337 W3 — ONE crate, two witnesses. Both keys resolve to the
-        // SAME ZST: the board marker only selects trait impls, and those never
-        // differed between arm virt and rv-virt (the arch delta is defconfig +
-        // toolchain DATA). The keys stay distinct because they select the
-        // `[[board]]` descriptor — and therefore the target triple — not the type.
-        "nuttx" | "qemu-armv7a-nuttx" | "nuttx-riscv" | "rv-virt-nuttx" => {
-            "::nros_board_nuttx_qemu::NuttxQemu"
-        }
-        // Phase 225.O — CI-runnable ESP32-C3 QEMU (OpenETH) board. Routed
-        // through `Framework::Esp32` emit shape in the proc-macro.
-        "esp32-qemu" | "esp32-c3-baremetal" => "::nros_board_esp32_qemu::Esp32QemuEntry",
-        // Phase 225.P — Zephyr owns `main`; the board ZST impls `NetworkWait`
-        // only (NOT `BoardEntry`). The proc-macro routes through
-        // `Framework::Zephyr` and emits a `rust_main` staticlib export.
-        "zephyr" => "::nros_board_zephyr::ZephyrBoard",
-        // phase-337 W6.a — the RTIC entry surface moved INTO
-        // `nros-board-mps2-an385` (its `rtic` feature); the ZST kept its name.
-        // The deploy key stays distinct because the two entry shapes are
-        // distinct — this one routes through the RTIC framework emit.
-        "rtic-mps2-an385" | "qemu-rtic-mps2-an385" => "::nros_board_mps2_an385::RticMps2An385",
-        // Phase 244.D1 — pure bare-metal (no-RTOS) MPS2-AN385 direct-exec
-        // board. Board ZST impls `nros_platform::BoardEntry`. Distinct from
-        // `rtic-mps2-an385`, which routes through the RTIC framework emit.
-        "qemu-mps2-an385" | "mps2-an385" => "::nros_board_mps2_an385::Mps2An385",
-        // phase-337 W7.a — the three STM32F4 keys (`stm32f4`, `rtic-stm32f4`,
-        // `embassy-stm32f4`) left with their board crates. Unlike W6.a's
-        // `rtic-mps2-an385`, no key survives: the ZSTs are gone, not moved, so
-        // an entry naming one must fail to resolve rather than silently pick
-        // another board. Out-of-tree replacements supply their own
-        // `board_crate` — see `book/src/porting/stm32f4-out-of-tree.md`.
-        _ => return None,
-    })
+    BOARD_PATHS
+        .iter()
+        .find(|(k, _)| *k == key)
+        .map(|(_, path)| *path)
+}
+
+/// The keys of [`BOARD_PATHS`], in table order.
+pub fn board_path_keys() -> impl Iterator<Item = &'static str> {
+    BOARD_PATHS.iter().map(|(key, _)| *key)
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes issue 1285 (filed and resolved in this PR: `docs/issues/archived/1285-board-key-family-mapped-four-times.md`). It is RFC-0091 §8b's residue: Defect 1 as written was already fixed, and this handles the fact underneath it.

## What was wrong

Four places each worked out which family a board key belongs to, and they disagreed. These are the rows where they differ; the full 27-row table is in the issue.

| key | `board_family` | `board_to_rtos` | Rust `board_path_for` | `known_boards_csv` |
|---|---|---|---|---|
| `s32z270`, `an536` | Freertos | **posix** (substring) | not known | not listed |
| `armfvp`, `fvp-aemv8r-smp` | Zephyr | **posix** (substring) | not known | not listed |
| `nuttx-riscv` | **Native** (fallback) | nuttx | NuttxQemu | listed |
| `freertos-qemu-mps2-an385` | **Native** (fallback) | freertos | Mps2An385 FreeRTOS | not listed |
| esp32 / rtic / bare-metal mps2 (6) | **Native** (fallback) | posix | no-RTOS boards | 4 listed |

On top of that, `emit_c.rs`'s `c_runner_names` named `nros_board_threadx_run_tiers`, a symbol that is defined nowhere, and nothing tied that table to the routing predicate.

It was latent. No in-tree C/C++ entry passes a key the four disagree on: CMake passes only `native` or `zephyr`.

## Fix

- **One table, `nros_entry_lower::BOARD_KEYS`** (21 rows). `board_family` and `board_to_rtos` both read it. It lives in the lowest crate that both `nros-cli-core` and `nros-macros` already depend on, and that crate is serde-only, so the proc-macro can afford it.
- **An unknown key is an error.** `board_family` returns `Result<_, UnknownBoard>`, and the message lists the known keys. It never falls back to `Native` or `posix`. Every caller now handles the error: `entry_pack_for` (which CMake turns into a configure `FATAL_ERROR`), the typed `nros codegen entry` path, `emit_c::emit_typed`, `emit_cpp::emit_typed_with_tail` and `LoweredEntry::family()`. `plan_from_model` deliberately does not refuse, because it also serves `nros build`'s Rust entries, where any key is legal.
- **The Rust pack keeps its own spelling.** `nros_orchestration_ir::BOARD_PATHS` is now a table instead of a `match`, and `known_boards_csv` is built from it. A new test checks it against `BOARD_KEYS` family by family.
- **`BoardFamily::c_abi_runners() -> Option<CAbiRunners { run_components, run_tiers }>`**, where each half is optional on its own, because ThreadX will ship `run_components` without `run_tiers` (issue 1286).
  - `has_c_run_components()` is derived from it, and `c_runner_names` is deleted.
  - A test checks that every symbol it names is defined in the board C sources or `nros-cpp`.
  - ThreadX stays `None` here, so routing does not change.
- **#903's `board_has_run_tiers` now reads the `run_tiers` half.** It gives the same answers as before, with ThreadX false.

## Verification

- `nros-entry-lower` + `nros-cli-core`: 1248 passed, 0 failed across 24 test binaries. That includes #903's `both_entry_packs_take_the_plans_executor_branch` and the six new `board_key_table` tests.
- Root workspace: `nros-macros` 39 passed, `nros-orchestration-ir` 115 passed.
- Clippy `-D warnings` is clean on all four crates, and nightly rustfmt is clean.
- **Goldens changed: none.**
- `just ci gate` did not complete in the agent worktree. Steps 1 and 2 passed. `check-build` failed on three gates that need the cyclonedds submodule, which the worktree doesn't have, plus one gate that was refused because another build held the jobserver pool. `api-parity`, `test-unit` and `test-lane-contracts` did not run, so the queue is their first run.

## Noted, not changed

Three more sites use the same substring shape. They are recorded in the issue but left alone, because each works in a different key namespace or answers to a different authority:
- the macro's `derive_target_rtos`;
- `tier_resolver::derive_target_rtos`, which reads image board ids and maps `native_sim/native/64` to `posix`. It is latent, and the right fix is a board-catalog lookup;
- `emit_rust`'s `LinuxBoard` fallback, which only the golden harness reaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zw1nseWJBSTRqVQzRAZcg
