### PR TITLE
fix(#1284): a stated executor backing is checked against the measured default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -737,7 +737,8 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   mps2_an385 vs 88,328 B on native_sim/native/64 for ONE conf), so a subtrahend copied
   from `nm` drifts on the next knob move and was never right for both boards.
   Gate: `check-executor-backing-arena-pairing`; a statement below what the executor
-  needs is a compile error naming the knob.
+  needs is a compile error naming the knob — and, since that fails only in an image
+  no merge lane builds, `node-std-tests` checks it against the MEASURED default (issue 1284).
   The companion stale number: `APP_TASK_STACK` was deleted in phase-76, and the
   `app_stack_bytes` that replaced it was **384 KiB by bisection** until issue 1146
   MEASURED it — `uxTaskGetStackHighWaterMark` at the end of the register pass, 8

--- a/docs/issues/archived/1284-executor-backing-gate-checks-sum-not-default.md
+++ b/docs/issues/archived/1284-executor-backing-gate-checks-sum-not-default.md
@@ -1,0 +1,136 @@
+---
+id: 1284
+title: "`check-executor-backing-arena-pairing` checks that the numbers SUM, not that
+  the stated backing MEETS the executor's default — three drifts in a week"
+status: resolved
+type: tech-debt
+area: build, zephyr, ci
+severity: medium
+resolved_in: "fix(#1284): a stated executor backing is checked against the measured default"
+related: [issue-1145, issue-1171, issue-1172]
+---
+
+## What happens
+
+A Zephyr image that lowers `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` states the
+executor backing it pays for: `CONFIG_NROS_EXECUTOR_BACKING_U64S`, with
+`arena + 8 * backing == nros-arena-base` (issues 1145, 1171). Two checks guard it:
+
+- `check-executor-backing-arena-pairing` (fast line): the three numbers sum.
+- `executor::backing`'s const assertion: `EXECUTOR_BACKING_U64S >=
+  ExecutorSizing::DEFAULT.u64_len()`. This is a COMPILE error, so it fires only
+  when the image is built.
+
+No merge-gating lane builds a Zephyr Rust image. So when the executor grows, the
+twelve `examples/zephyr/rust/*/prj-{zenoh,cyclonedds}.conf` leaves stay exactly
+paired, the fast-line gate stays green, and the images stop compiling on main.
+
+## Measured drifts, one week
+
+| when | default grew | leaves stated | caught by |
+| --- | --- | --- | --- |
+| phase-436 poll/wake revision | 11041 -> 11065 | 11041 | a W3.1 acceptance build, days later |
+| #741 (issue 1172), `ActiveGroup` 40 -> 48 B | 11065 -> 11069 | 11045 (measured on a base that moved before merge) | the #741 follow-up, PR #898 |
+
+Each value was measured with `ExecutorSizing::DEFAULT.u64_len()` under
+`nros-node --features std,rmw-cffi`.
+
+## Fix
+
+Make the stated backing a checked claim against the MEASURED default, in a lane
+that gates merges. One shape: a host test in `nros-node` that reads every
+tracked conf stating `CONFIG_NROS_EXECUTOR_BACKING_U64S` and asserts it is
+`>= ExecutorSizing::DEFAULT.u64_len()`, naming the file and both numbers on
+failure. Then extend the pairing gate, or cross-reference it, so the rule has
+one home.
+
+The host figure is only valid for a conf whose image sets no executor-sizing
+knob and whose target matches the host's pointer width. The twelve leaves build
+for `native_sim/native/64` and set none. The check must REFUSE, not assume, for
+a conf that breaks either condition: an unverifiable conf is a failure with a
+reason, never a skip.
+
+## Acceptance
+
+- Mutation: state `11068` in one leaf. The new check goes red naming it, while
+  the old pairing gate (re-paired arena) stays green.
+- The check runs in a merge-gating lane. Show which one (`check-lane-contracts`
+  / `check-default-gates-run-somewhere` agree).
+
+## Resolution
+
+A stated backing is now a CLAIM, checked against the measured default in
+`just check node-std-tests`, which `gate.yml` runs on BOTH `pull_request` and
+`merge_group`.
+
+**The premise above was one conf short.** `examples/zephyr/rust/talker/prj-zenoh.conf`
+is also built for `mps2_an385` (the `zephyr-cortex-m` fixture row), a 32-bit
+board, so "the twelve leaves build for `native_sim/native/64`" held for eleven.
+The host figure cannot vouch for that claim, and refusing it would have made the
+check red by construction. So it is MEASURED instead, at its own width.
+
+Three pieces, one home for the conf side:
+
+- **`scripts/check-executor-backing-arena-pairing.py`** owns which confs claim
+  what. Its new `--claims` mode lists every (conf, board) claim, attributing
+  boards from the `examples/fixtures.toml` rows that build each conf, and
+  REFUSES (fast line as well as `--claims`) any claim it cannot vouch for: no
+  fixture row builds the conf; a board with no entry in `BOARD_TARGETS` (pointer
+  width + measuring target); any fragment the image may merge (the row's own
+  confs, the leaf's `boards/*.conf`, every shared `cmake/zephyr/*.conf` /
+  `zephyr/*.conf`) sets an executor-sizing knob; the Zephyr platform descriptor
+  sets an executor knob. The sizing-knob table is cross-checked against every
+  `"NROS_*"` name `nros-node/build.rs` reads, in both directions, so a new knob
+  cannot slip in unclassified.
+- **Cross-width claims** (today: mps2 on `thumbv7m-none-eabi`): the
+  `node-std-tests` recipe compiles `nros-node --lib` for the board's own target
+  with `NROS_EXECUTOR_BACKING_U64S=<stated>` and `alloc,rmw-cffi`, so the crate's
+  own const assertion rules at that pointer width. It first runs a NEGATIVE
+  CONTROL (a 1-word backing must fail with the knob's message). Cost measured:
+  11.3 s cold for the control, 2.0 s for the claim.
+- **Host-width claims**: `packages/core/nros-node/tests/executor_backing_claims.rs`
+  (`#[ignore]`, run by the recipe) compares each claim with
+  `ExecutorSizing::DEFAULT.u64_len()` as compiled on the host, naming the conf,
+  the board and both numbers. It refuses a cross-width claim the recipe did not
+  list in `NROS_BACKING_CROSS_VERIFIED`, a sizing knob or resolution rung
+  (`DOTCONFIG`, `NROS_PLATFORM_NAME`, `NROS_BOARD_TOML`, …) in its environment,
+  and a `zephyr/Kconfig` sizing default that is neither a derive sentinel nor
+  what the host build resolved.
+
+The pairing gate's failure text, the const assertion's doc, the `Kconfig` help
+and the test's doc each point to the others.
+
+Measured on the base (`045c689f8`): `DEFAULT = 11069` words on the 64-bit host.
+The lane went red there on exactly the twelve `native_sim/native/64` claims
+(`11045 … 24 short`), while the mps2 claim passed its 32-bit compile. The
+restatement to 11069 is PR #898's; this branch carries its commit unchanged so
+the lane is green here, and it drops by patch-id if #898 lands first.
+
+### Mutation
+
+`examples/zephyr/rust/listener/prj-zenoh.conf` set to `11068`, arena re-paired
+to `1048576 - 8 * 11068 = 960032`, everything else restated at 11069:
+
+- `check-executor-backing-arena-pairing`: **OK** ("12 conf(s) pair the arena
+  with a stated backing"), which is correct because the sum still holds.
+- `just check node-std-tests`: **FAILED**:
+
+      examples/zephyr/rust/listener/prj-zenoh.conf states
+      CONFIG_NROS_EXECUTOR_BACKING_U64S=11068 for `native_sim/native/64`, but the
+      executor's default measured on this 64-bit host is 11069 words (1 short).
+
+The cross-width path has its own negative control on every run: a 1-word
+backing on `thumbv7m-none-eabi` must fail with the knob's const-assertion
+message, or the lane fails before it believes any pass.
+
+### What is still assumed
+
+- A Zephyr Rust image reaches `nros-node` with `alloc,rmw-cffi` (through `nros`)
+  and with no `NROS_DECLARED_*` / `NROS_ENTITY_COUNT_*` from cmake, because
+  `rust_cargo_application` builds its own environment (issue 0460). The check
+  refuses those in its own environment, not in the image's. That the two agree
+  is what the week's measurements show (11069 on the host, and the same number
+  required by the images), not something the check proves.
+- `BOARD_TARGETS` maps `mps2_an385` to `thumbv7m-none-eabi`, which is the
+  board's Rust target, and treats any 64-bit host as `native_sim/native/64`'s
+  width. A new board is refused until someone adds a row.

--- a/docs/issues/archived/1284-executor-backing-gate-checks-sum-not-default.md
+++ b/docs/issues/archived/1284-executor-backing-gate-checks-sum-not-default.md
@@ -103,8 +103,8 @@ and the test's doc each point to the others.
 Measured on the base (`045c689f8`): `DEFAULT = 11069` words on the 64-bit host.
 The lane went red there on exactly the twelve `native_sim/native/64` claims
 (`11045 … 24 short`), while the mps2 claim passed its 32-bit compile. The
-restatement to 11069 is PR #898's; this branch carries its commit unchanged so
-the lane is green here, and it drops by patch-id if #898 lands first.
+restatement to 11069 is PR #898's, merged 2026-09-10; with it on `main` the lane
+is green.
 
 ### Mutation
 

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -1767,6 +1767,77 @@ node-std-tests:
         cargo test -p nros-node --lib \
         --features std,sim-time,param-services --quiet -- --ignored --exact \
         executor::backing::tests::the_static_is_handed_out_once_and_only_once
+    # Issue 1284 — a STATED executor backing must MEET the executor's default.
+    # `check-executor-backing-arena-pairing` (fast line) holds `arena + 8 *
+    # words == base`, i.e. that the numbers SUM; whether `words` is ENOUGH was
+    # only `executor::backing`'s const assertion, a compile error in an image
+    # no merge-gating lane builds, so twelve Zephyr leaves drifted twice in a
+    # week (11041 vs 11065, 11045 vs 11069) with every gate green.
+    #
+    # The conf side has one home: the pairing gate's `--claims` names every
+    # (conf, board) claim, and refuses what nothing can vouch for. Two
+    # measurements consume it:
+    #   * a board of ANOTHER pointer width — compile nros-node for that board's
+    #     own target with the stated value, so the crate's const assertion rules
+    #     at that width (after a negative control proving it CAN fire there);
+    #   * a board of the host's width — `executor_backing_claims`, which compares
+    #     against `ExecutorSizing::DEFAULT` as compiled here and names the conf
+    #     and both numbers. It refuses a cross-width claim this step did not list
+    #     in NROS_BACKING_CROSS_VERIFIED, so a bare run fails closed.
+    # `alloc,rmw-cffi` is what a Zephyr Rust image hands nros-node via `nros`,
+    # and the backing's layout depends on both. The sizing knobs and rungs the
+    # listing names are UNSET for the compile: the measurement is of an image
+    # that sets none, and the gate has already refused any image that does.
+    rc=0
+    claims="$(python3 scripts/check-executor-backing-arena-pairing.py --claims)" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        printf '%s\n' "$claims" | awk -F'\t' '$1 == "refuse" { print "  " $2 ": " $3 }'
+        echo "node-std-tests: the executor-backing claims listing refused (above) — issue 1284" >&2
+        exit 1
+    fi
+    unset_args=()
+    while IFS=$'\t' read -r _ name; do
+        unset_args+=(-u "$name")
+    done < <(printf '%s\n' "$claims" | awk -F'\t' '$1 == "knob" || $1 == "rung"')
+    cross_verified=""
+    while IFS=$'\t' read -r target words confs; do
+        [ -n "$target" ] || continue
+        backing_check() {
+            env "${unset_args[@]}" NROS_EXECUTOR_BACKING_U64S="$1" \
+                cargo check -p nros-node --lib --target "$target" \
+                --no-default-features --features alloc,rmw-cffi --quiet 2>&1
+        }
+        case ",$cross_verified," in
+            *",$target,"*) ;;
+            *)
+                rc=0; out="$(backing_check 1)" || rc=$?
+                if [ "$rc" -eq 0 ] || [[ "$out" != *"NROS_EXECUTOR_BACKING_U64S is below"* ]]; then
+                    printf '%s\n' "$out"
+                    printf '%s\n' \
+                        "node-std-tests: NEGATIVE CONTROL failed on $target — a backing of 1 word" \
+                        "  compiled (rc=$rc) or failed for another reason, so a pass below would" \
+                        "  say nothing about the stated claims (issue 1284)." >&2
+                    exit 1
+                fi ;;
+        esac
+        rc=0; out="$(backing_check "$words")" || rc=$?
+        if [ "$rc" -ne 0 ]; then
+            printf '%s\n' "$out"
+            printf '%s\n' \
+                "node-std-tests: CONFIG_NROS_EXECUTOR_BACKING_U64S=$words is refused by nros-node" \
+                "  compiled for $target, the target of: $confs" \
+                "  The image will not compile. Restate the backing at or above the executor's" \
+                "  default for that target and re-pair the arena (issue 1284)." >&2
+            exit 1
+        fi
+        cross_verified="${cross_verified:+$cross_verified,}$target"
+    done < <(printf '%s\n' "$claims" \
+        | awk -F'\t' '$1 == "claim" && $6 != "-" { k = $6 "\t" $3; c[k] = c[k] " " $2 }
+                      END { for (k in c) print k "\t" c[k] }' | sort)
+    ran_tests "the executor-backing claims test" \
+        env NROS_BACKING_CROSS_VERIFIED="$cross_verified" \
+        cargo test -p nros-node --features std,rmw-cffi --test executor_backing_claims \
+        --quiet -- --ignored --exact every_stated_executor_backing_meets_the_measured_default
     # `env,std` and NOT `rmw-cffi`: the cffi flavour makes the wall clock an
     # extern the linker wants a platform port for, and this lane links none.
     cargo test -p nros --lib --features env,std --quiet

--- a/packages/core/nros-node/src/executor/backing.rs
+++ b/packages/core/nros-node/src/executor/backing.rs
@@ -142,6 +142,15 @@ include!(concat!(env!("OUT_DIR"), "/nros_executor_backing.rs"));
 /// that wants to hear about it from the build they just ran, not from a test
 /// suite they may not run at all. `0` is the documented opt-out and is not
 /// reached here — it emits no static, so this whole arm is `cfg`'d away.
+///
+/// **It also goes false the OTHER way, and a const assertion alone cannot see
+/// that** (issue 1284): a conf that STATES the knob stays put while the executor
+/// grows under it. That fails only in the image's own build, which no
+/// merge-gating lane runs, so twelve Zephyr leaves drifted twice in a week. `just
+/// check node-std-tests` now runs this assertion per stated claim at each
+/// claimed board's pointer width, and `tests/executor_backing_claims.rs` checks
+/// the host-width claims against [`EXECUTOR_BACKING_DEFAULT_U64S`] by number;
+/// `check-executor-backing-arena-pairing --claims` says which confs claim what.
 #[cfg(nros_executor_backing_static)]
 const _: () = assert!(
     EXECUTOR_BACKING_U64S >= EXECUTOR_BACKING_DEFAULT_U64S,

--- a/packages/core/nros-node/tests/executor_backing_claims.rs
+++ b/packages/core/nros-node/tests/executor_backing_claims.rs
@@ -1,0 +1,196 @@
+//! Issue 1284 — a STATED executor backing must MEET the executor's default,
+//! measured, in a lane that gates merges.
+//!
+//! A Zephyr image that lowers `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` states the
+//! reservation it pays for, `CONFIG_NROS_EXECUTOR_BACKING_U64S=<words>` (issues
+//! 1145/1171). `check-executor-backing-arena-pairing` holds `arena + 8 * words
+//! == base` — that the numbers SUM. Whether `words` is ENOUGH is
+//! `executor::backing`'s const assertion, a compile error, and no merge-gating
+//! lane builds a Zephyr Rust image: twelve leaves stayed exactly paired at
+//! 11041 and then 11045 while the default grew to 11065 and then 11069 under
+//! them, each drift found by a build days later.
+//!
+//! This test is the host half of that claim check. The conf side — which confs
+//! claim, for which boards, and which of them nothing can vouch for — has ONE
+//! home, the pairing gate's `--claims` output, and this reads it rather than
+//! re-parsing a conf. For each claim on a board of THIS host's pointer width it
+//! compares `words` against [`ExecutorSizing::DEFAULT`] as compiled here, and
+//! names the conf and both numbers when it falls short.
+//!
+//! It REFUSES — fails with a reason, never skips — whatever it cannot vouch for:
+//!
+//! * a claim the gate itself refused (no fixture row, an unknown board, a
+//!   merged fragment that sets an executor-sizing knob);
+//! * a claim on a board of another pointer width, unless the lane has already
+//!   compiled `nros-node` for that board's own target with the stated value
+//!   and says so in `NROS_BACKING_CROSS_VERIFIED`;
+//! * a sizing knob or a knob-resolution rung (`DOTCONFIG`, the platform
+//!   descriptor) in this process's environment — the one `cargo` handed the
+//!   build that computed `DEFAULT` — because then `DEFAULT` is not the image's;
+//! * a `zephyr/Kconfig` default for a sizing knob that is neither a derive
+//!   sentinel nor the value this build resolved, for the same reason.
+//!
+//! `#[ignore]`d and run by `just check node-std-tests` (pull_request AND
+//! merge_group), which does the cross-width compile first. A bare
+//! `cargo test -- --ignored` without that step refuses the cross-width claims,
+//! which is the correct answer for a run that did not measure them.
+//!
+//! Built with `std,rmw-cffi` because the default's layout depends on the RMW
+//! seam (`ConcreteSession` is `CffiSession` only under `rmw-cffi`) and on
+//! `alloc`; a Zephyr Rust image reaches `nros-node` through `nros`'s
+//! `alloc,rmw-cffi`.
+#![cfg(all(feature = "std", feature = "rmw-cffi"))]
+
+use std::{path::PathBuf, process::Command};
+
+use nros_node::ExecutorSizing;
+
+const SCRIPT: &str = "scripts/check-executor-backing-arena-pairing.py";
+const CROSS_VERIFIED_ENV: &str = "NROS_BACKING_CROSS_VERIFIED";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("nros-node sits three levels below the repository root")
+}
+
+/// What this build resolved for a sizing knob whose `zephyr/Kconfig` default is
+/// a literal rather than a derive sentinel. `None`: not exposed as a const, so a
+/// literal Kconfig default for it cannot be compared and is refused.
+fn resolved_here(knob: &str) -> Option<usize> {
+    use nros_node::config;
+    match knob {
+        "NROS_EXECUTOR_MAX_CBS" => Some(config::MAX_CBS),
+        "NROS_EXECUTOR_MAX_SC" => Some(config::MAX_SC),
+        "NROS_EXECUTOR_MAX_NODES" => Some(config::MAX_NODES),
+        "NROS_EXECUTOR_ARENA_SIZE" => Some(config::ARENA_SIZE),
+        "NROS_EXECUTOR_ACTION_CLIENTS" => Some(config::ARENA_ACTION_CLIENTS),
+        "NROS_SUBSCRIPTION_BUFFER_SIZE" => Some(config::DEFAULT_RX_BUF_SIZE),
+        "NROS_PUBSUB_QOS_DEPTH" => Some(config::arena_model::BUDGETED_QOS_DEPTH as usize),
+        _ => None,
+    }
+}
+
+/// A Kconfig default `build.rs` does not take literally: a negative value does
+/// not parse as `usize` and falls through to the next rung (`-1 = derive`), and
+/// `NROS_EXECUTOR_ARENA_SIZE=0` is that knob's own derive sentinel.
+fn is_derive_sentinel(knob: &str, default: i64) -> bool {
+    default < 0 || (knob == "NROS_EXECUTOR_ARENA_SIZE" && default == 0)
+}
+
+#[test]
+#[ignore = "run by `just check node-std-tests`, which compiles the cross-width \
+            claims first; without that step they are refused, not skipped"]
+fn every_stated_executor_backing_meets_the_measured_default() {
+    let root = repo_root();
+    let out = Command::new("python3")
+        .arg(root.join(SCRIPT))
+        .arg("--claims")
+        .current_dir(&root)
+        .output()
+        .unwrap_or_else(|e| panic!("could not run python3 {SCRIPT} --claims: {e}"));
+    let listing = String::from_utf8_lossy(&out.stdout);
+
+    let default = ExecutorSizing::DEFAULT.u64_len();
+    let host_width = usize::BITS as usize;
+    let cross_verified: Vec<String> = std::env::var(CROSS_VERIFIED_ENV)
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+
+    let mut failures = Vec::new();
+    let mut scanned: Option<usize> = None;
+    let (mut met, mut by_compile) = (0usize, 0usize);
+
+    for line in listing.lines() {
+        let f: Vec<&str> = line.split('\t').collect();
+        match f.as_slice() {
+            ["scanned", n] => scanned = n.parse().ok(),
+            ["refuse", what, why] => failures.push(format!("{what}: {why}")),
+            ["knob" | "rung", name] => {
+                if let Some(v) = std::env::var_os(name) {
+                    failures.push(format!(
+                        "`{name}={}` is in this environment, so the nros-node build \
+                         that computed DEFAULT = {default} words saw it: that is not \
+                         the default of an image that sets nothing. Unset it.",
+                        v.to_string_lossy()
+                    ));
+                }
+            }
+            ["kconfig", knob, value] => {
+                let value: i64 = value.parse().expect("the gate prints integers");
+                if is_derive_sentinel(knob, value) {
+                    continue;
+                }
+                match resolved_here(knob) {
+                    Some(here) if here as i64 == value => {}
+                    Some(here) => failures.push(format!(
+                        "zephyr/Kconfig defaults {knob} to {value}, but this build \
+                         resolved {here}: every Zephyr image gets {value}, so the \
+                         host DEFAULT is not theirs"
+                    )),
+                    None => failures.push(format!(
+                        "zephyr/Kconfig defaults {knob} to the literal {value}, and \
+                         this test cannot see what the host build resolved for it, \
+                         so it cannot vouch that the host DEFAULT is an image's"
+                    )),
+                }
+            }
+            ["claim", conf, words, board, width, cross] => {
+                let words: usize = words.parse().expect("the gate prints integers");
+                let width: usize = width.parse().expect("the gate prints integers");
+                if width == host_width {
+                    if words >= default {
+                        met += 1;
+                    } else {
+                        failures.push(format!(
+                            "{conf} states CONFIG_NROS_EXECUTOR_BACKING_U64S={words} for \
+                             `{board}`, but the executor's default measured on this \
+                             {host_width}-bit host is {default} words ({} short). The image \
+                             will not compile. Restate it as {default} and re-pair the arena \
+                             (`arena = nros-arena-base - 8 * {default}`).",
+                            default - words
+                        ));
+                    }
+                } else if *cross != "-" && cross_verified.iter().any(|t| t == cross) {
+                    by_compile += 1;
+                } else {
+                    failures.push(format!(
+                        "{conf} states {words} words for `{board}` ({width}-bit), and \
+                         this host is {host_width}-bit, so its DEFAULT = {default} is not \
+                         that board's. Nothing measured it: `{cross}` is not in \
+                         {CROSS_VERIFIED_ENV}. Run `just check node-std-tests`, which \
+                         compiles nros-node for that target with the stated value first."
+                    ));
+                }
+            }
+            _ => failures.push(format!("unparseable claims line: {line:?}")),
+        }
+    }
+
+    assert!(
+        out.status.success() || !failures.is_empty(),
+        "{SCRIPT} --claims failed with no refusal to show:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        scanned.is_some_and(|n| n > 0),
+        "{SCRIPT} --claims scanned no conf at all — the listing is empty, which is \
+         what a broken listing also prints:\n{listing}"
+    );
+    assert!(
+        failures.is_empty(),
+        "issue 1284 — {} stated executor backing claim(s) fail or cannot be vouched \
+         for (DEFAULT = {default} words, {host_width}-bit host):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+    println!(
+        "executor backing claims: {met} met DEFAULT = {default} words on this \
+         {host_width}-bit host; {by_compile} verified by the cross-width compile"
+    );
+}

--- a/scripts/check-executor-backing-arena-pairing.py
+++ b/scripts/check-executor-backing-arena-pairing.py
@@ -45,14 +45,48 @@ The gate also refuses a `CONFIG_NROS_EXECUTOR_BACKING_U64S` line in a conf when
 assignment to an undeclared symbol, so such a line reads as a decision and
 reaches nothing — issue 0460's failure mode, one layer up.
 
+THE OTHER HALF (issue 1284). `arena + 8 * words == base` says the three numbers
+SUM. It says nothing about whether `words` is enough, and that is the half that
+drifted: twelve leaves stayed exactly paired at 11041, then 11045, while the
+executor grew to 11065 and then 11069 under them, and this gate stayed green
+because the sum held. `executor::backing`'s const assertion catches it, but it
+is a COMPILE error and no merge-gating lane builds a Zephyr Rust image.
+
+So a stated backing is a CLAIM, and the claim is checked against the MEASURED
+default in `just check node-std-tests` (pull_request AND merge_group):
+
+  * host-width boards — `nros-node/tests/executor_backing_claims.rs` compares
+    `words` with `ExecutorSizing::DEFAULT.u64_len()` as compiled on the host,
+    naming the conf and both numbers;
+  * every other board — the recipe compiles `nros-node` for that board's own
+    target with `NROS_EXECUTOR_BACKING_U64S=<words>`, so the crate's const
+    assertion rules on it at the board's pointer width.
+
+This file owns the conf side of both: which confs claim, for which boards, and
+which of them no measurement can vouch for. `--claims` prints that for the two
+consumers above. A claim is REFUSED — a failure with a reason, never a skip —
+when
+
+  * no fixture row builds the conf, so nothing names the board it is for;
+  * a row names a board this file has no pointer width / measurement for;
+  * any fragment the image merges sets an EXECUTOR-SIZING knob, so the default
+    measured without it is not the image's default;
+  * `nros-node/build.rs` reads a knob this file has not classified (the knob
+    table cannot go stale toward OK).
+
 Usage:
-    python3 scripts/check-executor-backing-arena-pairing.py [--self-test]
+    python3 scripts/check-executor-backing-arena-pairing.py [--self-test | --claims]
 """
 
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # python < 3.11
+    import tomli as tomllib
 
 BACKING_KEY = "CONFIG_NROS_EXECUTOR_BACKING_U64S"
 ARENA_KEY = "CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE"
@@ -67,6 +101,105 @@ BYTES_PER_WORD = 8
 BACKING_RE = re.compile(rf"^\s*{BACKING_KEY}\s*=\s*(-?\d+)\s*$", re.M)
 ARENA_RE = re.compile(rf"^\s*{ARENA_KEY}\s*=\s*(\d+)\s*$", re.M)
 BASE_RE = re.compile(rf"#\s*{BASE_MARKER}\s*:\s*(\d+)")
+
+# --- issue 1284: the claim half -------------------------------------------
+#
+# Every `NROS_*` name `packages/core/nros-node/build.rs` reads, classified. The
+# gate harvests the names from build.rs and fails on one that is in neither
+# table, and on a table entry build.rs no longer reads — both directions, so the
+# table cannot drift toward OK.
+#
+# SIZING: feeds `ExecutorSizing::DEFAULT` (cbs / sc / nodes / arena). An image
+# that sets one has a default the host build did not measure. The Zephyr
+# spelling is `CONFIG_<name>`, read from `$DOTCONFIG` (issue 0460).
+SIZING_KNOBS = {
+    "NROS_EXECUTOR_MAX_CBS": "`cbs`, and every per-slot arena term",
+    "NROS_DECLARED_EXECUTOR_MAX_CBS": "the declared rung of `cbs` (issue 1199)",
+    "NROS_EXECUTOR_MAX_SC": "`sc`",
+    "NROS_EXECUTOR_MAX_NODES": "`nodes`",
+    "NROS_EXECUTOR_ARENA_SIZE": "`arena`, directly",
+    "NROS_EXECUTOR_ACTION_CLIENTS": "the arena's action-client term",
+    "NROS_DECLARED_EXECUTOR_ACTION_CLIENTS": "the declared rung of the same",
+    "NROS_SUBSCRIPTION_BUFFER_SIZE": "the arena's rx-buffer terms",
+    "NROS_SUBSCRIBER_BUFFER_SIZE": "the arena's pub/sub region",
+    "NROS_PUBSUB_QOS_DEPTH": "the arena's pub/sub region depth (issue 1190)",
+    "NROS_DECLARED_MAX_QOS_DEPTH": "the declared rung of that depth",
+    "NROS_ENTITY_COUNT_SUBSCRIPTION": "the per-kind arena sum (phase-403)",
+    "NROS_ENTITY_COUNT_TIMER": "the per-kind arena sum",
+    "NROS_ENTITY_COUNT_SERVICE_SERVER": "the per-kind arena sum",
+    "NROS_ENTITY_COUNT_ACTION_CLIENT": "the per-kind arena sum",
+    "NROS_ENTITY_COUNT_ACTION_SERVER": "the per-kind arena sum",
+    "NROS_ENTITY_DECLARED_DEPTHS": "the per-kind subscription region sum",
+    "NROS_ENTITY_UNDECLARED_DEPTH_COUNT_SUBSCRIPTION": "the same sum's guard",
+}
+NOT_SIZING = {
+    "NROS_EXECUTOR_BACKING_U64S": "the claim itself",
+    "NROS_EXECUTOR_BACKING_SECTION": "placement only, not size",
+    "NROS_BOOT_REPORT": "a cfg, no size",
+    "NROS_PARAM_SERVICE_BUFFER_SIZE": "emitted as a const, not in the arena sum",
+    "NROS_EXECUTOR_MAX_SHUTDOWN_CBS": "sizes the Executor HEADER, not the backing",
+}
+# Not knobs, but inputs that move a knob's resolution in build.rs: the Kconfig
+# reader and the board/platform descriptor rung (`BuildRungs::from_build_env`).
+# The host measurement is only the image's when none of these reached it.
+BUILD_ENV_RUNGS = (
+    "DOTCONFIG",
+    "NROS_PLATFORM_NAME",
+    "NROS_BOARD_TOML",
+    "NROS_BOARD",
+    "NROS_PLATFORMS_DIR",
+)
+# The descriptor rung, per knob name, as `BuildRungs::executor_rungs` spells it.
+DESCRIPTOR_KNOB_RE = re.compile(
+    r"^\s*(max_cbs|max_sc|max_nodes|arena_size|action_clients|"
+    r"subscription_buffer_size)\s*=",
+    re.M,
+)
+ZEPHYR_PLATFORM_DESCRIPTOR = "packages/platform/nros-platform-zephyr/nros-platform.toml"
+
+# A board's pointer width, and the Rust target that measures it when that width
+# is not the host's (None: only a host of that width can measure it). A board
+# absent from this table is REFUSED, never guessed.
+BOARD_TARGETS = {
+    "native_sim/native/64": (64, None),
+    "mps2_an385": (32, "thumbv7m-none-eabi"),
+}
+
+# Fragments EVERY Zephyr image may merge after the leaf's own (the board / line
+# tails `scripts/build/zephyr-fixture-leaves.sh` appends). All of them are read,
+# not the one a board picks: a sizing knob in any of them is refused, which is
+# the conservative direction and needs no second copy of that script's `case`.
+SHARED_FRAGMENT_GLOBS = ("cmake/zephyr/*.conf", "zephyr/*.conf")
+
+NAME_LITERAL_RE = re.compile(r'"(NROS_[A-Z0-9_]+)"')
+
+
+def sizing_assignments(text):
+    """-> [(key, value)] for every executor-sizing knob a fragment assigns."""
+    out = []
+    for knob in SIZING_KNOBS:
+        for m in re.finditer(rf"^\s*CONFIG_{knob}\s*=\s*(\S+)", text, re.M):
+            out.append((f"CONFIG_{knob}", m.group(1)))
+    return out
+
+
+def classify(build_rs_names):
+    """-> complaints: a name build.rs reads that no table classifies, or a table
+    entry build.rs no longer reads."""
+    bad = []
+    known = set(SIZING_KNOBS) | set(NOT_SIZING)
+    for name in sorted(build_rs_names - known):
+        bad.append(
+            f"nros-node/build.rs reads `{name}`, which this gate has not "
+            f"classified. Add it to SIZING_KNOBS if it feeds "
+            f"ExecutorSizing::DEFAULT, else to NOT_SIZING with a reason."
+        )
+    for name in sorted(known - build_rs_names):
+        bad.append(
+            f"`{name}` is classified here but nros-node/build.rs no longer "
+            f"reads it — delete the entry"
+        )
+    return bad
 
 
 def last_int(pattern, text):
@@ -136,6 +269,25 @@ SELF_TESTS = [
 ]
 
 
+SIZING_SELF_TESTS = [
+    # (name, fragment body, expected number of sizing assignments)
+    ("a sizing knob", "CONFIG_NROS_EXECUTOR_MAX_CBS=8\n", 1),
+    ("the arena knob, even as the derive sentinel",
+     "CONFIG_NROS_EXECUTOR_ARENA_SIZE=0\n", 1),
+    ("the claim itself is not a sizing knob", f"{BACKING_KEY}=11069\n", 0),
+    ("a commented-out knob", "# CONFIG_NROS_EXECUTOR_MAX_SC=16\n", 0),
+    ("a prefix is not the knob", "CONFIG_NROS_EXECUTOR_MAX_CBS_EXTRA=1\n", 0),
+]
+
+CLASSIFY_SELF_TESTS = [
+    # (name, names build.rs reads, expected number of complaints)
+    ("exactly the tables", set(SIZING_KNOBS) | set(NOT_SIZING), 0),
+    ("an unclassified read",
+     set(SIZING_KNOBS) | set(NOT_SIZING) | {"NROS_EXECUTOR_NEW_TABLE"}, 1),
+    ("a stale entry", (set(SIZING_KNOBS) | set(NOT_SIZING)) - {"NROS_EXECUTOR_MAX_SC"}, 1),
+]
+
+
 def self_test():
     bad = 0
     for name, body, expect in SELF_TESTS:
@@ -143,14 +295,149 @@ def self_test():
         if len(got) != expect:
             print(f"  {name}: expected {expect} complaint(s), got {len(got)}: {got}")
             bad += 1
+    for name, body, expect in SIZING_SELF_TESTS:
+        got = sizing_assignments(body)
+        if len(got) != expect:
+            print(f"  {name}: expected {expect} sizing assignment(s), got {got}")
+            bad += 1
+    for name, names, expect in CLASSIFY_SELF_TESTS:
+        got = classify(names)
+        if len(got) != expect:
+            print(f"  {name}: expected {expect} complaint(s), got {len(got)}: {got}")
+            bad += 1
+    total = len(SELF_TESTS) + len(SIZING_SELF_TESTS) + len(CLASSIFY_SELF_TESTS)
     if bad:
         print(f"check-executor-backing-arena-pairing --self-test: {bad} case(s) FAILED")
         return 1
-    print(
-        "check-executor-backing-arena-pairing --self-test: "
-        f"{len(SELF_TESTS)} case(s) OK"
-    )
+    print(f"check-executor-backing-arena-pairing --self-test: {total} case(s) OK")
     return 0
+
+
+def self_test_quiet():
+    """`self_test` with its report on stderr, for `--claims` whose stdout is data."""
+    real, sys.stdout = sys.stdout, sys.stderr
+    try:
+        return self_test()
+    finally:
+        sys.stdout = real
+
+
+def tracked(repo, *globs):
+    out = subprocess.run(
+        ["git", "ls-files", "-z", "--", *globs],
+        capture_output=True, text=True, check=True, cwd=repo,
+    ).stdout.split("\0")
+    return [f for f in out if f]
+
+
+def kconfig_defaults(kconfig):
+    """{knob: default} for every SIZING knob `zephyr/Kconfig` declares."""
+    out = {}
+    for knob in SIZING_KNOBS:
+        m = re.search(
+            rf"^config\s+{knob}\s*$(.*?)(?=^config\s|\Z)", kconfig, re.M | re.S
+        )
+        if not m:
+            continue
+        d = re.search(r"^\s*default\s+(-?\d+)\s*$", m.group(1), re.M)
+        if d:
+            out[knob] = int(d.group(1))
+    return out
+
+
+def claims(repo, stating):
+    """-> (claims, refusals) for `stating` = {rel conf: words}.
+
+    A claim is (conf, words, board, width, cross_target); a refusal is
+    (conf, reason)."""
+    rows = tomllib.loads(
+        (repo / "examples" / "fixtures.toml").read_text(errors="replace")
+    ).get("fixture", [])
+    shared = tracked(repo, *SHARED_FRAGMENT_GLOBS)
+    out, refused = [], []
+
+    descriptor = repo / ZEPHYR_PLATFORM_DESCRIPTOR
+    if descriptor.is_file():
+        for m in DESCRIPTOR_KNOB_RE.finditer(descriptor.read_text(errors="replace")):
+            refused.append((
+                ZEPHYR_PLATFORM_DESCRIPTOR,
+                f"sets executor knob `{m.group(1)}` for every Zephyr image, so "
+                f"no Zephyr image's default is the one the host measured",
+            ))
+
+    for rel, words in sorted(stating.items()):
+        leaf, name = rel.rsplit("/", 1)
+        building = [
+            r for r in rows
+            if r.get("dir") == leaf and name in (r.get("conf_files") or [])
+        ]
+        if not building:
+            refused.append((rel, (
+                "no examples/fixtures.toml row builds this conf, so nothing names "
+                "the board -- and so the pointer width -- the stated backing is for"
+            )))
+            continue
+        for row in building:
+            board = row.get("board", "")
+            if board not in BOARD_TARGETS:
+                refused.append((rel, (
+                    f"built for board `{board}`, which has no entry in "
+                    f"BOARD_TARGETS: no pointer width and no measurement is "
+                    f"known for it. Add one; do not guess."
+                )))
+                continue
+            width, cross = BOARD_TARGETS[board]
+            fragments = [f"{leaf}/{c}" for c in row.get("conf_files") or []]
+            fragments += tracked(repo, f"{leaf}/boards/*.conf") + shared
+            for frag in dict.fromkeys(fragments):
+                path = repo / frag
+                if not path.is_file():
+                    continue
+                for key, value in sizing_assignments(path.read_text(errors="replace")):
+                    refused.append((rel, (
+                        f"its `{board}` image merges {frag}, which sets "
+                        f"{key}={value}: the executor default measured without "
+                        f"that knob is not this image's, so the stated backing "
+                        f"cannot be checked against it"
+                    )))
+            out.append((rel, words, board, width, cross))
+    return out, refused
+
+
+def claim_half(repo, confs):
+    """-> (claims, refusals, knob complaints) over the tracked `confs`."""
+    stating = {}
+    for rel in confs:
+        path = repo / rel
+        if not path.is_file():
+            continue
+        words = last_int(BACKING_RE, path.read_text(errors="replace"))
+        if words is not None and words > 0:
+            stating[rel] = words
+    build_rs = (repo / "packages/core/nros-node/build.rs").read_text(errors="replace")
+    complaints = classify(set(NAME_LITERAL_RE.findall(build_rs)))
+    got, refused = claims(repo, stating)
+    return got, refused, complaints
+
+
+def print_claims(repo, confs):
+    """`--claims`: the TSV the two claim consumers read (see the docstring)."""
+    got, refused, complaints = claim_half(repo, confs)
+    kconfig = (repo / "zephyr" / "Kconfig").read_text(errors="replace")
+    print(f"scanned\t{len(confs)}")
+    for knob in SIZING_KNOBS:
+        print(f"knob\t{knob}")
+    for rung in BUILD_ENV_RUNGS:
+        print(f"rung\t{rung}")
+    for knob, default in sorted(kconfig_defaults(kconfig).items()):
+        print(f"kconfig\t{knob}\t{default}")
+    for conf, words, board, width, cross in got:
+        print(f"claim\t{conf}\t{words}\t{board}\t{width}\t{cross or '-'}")
+    for conf, reason in refused:
+        print(f"refuse\t{conf}\t{reason}")
+    for complaint in complaints:
+        print(f"refuse\tpackages/core/nros-node/build.rs\t{complaint}")
+    return 1 if (refused or complaints) else 0
 
 
 def main():
@@ -162,21 +449,23 @@ def main():
     )
     if "--self-test" in sys.argv:
         return self_test()
+
+    # Tracked files only -- a filesystem walk reaches build output and other
+    # checkouts' worktrees (issues 1157/1166).
+    confs = tracked(repo, "*.conf")
+
+    if "--claims" in sys.argv:
+        # Machine output for `just check node-std-tests` and the nros-node
+        # claims test. The self-test still runs, on stderr, so a consumer never
+        # reads claims from a parser that no longer parses.
+        if self_test_quiet():
+            return 1
+        return print_claims(repo, confs)
+
     # On the NORMAL path too, never behind a flag: a negative control nobody
     # runs decays into a comment (AGENTS.md "a gate must run its own selftest").
     if self_test():
         return 1
-
-    # Tracked files only -- a filesystem walk reaches build output and other
-    # checkouts' worktrees (issues 1157/1166).
-    confs = [
-        f
-        for f in subprocess.run(
-            ["git", "ls-files", "-z", "*.conf"],
-            capture_output=True, text=True, check=True, cwd=repo,
-        ).stdout.split("\0")
-        if f
-    ]
 
     kconfig = (repo / "zephyr" / "Kconfig").read_text(errors="replace")
     declared = re.search(
@@ -204,6 +493,13 @@ def main():
         for complaint in bad:
             failures.append(f"  {rel}: {complaint}")
 
+    # issue 1284 — the claim half's STATIC refusals belong on the fast line too:
+    # they are text facts, and a conf nothing can vouch for should be refused
+    # on the pull request, not only where the measurement runs.
+    got, refused, complaints = claim_half(repo, confs)
+    refusals = [f"  {conf}: {reason}" for conf, reason in refused]
+    refusals += [f"  packages/core/nros-node/build.rs: {c}" for c in complaints]
+
     if failures:
         print("check-executor-backing-arena-pairing: FAIL\n")
         print("\n".join(failures))
@@ -217,13 +513,28 @@ def main():
             f"    {BACKING_KEY}=<words>\n"
             f"    {ARENA_KEY}=<base - 8 * words>\n"
             "\n"
-            "See issues 1145 and 1171."
+            "See issues 1145 and 1171. That the three numbers SUM says nothing\n"
+            "about whether <words> MEETS the executor's default -- that half is\n"
+            "`just check node-std-tests` (issue 1284)."
+        )
+        return 1
+
+    if refusals:
+        print("check-executor-backing-arena-pairing: FAIL (unverifiable claim)\n")
+        print("\n".join(refusals))
+        print(
+            f"\nA conf stating {BACKING_KEY} claims the executor needs at most that\n"
+            "many words. `just check node-std-tests` checks the claim against the\n"
+            "MEASURED default, and can only do that for an image whose default is\n"
+            "the one it measures. The claims above it cannot vouch for, so they\n"
+            "fail here rather than pass unchecked (issue 1284)."
         )
         return 1
 
     print(
         "check-executor-backing-arena-pairing: OK "
         f"({paired} conf(s) pair the arena with a stated backing; "
+        f"{len(got)} (conf, board) claim(s) attributed for node-std-tests; "
         f"{len(confs)} conf(s) scanned)"
     )
     return 0

--- a/scripts/check-executor-backing-arena-pairing.py
+++ b/scripts/check-executor-backing-arena-pairing.py
@@ -234,7 +234,9 @@ def check_conf(text):
             f"states {BACKING_KEY}={words} but does not set {ARENA_KEY}, so the "
             f"reservation is made and nothing is given back"
         )
-    if stated and base is not None and arena is not None:
+    # `words is not None` is implied by `stated`, but a type checker cannot see
+    # through the alias, so it is spelled out rather than suppressed.
+    if stated and words is not None and base is not None and arena is not None:
         want = base - words * BYTES_PER_WORD
         if arena != want:
             bad.append(

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1385,6 +1385,10 @@ config NROS_EXECUTOR_BACKING_U64S
           CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=960248
 
       check-executor-backing-arena-pairing holds every conf to that arithmetic.
+      That the numbers SUM does not make the stated value ENOUGH: the executor
+      grows, the conf does not, and the image stops compiling. `just check
+      node-std-tests` checks every stated value against the MEASURED default
+      on each board the conf is built for (issue 1284), so restate it there.
 
       0 declines the static entirely and restores the pre-W6 leak, for an image
       that would rather keep the bytes in the allocator arena than have the


### PR DESCRIPTION
Closes issue 1284 (filed and resolved in this PR: `docs/issues/archived/1284-executor-backing-gate-checks-sum-not-default.md`).

## What was wrong

`check-executor-backing-arena-pairing` checked only that the numbers sum: `arena + 8 * backing == nros-arena-base`. The rule that matters is that the stated backing is `>= ExecutorSizing::DEFAULT.u64_len()`, and only a const assertion enforced that. A const assertion fires only when something builds the image, and no merge-gating lane builds a Zephyr Rust image. So the twelve `examples/zephyr/rust/*` leaves stayed perfectly paired while falling behind twice in one week (11041 against 11065, then 11045 against 11069), each time caught days later by hand.

## Fix

A stated backing is now checked against the default measured on each board's own pointer width, in a lane that gates merges.

- **The conf side lives in one place:** `scripts/check-executor-backing-arena-pairing.py --claims`. It lists every (conf, board) claim, taking the boards from the `examples/fixtures.toml` rows that build each conf. It refuses a claim it cannot vouch for:
  - no fixture row builds the conf;
  - the board is missing from `BOARD_TARGETS`;
  - any fragment the image may merge sets an executor-sizing knob, or the Zephyr platform descriptor does.

  The table of sizing knobs is checked in both directions against every `NROS_*` name that `nros-node/build.rs` reads, so a new knob cannot slip past unclassified.
- **Claims at the host's pointer width** (`native_sim/native/64`): `packages/core/nros-node/tests/executor_backing_claims.rs` compares each claim with `DEFAULT.u64_len()` as compiled on the host, and names the conf, the board and both numbers on failure. It also refuses:
  - a sizing knob or resolution input set in its own environment;
  - a `zephyr/Kconfig` sizing default that differs from what the host resolved;
  - a cross-width claim the recipe did not verify.
- **Claims at another pointer width** (`mps2_an385` today): `node-std-tests` runs `cargo check` on `nros-node` for `thumbv7m-none-eabi` with the stated backing, so the crate's own const assertion decides at 32 bits. A negative control runs first. Cost: 11.3 s cold, 2.0 s warm.
- **Where it runs:** `node-std-tests` runs on `pull_request` and `merge_group`. `default-gates-run-somewhere --survey` and `check-lane-contracts` both agree, and the lane contracts show it needs no fixture.

The brief listed twelve claims, and there are thirteen: `talker/prj-zenoh.conf` also builds for mps2. Measuring it on the host would have been wrong, and refusing it would have made the check red from day one.

## Evidence

- **Default measured:** 11069 words on the 64-bit host, both on `045c689f8` and on today's main. On the old base the lane went red on exactly the 12 native_sim claims (`11045 … 24 short`).
- **Mutation:** `listener/prj-zenoh.conf` set to `11068`, with its arena re-paired. The old pairing gate stays green. The new check goes red: `… states CONFIG_NROS_EXECUTOR_BACKING_U64S=11068 for 'native_sim/native/64', but the executor's default measured on this 64-bit host is 11069 words (1 short).`

Gate results, run in the agent worktree:

| gate | result |
| --- | --- |
| `node-std-tests` | green |
| pairing gate | `OK (12 conf(s) pair …; 13 (conf, board) claim(s) attributed …; 158 conf(s) scanned)` |
| `check-lane-contracts` | OK |
| `check-default-gates-run-somewhere` | OK |
| `required-features-reachable` | OK |
| `just check fast` | 286 ran, 0 failed; 9 skipped (8 need a built `nros` CLI, 1 needs `NV_SPE_FSP_DIR`) |
| `api-parity`, `test-unit` (1295 passed; the 1 failure is a `[SKIPPED]` precondition), `test-lane-contracts` (17/17) | green, run individually |

`just ci gate` stopped at `check::build` on two gates. Neither is in files this PR touches:
- `cli-tests`: `nros-launch-resolve` is not built in the worktree.
- `rmw-cyclonedds`: `undefined reference to 'nros_test_srv_dds__SumSeq_Request__desc'`, not reproduced on main. This lane runs only on schedule and dispatch.

## Still assumed

A Zephyr Rust image reaches `nros-node` with `alloc,rmw-cffi` and with none of cmake's `NROS_DECLARED_*` / `NROS_ENTITY_COUNT_*` values. The check refuses those values in its own environment, not in the image's. This is recorded in the issue. Any new board is refused until someone adds a `BOARD_TARGETS` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zw1nseWJBSTRqVQzRAZcg
