### PR TITLE
fix(phase-444 W4.a, #1092): a declared RMW deviation pins the shape it licenses

### DIFF
--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -15,10 +15,12 @@
 #         control; deleting the sentence would delete the test's description.
 #         The same class `check-doc-recipe-refs` calls NEGATION.
 #
-#         TWO documents cite it now: issue 1092, which describes the test, and
-#         issue 1241 (archived — it landed resolved), which quotes 1092's
-#         control while explaining why this header is worth a gate. `archived/`
-#         is not scanned, so only 1092's citation needs a row.
+#         TWO documents cite it: issue 1092, which describes the test, and
+#         issue 1241, which quotes 1092's control. BOTH are archived now
+#         (1092 landed resolved in phase-444 W4.a) and `archived/` is not
+#         scanned, so the row this note explained is gone. The live tools
+#         spell the control as "an id with no file (9999)", which the ref
+#         regex does not read as a citation.
 #
 #   1110  DELIBERATELY WITHDRAWN. The file DID exist, on the phase-431
 #         branch only: W6 filed it while the rustdoc lane was red, and
@@ -29,7 +31,6 @@
 #         0319/0896 class — is still worth reading, and `refs/issue-ids/1110`
 #         is claimed either way.
 #
-docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
 docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
 docs/roadmap/archived/phase-431-ship-the-nros-binary.md:1110
 just/check/docs.just:1110

--- a/docs/issues/archived/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md
+++ b/docs/issues/archived/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md
@@ -3,7 +3,7 @@ id: 1092
 title: "`rmw-abi-shape` licenses a deviation without pinning it — 7 of 24
   mutations left every RMW gate green, including a `void` return and a gutted
   slot"
-status: open
+status: resolved
 type: bug
 area: ci, rmw
 related: [phase-393, phase-428, rfc-0089]
@@ -104,3 +104,78 @@ a different `generated.rs`, so it would go red — on a host that has bindgen; t
 recipe skips when it is absent. The snapshot files were not mutated; the
 contract half re-derives byte-identically on this Humble install and nothing is
 claimed about other distros.
+
+## Resolution — every declaration pins what it licenses (2026-09-11, phase-444 W4.a)
+
+All four ranked fixes landed in `scripts/rmw-abi-shape.py`, plus the parity
+map's half of fix 4 in `scripts/rmw-api-parity.py`.
+
+1. **`ADDED` entries are `Added(ret, args, why)`.** Each key must be a live
+   slot (else `orphan_pin`) whose return and argument list equal the pin (else
+   `added_drift`), and an `ADDED` slot that turns out to have an upstream
+   counterpart is refused. Closes both `has_data` mutations.
+2. **`ARG_DEVIATIONS` / `RET_DEVIATIONS` entries are `ArgPin(upstream, ours,
+   why)` / `RetPin(upstream, ours, why)`**, in the normalised spelling the
+   comparison uses. A declared slot passes only while BOTH sides still read
+   exactly the pin; any change to the header or to the upstream snapshot is
+   `pin_drift` and prints the current shape to paste. There is deliberately no
+   flag that rewrites pins — a gate you clear by regenerating its expectation
+   is the staleness gate this issue found `rmw-api-comparison` to be. The
+   stale-pin check (a pin on a slot that now matches) moved out of
+   `--self-test` into `compare()`, so `--check` fails on it too, and a pin no
+   comparison ever consults is `orphan_pin`.
+3. **Grouped-ONLY targets are compared** against the upstream symbol grouped
+   onto them: `create_session` ← `rmw_init`, `destroy_session` ← `rmw_shutdown`
+   and `rmw_context_fini`, `subscription_take_event` ← `rmw_take_event`. The
+   first two gained pins with reasons; the third's entry already existed and
+   had never been read.
+4. **Deferral ids resolve.** `scripts/lib/issue_status.py` is the one resolver;
+   a `gap` reason defers only to an issue whose file says `status: open`, and a
+   `not-implemented` row's `issue =` must do the same (`9999`, `0776` and
+   `"banana"` are all refused now). The docstring/error exemplar is no longer
+   the resolved 0776.
+
+### What the pins found on the way in
+
+* `ARG_DEVIATIONS["subscription_get_network_flow_endpoints"]` declared a
+  deviation on a slot that has never existed (both network-flow symbols are
+  `declined`, issue 0956), "as" a sibling entry that did not exist either.
+  Deleted; `orphan_pin` is the check that would have caught it.
+* `take`'s reason listed `(sub, buf, buf_len, size_t *out_len, bool *taken)`
+  — five arguments, the pre-phase-406 shape — beside a header that takes
+  three `(sub, rmw_mut_byte_span_t *, bool *)`. Reason corrected. That is the
+  argument for pinning in one line: the prose had been false since phase-406
+  and nothing could see it.
+
+### Coverage, recomputed
+
+| | slots |
+| --- | ---: |
+| identical to upstream | 15 |
+| name matches upstream, difference PINNED | 39 |
+| grouped-only target, difference PINNED | 3 |
+| RTOS addition, signature PINNED | 11 |
+| **compared with no licence to vary** | **68 of 68** |
+
+### Acceptance (phase-428 W7: all seven surviving mutations fail)
+
+Executable, not recorded: `--self-test` replays the seven mutations above
+against the REAL header on every run (`MUTATIONS`), and fails if any one adds
+no `--check` failure the unmutated tree lacks — `OK (71 slot(s) parsed, 28
+case(s), 7 of issue 1092's mutations caught)`. The planted cases cover an
+unchanged pin passing, an appended argument / a retyped handle / a `void`
+return / upstream moving under a pin each failing, and stale ARG and RET pins
+being reported.
+
+Negative control on the real tree: `take` given a trailing `uint64_t
+bogus_extra` in `rmw_vtable.h` → `just check rmw-abi-shape` rc=1 with
+
+```
+take: the args changed under a PINNED deviation
+    pinned ours: ("const rmw_subscription_t *", "rmw_mut_byte_span_t *", "bool *")
+    header now : ("const rmw_subscription_t *", "rmw_mut_byte_span_t *", "bool *", "uint64_t")
+```
+
+while `origin/main`'s copy of the script, run against the same mutated
+header, printed `name matches, args DECLARED : 39` and exited 0. Header
+restored.

--- a/justfile
+++ b/justfile
@@ -3135,9 +3135,9 @@ rmw-ret-sign:
     @python3 scripts/check-rmw-ret-sign.py
 
 # Phase 376 W2 — how far our vtable is from mirroring upstream, slot by slot and
-# arg by arg. REPORTING ONLY, deliberately not on the `check` line: `--check`
-# fails by construction until the W3+ migration lands, and a gate that cannot
-# pass is a gate people learn to skip. It joins `check` at the end of W3.
+# arg by arg. The REPORT, without `--check`; the gate is `just check
+# rmw-abi-shape` on the fast line (it joined when W3 landed, and since issue
+# 1092 every declared deviation pins both shapes it licenses).
 [group("check")]
 rmw-abi-shape:
     @python3 scripts/rmw-abi-shape.py

--- a/scripts/lib/issue_status.py
+++ b/scripts/lib/issue_status.py
@@ -1,0 +1,48 @@
+"""Resolve an issue id to the `status:` its file declares.
+
+Issue 1092: two RMW gates accepted "names an issue" as a deferral, and checked
+the NAME only — a regex for four digits, or truthiness of an `issue =` field.
+an id with no file (9999), `issue 0776` (resolved and archived) and
+`issue = "banana"` were all accepted, so the exception mechanism that lets a
+real gap sit on the fast line could hold a gap nobody was tracking. A
+deferral is only a deferral while the issue it names is OPEN; this is the one
+place that question is answered.
+"""
+
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_DIRS = (
+    os.path.join("docs", "issues"),
+    os.path.join("docs", "issues", "archived"),
+)
+_FM = re.compile(r"^---\n(.*?)\n---", re.S)
+_STATUS = re.compile(r"^status:\s*[\"']?([A-Za-z_-]+)", re.M)
+
+
+def issue_status(num, root=ROOT):
+    """`"open"` / `"resolved"` / … for issue `num`, or None when no issue file
+    carries that id (or `num` is not an issue id at all).
+
+    Accepts `776`, `"0776"` and `"issue 0776"`-free digits alike; anything that
+    is not digits resolves to None rather than raising, because the callers
+    hold AUTHORED values and "banana" must read as "no such issue".
+    """
+    s = str(num).strip()
+    if not s.isdigit():
+        return None
+    prefix = f"{int(s):04d}-"
+    for rel in _DIRS:
+        d = os.path.join(root, rel)
+        try:
+            names = os.listdir(d)
+        except FileNotFoundError:
+            continue
+        for fn in sorted(names):
+            if fn.startswith(prefix) and fn.endswith(".md"):
+                with open(os.path.join(d, fn), encoding="utf-8") as fh:
+                    m = _FM.match(fh.read())
+                st = _STATUS.search(m.group(1)) if m else None
+                return st.group(1) if st else "unknown"
+    return None

--- a/scripts/rmw-abi-shape.py
+++ b/scripts/rmw-abi-shape.py
@@ -13,9 +13,12 @@ So the target state is mechanical, and therefore checkable:
 
 * every symbol in the implementation contract has a vtable slot named exactly
   the upstream name minus its `rmw_` prefix (`rmw_take` -> `take`);
-* that slot's parameters match upstream's, or the difference is DECLARED with
-  its RTOS reason;
-* every slot with no upstream counterpart is a DECLARED addition, with a reason.
+* that slot's parameters and return type match upstream's, or the difference
+  is DECLARED — pinned, both sides, with its RTOS reason (issue 1092: a
+  declaration that names a slot without pinning its shape licenses every
+  future change to it);
+* every slot with no upstream counterpart is a DECLARED addition, with a reason
+  and its pinned signature.
 
 Nothing here is a matter of taste: a rename is a rename, an argument is present
 or it is not. What needs judgement — whether a deviation is justified — is
@@ -38,8 +41,11 @@ import argparse
 import os
 import re
 import sys
+from typing import NamedTuple
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
+from issue_status import issue_status  # noqa: E402
 VTABLE = os.path.join(ROOT, "packages", "core", "nros-rmw-abi", "include", "nros", "rmw_vtable.h")
 SIGS = os.path.join(ROOT, "docs", "reference", "rmw-implementation-signatures.txt")
 CONTRACT = os.path.join(ROOT, "docs", "reference", "rmw-implementation-contract.txt")
@@ -151,14 +157,64 @@ GROUPED_SYMBOLS = {
     "rmw_context_fini": "destroy_session",
 }
 
+# ---------------------------------------------------------------------------
+# A declaration PINS the shape it licenses (issue 1092, phase-428 W7).
+#
+# Every value in ADDED / RET_DEVIATIONS / ARG_DEVIATIONS below was a reason
+# string until 2026-09-11, and the check was MEMBERSHIP: once a slot was
+# listed, the header could say anything. Twenty-four mutations against a
+# scratch mirror left seven green — a `void` return on `create_node` (the exact
+# defect W5 existed to remove), a `uint64_t` appended to `take`, `has_data`
+# gutted or deleted outright.
+#
+# So an entry now records BOTH sides of the difference it explains, in the
+# normalised spelling the comparison uses (parameter names stripped), and a
+# difference on a declared slot passes only while both sides still read
+# exactly that. Any change to the slot — or to the upstream snapshot — fails
+# until someone edits the entry, which puts the reason in front of them at the
+# moment it may have stopped being true. The failure prints the current shape
+# to paste; there is deliberately no flag that rewrites the pins, because a
+# gate cleared by regenerating its expectation is a staleness gate, which is
+# what issue 1092 found `rmw-api-comparison` to be.
+# ---------------------------------------------------------------------------
+
+
+class ArgPin(NamedTuple):
+    """A parameter-list difference: upstream's list, ours, and why."""
+
+    upstream: tuple
+    ours: tuple
+    why: str
+
+
+class RetPin(NamedTuple):
+    """A return-type difference: upstream's type, ours, and why."""
+
+    upstream: str
+    ours: str
+    why: str
+
+
+class Added(NamedTuple):
+    """An RTOS-only slot: its whole signature, since there is nothing to diff."""
+
+    ret: str
+    args: tuple
+    why: str
+
+
 # Slots we add that upstream has no equivalent for.
 ADDED = {
-    "publisher_take_event": (
-        "the publisher half of upstream's single `rmw_take_event`. Upstream "
-        "needs one function because its `rmw_event_t` carries the entity; that "
-        "handle is declined here, so the entity is an argument and the two "
-        "sides cannot share a signature. `subscription_take_event` is the "
-        "grouped answer to the upstream name; this is its twin (issue 0780)"
+    "publisher_take_event": Added(
+        ret="rmw_ret_t",
+        args=("const rmw_publisher_t *", "rmw_event_type_t", "rmw_event_payload_t *", "bool *"),
+        why=(
+            "the publisher half of upstream's single `rmw_take_event`. Upstream "
+            "needs one function because its `rmw_event_t` carries the entity; that "
+            "handle is declined here, so the entity is an argument and the two "
+            "sides cannot share a signature. `subscription_take_event` is the "
+            "grouped answer to the upstream name; this is its twin (issue 0780)"
+        ),
     ),
     # `create_session` and `destroy_session` are NOT here. They were, and their
     # own reasons said why they should not be — "grouped onto it in
@@ -168,78 +224,128 @@ ADDED = {
     # grouped targets, so removing them made both slots report as undeclared
     # extras. Fixed at the union instead of by parking them here, and the
     # self-test now refuses the overlap outright.
-    "drive_io": (
-        "the caller donates the thread. A backend may pump its own transport here "
-        "(XRCE, single-threaded zenoh) or merely PACE the caller when it owns RX "
-        "threads of its own (cyclonedds' is a sleep, and says so; uORB's is a "
-        "no-op) — what the ABI never does is assume a background transport "
-        "thread the target may not have. Do not shorten this back to \"the caller "
-        "donates the CPU that does I/O\": that is false on half the backends"
+    "drive_io": Added(
+        ret="rmw_ret_t",
+        args=("rmw_session_t *", "int32_t"),
+        why=(
+            "the caller donates the thread. A backend may pump its own transport here "
+            "(XRCE, single-threaded zenoh) or merely PACE the caller when it owns RX "
+            "threads of its own (cyclonedds' is a sleep, and says so; uORB's is a "
+            "no-op) — what the ABI never does is assume a background transport "
+            "thread the target may not have. Do not shorten this back to \"the caller "
+            "donates the CPU that does I/O\": that is false on half the backends"
+        ),
     ),
-    "next_deadline_ms": (
-        "an upper BOUND on how long the backend may be left undriven before its "
-        "own timers slip (lease keepalive, heartbeat, ACK-NACK); the executor "
-        "caps its `drive_io` wait against it. Not \"sleep EXACTLY until the next "
-        "internal event\" — its one implementation cannot do that and says so: "
-        "zenoh-pico does not expose the next-keepalive timestamp through FFI, so "
-        "the shim returns the constant `Z_TRANSPORT_LEASE / EXPIRE_FACTOR`. A "
-        "bound is what the caller needs anyway; the value of a bound is that the "
-        "loop never OVER-sleeps"
+    "next_deadline_ms": Added(
+        ret="rmw_ret_t",
+        args=("const rmw_session_t *", "uint32_t *", "bool *"),
+        why=(
+            "an upper BOUND on how long the backend may be left undriven before its "
+            "own timers slip (lease keepalive, heartbeat, ACK-NACK); the executor "
+            "caps its `drive_io` wait against it. Not \"sleep EXACTLY until the next "
+            "internal event\" — its one implementation cannot do that and says so: "
+            "zenoh-pico does not expose the next-keepalive timestamp through FFI, so "
+            "the shim returns the constant `Z_TRANSPORT_LEASE / EXPIRE_FACTOR`. A "
+            "bound is what the caller needs anyway; the value of a bound is that the "
+            "loop never OVER-sleeps"
+        ),
     ),
-    "set_wake_callback": (
-        "wake the executor from the transport's own thread or ISR, without a wait-set. "
-        "SESSION-scoped: the per-entity `*_set_on_new_*_callback` slots are the upstream "
-        "family, and this is not a substitute for them"
+    "set_wake_callback": Added(
+        ret="rmw_ret_t",
+        args=("rmw_session_t *", "void (*)(void *ctx)", "void *"),
+        why=(
+            "wake the executor from the transport's own thread or ISR, without a wait-set. "
+            "SESSION-scoped: the per-entity `*_set_on_new_*_callback` slots are the upstream "
+            "family, and this is not a substitute for them"
+        ),
     ),
-    "ping_session": (
-        "reachability of the AGENT/ROUTER behind the session, which an RTOS image "
-        "on a serial or agent link needs in order to reconnect: a session over "
-        "such a transport can die with no entity-level symptom, and there is "
-        "nothing else in this ABI that reports it (`drive_io` reports nothing on "
-        "cyclonedds, whose implementation is a sleep). The old reason — "
-        "\"upstream expresses liveness through a context that cannot fail\" — was "
-        "a remark about upstream's data model, equally true on a workstation, "
-        "which is what makes it not a target reason"
+    "ping_session": Added(
+        ret="rmw_ret_t",
+        args=("rmw_session_t *", "int32_t"),
+        why=(
+            "reachability of the AGENT/ROUTER behind the session, which an RTOS image "
+            "on a serial or agent link needs in order to reconnect: a session over "
+            "such a transport can die with no entity-level symptom, and there is "
+            "nothing else in this ABI that reports it (`drive_io` reports nothing on "
+            "cyclonedds, whose implementation is a sleep). The old reason — "
+            "\"upstream expresses liveness through a context that cannot fail\" — was "
+            "a remark about upstream's data model, equally true on a workstation, "
+            "which is what makes it not a target reason"
+        ),
     ),
-    "has_data": "a poll that allocates nothing, for a loop with no wait-set",
-    "has_request": "as above, service side",
-    "publish_streamed": (
-        "saves the per-publisher STAGING buffer: a static `.bss` array sized for "
-        "the largest message the node can send, on a target with no allocator. "
-        "That is the header's own justification and it is the one that holds. It "
-        "is NOT \"publish a payload larger than any single buffer the target can "
-        "hold\" — neither implementation delivers that (XRCE `malloc`s the whole "
-        "payload and returns MESSAGE_TOO_LARGE past one stream slot; zenoh grows "
-        "a `z_owned_bytes_writer_t` to full size), and on the target class the "
-        "slot exists for, XRCE's is a same-sized heap allocation in place of the "
-        "static buffer — see the follow-up issue"
+    "has_data": Added(
+        ret="rmw_ret_t",
+        args=("rmw_subscription_t *", "bool *"),
+        why="a poll that allocates nothing, for a loop with no wait-set",
     ),
-    "subscription_supports_in_place": (
-        "the in-place capability, which slot nullity cannot carry: "
-        "`RustBackendAdapter::<R>::VTABLE` is a `const` and installs "
-        "`process_raw_in_place` for every `R: RustBackend`, while the answer is a "
-        "runtime `&self` method because `CffiSubscription` multiplexes over "
-        "whichever backend registered — zenoh true, metadata false, same nullity "
-        "(issue 0781)"
+    "has_request": Added(
+        ret="rmw_ret_t",
+        args=("rmw_service_t *", "bool *"),
+        why="as above, service side",
     ),
-    "required_rx_bytes": (
-        "how many bytes of TAKE buffer a type needs, asked BEFORE the "
-        "subscription exists. Upstream never asks: `rmw_take` there fills a "
-        "typed `void *ros_message` the caller allocated from a heap, so the "
-        "size question is answered by the typesupport above rmw. Here the "
-        "payload is bytes into a caller buffer that is a `.bss` array or an "
-        "arena slot, sized once at build time from a global constant, and the "
-        "backend is the only party that knows what its framing and size "
-        "classes add. Upstream's nearest name, "
-        "`rmw_get_serialized_message_size`, is about a MESSAGE and is "
-        "unimplemented in all three reference implementations (phase-403 W1)"
+    "publish_streamed": Added(
+        ret="rmw_ret_t",
+        args=(
+            "rmw_publisher_t *",
+            "void (*)(size_t *out_total_len, void *user_ctx)",
+            "void (*)(uint8_t *out_buf, size_t cap, size_t *out_written, void *user_ctx)",
+            "void *",
+        ),
+        why=(
+            "saves the per-publisher STAGING buffer: a static `.bss` array sized for "
+            "the largest message the node can send, on a target with no allocator. "
+            "That is the header's own justification and it is the one that holds. It "
+            "is NOT \"publish a payload larger than any single buffer the target can "
+            "hold\" — neither implementation delivers that (XRCE `malloc`s the whole "
+            "payload and returns MESSAGE_TOO_LARGE past one stream slot; zenoh grows "
+            "a `z_owned_bytes_writer_t` to full size), and on the target class the "
+            "slot exists for, XRCE's is a same-sized heap allocation in place of the "
+            "static buffer — see the follow-up issue"
+        ),
     ),
-    "process_raw_in_place": (
-        "a SCOPED borrow: it ends when the callback returns, so there is no "
-        "release token to leak. Upstream's `rmw_take_loaned_message` is unscoped, "
-        "and a caller who forgets the return retires one entry of a fixed-depth "
-        "receive ring on a target that will never reclaim it. Not 'no copy' — "
-        "upstream has a name for that and we carry it (issue 0781)"
+    "subscription_supports_in_place": Added(
+        ret="rmw_ret_t",
+        args=("rmw_subscription_t *", "bool *"),
+        why=(
+            "the in-place capability, which slot nullity cannot carry: "
+            "`RustBackendAdapter::<R>::VTABLE` is a `const` and installs "
+            "`process_raw_in_place` for every `R: RustBackend`, while the answer is a "
+            "runtime `&self` method because `CffiSubscription` multiplexes over "
+            "whichever backend registered — zenoh true, metadata false, same nullity "
+            "(issue 0781)"
+        ),
+    ),
+    "required_rx_bytes": Added(
+        ret="rmw_ret_t",
+        args=("const char *", "const char *", "size_t", "size_t *"),
+        why=(
+            "how many bytes of TAKE buffer a type needs, asked BEFORE the "
+            "subscription exists. Upstream never asks: `rmw_take` there fills a "
+            "typed `void *ros_message` the caller allocated from a heap, so the "
+            "size question is answered by the typesupport above rmw. Here the "
+            "payload is bytes into a caller buffer that is a `.bss` array or an "
+            "arena slot, sized once at build time from a global constant, and the "
+            "backend is the only party that knows what its framing and size "
+            "classes add. Upstream's nearest name, "
+            "`rmw_get_serialized_message_size`, is about a MESSAGE and is "
+            "unimplemented in all three reference implementations (phase-403 W1)"
+        ),
+    ),
+    "process_raw_in_place": Added(
+        ret="rmw_ret_t",
+        args=(
+            "rmw_subscription_t *",
+            "void *",
+            "void (*)(void *ctx, rmw_byte_span_t message)",
+            "bool *",
+        ),
+        why=(
+            "a SCOPED borrow: it ends when the callback returns, so there is no "
+            "release token to leak. Upstream's `rmw_take_loaned_message` is unscoped, "
+            "and a caller who forgets the return retires one entry of a fixed-depth "
+            "receive ring on a target that will never reclaim it. Not 'no copy' — "
+            "upstream has a name for that and we carry it (issue 0781)"
+        ),
     ),
 }
 
@@ -252,15 +358,39 @@ RET_DEVIATIONS = {
     # OUT parameter. Same decision as their ARG_DEVIATIONS entry — no runtime
     # allocation, so the caller owns the storage — and returning a status is
     # strictly more informative than NULL.
-    "node_get_graph_guard_condition": (
-        "registers a callback and returns a status, where upstream returns the guard "
-        "condition itself — see the ARG_DEVIATIONS entry"
+    "node_get_graph_guard_condition": RetPin(
+        upstream="const rmw_guard_condition_t *",
+        ours="rmw_ret_t",
+        why=(
+            "registers a callback and returns a status, where upstream returns the guard "
+            "condition itself — see the ARG_DEVIATIONS entry"
+        ),
     ),
-    "create_node": "node is an OUT parameter; the return carries the status — the caller owns the node struct, as every other create here",
-    "create_publisher": "entity is an OUT parameter; the return carries the status. The CALLER owns the entity struct — this is not a claim that nothing allocates (issue 0777)",
-    "create_subscription": "as create_publisher",
-    "create_service": "as create_publisher",
-    "create_client": "as create_publisher",
+    "create_node": RetPin(
+        upstream="rmw_node_t *",
+        ours="rmw_ret_t",
+        why="node is an OUT parameter; the return carries the status — the caller owns the node struct, as every other create here",
+    ),
+    "create_publisher": RetPin(
+        upstream="rmw_publisher_t *",
+        ours="rmw_ret_t",
+        why="entity is an OUT parameter; the return carries the status. The CALLER owns the entity struct — this is not a claim that nothing allocates (issue 0777)",
+    ),
+    "create_subscription": RetPin(
+        upstream="rmw_subscription_t *",
+        ours="rmw_ret_t",
+        why="as create_publisher",
+    ),
+    "create_service": RetPin(
+        upstream="rmw_service_t *",
+        ours="rmw_ret_t",
+        why="as create_publisher",
+    ),
+    "create_client": RetPin(
+        upstream="rmw_client_t *",
+        ours="rmw_ret_t",
+        why="as create_publisher",
+    ),
     # The six `void` slots are GONE (2026-08-24). They are recorded here as a
     # deleted entry rather than an absence, because the reason they carried was
     # the shape a bad deviation takes: "cleanup is best-effort" described the
@@ -271,78 +401,215 @@ RET_DEVIATIONS = {
 
 # Parameter differences on slots that DO correspond to an upstream function.
 ARG_DEVIATIONS = {
+    # ---- Grouped-ONLY targets, compared against the symbol grouped onto them ----
+    # These three slots have no upstream namesake, so until issue 1092 nothing
+    # compared them at all: `create_session` could become `void(int, char)` and
+    # every RMW gate stayed green. `subscription_take_event`'s entry below was
+    # already here and was never read.
+    "create_session": ArgPin(
+        upstream=("const rmw_init_options_t *", "rmw_context_t *"),
+        ours=(
+            "const char *",
+            "uint8_t",
+            "uint32_t",
+            "const char *",
+            "const rmw_session_options_t *",
+            "rmw_session_t *",
+        ),
+        why=(
+            "`rmw_init` fills a CONTEXT from an options struct built by "
+            "`rmw_init_options_init`, which allocates; ours opens the one session "
+            "an image has from its baked facts — locator, mode, domain id, node "
+            "name — plus transport options, and writes it through an OUT "
+            "parameter the caller owns, as every create here. Session fuses "
+            "upstream's context and node for an image that opens exactly one of "
+            "each (see TYPE_TARGET)"
+        ),
+    ),
+    "destroy_session": ArgPin(
+        upstream=("rmw_context_t *",),
+        ours=("rmw_session_t *",),
+        why=(
+            "the session IS the context here (see `create_session`), so "
+            "`rmw_shutdown` and `rmw_context_fini` — identical in shape, and "
+            "both grouped onto this slot — take the one handle there is"
+        ),
+    ),
     # ---- phase-406: correlated arguments grouped into allocator-free PODs ----
     # Each is the SAME defect as the type support: two or three arguments that
     # are meaningless apart, where upstream passes one thing. Grouping them
     # makes "pass one, forget the other" unrepresentable rather than merely
     # discouraged, and costs nothing at the ABI — every one of these structs is
     # a POD the caller builds on the stack.
-    "return_loaned_message_from_publisher": (
-        "upstream's loan handle is a bare `void *`; ours is an opaque "
-        "`rmw_loan_token_t *`. The bare pointer let a caller return a PUBLISHER's "
-        "token to a subscription, or a token from one backend to another — both "
-        "compile, and both are undefined behaviour discovered at run time on a target "
-        "with no allocator to notice. An incomplete type costs nothing at the ABI (it "
-        "is still a pointer) and makes both a compile error. Issue 0781 asked whether "
-        "these slots earn their place given nothing implements them; the answer taken "
-        "in phase-406 is KEEP AND TYPE, because a slot nobody can use SAFELY is worse "
-        "than one nobody uses."
+    "return_loaned_message_from_publisher": ArgPin(
+        upstream=("const rmw_publisher_t *", "void *"),
+        ours=("const rmw_publisher_t *", "rmw_loan_token_t *"),
+        why=(
+            "upstream's loan handle is a bare `void *`; ours is an opaque "
+            "`rmw_loan_token_t *`. The bare pointer let a caller return a PUBLISHER's "
+            "token to a subscription, or a token from one backend to another — both "
+            "compile, and both are undefined behaviour discovered at run time on a target "
+            "with no allocator to notice. An incomplete type costs nothing at the ABI (it "
+            "is still a pointer) and makes both a compile error. Issue 0781 asked whether "
+            "these slots earn their place given nothing implements them; the answer taken "
+            "in phase-406 is KEEP AND TYPE, because a slot nobody can use SAFELY is worse "
+            "than one nobody uses."
+        ),
     ),
-    "return_loaned_message_from_subscription": (
-        "as return_loaned_message_from_publisher — opaque `rmw_loan_token_t *`."
+    "return_loaned_message_from_subscription": ArgPin(
+        upstream=("const rmw_subscription_t *", "void *"),
+        ours=("const rmw_subscription_t *", "rmw_loan_token_t *"),
+        why=(
+            "as return_loaned_message_from_publisher — opaque `rmw_loan_token_t *`."
+        ),
     ),
-    "publish_loaned_message": (
-        "as return_loaned_message_from_publisher — opaque `rmw_loan_token_t *`."
+    "publish_loaned_message": ArgPin(
+        upstream=("const rmw_publisher_t *", "void *", "rmw_publisher_allocation_t *"),
+        ours=("const rmw_publisher_t *", "rmw_loan_token_t *", "size_t"),
+        why=(
+            "as return_loaned_message_from_publisher — opaque `rmw_loan_token_t *`."
+        ),
     ),
     # Keyed by slot name. Each entry is a difference from upstream's parameter
     # list that a target constraint forces, and the reason must be about the
     # TARGET rather than about our convenience.
-    "take": (
-        "upstream takes (sub, void *ros_message, bool *taken, allocation); ours takes "
-        "(sub, buf, buf_len, size_t *out_len, bool *taken) — there is no typesupport "
-        "indirection on target, so the payload is BYTES and the caller owns the buffer, "
-        "which means it needs the length back; the allocation argument has nothing to "
-        "pre-size — see the allocation note on `publish`"
+    "take": ArgPin(
+        upstream=(
+            "const rmw_subscription_t *",
+            "void *",
+            "bool *",
+            "rmw_subscription_allocation_t *",
+        ),
+        ours=("const rmw_subscription_t *", "rmw_mut_byte_span_t *", "bool *"),
+        why=(
+            "upstream takes (sub, void *ros_message, bool *taken, allocation); ours takes "
+            "(sub, rmw_mut_byte_span_t *span, bool *taken) — there is no typesupport "
+            "indirection on target, so the payload is BYTES and the caller owns the buffer, "
+            "which means it needs the length back (the span carries buffer, capacity and "
+            "written length in one POD since phase-406; this reason still listed the three "
+            "loose arguments until the pin put the real list beside it); the allocation "
+            "argument has nothing to pre-size — see the allocation note on `publish`"
+        ),
     ),
-    "take_request": (
-        "upstream takes (service, rmw_service_info_t *, void *ros_request, bool *taken); ours "
-        "takes bytes (buf/buf_len/out_len) because there is no typesupport on target, and a "
-        "bare `int64_t *seq_out` in place of the info struct — an RTOS reply needs the sequence "
-        "number and nothing else in it. NOTE issue 0778: on cyclonedds this int64 is not a "
-        "sequence at all but an index into a 32-entry table released only by send_response, "
-        "so a request taken and never answered leaks a slot"
+    "take_request": ArgPin(
+        upstream=("const rmw_service_t *", "rmw_service_info_t *", "void *", "bool *"),
+        ours=("const rmw_service_t *", "rmw_mut_byte_span_t *", "int64_t *", "bool *"),
+        why=(
+            "upstream takes (service, rmw_service_info_t *, void *ros_request, bool *taken); ours "
+            "takes bytes (buf/buf_len/out_len) because there is no typesupport on target, and a "
+            "bare `int64_t *seq_out` in place of the info struct — an RTOS reply needs the sequence "
+            "number and nothing else in it. NOTE issue 0778: on cyclonedds this int64 is not a "
+            "sequence at all but an index into a 32-entry table released only by send_response, "
+            "so a request taken and never answered leaks a slot"
+        ),
     ),
-    "take_response": (
-        "bytes for the typed `void *ros_response`, as `take_request` — but the "
-        "SECOND deviation is NOT the same one, and reading it as \"same two, "
-        "client side\" is how the difference stayed invisible. `take_request` "
-        "REPLACES upstream's `rmw_service_info_t *` with `*seq_out`; this slot "
-        "DROPS it with nothing in its place, so a client cannot correlate a reply "
-        "to a request at all. That asymmetry is the client half of issue 0778"
+    "take_response": ArgPin(
+        upstream=("const rmw_client_t *", "rmw_service_info_t *", "void *", "bool *"),
+        ours=("const rmw_client_t *", "rmw_mut_byte_span_t *", "int64_t *", "bool *"),
+        why=(
+            "bytes for the typed `void *ros_response`, as `take_request` — but the "
+            "SECOND deviation is NOT the same one, and reading it as \"same two, "
+            "client side\" is how the difference stayed invisible. `take_request` "
+            "REPLACES upstream's `rmw_service_info_t *` with `*seq_out`; this slot "
+            "DROPS it with nothing in its place, so a client cannot correlate a reply "
+            "to a request at all. That asymmetry is the client half of issue 0778"
+        ),
     ),
     # ---- Entity lifecycle ----
     # The session/node difference and the OUT-parameter shape are one decision
     # applied consistently, described in the phase doc: an image opens ONE
     # session, there is no typesupport indirection on target, and nothing is
     # allocated at create time.
-    "create_node": (
-        "no `rmw_context_t *`: an image has one session and reaches it directly. "
-        "Node is an OUT parameter, as every other create here"
+    "create_node": ArgPin(
+        upstream=("rmw_context_t *", "const char *", "const char *"),
+        ours=("rmw_session_t *", "const char *", "const char *", "rmw_node_t *"),
+        why=(
+            "no `rmw_context_t *`: an image has one session and reaches it directly. "
+            "Node is an OUT parameter, as every other create here"
+        ),
     ),
-    "create_publisher": (
-        "`const rmw_node_t *` matches upstream since W5/B1 — the \"session not "
-        "node\" deviation is RETIRED, not declared. What remains: baked "
-        "pkg/type strings plus a `type_hash` in place of upstream's "
-        "`rosidl_message_type_support_t *`, because there is no typesupport "
-        "indirection on target; an explicit `uint32_t domain_id`, which "
-        "upstream carries in the context; and the entity as an OUT parameter, "
-        "because the CALLER owns that struct's storage (upstream mallocs it and "
-        "returns a pointer). That last clause is about the entity STRUCT only — "
-        "the backend still heap-allocates its `backend_data` in the same call"
+    "create_publisher": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "const rosidl_message_type_support_t *",
+            "const char *",
+            "const rmw_qos_profile_t *",
+            "const rmw_publisher_options_t *",
+        ),
+        ours=(
+            "const rmw_node_t *",
+            "const rmw_message_type_support_t *",
+            "const char *",
+            "uint32_t",
+            "const rmw_qos_profile_t *",
+            "const rmw_publisher_options_t *",
+            "rmw_publisher_t *",
+        ),
+        why=(
+            "`const rmw_node_t *` matches upstream since W5/B1 — the \"session not "
+            "node\" deviation is RETIRED, not declared. What remains: baked "
+            "pkg/type strings plus a `type_hash` in place of upstream's "
+            "`rosidl_message_type_support_t *`, because there is no typesupport "
+            "indirection on target; an explicit `uint32_t domain_id`, which "
+            "upstream carries in the context; and the entity as an OUT parameter, "
+            "because the CALLER owns that struct's storage (upstream mallocs it and "
+            "returns a pointer). That last clause is about the entity STRUCT only — "
+            "the backend still heap-allocates its `backend_data` in the same call"
+        ),
     ),
-    "create_subscription": ("as create_publisher"),
-    "create_service": ("as create_publisher"),
-    "create_client": ("as create_publisher"),
+    "create_subscription": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "const rosidl_message_type_support_t *",
+            "const char *",
+            "const rmw_qos_profile_t *",
+            "const rmw_subscription_options_t *",
+        ),
+        ours=(
+            "const rmw_node_t *",
+            "const rmw_message_type_support_t *",
+            "const char *",
+            "uint32_t",
+            "const rmw_qos_profile_t *",
+            "const rmw_subscription_options_t *",
+            "rmw_subscription_t *",
+        ),
+        why=("as create_publisher"),
+    ),
+    "create_service": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "const rosidl_service_type_support_t *",
+            "const char *",
+            "const rmw_qos_profile_t *",
+        ),
+        ours=(
+            "const rmw_node_t *",
+            "const rmw_service_type_support_t *",
+            "const char *",
+            "uint32_t",
+            "const rmw_qos_profile_t *",
+            "rmw_service_t *",
+        ),
+        why=("as create_publisher"),
+    ),
+    "create_client": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "const rosidl_service_type_support_t *",
+            "const char *",
+            "const rmw_qos_profile_t *",
+        ),
+        ours=(
+            "const rmw_node_t *",
+            "const rmw_service_type_support_t *",
+            "const char *",
+            "uint32_t",
+            "const rmw_qos_profile_t *",
+            "rmw_client_t *",
+        ),
+        why=("as create_publisher"),
+    ),
     # The `const`-only deviations are GONE (2026-08-24). Fifteen slots took a
     # NON-const handle where upstream takes `const`; W5 checked every backend
     # for a write through that pointer and found none — all four `*_data_mut`
@@ -363,125 +630,396 @@ ARG_DEVIATIONS = {
     #     `rmw_node_t` deliberately carries no `context` field, so a backend
     #     handed only a node could not reach the session to answer. Upstream
     #     reaches its context THROUGH the node; we pass the session directly.
-    "destroy_publisher": (
-        "upstream takes (node, entity). The node is VALIDATION context there; here "
-        "the entity's `backend_data` is self-sufficient, so the parameter would be "
-        "inert. NOT \"an image has no node object\" — it has had one since W4"
+    "destroy_publisher": ArgPin(
+        upstream=("rmw_node_t *", "rmw_publisher_t *"),
+        ours=("rmw_publisher_t *",),
+        why=(
+            "upstream takes (node, entity). The node is VALIDATION context there; here "
+            "the entity's `backend_data` is self-sufficient, so the parameter would be "
+            "inert. NOT \"an image has no node object\" — it has had one since W4"
+        ),
     ),
-    "destroy_subscription": ("as destroy_publisher"),
-    "destroy_service": ("as destroy_publisher"),
-    "destroy_client": ("as destroy_publisher"),
+    "destroy_subscription": ArgPin(
+        upstream=("rmw_node_t *", "rmw_subscription_t *"),
+        ours=("rmw_subscription_t *",),
+        why=("as destroy_publisher"),
+    ),
+    "destroy_service": ArgPin(
+        upstream=("rmw_node_t *", "rmw_service_t *"),
+        ours=("rmw_service_t *",),
+        why=("as destroy_publisher"),
+    ),
+    "destroy_client": ArgPin(
+        upstream=("rmw_node_t *", "rmw_client_t *"),
+        ours=("rmw_client_t *",),
+        why=("as destroy_publisher"),
+    ),
     # ---- Data plane ----
-    "publish": (
-        "bytes (`const uint8_t *`, `size_t`) rather than a typed `const void *`, because "
-        "codegen bakes the type and there is no typesupport on target; and no "
-        "allocation argument, because upstream's allocation argument is an OPAQUE per-implementation handle (`rmw_publisher_allocation_t` is `{const char *implementation_identifier; void *data;}` — verified against Humble's `rmw/types.h`, and it contains no allocator), produced only by `rmw_init_publisher_allocation`, whose OTHER two parameters are a typesupport pointer and a `rosidl_runtime_c__Sequence__bound *` — both declined ABI-wide. With no way to produce one, the argument has nothing to point at. "
-        "TWO reasons have been wrong here in a week, both of them plausible: "
-        "'pools are baked' (FALSE — issue 0777 measured cyclonedds calling "
-        "ddsrt_malloc/calloc per publish AND per take, zenoh inside zenoh-pico, "
-        "the cffi shim per fallback loan; only uORB preallocates), then 'upstream "
-        "pre-sizes an rcutils_allocator_t the caller owns' (FALSE — there is no "
-        "allocator in that struct). Check the struct before writing a third"
+    "publish": ArgPin(
+        upstream=("const rmw_publisher_t *", "const void *", "rmw_publisher_allocation_t *"),
+        ours=("const rmw_publisher_t *", "rmw_byte_span_t"),
+        why=(
+            "bytes (`const uint8_t *`, `size_t`) rather than a typed `const void *`, because "
+            "codegen bakes the type and there is no typesupport on target; and no "
+            "allocation argument, because upstream's allocation argument is an OPAQUE per-implementation handle (`rmw_publisher_allocation_t` is `{const char *implementation_identifier; void *data;}` — verified against Humble's `rmw/types.h`, and it contains no allocator), produced only by `rmw_init_publisher_allocation`, whose OTHER two parameters are a typesupport pointer and a `rosidl_runtime_c__Sequence__bound *` — both declined ABI-wide. With no way to produce one, the argument has nothing to point at. "
+            "TWO reasons have been wrong here in a week, both of them plausible: "
+            "'pools are baked' (FALSE — issue 0777 measured cyclonedds calling "
+            "ddsrt_malloc/calloc per publish AND per take, zenoh inside zenoh-pico, "
+            "the cffi shim per fallback loan; only uORB preallocates), then 'upstream "
+            "pre-sizes an rcutils_allocator_t the caller owns' (FALSE — there is no "
+            "allocator in that struct). Check the struct before writing a third"
+        ),
     ),
-    "publish_loaned_message": ("a length instead of upstream's allocation argument: the loan is a byte slot, and the backend needs to know how much of it was written"),
-    "borrow_loaned_message": ("upstream loans a typed message via `void **`; ours reserves a byte slot of a requested size and reports the granted capacity plus an opaque token, because the payload is bytes and the backend owns the buffer until it is committed or discarded"),
-    "subscription_take_event": (
-        "no `rmw_event_t *` — that handle is declined, so the entity plus the "
-        "`kind` identifies the event — and the payload is the typed "
-        "`rmw_event_payload_t` union rather than upstream's `void *`, whose "
-        "shape the caller has to know out of band"
+    "publish_loaned_message": ArgPin(
+        upstream=("const rmw_publisher_t *", "void *", "rmw_publisher_allocation_t *"),
+        ours=("const rmw_publisher_t *", "rmw_loan_token_t *", "size_t"),
+        why=("a length instead of upstream's allocation argument: the loan is a byte slot, and the backend needs to know how much of it was written"),
     ),
-    # ---- Content filter / network flows: allocation replaced by a visitor ----
-    "subscription_get_network_flow_endpoints": ("as publisher_get_network_flow_endpoints"),
+    "borrow_loaned_message": ArgPin(
+        upstream=(
+            "const rmw_publisher_t *",
+            "const rosidl_message_type_support_t *",
+            "void * *",
+        ),
+        ours=(
+            "const rmw_publisher_t *",
+            "size_t",
+            "rmw_mut_byte_span_t *",
+            "rmw_loan_token_t * *",
+        ),
+        why=("upstream loans a typed message via `void **`; ours reserves a byte slot of a requested size and reports the granted capacity plus an opaque token, because the payload is bytes and the backend owns the buffer until it is committed or discarded"),
+    ),
+    "subscription_take_event": ArgPin(
+        upstream=("const rmw_event_t *", "void *", "bool *"),
+        ours=(
+            "const rmw_subscription_t *",
+            "rmw_event_type_t",
+            "rmw_event_payload_t *",
+            "bool *",
+        ),
+        why=(
+            "no `rmw_event_t *` — that handle is declined, so the entity plus the "
+            "`kind` identifies the event — and the payload is the typed "
+            "`rmw_event_payload_t` union rather than upstream's `void *`, whose "
+            "shape the caller has to know out of band"
+        ),
+    ),
+    # `subscription_get_network_flow_endpoints` is GONE (issue 1092). It
+    # declared a deviation on a slot that does not exist — both network-flow
+    # symbols are `declined` in the parity map (issue 0956) — "as" a sibling
+    # entry that did not exist either. Membership never asked whether the key
+    # named anything; `orphan_pins` now does.
     # ---- Events ----
-    "publisher_event_init": (
-        "upstream fills an `rmw_event_t` the caller then polls with "
-        "`rmw_take_event`; ours registers a CALLBACK directly, because an RTOS "
-        "executor has no wait-set to poll an event handle from. Taking the "
-        "callback at init also FUSES upstream's `rmw_event_set_callback` into "
-        "this slot, at the cost of being unable to replace or clear one later. "
-        "The extra `uint32_t` is `deadline_ms`, a duration consulted for the "
-        "DEADLINE_MISSED kinds only — it read \"the QoS-policy filter\" until "
-        "2026-08-24, which is a different thing that does not exist here — and "
-        "`void *` is the callback context"
+    "publisher_event_init": ArgPin(
+        upstream=("rmw_event_t *", "const rmw_publisher_t *", "rmw_event_type_t"),
+        ours=(
+            "const rmw_publisher_t *",
+            "rmw_event_type_t",
+            "uint32_t",
+            "rmw_status_event_callback_t",
+            "void *",
+        ),
+        why=(
+            "upstream fills an `rmw_event_t` the caller then polls with "
+            "`rmw_take_event`; ours registers a CALLBACK directly, because an RTOS "
+            "executor has no wait-set to poll an event handle from. Taking the "
+            "callback at init also FUSES upstream's `rmw_event_set_callback` into "
+            "this slot, at the cost of being unable to replace or clear one later. "
+            "The extra `uint32_t` is `deadline_ms`, a duration consulted for the "
+            "DEADLINE_MISSED kinds only — it read \"the QoS-policy filter\" until "
+            "2026-08-24, which is a different thing that does not exist here — and "
+            "`void *` is the callback context"
+        ),
     ),
-    "subscription_event_init": ("as publisher_event_init"),
-    "get_node_names": (
-        "visitor instead of an allocating `rcutils_string_array_t` pair; session "
-        "not node; and the `enclave` argument is what lets ONE slot answer both "
-        "`rmw_get_node_names` and `rmw_get_node_names_with_enclaves` — upstream "
-        "split those only because appending to a fixed out-parameter list would "
-        "have broken its ABI, which a visitor has no equivalent of"
+    "subscription_event_init": ArgPin(
+        upstream=("rmw_event_t *", "const rmw_subscription_t *", "rmw_event_type_t"),
+        ours=(
+            "const rmw_subscription_t *",
+            "rmw_event_type_t",
+            "uint32_t",
+            "rmw_status_event_callback_t",
+            "void *",
+        ),
+        why=("as publisher_event_init"),
     ),
-    "get_topic_names_and_types": ('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "get_service_names_and_types": ('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "get_publisher_names_and_types_by_node": ('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "get_subscriber_names_and_types_by_node": ('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "get_service_names_and_types_by_node": ('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "get_client_names_and_types_by_node": ('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "get_publishers_info_by_topic": ('upstream returns an ALLOCATING `rmw_topic_endpoint_info_array_t` — NOT `rmw_names_and_types_t`, which is the sibling family this entry was copy-pasted from; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "get_subscriptions_info_by_topic": ('upstream returns an ALLOCATING `rmw_topic_endpoint_info_array_t` — NOT `rmw_names_and_types_t`, which is the sibling family this entry was copy-pasted from; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
-    "count_publishers": (
-        "session, not node: a matched count is a SESSION-wide fact and our "
-        "`rmw_node_t` carries no `context`, so a backend handed only a node could "
-        "not reach the session to answer it. Upstream reaches its context THROUGH "
-        "the node. NOT \"an image has no node object\""
+    "get_node_names": ArgPin(
+        upstream=("const rmw_node_t *", "rcutils_string_array_t *", "rcutils_string_array_t *"),
+        ours=("const rmw_session_t *", "rmw_node_visitor_t"),
+        why=(
+            "visitor instead of an allocating `rcutils_string_array_t` pair; session "
+            "not node; and the `enclave` argument is what lets ONE slot answer both "
+            "`rmw_get_node_names` and `rmw_get_node_names_with_enclaves` — upstream "
+            "split those only because appending to a fixed out-parameter list would "
+            "have broken its ABI, which a visitor has no equivalent of"
+        ),
     ),
-    "count_subscribers": ("as count_publishers"),
-    "node_get_graph_guard_condition": (
-        "`rmw_session_t *` for upstream's `const rmw_node_t *`, as the rest of the "
-        "graph family and for the same reason. And upstream RETURNS a guard "
-        "condition for the caller to add to a wait set; we "
-        "have no wait set and guard conditions are an executor concept here, so this "
-        "registers a callback instead — the `set_wake_callback` shape. The callback "
-        "is an EDGE with no payload: saying WHAT changed means buffering it, which "
-        "is the graph cache a small target cannot afford"
+    "get_topic_names_and_types": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "rcutils_allocator_t *",
+            "bool",
+            "rmw_names_and_types_t *",
+        ),
+        ours=("const rmw_session_t *", "bool", "rmw_names_and_types_visitor_t"),
+        why=('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "take_with_info": (
-        "the same two deviations `take` declares — bytes rather than a typed "
-        "`void *ros_message` because there is no typesupport on target, and no "
-        "allocation argument — see `publish`"
+    "get_service_names_and_types": ArgPin(
+        upstream=("const rmw_node_t *", "rcutils_allocator_t *", "rmw_names_and_types_t *"),
+        ours=("const rmw_session_t *", "rmw_names_and_types_visitor_t"),
+        why=('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "take_loaned_message_with_info": (
-        "the same deviations `take_loaned_message` declares — a byte view plus an "
-        "opaque release token instead of a typed loan"
+    "get_publisher_names_and_types_by_node": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "rcutils_allocator_t *",
+            "const char *",
+            "const char *",
+            "bool",
+            "rmw_names_and_types_t *",
+        ),
+        ours=(
+            "const rmw_session_t *",
+            "const char *",
+            "const char *",
+            "bool",
+            "rmw_names_and_types_visitor_t",
+        ),
+        why=('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "publisher_wait_for_all_acked": (
-        "`uint32_t timeout_ms` for upstream's by-value `rmw_time_t {int64 sec, "
-        "uint64 nsec}`: 4 bytes against 16 in every entity and every call, and no "
-        "64-bit division on a 32-bit MCU. Millisecond resolution and a ~49.7-day "
-        "ceiling are the price (issue 0241). Do NOT restore the old claim that "
-        "\"every duration in this ABI is u32\" — `drive_io` and `ping_session` take "
-        "`int32_t timeout_ms`, so it is one unit and TWO widths"
+    "get_subscriber_names_and_types_by_node": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "rcutils_allocator_t *",
+            "const char *",
+            "const char *",
+            "bool",
+            "rmw_names_and_types_t *",
+        ),
+        ours=(
+            "const rmw_session_t *",
+            "const char *",
+            "const char *",
+            "bool",
+            "rmw_names_and_types_visitor_t",
+        ),
+        why=('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "send_request": (
-        "bytes rather than a typed `const void *`, and no `int64_t *sequence_id` "
-        "OUT parameter: upstream hands the caller the sequence it assigned, while "
-        "ours is a fire-and-forget publish whose reply is matched by "
-        "`take_response`. W5 verdict: this is a GAP, not a deviation — filed as issue "
-        "0778. Nothing matches the reply, because there is nothing to match it BY, and "
-        "each backend invented an unsafe policy to cope (cyclone abandons the first "
-        "request, zenoh assumes idempotence)"
+    "get_service_names_and_types_by_node": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "rcutils_allocator_t *",
+            "const char *",
+            "const char *",
+            "rmw_names_and_types_t *",
+        ),
+        ours=(
+            "const rmw_session_t *",
+            "const char *",
+            "const char *",
+            "rmw_names_and_types_visitor_t",
+        ),
+        why=('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "send_response": (
-        "bytes plus a bare `int64_t` sequence rather than upstream's "
-        "`rmw_request_id_t *`: an RTOS reply needs the sequence and nothing else "
-        "in that struct, the same deviation `take_request` declares on the way in"
+    "get_client_names_and_types_by_node": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "rcutils_allocator_t *",
+            "const char *",
+            "const char *",
+            "rmw_names_and_types_t *",
+        ),
+        ours=(
+            "const rmw_session_t *",
+            "const char *",
+            "const char *",
+            "rmw_names_and_types_visitor_t",
+        ),
+        why=('upstream returns an ALLOCATING `rmw_names_and_types_t` / `rcutils_string_array_t`; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "take_sequence": (
-        "upstream takes (sub, count, message_sequence, info_sequence, size_t *taken, allocation); "
-        "ours takes a contiguous byte block plus a per-slot length array, because there is no "
-        "typed message sequence on target and no allocator to pre-size"
+    "get_publishers_info_by_topic": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "rcutils_allocator_t *",
+            "const char *",
+            "bool",
+            "rmw_topic_endpoint_info_array_t *",
+        ),
+        ours=(
+            "const rmw_session_t *",
+            "const char *",
+            "bool",
+            "rmw_topic_endpoint_info_visitor_t",
+        ),
+        why=('upstream returns an ALLOCATING `rmw_topic_endpoint_info_array_t` — NOT `rmw_names_and_types_t`, which is the sibling family this entry was copy-pasted from; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "take_loaned_message": (
-        "upstream loans a typed `void **loaned_message`; ours is a byte view plus an opaque "
-        "token to release, because there is no typesupport and the backend owns the buffer "
-        "until `sub_release`"
+    "get_subscriptions_info_by_topic": ArgPin(
+        upstream=(
+            "const rmw_node_t *",
+            "rcutils_allocator_t *",
+            "const char *",
+            "bool",
+            "rmw_topic_endpoint_info_array_t *",
+        ),
+        ours=(
+            "const rmw_session_t *",
+            "const char *",
+            "bool",
+            "rmw_topic_endpoint_info_visitor_t",
+        ),
+        why=('upstream returns an ALLOCATING `rmw_topic_endpoint_info_array_t` — NOT `rmw_names_and_types_t`, which is the sibling family this entry was copy-pasted from; ours streams through a visitor callback, because there is no allocator at this seam and the ROS graph has no bound the CALLER can know — a buffer shape would make a 128 KiB image reserve for the worst graph it might ever meet. Session, not node, as everywhere else'),
     ),
-    "service_server_is_available": (
-        "upstream takes (node, client, bool *); the node is validation context "
-        "there and the client reaches its session directly here, so the parameter "
-        "would be inert. NOT \"an image has no node object\""
+    "count_publishers": ArgPin(
+        upstream=("const rmw_node_t *", "const char *", "size_t *"),
+        ours=("const rmw_session_t *", "const char *", "size_t *"),
+        why=(
+            "session, not node: a matched count is a SESSION-wide fact and our "
+            "`rmw_node_t` carries no `context`, so a backend handed only a node could "
+            "not reach the session to answer it. Upstream reaches its context THROUGH "
+            "the node. NOT \"an image has no node object\""
+        ),
+    ),
+    "count_subscribers": ArgPin(
+        upstream=("const rmw_node_t *", "const char *", "size_t *"),
+        ours=("const rmw_session_t *", "const char *", "size_t *"),
+        why=("as count_publishers"),
+    ),
+    "node_get_graph_guard_condition": ArgPin(
+        upstream=("const rmw_node_t *",),
+        ours=("rmw_session_t *", "rmw_event_callback_t", "const void *"),
+        why=(
+            "`rmw_session_t *` for upstream's `const rmw_node_t *`, as the rest of the "
+            "graph family and for the same reason. And upstream RETURNS a guard "
+            "condition for the caller to add to a wait set; we "
+            "have no wait set and guard conditions are an executor concept here, so this "
+            "registers a callback instead — the `set_wake_callback` shape. The callback "
+            "is an EDGE with no payload: saying WHAT changed means buffering it, which "
+            "is the graph cache a small target cannot afford"
+        ),
+    ),
+    "take_with_info": ArgPin(
+        upstream=(
+            "const rmw_subscription_t *",
+            "void *",
+            "bool *",
+            "rmw_message_info_t *",
+            "rmw_subscription_allocation_t *",
+        ),
+        ours=(
+            "const rmw_subscription_t *",
+            "rmw_mut_byte_span_t *",
+            "bool *",
+            "rmw_message_info_t *",
+        ),
+        why=(
+            "the same two deviations `take` declares — bytes rather than a typed "
+            "`void *ros_message` because there is no typesupport on target, and no "
+            "allocation argument — see `publish`"
+        ),
+    ),
+    "take_loaned_message_with_info": ArgPin(
+        upstream=(
+            "const rmw_subscription_t *",
+            "void * *",
+            "bool *",
+            "rmw_message_info_t *",
+            "rmw_subscription_allocation_t *",
+        ),
+        ours=(
+            "const rmw_subscription_t *",
+            "rmw_byte_span_t *",
+            "rmw_loan_token_t * *",
+            "bool *",
+            "rmw_message_info_t *",
+        ),
+        why=(
+            "the same deviations `take_loaned_message` declares — a byte view plus an "
+            "opaque release token instead of a typed loan"
+        ),
+    ),
+    "publisher_wait_for_all_acked": ArgPin(
+        upstream=("const rmw_publisher_t *", "rmw_time_t"),
+        ours=("const rmw_publisher_t *", "uint32_t"),
+        why=(
+            "`uint32_t timeout_ms` for upstream's by-value `rmw_time_t {int64 sec, "
+            "uint64 nsec}`: 4 bytes against 16 in every entity and every call, and no "
+            "64-bit division on a 32-bit MCU. Millisecond resolution and a ~49.7-day "
+            "ceiling are the price (issue 0241). Do NOT restore the old claim that "
+            "\"every duration in this ABI is u32\" — `drive_io` and `ping_session` take "
+            "`int32_t timeout_ms`, so it is one unit and TWO widths"
+        ),
+    ),
+    "send_request": ArgPin(
+        upstream=("const rmw_client_t *", "const void *", "int64_t *"),
+        ours=("const rmw_client_t *", "rmw_byte_span_t", "int64_t *"),
+        why=(
+            "bytes rather than a typed `const void *`, and no `int64_t *sequence_id` "
+            "OUT parameter: upstream hands the caller the sequence it assigned, while "
+            "ours is a fire-and-forget publish whose reply is matched by "
+            "`take_response`. W5 verdict: this is a GAP, not a deviation — filed as issue "
+            "0778. Nothing matches the reply, because there is nothing to match it BY, and "
+            "each backend invented an unsafe policy to cope (cyclone abandons the first "
+            "request, zenoh assumes idempotence)"
+        ),
+    ),
+    "send_response": ArgPin(
+        upstream=("const rmw_service_t *", "rmw_request_id_t *", "void *"),
+        ours=("const rmw_service_t *", "int64_t", "rmw_byte_span_t"),
+        why=(
+            "bytes plus a bare `int64_t` sequence rather than upstream's "
+            "`rmw_request_id_t *`: an RTOS reply needs the sequence and nothing else "
+            "in that struct, the same deviation `take_request` declares on the way in"
+        ),
+    ),
+    "take_sequence": ArgPin(
+        upstream=(
+            "const rmw_subscription_t *",
+            "size_t",
+            "rmw_message_sequence_t *",
+            "rmw_message_info_sequence_t *",
+            "size_t *",
+            "rmw_subscription_allocation_t *",
+        ),
+        ours=(
+            "const rmw_subscription_t *",
+            "uint8_t *",
+            "size_t",
+            "size_t",
+            "size_t *",
+            "size_t *",
+        ),
+        why=(
+            "upstream takes (sub, count, message_sequence, info_sequence, size_t *taken, allocation); "
+            "ours takes a contiguous byte block plus a per-slot length array, because there is no "
+            "typed message sequence on target and no allocator to pre-size"
+        ),
+    ),
+    "take_loaned_message": ArgPin(
+        upstream=(
+            "const rmw_subscription_t *",
+            "void * *",
+            "bool *",
+            "rmw_subscription_allocation_t *",
+        ),
+        ours=(
+            "const rmw_subscription_t *",
+            "rmw_byte_span_t *",
+            "rmw_loan_token_t * *",
+            "bool *",
+        ),
+        why=(
+            "upstream loans a typed `void **loaned_message`; ours is a byte view plus an opaque "
+            "token to release, because there is no typesupport and the backend owns the buffer "
+            "until `sub_release`"
+        ),
+    ),
+    "service_server_is_available": ArgPin(
+        upstream=("const rmw_node_t *", "const rmw_client_t *", "bool *"),
+        ours=("const rmw_client_t *", "bool *"),
+        why=(
+            "upstream takes (node, client, bool *); the node is validation context "
+            "there and the client reaches its session directly here, so the parameter "
+            "would be inert. NOT \"an image has no node object\""
+        ),
     ),
 }
 
@@ -505,26 +1043,60 @@ LAYERED = {
 # A `gap` whose reason names a TRACKED ISSUE is deferred, not forgotten, and
 # `--check` must not treat it as a red — otherwise the only way to put this
 # gate on the `just check` line is to stop tracking the gap, which is exactly
-# backwards. The issue id is the whole requirement: a bare "not yet" would let
-# anything sit here, while `issue 0776` is a file somebody has to close.
+# backwards. A bare "not yet" would let anything sit here, while `issue NNNN`
+# is a file somebody has to close.
+#
+# The id must RESOLVE, to an issue that is OPEN (issue 1092). This rule matched
+# the four digits and stopped: an id with no file at all (9999), and
+# `issue 0776`, resolved and archived — the very exemplar this comment, the
+# error text and the self-test all cited — both deferred a gap, so the
+# exception mechanism could hold a gap nobody was tracking.
 _ISSUE_REF = re.compile(r"\bissue[ -]?(\d{4})\b", re.I)
-DEFERRED = {
-    k: _ISSUE_REF.search(why).group(1)
-    for k, (bucket, why) in _parity.MAP.items()
-    if bucket == "gap" and _ISSUE_REF.search(why)
-}
 
 
-def vtable_slots():
-    """{slot: [param types]} from the vtable header.
+def deferral(why, status_of=issue_status):
+    """`(issue id, None)` when `why` defers to an OPEN issue, else `(None, why not)`."""
+    m = _ISSUE_REF.search(why)
+    if not m:
+        return None, "names no issue"
+    num = m.group(1)
+    st = status_of(num)
+    if st != "open":
+        return None, (
+            f"names issue {num}, which is "
+            + (f"`{st}`" if st else "not a file under docs/issues/")
+            + " — a deferral to an issue nobody holds open is an exemption"
+        )
+    return num, None
+
+
+DEFERRED, REFUSED_DEFERRAL = {}, {}
+for _sym, (_bucket, _why) in _parity.MAP.items():
+    if _bucket == "gap":
+        _num, _no = deferral(_why)
+        if _num:
+            DEFERRED[_sym] = _num
+        else:
+            REFUSED_DEFERRAL[_sym] = _no
+
+
+def strip_comments(src):
+    """C comments out, so a prose mention of `(*take)(` is not a declaration."""
+    body = re.sub(r"/\*.*?\*/", " ", src, flags=re.S)
+    return re.sub(r"(?m)//.*$", " ", body)
+
+
+def vtable_slots(src=None):
+    """{slot: [param types]} from the vtable header — or from `src`, the
+    self-test's mutated copy of it.
 
     Comments are stripped first: the header documents each slot in prose that
     names other slots, and a prose mention must not read as a declaration
     (issue 0719's trap).
     """
-    src = open(VTABLE, encoding="utf-8").read()
-    body = re.sub(r"/\*.*?\*/", " ", src, flags=re.S)
-    body = re.sub(r"(?m)//.*$", " ", body)
+    if src is None:
+        src = open(VTABLE, encoding="utf-8").read()
+    body = strip_comments(src)
 
     # Only the vtable STRUCT's members are slots. Phase 376 W4 added
     # file-scope visitor typedefs (`rmw_node_visit_fn` and friends) which match
@@ -578,11 +1150,24 @@ def _norm(raw):
     53 slots at once — because our side carried names and the upstream extract
     did not.
     """
-    sys.path.insert(0, os.path.join(ROOT, "scripts"))
-    spec = _util.spec_from_file_location("_inv", os.path.join(ROOT, "scripts", "rmw-api-inventory.py"))
-    mod = _util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return strip_param_names(mod.normalise_params(raw))
+    return strip_param_names(_inventory().normalise_params(raw))
+
+
+_INVENTORY = []
+
+
+def _inventory():
+    """`rmw-api-inventory.py`, loaded ONCE. It was re-executed per slot — 71
+    module loads per comparison — which cost nothing until the self-test began
+    replaying mutations through `compare()` eight times per run."""
+    if not _INVENTORY:
+        sys.path.insert(0, os.path.join(ROOT, "scripts"))
+        spec = _util.spec_from_file_location(
+            "_inv", os.path.join(ROOT, "scripts", "rmw-api-inventory.py"))
+        mod = _util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _INVENTORY.append(mod)
+    return _INVENTORY[0]
 
 
 def strip_param_names(params):
@@ -640,8 +1225,139 @@ def upstream_signatures(with_names=False):
     return sigs
 
 
-def compare():
-    slots, rets = vtable_slots()
+# What `--check` fails on, by bucket. ONE list, read by `main` and by the
+# self-test's mutation replay, so a bucket added to one cannot be missed by the
+# other.
+FAILING = (
+    "missing", "arg_diff", "ret_diff", "undeclared_extra", "vendor_types",
+    "pin_drift", "stale_pin", "orphan_pin", "added_drift",
+)
+
+
+def failures(r):
+    """The set of `(bucket, finding)` pairs that make `--check` red."""
+    out = set()
+    for b in FAILING:
+        items = r[b].items() if isinstance(r[b], dict) else r[b]
+        for it in items:
+            out.add((b, repr(it)))
+    return out
+
+
+def _fmt(params):
+    """A parameter list in the spelling a pin is written in, ready to paste."""
+    body = ", ".join(f'"{p}"' for p in params)
+    return "(" + body + ("," if len(params) == 1 else "") + ")"
+
+
+def shape_verdict(slot, up_ret, up_args, our_ret, our_args, arg_pins=None, ret_pins=None):
+    """One slot against one upstream counterpart, pins included.
+
+    Returns `(status, problems)`. `status` is `matched` (identical), `declared`
+    (every difference is pinned and each pin still reads exactly what the
+    header and the snapshot say) or `bad`; `problems` are `(bucket, finding)`
+    pairs. Pure, so the self-test can drive it with planted shapes.
+
+    Each axis is judged on its own: a slot can hold a live ARG pin and a stale
+    RET pin at once (`destroy_publisher` did), and folding the two into one
+    "declared" verdict is how the stale half hid.
+    """
+    arg_pins = ARG_DEVIATIONS if arg_pins is None else arg_pins
+    ret_pins = RET_DEVIATIONS if ret_pins is None else ret_pins
+    our_args, up_args = tuple(our_args), tuple(up_args)
+    problems = []
+
+    pin = arg_pins.get(slot)
+    if our_args == up_args:
+        if pin is not None:
+            problems.append((
+                "stale_pin",
+                f"ARG_DEVIATIONS[{slot!r}] pins an argument difference the header no "
+                "longer has — the args match upstream now; delete the entry",
+            ))
+    elif pin is None:
+        problems.append(("arg_diff", (slot, list(up_args), list(our_args))))
+    else:
+        if tuple(pin.ours) != our_args:
+            problems.append((
+                "pin_drift",
+                f"{slot}: the args changed under a PINNED deviation\n"
+                f"      pinned ours: {_fmt(pin.ours)}\n"
+                f"      header now : {_fmt(our_args)}",
+            ))
+        if tuple(pin.upstream) != up_args:
+            problems.append((
+                "pin_drift",
+                f"{slot}: upstream's args are not what the deviation was written against\n"
+                f"      pinned upstream: {_fmt(pin.upstream)}\n"
+                f"      snapshot now   : {_fmt(up_args)}",
+            ))
+
+    rpin = ret_pins.get(slot)
+    if our_ret == up_ret:
+        if rpin is not None:
+            problems.append((
+                "stale_pin",
+                f"RET_DEVIATIONS[{slot!r}] pins a return-type difference the header no "
+                "longer has — the return matches upstream now; delete the entry",
+            ))
+    elif rpin is None:
+        problems.append(("ret_diff", (slot, up_ret, our_ret)))
+    else:
+        if rpin.ours != our_ret:
+            problems.append((
+                "pin_drift",
+                f"{slot}: the return type changed under a PINNED deviation — pinned "
+                f"ours={rpin.ours!r}, header now {our_ret!r}",
+            ))
+        if rpin.upstream != up_ret:
+            problems.append((
+                "pin_drift",
+                f"{slot}: upstream's return type is not what the deviation was written "
+                f"against — pinned upstream={rpin.upstream!r}, snapshot now {up_ret!r}",
+            ))
+
+    for p in (pin, rpin):
+        if p is not None and not p.why.strip():
+            problems.append(("pin_drift", f"{slot}: a pin with no reason is a shape, not a declaration"))
+    if problems:
+        return "bad", problems
+    if our_args == up_args and our_ret == up_ret:
+        return "matched", []
+    return "declared", []
+
+
+def added_verdict(slot, entry, slots, rets):
+    """An RTOS-only slot must EXIST and keep the shape it was declared with.
+
+    Issue 1092: `ADDED` was checked for non-empty reasons and nothing else, so
+    `has_data` could be gutted (`void`, a publisher handle, two junk args) or
+    deleted outright and only bindgen noticed.
+    """
+    if slot not in slots:
+        return [(
+            "orphan_pin",
+            f"ADDED[{slot!r}] names no vtable slot — the slot was deleted or renamed "
+            "and its declaration was not",
+        )]
+    out = []
+    if entry.ret != rets.get(slot) or tuple(entry.args) != tuple(slots[slot]):
+        out.append((
+            "added_drift",
+            f"{slot}: the RTOS-only slot changed shape under its declaration\n"
+            f"      pinned    : ret={entry.ret!r} args={_fmt(entry.args)}\n"
+            f"      header now: ret={rets.get(slot)!r} args={_fmt(slots[slot])}",
+        ))
+    if not entry.why.strip():
+        out.append(("added_drift", f"{slot}: an addition with no reason is prose"))
+    return out
+
+
+_RANK = {"matched": 0, "declared": 1, "bad": 2}
+
+
+def compare(header_text=None):
+    slots, rets = vtable_slots(header_text)
     up = upstream_signatures()
     if up is None:
         return None
@@ -654,6 +1370,23 @@ def compare():
         [], [], [], [], [], [], [])
     deferred = []
     layered = []
+    pin_drift, stale_pin, orphan_pin, added_drift = [], [], [], []
+    buckets = {
+        "arg_diff": arg_diff, "ret_diff": ret_diff, "pin_drift": pin_drift,
+        "stale_pin": stale_pin, "orphan_pin": orphan_pin, "added_drift": added_drift,
+    }
+    # Every slot a deviation table was CONSULTED for. A pin nobody consults is
+    # an orphan: `subscription_get_network_flow_endpoints` declared a
+    # deviation on a slot that has never existed, and membership never asked.
+    consulted = set()
+    # Grouped-ONLY targets, by the worst verdict across their counterparts
+    # (`destroy_session` answers two upstream names).
+    grouped_only = {}
+
+    def file(problems):
+        for kind, finding in problems:
+            if finding not in buckets[kind]:
+                buckets[kind].append(finding)
 
     # What the headers actually DECLARE, so the table above cannot claim a
     # function nobody wrote.
@@ -679,29 +1412,53 @@ def compare():
                 missing.append((name, name, params))
             continue
         slot = GROUPED_SYMBOLS.get(name) or name[len("rmw_"):]
-        if name in GROUPED_SYMBOLS:
-            # An alias is satisfied by its target existing; the target's own
-            # entry is what checks the signature.
-            if slot in slots:
-                grouped.append((name, slot))
+        if name in GROUPED_SYMBOLS and slot in slots:
+            grouped.append((name, slot))
+            namesake = "rmw_" + slot
+            if namesake in up and namesake not in DECLINED:
+                # The target's own upstream name is what checks its shape.
                 continue
+            # A grouped-ONLY target has no namesake, so it is compared against
+            # the symbol grouped onto it. Before issue 1092 it was compared
+            # against nothing, and `create_session -> void(int, char)` passed.
+            consulted.add(slot)
+            status, problems = shape_verdict(
+                slot, up_ret, params, rets.get(slot, ""), slots[slot])
+            file(problems)
+            prev = grouped_only.get(slot, "matched")
+            grouped_only[slot] = max(prev, status, key=_RANK.__getitem__)
+            continue
         if slot not in slots:
             (deferred if name in DEFERRED else missing).append((name, slot, params))
             continue
         # Phase 376 W5 — the RETURN type is part of a signature. This tool did
         # not parse it, so six slots returned `void` where upstream returns
         # `rmw_ret_t` — a difference nobody had declared, on the axis that
-        # decides whether a caller can detect failure at all — and `--check` was
-        # about to join `just check` blind to it.
-        ret_ok = rets.get(slot, "") == up_ret
-        if slots[slot] == params and ret_ok:
+        # decides whether a caller can detect failure at all.
+        consulted.add(slot)
+        status, problems = shape_verdict(
+            slot, up_ret, params, rets.get(slot, ""), slots[slot])
+        file(problems)
+        if status == "matched":
             matched.append(slot)
-        elif slot in ARG_DEVIATIONS and (ret_ok or slot in RET_DEVIATIONS):
+        elif status == "declared":
             declared.append(slot)
-        elif not ret_ok and slot not in RET_DEVIATIONS:
-            ret_diff.append((slot, up_ret, rets.get(slot, "?")))
-        else:
-            arg_diff.append((slot, params, slots[slot]))
+
+    for table, tname in ((ARG_DEVIATIONS, "ARG_DEVIATIONS"), (RET_DEVIATIONS, "RET_DEVIATIONS")):
+        for s in sorted(set(table) - consulted):
+            orphan_pin.append(
+                f"{tname}[{s!r}] was never consulted — "
+                + ("there is no such vtable slot" if s not in slots else
+                   "the slot has no upstream counterpart to differ FROM (an RTOS-only "
+                   "slot belongs in ADDED)")
+            )
+    for s, entry in sorted(ADDED.items()):
+        file(added_verdict(s, entry, slots, rets))
+        if s in consulted:
+            orphan_pin.append(
+                f"ADDED[{s!r}] claims no upstream equivalent, but the slot is compared "
+                "against one — declare the difference in ARG_/RET_DEVIATIONS instead"
+            )
 
     # Grouped TARGETS are expected too. `create_session` / `destroy_session`
     # have no upstream name of their own (they answer `rmw_init` and
@@ -732,22 +1489,71 @@ def compare():
         "matched": matched,
         "abi_fns": abi_fns,
         "grouped": grouped,
+        "grouped_only": grouped_only,
         "declared": declared,
         "ret_diff": ret_diff,
         "undeclared_extra": undeclared_extra,
+        "pin_drift": pin_drift,
+        "stale_pin": stale_pin,
+        "orphan_pin": orphan_pin,
+        "added_drift": added_drift,
     }
+
+
+def mutate_slot(body, slot, ret=None, params=None, delete=False):
+    """Rewrite ONE slot's declaration in comment-stripped header text.
+
+    `params` is a replacement string or a function of the current one. Returns
+    None when the slot is not found, so a replay whose target was renamed
+    fails loudly instead of replaying nothing.
+    """
+    m = re.search(
+        r"([A-Za-z_][A-Za-z0-9_ ]*?[\w])[*\s]*\(\s*\*\s*%s\s*\)\s*\(" % re.escape(slot), body)
+    if m is None:
+        return None
+    depth, i = 1, m.end()
+    while depth:
+        depth += {"(": 1, ")": -1}.get(body[i], 0)
+        i += 1
+    raw = body[m.end(): i - 1]
+    end = body.index(";", i) + 1
+    if delete:
+        return body[: m.start()] + body[end:]
+    old_ret = m.group(0)[: m.group(0).index("(")].strip()
+    new_params = params(raw) if callable(params) else (raw if params is None else params)
+    return body[: m.start()] + f"{ret or old_ret} (*{slot})({new_params});" + body[end:]
+
+
+# Issue 1092's seven surviving mutations, replayed against the REAL header on
+# every run. Each left all four RMW gates green before the pins; each must now
+# add at least one `--check` failure the unmutated tree does not have. This is
+# phase-428 W7's acceptance, kept executable rather than recorded.
+MUTATIONS = (
+    ("has_data gutted: void, a publisher handle, two junk args", "has_data",
+     dict(ret="void", params="rmw_publisher_t *p, int junk_a, int junk_b")),
+    ("has_data deleted entirely", "has_data", dict(delete=True)),
+    ("create_node returns void", "create_node", dict(ret="void")),
+    ("take gains `uint64_t bogus_extra`", "take",
+     dict(params=lambda p: p + ", uint64_t bogus_extra")),
+    ("take's handle becomes `const rmw_publisher_t *`", "take",
+     dict(params=lambda p: re.sub(r"^\s*const\s+rmw_subscription_t\b", "const rmw_publisher_t", p))),
+    ("create_session becomes void(int, char)", "create_session",
+     dict(ret="void", params="int a, char b")),
+    ("subscription_take_event becomes void(rmw_publisher_t *, int)", "subscription_take_event",
+     dict(ret="void", params="rmw_publisher_t *p, int k")),
+)
 
 
 def self_test():
     bad = []
+    cases = 0
     slots, _rets = vtable_slots()
     if "create_publisher" not in slots:
         bad.append("vtable parse found no create_publisher slot")
-    if "cb" in slots and len(slots.get("cb", [])) == 0:
-        pass  # popped in compare(); parsing it here is fine
     # A prose mention must not become a slot.
-    probe = re.sub(r"/\*.*?\*/", " ", "/* calls (*take)(x) internally */ int (*real)(int a);", flags=re.S)
+    probe = strip_comments("/* calls (*take)(x) internally */ int (*real)(int a);")
     names = re.findall(r"\(\s*\*\s*([a-z_0-9]+)\s*\)\s*\(", probe)
+    cases += 1
     if names != ["real"]:
         bad.append(f"a slot named only in a COMMENT must not count: {names}")
     r = compare()
@@ -755,9 +1561,8 @@ def self_test():
         for tname in r["vendor_types"]:
             if tname not in TYPE_TARGET:
                 bad.append(f"{tname}: in a signature with no target spelling in TYPE_TARGET")
-    slots_now, _r = vtable_slots()
     for sym, target in GROUPED_SYMBOLS.items():
-        if target not in slots_now:
+        if target not in slots:
             bad.append(
                 f"{sym}: grouped onto {target!r}, which is NOT a slot — an alias to a "
                 "missing slot hides the gap it should report"
@@ -771,60 +1576,100 @@ def self_test():
         )
     if not ADDED:
         bad.append("ADDED is empty — every RTOS-only slot must carry its reason")
-    for slot, why in ADDED.items():
-        if not why.strip():
-            bad.append(f"{slot}: an addition with no reason is prose")
-    # The deferral rule, both ways: a `gap` reason without an issue id is NOT
-    # deferred, it is a red. Without this the rule degrades into "any gap is
-    # fine", which is the failure mode that would make `--check` on the
-    # `just check` line worth nothing.
-    for probe, want in (("issue 0776. the bound is not computed", True),
-                        ("issue-0776 tracked", True),
-                        ("not yet, no bound is computed", False),
-                        ("tracked in issue 77", False)):
-        if bool(_ISSUE_REF.search(probe)) != want:
-            bad.append(f"issue-ref rule: {probe!r} should be deferred={want}")
-    # The DERIVATION, not the tree's current contents. This asserted
-    # `if not DEFERRED` until 2026-08-27, which conflated "the link to the
-    # parity MAP is broken" with "there is nothing to derive" — and the second
-    # became true the moment the last gap closed (issue 0776 -> `layer`, once
-    # phase-380 W1 landed the size bound). A tripwire that fires when the tree
-    # gets HEALTHIER is a tripwire people learn to route around, so it is now
-    # checked against a synthetic mapping and holds whether or not any real gap
-    # exists.
-    _probe_map = {
-        "rmw_synthetic_deferred": ("gap", "issue 0776. deliberately unresolved"),
-        "rmw_synthetic_plain_gap": ("gap", "no issue named, so not deferred"),
-        "rmw_synthetic_answered": ("vtable", "issue 0776 mentioned but not a gap"),
-    }
-    derived = {
-        k: _ISSUE_REF.search(why).group(1)
-        for k, (bucket, why) in _probe_map.items()
-        if bucket == "gap" and _ISSUE_REF.search(why)
-    }
-    if derived != {"rmw_synthetic_deferred": "0776"}:
-        bad.append(f"deferred derivation: got {derived}, want only the issue-bearing gap")
 
-    # A deviation entry for a slot that no longer deviates is the same drift
-    # the parity MAP had (45 stale entries, two directions). Three ARG entries
-    # and six RET entries survived their own fix here, still explaining a
-    # difference the header had stopped having — and the RET ones read
-    # "NOT a target constraint, W5 candidate to change", which is a to-do
-    # item that had been done. Declarations are only worth reading if a stale
-    # one is impossible.
+    # ---- The pins, driven with planted shapes (issue 1092) ----
+    up_a = ("const rmw_subscription_t *", "void *", "bool *")
+    ours_a = ("const rmw_subscription_t *", "rmw_mut_byte_span_t *", "bool *")
+    arg_pins = {"probe": ArgPin(up_a, ours_a, "planted")}
+    ret_pins = {"probe": RetPin("rmw_node_t *", "rmw_ret_t", "planted")}
+    for label, (uret, uargs, oret, oargs), pins, want_status, want_kinds in (
+        ("an UNCHANGED pinned deviation passes",
+         ("rmw_node_t *", up_a, "rmw_ret_t", ours_a), True, "declared", set()),
+        ("an argument appended to a pinned slot fails",
+         ("rmw_node_t *", up_a, "rmw_ret_t", ours_a + ("uint64_t",)), True, "bad", {"pin_drift"}),
+        ("a handle retyped on a pinned slot fails",
+         ("rmw_node_t *", up_a, "rmw_ret_t", ("const rmw_publisher_t *",) + ours_a[1:]),
+         True, "bad", {"pin_drift"}),
+        ("a `void` return on a RET-pinned slot fails",
+         ("rmw_node_t *", up_a, "void", ours_a), True, "bad", {"pin_drift"}),
+        ("upstream moving under a pin fails",
+         ("rmw_node_t *", up_a[:2], "rmw_ret_t", ours_a), True, "bad", {"pin_drift"}),
+        ("a STALE arg pin (args now match upstream) is reported",
+         ("rmw_node_t *", ours_a, "rmw_ret_t", ours_a), True, "bad", {"stale_pin"}),
+        ("a STALE ret pin (return now matches upstream) is reported",
+         ("rmw_ret_t", up_a, "rmw_ret_t", ours_a), True, "bad", {"stale_pin"}),
+        ("an undeclared arg difference fails",
+         ("rmw_ret_t", up_a, "rmw_ret_t", ours_a), False, "bad", {"arg_diff"}),
+        ("an undeclared return difference fails",
+         ("rmw_ret_t", up_a, "void", up_a), False, "bad", {"ret_diff"}),
+        ("an identical slot with no pin matches",
+         ("rmw_ret_t", up_a, "rmw_ret_t", up_a), False, "matched", set()),
+    ):
+        cases += 1
+        status, problems = shape_verdict(
+            "probe", uret, uargs, oret, oargs,
+            arg_pins if pins else {}, ret_pins if pins else {})
+        kinds = {k for k, _f in problems}
+        if status != want_status or kinds != want_kinds:
+            bad.append(f"pin case {label!r}: got {status} {sorted(kinds)}, "
+                       f"want {want_status} {sorted(want_kinds)}")
+    added = Added("rmw_ret_t", ("rmw_subscription_t *", "bool *"), "planted")
+    for label, s_, r_, want in (
+        ("an unchanged addition passes",
+         {"probe": ["rmw_subscription_t *", "bool *"]}, {"probe": "rmw_ret_t"}, set()),
+        ("an addition that now returns void fails",
+         {"probe": ["rmw_subscription_t *", "bool *"]}, {"probe": "void"}, {"added_drift"}),
+        ("an addition whose slot is gone is an orphan", {}, {}, {"orphan_pin"}),
+    ):
+        cases += 1
+        kinds = {k for k, _f in added_verdict("probe", added, s_, r_)}
+        if kinds != want:
+            bad.append(f"added case {label!r}: got {sorted(kinds)}, want {sorted(want)}")
+
+    # ---- Issue 1092's seven mutations, against the REAL header ----
+    if r is not None:
+        baseline = failures(r)
+        body = strip_comments(open(VTABLE, encoding="utf-8").read())
+        for label, slot, how in MUTATIONS:
+            cases += 1
+            mutated = mutate_slot(body, slot, **how)
+            if mutated is None or mutated == body:
+                bad.append(f"mutation {label!r} did not apply — `{slot}` moved; update MUTATIONS")
+                continue
+            if not failures(compare(mutated)) - baseline:
+                bad.append(f"mutation {label!r} left --check GREEN — a pin is not pinning")
+
+    # ---- The deferral rule: an issue id must RESOLVE to an OPEN issue ----
+    fake = {"0776": "resolved", "1092": "open"}.get
+    for probe, want in (("issue 1092. the bound is not computed", "1092"),
+                        ("issue-1092 tracked", "1092"),
+                        ("not yet, no bound is computed", None),
+                        ("tracked in issue 77", None),
+                        ("issue 0776, which is resolved", None),
+                        # An id the resolver has no status for, i.e. no file.
+                        ("issue 1219, unknown to the planted resolver", None)):
+        cases += 1
+        got, _why = deferral(probe, fake)
+        if got != want:
+            bad.append(f"deferral rule: {probe!r} deferred to {got}, want {want}")
+    # The resolver itself, against the real tree: a resolved archived issue, an
+    # id with no file, and an authored value that is not an id at all.
+    cases += 1
+    real = (issue_status("0776"), issue_status("9999"), issue_status("banana"))
+    if real != ("resolved", None, None):
+        bad.append(f"issue_status: (0776, 9999, banana) resolved to {real}, "
+                   "want ('resolved', None, None)")
+
+    # A handle upstream takes as `const` must be `const` here too.
+    #
+    # Matched BY TYPE, never by position — the first sweep of this class
+    # (15 slots, commit 0814b645d) compared arguments positionally and so
+    # missed three: upstream puts an `rmw_event_t *` or a `const rmw_node_t *`
+    # ahead of the handle in `{publisher,subscription}_event_init` and
+    # `service_server_is_available`, and ours does not, so zip() lined the
+    # handle up against something else and saw nothing.
     up = upstream_signatures()
     if up is not None:
-        our_args, our_rets = vtable_slots()
-        # A handle upstream takes as `const` must be `const` here too.
-        #
-        # Matched BY TYPE, never by position — the first sweep of this class
-        # (15 slots, commit 0814b645d) compared arguments positionally and so
-        # missed three: upstream puts an `rmw_event_t *` or a `const rmw_node_t *`
-        # ahead of the handle in `{publisher,subscription}_event_init` and
-        # `service_server_is_available`, and ours does not, so zip() lined the
-        # handle up against something else and saw nothing. The class fix
-        # stopped one short of the class for a reason that had nothing to do
-        # with the class.
         handles = {
             "rmw_publisher_t", "rmw_subscription_t", "rmw_service_t",
             "rmw_client_t", "rmw_node_t", "rmw_session_t",
@@ -840,10 +1685,10 @@ def self_test():
 
         for name, (_uret, uargs) in sorted(up.items()):
             slot = GROUPED_SYMBOLS.get(name) or name[len("rmw_"):]
-            if slot not in our_args:
+            if slot not in slots:
                 continue
             theirs = _handle_constness(uargs)
-            ours = _handle_constness(our_args[slot])
+            ours = _handle_constness(slots[slot])
             for ty, is_const in theirs.items():
                 if is_const and ty in ours and not ours[ty]:
                     bad.append(
@@ -851,34 +1696,17 @@ def self_test():
                         "`const` — no backend writes the handle, so this is a "
                         "signature to fix, not a deviation to declare"
                     )
-        # Per SLOT, not per bucket: a slot can legitimately hold an ARG entry
-        # and a stale RET entry at once (`destroy_publisher` did — it still
-        # drops upstream's node argument, which kept it in the "declared"
-        # bucket and hid that its return had stopped differing). So compare
-        # each axis against the header directly.
-        up_by_slot = {}
-        for name, (uret, uargs) in up.items():
-            up_by_slot[GROUPED_SYMBOLS.get(name) or name[len("rmw_"):]] = (uret, uargs)
-        for s in sorted(ARG_DEVIATIONS):
-            u = up_by_slot.get(s)
-            if u and s in our_args and our_args[s] == u[1]:
-                bad.append(
-                    f"ARG_DEVIATIONS[{s!r}] explains an argument difference the header "
-                    "no longer has"
-                )
-        for s in sorted(RET_DEVIATIONS):
-            u = up_by_slot.get(s)
-            if u and s in our_rets and our_rets[s] == u[0]:
-                bad.append(
-                    f"RET_DEVIATIONS[{s!r}] explains a return-type difference the header "
-                    "no longer has"
-                )
+    # Stale pins are no longer checked HERE: `compare()` files them in
+    # `stale_pin`, which `--check` fails on. They lived in the self-test until
+    # issue 1092, which put the one check that survives a rename in the mode
+    # nobody reads the output of.
 
     if bad:
         for b in bad:
             sys.stderr.write("rmw-abi-shape --self-test: " + b + "\n")
         return 2
-    print(f"rmw-abi-shape --self-test: OK ({len(slots)} slot(s) parsed, 7 case(s))")
+    print(f"rmw-abi-shape --self-test: OK ({len(slots)} slot(s) parsed, {cases} case(s), "
+          f"{len(MUTATIONS)} of issue 1092's mutations caught)")
     return 0
 
 
@@ -902,6 +1730,7 @@ def main(argv):
 
     total = (len(r["upstream"]) - len(DECLINED & set(r["upstream"]))
              - len(r["layered"]))
+    go = r["grouped_only"]
     print("rmw ABI shape — our vtable against upstream, name and args")
     print(f"  contract symbols to mirror : {total}")
     # Phase 376 W5 — three numbers, not two. This used to print ONE, counting a
@@ -910,14 +1739,18 @@ def main(argv):
     # measurement that folds "identical" into "different but explained" cannot
     # answer the question the campaign is actually asking.
     print(f"  slots identical to upstream : {len(r['matched'])}")
-    print(f"  name matches, args DECLARED : {len(r['declared'])}")
+    print(f"  name matches, diff PINNED  : {len(r['declared'])}")
     print(f"  answered by a GROUPED slot  : {len(r['grouped'])}")
+    print(f"  grouped-only target, PINNED: {sum(1 for v in go.values() if v == 'declared')}"
+          f" (+{sum(1 for v in go.values() if v == 'matched')} identical)")
     print(f"  plain ABI functions         : {len(r['abi_fns'])}")
     print(f"  answered at another layer   : {len(r['layered'])}")
     print(f"  slots present, args differ : {len(r['arg_diff'])}")
     print(f"  UNDECLARED return-type diff: {len(r['ret_diff'])}")
+    print(f"  PINNED shape drifted       : {len(r['pin_drift']) + len(r['added_drift'])}")
+    print(f"  STALE or ORPHAN pin        : {len(r['stale_pin']) + len(r['orphan_pin'])}")
     print(f"  no slot at all             : {len(r['missing'])}")
-    print(f"  deferred, issue tracked    : {len(r['deferred'])}")
+    print(f"  deferred, OPEN issue       : {len(r['deferred'])}")
     print(f"  declared RTOS additions    : {len(ADDED)}")
     print(f"  UNDECLARED extra slots     : {len(r['undeclared_extra'])}")
     print(f"  vendor-named types in sigs : {len(r['vendor_types'])}")
@@ -942,9 +1775,19 @@ def main(argv):
         print(f"## args differ ({len(r['arg_diff'])})")
         for slot, want, got in r["arg_diff"]:
             print(f"  {slot}")
-            print(f"      upstream: ({', '.join(want)})")
-            print(f"      ours:     ({', '.join(got)})")
+            print(f"      upstream: {_fmt(want)}")
+            print(f"      ours:     {_fmt(got)}")
         print()
+
+    for key, title in (("pin_drift", "a PINNED deviation no longer reads what it licensed"),
+                       ("added_drift", "an RTOS-only slot changed shape under its declaration"),
+                       ("stale_pin", "a pin explains a difference that is gone"),
+                       ("orphan_pin", "a declaration names nothing it can be checked against")):
+        if r[key]:
+            print(f"## {title} ({len(r[key])})")
+            for msg in r[key]:
+                print(f"  {msg}")
+            print()
 
     if r["undeclared_extra"]:
         print(f"## extra slots with no declaration ({len(r['undeclared_extra'])})")
@@ -953,7 +1796,7 @@ def main(argv):
         print()
 
     if r["deferred"]:
-        print(f"## deferred, tracked by an issue ({len(r['deferred'])})")
+        print(f"## deferred, tracked by an OPEN issue ({len(r['deferred'])})")
         for name, slot, params in r["deferred"]:
             print(f"  {slot:44s} <- issue {DEFERRED[name]}")
         print()
@@ -962,22 +1805,25 @@ def main(argv):
         print(f"## no slot ({len(r['missing'])})")
         for name, slot, params in r["missing"]:
             print(f"  {slot:44s} <- {name}({', '.join(params)})")
+            if name in REFUSED_DEFERRAL:
+                print(f"  {'':44s}    not deferred: the gap reason {REFUSED_DEFERRAL[name]}")
         print()
 
     rc = 0
-    if args.check and (
-        r["missing"] or r["arg_diff"] or r["ret_diff"] or r["undeclared_extra"]
-        or r["vendor_types"]
-    ):
+    if args.check and failures(r):
         sys.stderr.write(
             "rmw-abi-shape: the vtable does not mirror upstream.\n"
             "  Every contract symbol needs a slot named after it, with matching\n"
-            "  args — or an entry in ARG_DEVIATIONS / ADDED / the parity table's\n"
-            "  `declined` bucket, carrying the RTOS reason for the difference.\n"
+            "  args — or an entry in ARG_DEVIATIONS / RET_DEVIATIONS / ADDED / the\n"
+            "  parity table's `declined` bucket, carrying the RTOS reason for the\n"
+            "  difference. A deviation entry PINS both shapes it explains (issue\n"
+            "  1092): when a declared slot changes, edit its entry — the report\n"
+            "  above prints the current shape to paste — and re-read the reason,\n"
+            "  because the change may have made it false.\n"
             "  A gap that is real but not yet closed goes in the parity table's\n"
-            "  `gap` bucket with a TRACKED ISSUE ID in the reason (`issue 0776`),\n"
-            "  which is deferral with a name on it rather than an exemption.\n"
-            "  Signatures must also be vendor-free: see TYPE_TARGET.\n"
+            "  `gap` bucket naming an OPEN issue (`issue NNNN`, resolved against\n"
+            "  docs/issues/), which is deferral with a name on it rather than an\n"
+            "  exemption. Signatures must also be vendor-free: see TYPE_TARGET.\n"
         )
         rc = 1
     return rc

--- a/scripts/rmw-api-parity.py
+++ b/scripts/rmw-api-parity.py
@@ -54,6 +54,8 @@ import re
 import importlib.util as _util
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
+from issue_status import issue_status  # noqa: E402
 
 # `librmw_zenoh_cpp.so`, not `librmw_dds_common__rosidl_typesupport_fastrtps_cpp.so`.
 IMPL_LIB = re.compile(r"librmw_[a-z0-9]+_cpp\.so")
@@ -115,15 +117,20 @@ STATUSES = ("same", "re-shaped", "re-mapped", "not-supported", "not-implemented"
 DERIVED_ONLY = ("same", "re-shaped")
 
 
-def check_status():
+def check_status(rows=None, status_of=None):
     """The `status` axis: vocabulary, and the rules that keep it honest.
 
     Added because `where` was doing two jobs. `declined` covered `rmw_wait`,
     decomposed into five live slots, and `rmw_init_publisher_allocation`, where
     nothing crosses the seam — opposite facts under one word.
+
+    `rows` / `status_of` default to the real map and the real issue tree; the
+    self-test passes planted ones.
     """
+    rows = MAP_ROWS if rows is None else rows
+    status_of = issue_status if status_of is None else status_of
     bad = []
-    for sym, row in sorted(MAP_ROWS.items()):
+    for sym, row in sorted(rows.items()):
         status, where = row.get("status"), row["where"]
         if status is None:
             if where in ("layer", "declined"):
@@ -152,6 +159,18 @@ def check_status():
                 "gap is indistinguishable from a decision, and silence turns the "
                 "first into the second"
             )
+        elif status == "not-implemented":
+            # Issue 1092: this tested TRUTHINESS, so `issue = 9999` (no such
+            # file) and `issue = "banana"` were both accepted. The id has to
+            # name an issue somebody holds OPEN, or the gap is an exemption.
+            st = status_of(row["issue"])
+            if st != "open":
+                bad.append(
+                    f"{sym}: `issue = {row['issue']!r}` must name an OPEN issue under "
+                    "docs/issues/ — it resolves to "
+                    + (f"a `{st}` one" if st else "no issue file")
+                    + ". A deferral to an issue nobody holds open is an exemption"
+                )
         if status == "not-supported" and row.get("issue"):
             bad.append(f"{sym}: `not-supported` is a decision, so it takes no `issue`")
     return bad
@@ -333,6 +352,18 @@ def self_test():
     # The `status` axis: vocabulary, and the rules that stop a gap from
     # decaying into a decision by silence.
     bad.extend(check_status())
+    # ... and a `not-implemented` row's `issue` must RESOLVE to an open issue
+    # (issue 1092), planted, since the real map has no such row today.
+    def fake(n):
+        s = str(n)
+        return {"1092": "open", "0776": "resolved"}.get(f"{int(s):04d}") if s.isdigit() else None
+
+    for issue, want_ok in (("1092", True), (1092, True), ("0776", False),
+                           ("9999", False), ("banana", False)):
+        row = {"where": "gap", "status": "not-implemented", "issue": issue}
+        got_ok = not check_status({"rmw_planted": row}, fake)
+        if got_ok != want_ok:
+            bad.append(f"check_status: `issue = {issue!r}` accepted={got_ok}, want {want_ok}")
     if bad:
         for b in bad:
             sys.stderr.write("rmw-api-parity --self-test: " + b + "\n")
@@ -340,7 +371,7 @@ def self_test():
     n_status = sum(1 for r in MAP_ROWS.values() if r.get("status"))
     print(
         f"rmw-api-parity --self-test: OK ({len(MAP)} mapping(s), "
-        f"{n_status} authored status(es), 2 case(s))"
+        f"{n_status} authored status(es), 7 case(s))"
     )
     return 0
 


### PR DESCRIPTION
## phase-444 W4.a — issue #1092: a declared RMW deviation pins the shape it licenses

`rmw-abi-shape` checked MEMBERSHIP: once a slot was listed in `ARG_DEVIATIONS` / `RET_DEVIATIONS` / `ADDED`, the header could say anything about it. Issue #1092 applied 24 mutations to a scratch mirror and **7 stayed green** — `create_node` returning `void` (the exact defect W5 existed to remove), `take` gaining a `uint64_t`, `take`'s handle retyped to a publisher, `has_data` gutted, `has_data` deleted outright, `create_session` reduced to `void(int, char)`, `subscription_take_event` likewise.

### What changed

- **Every entry records BOTH sides it explains**, in the normalised spelling the comparison uses: `ArgPin(upstream, ours, why)`, `RetPin(upstream, ours, why)`, `Added(ret, args, why)`. A declared slot passes only while the header AND the upstream snapshot still read exactly the pin.
- **New `--check` buckets**: `pin_drift` (a declared slot changed shape), `added_drift` (an RTOS-only slot changed), `stale_pin` (a pin for a difference that is gone — moved out of `--self-test` into `compare()`, so `--check` fails on it), `orphan_pin` (a pin no comparison consults).
- **Grouped-ONLY targets are now compared** against the symbol grouped onto them: `create_session` ← `rmw_init`, `destroy_session` ← `rmw_shutdown`/`rmw_context_fini`, `subscription_take_event` ← `rmw_take_event`. Before this they were compared against nothing.
- **No flag rewrites pins.** The failure prints the current shape to paste, so clearing it means editing the entry next to its reason — a gate you clear by regenerating its expectation is the staleness gate #1092 found `rmw-api-comparison` to be.
- **Fix 4 of the issue**: a `gap` deferral and a `not-implemented` row's `issue =` must resolve to a file under `docs/issues/` whose frontmatter says `status: open`. `9999` (no file), `0776` (resolved and archived — the exemplar the tool itself cited) and `"banana"` are all refused now. One resolver: `scripts/lib/issue_status.py`, in its own commit so phase-444 W4.b can carry it.

### Found on the way in

- `ARG_DEVIATIONS["subscription_get_network_flow_endpoints"]` declared a deviation on a slot that has never existed (both network-flow symbols are `declined`, issue 0956), "as" a sibling entry that did not exist either. Deleted — `orphan_pin` is the check that would have caught it.
- `take`'s reason described `(sub, buf, buf_len, size_t *out_len, bool *taken)`, the pre-phase-406 five-argument shape, beside a header taking three. The prose had been false since phase-406 and nothing could see it. Corrected.

Coverage: **15** identical + **39** pinned + **3** grouped-only pinned + **11** additions pinned = **68 of 68** slots compared with no licence to vary (was 15 exactly enforced).

### Acceptance (phase-428 W7: "all seven surviving mutations fail")

Executable, not recorded. `--self-test` replays #1092's seven mutations against the REAL header on every run and fails if any one adds no `--check` failure the unmutated tree lacks. Planted cases cover: an unchanged pin passing; an appended argument, a retyped handle, a `void` return and upstream moving under a pin each failing; stale ARG and RET pins reported; `ADDED` drift and an `ADDED` slot that is gone.

```
rmw-abi-shape --self-test: OK (71 slot(s) parsed, 28 case(s), 7 of issue 1092's mutations caught)
```

**Negative control on the real tree** — `take` given a trailing `uint64_t bogus_extra` in `rmw_vtable.h`, `just check rmw-abi-shape` → rc=1:

```
take: the args changed under a PINNED deviation
      pinned ours: ("const rmw_subscription_t *", "rmw_mut_byte_span_t *", "bool *")
      header now : ("const rmw_subscription_t *", "rmw_mut_byte_span_t *", "bool *", "uint64_t")
```

`origin/main`'s copy of the script, against the same mutated header, printed `name matches, args DECLARED : 39` and exited **0**. Header restored.

### Local gates

- `just check fast` — **PASS**, 295 gates (an earlier run failed `capability-conditionals` and `xrce-vendored-versions`; both were this worktree's uninitialised submodules — `git submodule update --init` on zenoh-pico / micro-cdr / micro-xrce-dds-client, then both green).
- `just ci gate` — `check::cli-fresh` ok, `check::fast` ok, **`check::build` FAILED** (`8 of 21 gate(s) FAILED`), and the lane stops there, so `api-parity` / `test-unit` / `test-lane-contracts` did not run. Every one of the 8 is **this worktree's missing provisioning, not this diff**:
  - `nros CLI not found. Run: just setup-cli` — `borrowed-e2e`, `staticlib-symbols`, `required-features-tests`, `source-gates` (each gate's own compile succeeded first; the nextest step is what died);
  - `` `nros-launch-resolve` not found `` — `cli-tests` (1 of 30 in `build_verb_pipeline`);
  - `cyclonedds-sys: source dir third-party/dds/cyclonedds has no CMakeLists.txt — source not provisioned` — `test-targets`, `workspace-all`, `workspace-features` (the submodule is uninitialised here: `git submodule status` reports `-67ff7518…`).

  This change touches only `scripts/*.py`, one justfile comment, a config baseline and docs — no gate in that tier reads any of them, and the identical 8 fail on the W4.b branch built from this one.

Closes issue #1092 (moved to `docs/issues/archived/`, status `resolved`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7tie7AFCdqoRkxphQcqRx
