### PR TITLE
fix(#1286): ThreadX takes the shared C runner, so a C ThreadX entry is pure C

### DIFF
--- a/cmake/board/nano-ros-board-rv-virt-threadx.cmake
+++ b/cmake/board/nano-ros-board-rv-virt-threadx.cmake
@@ -454,10 +454,30 @@ file(WRITE "${_NROS_APP_CONFIG_DEF_C}"
 # the curated link order). Exporting THREADX_APP_DEFINE_SOURCE empty
 # tells nros_platform_link_app to skip the per-app add.
 # ---------------------------------------------------------------------------
+# issue 1286 — the C-ABI single-executor runner, SHARED by every RTOS board
+# (`nros_board_rtos_run_components`), which a `--lang c` ThreadX entry calls.
+#
+# It goes HERE, in the app target, and NOT into `threadx_glue` above with the
+# other board glue, for two measured reasons:
+#   - `threadx_glue` sees no nros-cpp include path, so the runner's
+#     `__has_include(<nros/nros_cpp_config_generated.h>)` finds nothing and it
+#     silently takes its 81920-byte fallback where the per-build header says
+#     more. An undersized executor buffer is issue 0245's heap corruption. In
+#     the app target the per-build header is on the path, and without it the
+#     in-tree stub `#error`s. So a wrong size is a compile error, never a
+#     silent one.
+#   - `threadx_glue` is an ARCHIVE, reached through `threadx_platform` after
+#     `libnros_cpp.a`, so the runner's `nros_cpp_*` references would come
+#     unresolved in ld's single pass (the Phase 112.E.fix class this file's
+#     THREADX_APP_DEFINE note describes).
+# An image that never calls it (a plain C/C++ example, a Rust image) drops it:
+# `nros_board_link_app` links every app with `--gc-sections`, and an unreferenced
+# section's undefined references are not reported. The cargo lane is untouched.
 set(THREADX_STARTUP_SOURCE
     "${_NROS_BOARD_STARTUP_C}"
     "${_NROS_APP_CONFIG_DEF_C}"
-    CACHE INTERNAL "ThreadX / rv-virt-threadx startup TU + NROS_APP_CONFIG def")
+    "${_NROS_BOARD_ROOT}/packages/boards/nros-board-common/c/nros_rtos_run_components.c"
+    CACHE INTERNAL "ThreadX / rv-virt-threadx startup TU + NROS_APP_CONFIG def + C runner")
 
 set(THREADX_APP_DEFINE_SOURCE ""
     CACHE INTERNAL "Empty — RV64's app_define.c lives in threadx_glue STATIC")

--- a/cmake/board/nano-ros-board-threadx-linux.cmake
+++ b/cmake/board/nano-ros-board-threadx-linux.cmake
@@ -199,9 +199,20 @@ set(THREADX_STARTUP_SOURCE
     "${_NROS_BOARD_STARTUP_C}"
     CACHE INTERNAL "ThreadX / threadx-linux startup TU")
 
+# issue 1286 — the C-ABI single-executor runner, SHARED by every RTOS board
+# (`nros_board_rtos_run_components`). A `--lang c` ThreadX entry calls it, so
+# the entry is a pure C image with no C++ runtime. It compiles IN the app
+# target, like the rest of this list, because only there is the per-build
+# `<nros/nros_cpp_config_generated.h>` on the include path: the runner sizes
+# its executor storage from it, and the fallback size is issue 0245's heap
+# corruption. The TU references `nros_cpp_*`, which every threadx-linux C/C++
+# image links (`libnros_cpp.a`, issue 0425). The CARGO lane deliberately does
+# NOT compile it: `nros-board-threadx-linux`'s glue is `+whole-archive`
+# (issue 0582), which would pull those references into every Rust image.
 set(THREADX_APP_DEFINE_SOURCE
     "${_NROS_BOARD_APP_DEFINE_C}"
     "${_NROS_BOARD_THREADX_HOOKS_C}"
+    "${_NROS_BOARD_ROOT}/packages/boards/nros-board-common/c/nros_rtos_run_components.c"
     CACHE INTERNAL "ThreadX / threadx-linux app_define TU")
 
 set(THREADX_STARTUP_INCLUDES

--- a/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
+++ b/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
@@ -348,7 +348,9 @@ still links `stdc++` however the entry is written. The gain is real and it is
 not universal; do not state it unqualified.
 
 The reason is an accident of which entry points were declared, not a design
-decision. The C-callable board surface:
+decision. The C-callable board surface as this section found it (phase-432
+W3.1 and issue 1286 have since filled the `run_components` column; see the
+end of this section):
 
 | board | `run_components` | `run_tiers` |
 | --- | --- | --- |
@@ -377,8 +379,22 @@ them as `""` and `0` — a pure-C entry would compile, link, boot and dial
 nothing, which is issue #174 exactly; one ladder now lives in
 `<nros/entry_config.h>`, included by both languages. See phase-432 W3.1. That deletes the language-crossing branch from
 `cmd/codegen.rs` and lets the C pack serve every board the C++ one does.
-**ThreadX has no C board API at all and is declared C++-entry-only**, rather
-than silently routed.
+
+**ThreadX has a C entry too (issue 1286).** This section used to declare it
+C++-entry-only, on the grounds that it had neither runner and so "nothing to
+copy". That stopped being true once W3.1 made `run_components` ONE shared TU
+(`nros_board_rtos_run_components`): ThreadX's C++ `run_components` is
+FreeRTOS's line for line, and the shared TU's per-tick yield is empty off
+Zephyr, which is what ThreadX needs. So ThreadX takes that runner and has NO
+`run_tiers`. A multi-tier ThreadX plan takes the single-executor
+sched-context path in the C pack, exactly as it does in the C++ one; issue
+1283 is what gave the C pack that path. The surface now:
+
+| board | `run_components` | `run_tiers` |
+| --- | --- | --- |
+| native | yes (+`_named`) | yes |
+| freertos / zephyr / nuttx | yes (shared) | yes |
+| threadx | yes (shared) | — (sched contexts) |
 
 ---
 
@@ -746,8 +762,12 @@ language first is what made the shortcut visible at all.
 - Retiring `TargetProfile` amends RFC-0068, which is **Stable**. Does that edit
   land there or here? Recorded as an amendment above; the mechanics are a
   maintainer call.
-- `nros_board_threadx_run_components` does not exist and neither does its
-  `run_tiers` — is pure-C ThreadX worth the shim, or is the declaration enough?
+- ~~`nros_board_threadx_run_components` does not exist and neither does its
+  `run_tiers` — is pure-C ThreadX worth the shim, or is the declaration
+  enough?~~ ANSWERED by issue 1286: no shim was needed. ThreadX takes the
+  shared `nros_board_rtos_run_components`, has no `run_tiers`, and a tiered
+  plan uses sched contexts. `workspace-c-threadx-linux` builds with no C++
+  runtime.
 - ~~Does the designated-initialiser change land with the C++ pack conversion or
   ahead of it?~~ ANSWERED: its own branch immediately after W2.3, with its own
   goldens diff (8 goldens, tier rows only).
@@ -769,3 +789,9 @@ does for those boards — an embedded C entry routes to the C++ emitter. They ar
 byte-identical to the native rows except a comment and read as board coverage
 they do not have. Route the harness through the dispatch, or relabel them to pin
 what they actually prove. Tracked on issue 1102.
+
+Since phase-432 W3.1 and issue 1286 every family has a C runner, so the
+dispatch DOES call `emit_c` for all five boards. The rows now record what the
+pipeline produces: each calls its family's runner in its boot shape.
+`c_threadx_one` used to pin the refusal text; `c_threadx_tiers` pins the
+sched-context path a tiered ThreadX C plan takes.

--- a/docs/issues/archived/1286-threadx-c-entry-needs-cpp-runtime.md
+++ b/docs/issues/archived/1286-threadx-c-entry-needs-cpp-runtime.md
@@ -1,0 +1,169 @@
+---
+id: 1286
+title: "A C-only ThreadX entry still needs the C++ runtime: ThreadX is the one RTOS
+  the C-ABI board surface skips"
+status: resolved
+type: limitation
+area: cli, codegen, threadx
+severity: low
+resolved_in: "fix(#1286): ThreadX takes the shared C runner, so a C ThreadX entry is pure C"
+related: [issue-1283, issue-1285, issue-0582, issue-0245, phase-432, rfc-0091]
+---
+
+## What happens
+
+Phase-432 W3.1 gave FreeRTOS, Zephyr and NuttX a C runner
+(`nros_board_rtos_run_components`, one TU for all three), so a C entry on those
+boards is a pure C image. ThreadX was left out: `BoardFamily::Threadx`'s
+`has_c_run_components()` is false, so `entry-pack` routes a ThreadX C entry to
+the C++ pack. A certified-C, no-C++-runtime consumer cannot target ThreadX.
+
+RFC-0091 §11 records the reason as "nothing to copy". That is no longer true:
+the shared runner exists, and ThreadX's C++ `run_components` is line for line
+FreeRTOS's (network wait, init, setup, spin loop, shutdown). The boot path fits
+the C pack's `app` shape: the board's weak `main` calls `tx_kernel_enter()`, and
+the app thread calls the weak `app_main()` that `NROS_APP_MAIN_REGISTER_VOID()`
+defines. No per-tick yield is needed (`entry_tick_yield` acts only on Zephyr,
+and `spin_once(10)` blocks).
+
+## Measured (2026-09-11, threadx-linux, zenoh, then reverted)
+
+The CLI predicate was flipped and `workspace-c-threadx-linux` was built
+(`NROS_FIXTURE_ID=workspace-c-threadx-linux bash
+scripts/build/workspace-fixtures-build.sh threadx-linux c`):
+
+- `entry-pack` answered `pack=c`. The entry and `nros_rtos_run_components.c`
+  compiled as C: 0 CXX objects, linked with `cc`.
+- `libstdc++.so.6` no longer NEEDED. `__cxa|_ZSt|_ZN9__gnu_cxx` matches went
+  7 -> 4, and the remaining 4 are glibc's `__cxa_finalize` /
+  `__cxa_thread_atexit_impl`.
+- `nros_board_rtos_run_components`, `nros_app_main` and `app_main` are GLOBAL.
+- Not tested: runtime, the rv-virt board, Rust ThreadX images.
+
+## Why it is not a one-line flip
+
+TIERS. There is no `nros_board_threadx_run_tiers`. The C++ pack handles a tiered
+ThreadX plan on a single executor with sched-contexts, and the C pack has no
+sched-context path (issue 1283). Routing cannot depend on the plan either:
+CMake asks `nros codegen entry-pack --lang --board` for the file extension
+before any plan exists (`NanoRosEntry.cmake`, around line 975).
+
+So the order is: issue 1283 gives the C pack sched-contexts, then ThreadX routes
+to C unconditionally, and a tiered ThreadX plan takes the sched-context path,
+exactly as in C++.
+
+## Risk to keep in view
+
+The runner's fallback storage size is 81920. The per-build
+`nros_cpp_config_generated.h` for this image says 90392. If that header is ever
+not visible to a ThreadX compile of the runner, that is issue 0245's
+heap-corruption shape. Assert the header is on the ThreadX include path rather
+than trusting the fallback.
+
+## Acceptance
+
+`workspace-c-threadx-linux` builds as a C image with 0 C++ runtime NEEDED
+entries, on both threadx-linux and rv-virt-threadx, and a tiered ThreadX C plan's
+golden emits the sched-context path.
+
+## Resolution
+
+Fixed, on top of issue 1283 (the C pack's sched-context path) and issue 1285
+(`BoardFamily::c_abi_runners`).
+
+**Routing.** `BoardFamily::Threadx.c_abi_runners()` is now
+`run_components = nros_board_rtos_run_components`, `run_tiers = None`. So
+`has_c_run_components()` is true for every family, and a ThreadX `--lang c`
+entry renders through the C pack. A multi-tier ThreadX plan gets
+`ExecutorShape::SchedContexts` from `Plan::executor_shape`, because
+`board_has_run_tiers` reads the `None` half. Both packs take that branch.
+`both_entry_packs_take_the_plans_executor_branch` now includes ThreadX
+(20 rows, was 16). Its ThreadX multi-tier row expects `SchedContexts`, and
+the expectation is written out rather than derived from the predicate it
+checks.
+
+**Boot shape, read in the board C rather than assumed.** threadx-linux:
+`startup.c`'s weak `main` calls `tx_kernel_enter()`.
+`threadx_hooks.c::tx_application_define` creates the app thread, and that
+thread calls the weak `app_main` off RISC-V. rv-virt: `startup.c::main`
+registers `app_main` explicitly (`nros_threadx_set_app_main(app_main)`),
+because a weak-undefined `app_main` cannot be reached with
+`R_RISCV_PCREL_HI20`. Both reach the `app_main` that the C pack's
+`NROS_APP_MAIN_REGISTER_VOID()` defines.
+
+**CMake, and where the runner compiles.** The shared TU goes into the APP
+target on both boards. threadx-linux: `THREADX_APP_DEFINE_SOURCE`. rv-virt:
+`THREADX_STARTUP_SOURCE`, and deliberately NOT `_glue_srcs`:
+
+- `threadx_glue` sees no nros-cpp include path. Its `threadx_hooks.c`
+  compile has no nros-cpp or nros-c `-I`, measured in `compile_commands.json`.
+  The runner there would silently take its 81920-byte fallback.
+- It is an archive after `libnros_cpp.a`, so the runner's `nros_cpp_*`
+  references would be unresolved.
+
+In the app target the per-build mirror dir comes BEFORE the in-tree stub on
+both boards, so a missing header is the stub's `#error`, never the fallback.
+That is the existing mechanism, so nothing new was added.
+
+The cargo lane is unchanged: `nros-board-threadx-linux`'s glue is
+`+whole-archive` (issue 0582), and the runner there would pull `nros_cpp_*`
+into every Rust image.
+
+**The storage risk was real.** The per-build `NROS_CPP_EXECUTOR_STORAGE_SIZE`
+is 90424 on BOTH boards (32 above this issue's 90392: issue 1172 grew the
+executor). That is 8504 bytes over the fallback. Which header each runner
+compile used, from its own depfile:
+- threadx-linux `nros_rtos_run_components.c.o.d` names
+  `…/cmake/nano_ros/packages/api/nros-cpp/include/nros/nros_cpp_config_generated.h`
+  (90424).
+- rv-virt `ninja -t deps` (VALID) names
+  `…/nano_ros/packages/api/nros-cpp/include/nros/nros_cpp_config_generated.h`
+  (90424).
+
+**Build evidence (2026-09-11).**
+
+threadx-linux, zenoh:
+`NROS_FIXTURE_ID=workspace-c-threadx-linux bash scripts/build/workspace-fixtures-build.sh threadx-linux c`
+- `nros codegen entry-pack --lang c --board threadx-linux` answers `pack=c`,
+  `routed=0`. The build log has no "rendered by the C++ pack" line.
+- The entry TU is `threadx_entry_nros_main_generated.c`, with 0 C++ objects
+  in the build.
+- `threadx_entry` (built 11:43:12): `readelf -d` NEEDED is `libgcc_s.so.1`,
+  `libc.so.6` and `ld-linux-x86-64.so.2`, with no `libstdc++.so.6`. The only
+  `__cxa|_ZSt|_ZN9__gnu_cxx` undefined symbols are glibc's weak
+  `__cxa_finalize` and `__cxa_thread_atexit_impl`.
+- `nm`: `nros_board_rtos_run_components`, `nros_app_main` and `app_main` are
+  all `T`.
+
+rv-virt-threadx, zenoh, xPack `riscv-none-elf-gcc` 14.2:
+- There is no rv-virt C workspace row in `examples/fixtures.toml`, so no
+  workspace build exists to run. `examples/rv-virt-threadx/c/talker` (a plain
+  `nano_ros_add_executable` image) was configured and built with the lane's
+  own `-D` set.
+- The runner compiled in the app target against the per-build header.
+- `c_talker` linked. It carries neither `nros_board_rtos_run_components` nor
+  an undefined `nros_cpp_*`: every rv-virt app links with `--gc-sections`,
+  and an unreferenced section's undefined references are not reported
+  (checked with a two-line probe: rc 0 with gc, an error without).
+- NOT measured: a C WORKSPACE entry on rv-virt, which needs a fixture row
+  first.
+
+**Goldens.**
+- `c_threadx_one`: was the refusal text, now a C entry calling
+  `nros_board_rtos_run_components` in the `app` shape.
+- `c_threadx_tiers` (new): the three sched calls plus the same runner.
+
+**Runtime (threadx-linux).** PASSED, solo. The command was
+`cargo test -p nros-tests --test entry_e2e entry_matrix`, and it printed
+`entry_matrix: 1 ran, 15 skipped, 0 failed`. The cell that ran is
+`threadx-linux/c/entry_pubsub`.
+
+That cell boots the pure-C `threadx_entry` built above. A native C listener
+observer must log `INT32_LISTENER_LOG_PREFIX` at least 3 times within 20 s,
+so the shared runner's init, setup, spin and publish all ran on ThreadX. Its
+observer is the `workspace-c-native-robot2` row's `native_robot2_entry`,
+built for this run.
+
+The 15 skips are cells whose fixtures this worktree did not build: Zephyr,
+FreeRTOS, NuttX, and the threadx-linux C++ and mixed cells. rv-virt has no C
+workspace cell, so its runtime is untested.

--- a/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
+++ b/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
@@ -22,8 +22,11 @@ Every wave below carries its own state. What is left, in one place:
   | zephyr | `zephyr.elf`, 30.6 MB | `nros_board_rtos_run_components` GLOBAL, from `nros_rtos_run_components.c`; entry object is the `.c` |
   | nuttx | `nuttx_entry`, 825 KB | same symbol + `nros_app_main`; 0 C++ runtime symbols |
 
-  ThreadX deliberately gets none — no `run_tiers` to copy, so it stays
-  C++-entry-only with the routing REPORTED rather than refused.
+  ThreadX got none here, on the reasoning that it had no `run_tiers` to
+  copy. Issue 1286 reversed that after this item landed: once the runner was
+  one shared TU there was nothing ThreadX-specific to copy, so ThreadX takes
+  `nros_board_rtos_run_components`, has no `run_tiers`, and a tiered plan uses
+  sched contexts (issue 1283). `workspace-c-threadx-linux` is a pure C image.
 - **W3.5** — DECIDED 2026-09-08, and no work item: no in-tree reference
   language, split by WHO owns the language. See the item.
 - **RFC-0091 is `Stable`** as of 2026-09-10. W1.3 said to move its status once
@@ -430,10 +433,10 @@ settled work.
   than in a surprise later. The headline benefit is **RMW-conditional**: it
   drops a C++ toolchain requirement for zenoh and XRCE, and NOT for cyclonedds
   or uORB, whose RMW libraries are themselves C++ — so the acceptance fixture
-  is pinned to zenoh or it measures a claim it cannot support. And ThreadX
-  still gets no C runner: it has no `run_tiers` either, so there is nothing to
-  copy, and it stays C++-entry-only with the routing REPORTED rather than
-  refused.
+  is pinned to zenoh or it measures a claim it cannot support. ThreadX was
+  left without a C runner on the grounds that it had no `run_tiers` either,
+  so "nothing to copy". Issue 1286 later showed that did not hold once the
+  runner was one shared TU (see W3.1's result).
 
   Assessed in depth; the
   CONCLUSION survives and the JUSTIFICATION did not. Correct the reasoning
@@ -588,6 +591,11 @@ settled work.
   **ThreadX: do NOT** build it a C runner. It has no C entry runner at all — no
   `nros_board_threadx_run_tiers` either — so it needs a new TU plus `build.rs`
   wiring with nothing to copy.
+
+  *Superseded by issue 1286.* The premise was a per-board runner. W3.1 made it
+  ONE shared TU, so ThreadX needed no new TU, only the CMake wiring (and no
+  `build.rs` change, deliberately: that glue is `+whole-archive`, issue 0582).
+  It has no `run_tiers`, so a tiered plan takes sched contexts (issue 1283).
 
   **But the prescribed `FATAL_ERROR` was wrong, and is not what landed.** Half
   the reasoning holds: "a ThreadX C entry silently becomes a `.cpp` with no

--- a/packages/cli/nros-cli-core/src/cmd/codegen.rs
+++ b/packages/cli/nros-cli-core/src/cmd/codegen.rs
@@ -370,39 +370,32 @@ fn run_entry(args: EntryArgs) -> Result<()> {
         let family = nros_entry_lower::board_family(&plan.board).map_err(|e| eyre!("{e}"))?;
         entry_codegen::resolve_plan_sched(&mut plan, family.tier_rtos_key())?;
         match lang {
-            // phase-263 C2 (issue 0097) — the C emitter is native-only (it emits a
-            // pure-`.c` TU calling the C `nros_board_native_run_components`). The
-            // embedded board runners are C++ only (`ThreadxBoard::run_components`, …), so
-            // an embedded C entry routes through the C++ emitter (which produces a `.cpp`
-            // TU that invokes each C node via its `extern "C"` `__nros_c_component_*` seam
-            // — exactly the single-node `threadx_entry_main_c_typed.cpp.in` shape). The
-            // cmake side (`nano_ros_entry`) gives the `.out` a `.cpp` extension + links
-            // `NanoRosCpp` for an embedded C entry.
+            // The C emitter renders a pure-`.c` TU that calls the board family's
+            // C-ABI runner (`BoardFamily::c_abi_runners`). phase-432 W3.1 gave
+            // FreeRTOS, Zephyr and NuttX one (`nros_board_rtos_run_components`)
+            // and issue 1286 gave it to ThreadX, so every family takes this arm
+            // today. The one CMake asks (`nros codegen entry-pack`) and this one
+            // read the same predicate, so the TU's extension and its contents
+            // agree.
             entry_codegen::Lang::C if family.has_c_run_components() => {
                 entry_codegen::emit_c::emit_typed(&plan).map_err(|e| eyre!("{e}"))?
             }
             // phase-432 W3.1 — SAY that the routing fired.
             //
-            // The phase doc asked for a configure-time FATAL_ERROR on ThreadX,
-            // on the grounds that "a ThreadX C entry silently becomes a `.cpp`
-            // with no diagnostic, which is worse than a refusal". Half of that
-            // is right and half is not: the silence was the defect, but the
-            // routing WORKS — the C++ board runner drives the entry and reaches
-            // each C node through its `extern "C"` seam — so refusing would
-            // break something that ships. ThreadX is not special here either;
-            // every embedded board routes the same way.
-            //
-            // So: a line on stderr, not a refusal. The author of a `--lang c`
-            // entry learns their TU is C++ and why, and nothing that worked
-            // stops working.
+            // No family in `BOARD_KEYS` reaches this arm since issue 1286 gave
+            // ThreadX a C runner. It stays for a future family that ships none:
+            // the routing WORKS there (the C++ board runner drives the entry
+            // and reaches each C node through its `extern "C"` seam), so it is
+            // a line on stderr, not a refusal. The author of a `--lang c` entry
+            // learns their TU is C++ and why, and nothing that worked stops
+            // working.
             entry_codegen::Lang::C => {
                 eprintln!(
-                    "nros codegen entry: board `{}` has no C-ABI `run_components`, so this \
-                     `--lang c` entry is rendered by the C++ pack (a `.cpp` TU that drives \
-                     the C++ board runner and calls each C node through its `extern \"C\"` \
-                     seam). phase-432 W3.1 is the item that would give this board a C \
-                     runner; `nros codegen entry-pack --lang c --board {}` reports the \
-                     routing.",
+                    "nros codegen entry: board `{}` has no C-ABI `run_components` \
+                     (`BoardFamily::c_abi_runners`), so this `--lang c` entry is \
+                     rendered by the C++ pack (a `.cpp` TU that drives the C++ board \
+                     runner and calls each C node through its `extern \"C\"` seam). \
+                     `nros codegen entry-pack --lang c --board {}` reports the routing.",
                     plan.board, plan.board,
                 );
                 entry_codegen::emit_cpp::emit_typed(&plan).map_err(|e| eyre!("{e}"))?

--- a/packages/cli/nros-cli-core/src/codegen/entry/emit_c.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/emit_c.rs
@@ -3,8 +3,11 @@
 //! Maps a [`Plan`] (see `super::mod`) onto a generated typed `main.c`: per launch
 //! node it creates a `nros_cpp_node_t` (`nros_cpp_node_create`) and calls the
 //! node's `NROS_C_COMPONENT` factory/configure seam
-//! (`__nros_c_component_<pkg>_{create,configure}`) on the real executor; `main`
-//! drives `nros_board_native_run_components`. The C counterpart of
+//! (`__nros_c_component_<pkg>_{create,configure}`) on the real executor; the
+//! board's entry point drives the family's C-ABI runner
+//! (`BoardFamily::c_abi_runners`: `nros_board_native_*` on the host,
+//! `nros_board_rtos_run_components` and the per-RTOS `run_tiers` elsewhere).
+//! The C counterpart of
 //! [`super::emit_cpp::emit_typed`]. The legacy non-typed emitter (the
 //! `EntryNodeRuntime` interpreter via `nros_board_native_run`) was retired in
 //! phase-257 Stage-3.
@@ -137,28 +140,21 @@ fn node_view(n: &super::PlanNode, i: usize, on_executor: usize) -> CNodeView {
 }
 
 pub fn emit_typed(plan: &Plan) -> Result<String, String> {
-    // phase-432 W3.1 — this emitter is NATIVE-ONLY, and now says so.
+    // phase-432 W3.1 — the board call is the FAMILY's runner, never a
+    // hardcoded `nros_board_native_*`.
     //
-    // Every board call it renders is hardcoded `nros_board_native_*`, because
-    // that is the whole C-ABI board surface that exists: native has
-    // `run_components`, `run_components_named` and `run_tiers`; the three RTOS
-    // boards have `run_tiers` alone; ThreadX has neither.
+    // This emitter used to render `nros_board_native_*` for every board, and
+    // so produced source that NAMED A SYMBOL THE TARGET DID NOT HAVE:
+    // `c_freertos_one.c.golden` called `nros_board_native_run_components_named`
+    // for `board = freertos`. Nothing shipped through it, because the dispatch
+    // routed an embedded C entry to the C++ emitter, so the wrong bytes sat in
+    // a file nobody compiled.
     //
-    // Emitting anyway is what it used to do, and it produced source that
-    // NAMES A SYMBOL THE TARGET DOES NOT HAVE — `c_freertos_one.c.golden`
-    // called `nros_board_native_run_components_named` for `board = freertos`,
-    // and `c_nuttx_tiers` called `nros_board_native_run_tiers` for
-    // `board = nuttx`. Five goldens recorded that as if it were coverage.
-    //
-    // Nothing shipped through it: the dispatch routes an embedded C entry to
-    // the C++ emitter, so only the golden harness ever called this with an
-    // embedded board. That is exactly why it survived — the bytes were wrong
-    // in a file nobody compiled. Refusing turns five silent wrong records into
-    // five true ones, and makes the routing rule load-bearing instead of
-    // merely observed.
-    //
-    // W3.1 is the item that lifts this: give each RTOS board a C-ABI
-    // `run_components` and the refusal narrows to what still lacks one.
+    // The runner names now come from `BoardFamily::c_abi_runners`, the same
+    // record the routing reads, so the two cannot disagree. Every family has a
+    // `run_components` since issue 1286 (ThreadX was the last). The refusal
+    // below stays for a family that ships none, which the routing would send
+    // to the C++ pack before it got here.
     let family = nros_entry_lower::board_family(&plan.board)
         .map_err(|e| format!("typed C entry emit: {e}"))?;
     let Some(runners) = family
@@ -166,13 +162,11 @@ pub fn emit_typed(plan: &Plan) -> Result<String, String> {
         .filter(|r| r.run_components.is_some())
     else {
         return Err(format!(
-            "typed C entry emit: board `{}` has no C-ABI `run_components` — the C \
-             board surface is native-only, so this emitter would name \
-             `nros_board_native_*` on a target that does not have it. An embedded \
-             C entry is rendered by the C++ pack (which drives the C++ board runner \
-             and calls each C node through its `extern \"C\"` seam); that routing is \
-             what `nros codegen entry-pack --lang c --board {}` reports. phase-432 \
-             W3.1 is the item that would give this board a C runner.",
+            "typed C entry emit: board `{}` has no C-ABI `run_components` \
+             (`BoardFamily::c_abi_runners`), so the C pack has no runner to call. \
+             A C entry for it is rendered by the C++ pack (which drives the C++ \
+             board runner and calls each C node through its `extern \"C\"` seam); \
+             `nros codegen entry-pack --lang c --board {}` reports that routing.",
             plan.board, plan.board,
         ));
     };

--- a/packages/cli/nros-cli-core/src/codegen/entry/golden.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/golden.rs
@@ -354,6 +354,12 @@ fn cases() -> Vec<(&'static str, Plan, Lang)> {
     out.push(("c_native_tiers", c_tiered_plan("native"), Lang::C));
     out.push(("c_nuttx_tiers", c_tiered_plan("nuttx"), Lang::C));
 
+    // issue 1286 — ThreadX has a C `run_components` and NO `run_tiers`, so a
+    // two-tier C plan takes the single-executor sched-context path: the three
+    // sched calls plus `nros_board_rtos_run_components`. The C twin of
+    // `cpp_threadx_tiers`.
+    out.push(("c_threadx_tiers", c_tiered_plan("threadx"), Lang::C));
+
     // issue 1283 — the two C shapes that had no golden, and were wrong. A
     // group-split plan emits the three sched calls (it used to emit none, and
     // every group ran at the default scheduling); callback groups with no
@@ -724,15 +730,23 @@ fn branch_of(src: &str) -> super::ExecutorShape {
 /// had no sched-context arm (so a group split was plain single-executor in C,
 /// sched contexts in C++).
 ///
-/// Boards: every family the C pack renders for. ThreadX is refused by the C
-/// pack (no C-ABI runner), so there is no C side to compare there.
+/// Boards: every family the C pack renders for. That includes ThreadX since
+/// issue 1286. ThreadX has no `run_tiers`, so its multi-tier row takes
+/// sched contexts in both packs rather than `run_tiers`.
 #[test]
 fn both_entry_packs_take_the_plans_executor_branch() {
     use super::ExecutorShape::{SchedContexts, Single, Tiers};
     let mut checked = 0usize;
-    for board in ["native", "zephyr", "nuttx", "freertos"] {
+    for board in ["native", "zephyr", "nuttx", "freertos", "threadx"] {
+        // Written out, not derived from `board_has_run_tiers`: this test
+        // checks that predicate too.
+        let multi_tier = if board == "threadx" {
+            SchedContexts
+        } else {
+            Tiers
+        };
         let rows = [
-            ("multi-tier", c_tiered_plan(board), Tiers),
+            ("multi-tier", c_tiered_plan(board), multi_tier),
             (
                 "group split",
                 group_split(c_tiered_plan(board)),
@@ -760,5 +774,5 @@ fn both_entry_packs_take_the_plans_executor_branch() {
             checked += 1;
         }
     }
-    assert_eq!(checked, 16, "every (board x plan) row must be compared");
+    assert_eq!(checked, 20, "every (board x plan) row must be compared");
 }

--- a/packages/cli/nros-cli-core/src/codegen/entry/mod.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/mod.rs
@@ -252,14 +252,14 @@ impl Plan {
     }
 }
 
-/// Whether the board family has a `run_tiers` runner. ThreadX does not
-/// (issue 1286), so a tiered ThreadX plan keeps the sched-context path.
+/// Whether the board family has a `run_tiers` runner. ThreadX does not, so a
+/// tiered ThreadX plan takes the sched-context path in BOTH packs.
 ///
 /// Issue 1285: this reads the `run_tiers` half of
 /// `BoardFamily::c_abi_runners`, the one record of which runners each family
-/// exports. It no longer names ThreadX. When issue 1286 gives ThreadX a
-/// `run_components` and no `run_tiers`, this stays `false` without an edit.
-/// Both packs' `run_tiers` sit on those C-ABI symbols.
+/// exports, and it names no board. Issue 1286 gave ThreadX a
+/// `run_components` and no `run_tiers`, and this stayed `false` for it
+/// without an edit. Both packs' `run_tiers` sit on those C-ABI symbols.
 ///
 /// An unknown key answers `false` here rather than guessing a family. Every
 /// emitter refuses such a key, naming the known ones, before it renders

--- a/packages/cli/nros-cli-core/src/codegen/entry/pack.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/pack.rs
@@ -45,8 +45,8 @@
 //! ## What is deliberately NOT in a manifest
 //!
 //! Which pack renders for a given (language, board) is a rule with a reason —
-//! the RTOS board runners are C++ only, so an embedded C entry must be
-//! rendered as C++ — and a rule belongs in reviewed Rust, not in data a
+//! a C entry can be rendered as C only where the board exports a C-ABI
+//! `run_components` — and a rule belongs in reviewed Rust, not in data a
 //! template author can edit. RFC-0091 draws the same line for target facts.
 
 use std::collections::BTreeMap;
@@ -119,13 +119,15 @@ pub struct EntryPackInfo {
 
 /// The one routing decision: which pack renders `language` on `board`.
 ///
-/// The rule and its reason: the RTOS board runners
-/// (`ThreadxBoard::run_components` and siblings) are C++ only, so an embedded
-/// C entry is rendered by the C++ pack, which drives the C++ runner and calls
-/// each C node through its `extern "C"` seam. Native C stays C.
+/// The rule and its reason: a C entry is rendered by the C pack only where the
+/// board family exports a C-ABI `run_components`. Where it does not, the C++
+/// pack renders it, driving the C++ board runner and calling each C node
+/// through its `extern "C"` seam.
 ///
-/// W3.1 is the item that would delete this branch, by giving every board a
-/// C-ABI `run_components`.
+/// Since issue 1286 every family has one (ThreadX was the last), so the
+/// C-to-C++ arm is reached by no board in `BOARD_KEYS`. It stays as the
+/// answer for a future family that ships no C runner, rather than being
+/// deleted and re-derived.
 pub fn entry_pack_for(language: Language, board: &str) -> Result<EntryPackInfo, String> {
     // phase-432 W3.1 — the question is whether this board HAS a C-ABI
     // `run_components`, not whether it is embedded. Those agreed only while
@@ -271,9 +273,9 @@ mod tests {
     /// The state of the surface, pinned so a board's runner landing is a
     /// DELIBERATE edit here rather than a silent change of what ships.
     ///
-    /// ThreadX is the one that is `false` on purpose rather than pending: it
-    /// has no `run_tiers` either, so there is nothing to copy, and it stays
-    /// C++-entry-only with the routing reported rather than refused.
+    /// Issue 1286 moved ThreadX, the last family routed to C++. It has the
+    /// shared `run_components` and no `run_tiers`, so a tiered ThreadX C plan
+    /// takes the sched-context path rather than being refused.
     #[test]
     fn the_c_board_surface_is_where_this_phase_left_it() {
         use nros_entry_lower::BoardFamily;
@@ -281,7 +283,22 @@ mod tests {
         assert!(BoardFamily::Freertos.has_c_run_components());
         assert!(BoardFamily::Zephyr.has_c_run_components());
         assert!(BoardFamily::Nuttx.has_c_run_components());
-        assert!(!BoardFamily::Threadx.has_c_run_components());
+        assert!(BoardFamily::Threadx.has_c_run_components());
+    }
+
+    /// Issue 1286 — both ThreadX board keys CMake passes answer `pack=c`, with
+    /// no routing reported. CMake asks this before any plan exists, which is
+    /// why the answer cannot depend on whether the plan declares tiers.
+    #[test]
+    fn a_threadx_c_entry_renders_as_c() {
+        for board in ["threadx", "threadx-linux", "rv-virt-threadx"] {
+            let got = entry_pack_for(Language::C, board).unwrap();
+            assert_eq!(
+                (got.pack.as_str(), got.extension.as_str(), got.routed),
+                ("c", "c", false),
+                "{board}"
+            );
+        }
     }
 
     /// A Rust entry is not a C-family TU, so CMake must not link it as one.

--- a/packages/cli/nros-cli-core/testdata/entry/c_threadx_tiers.c.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/c_threadx_tiers.c.golden
@@ -17,11 +17,14 @@
 /* C component factory + configure seam (NROS_C_COMPONENT). The node's
  * `nros_cpp_node_t*` + executor handle are handed to `configure`, which
  * registers the component's real callbacks on the executor. */
-extern void* __nros_c_component_c_talker_pkg_create(void);
-extern int32_t __nros_c_component_c_talker_pkg_configure(const nros_cpp_node_t* node, void* executor, void* self);
+extern void* __nros_c_component_ctrl_pkg_create(void);
+extern int32_t __nros_c_component_ctrl_pkg_configure(const nros_cpp_node_t* node, void* executor, void* self);
+extern void* __nros_c_component_telem_pkg_create(void);
+extern int32_t __nros_c_component_telem_pkg_configure(const nros_cpp_node_t* node, void* executor, void* self);
 
 /* Static per-node storage (outlives the spin loop; no heap). */
 static nros_cpp_node_t __nros_node_0;
+static nros_cpp_node_t __nros_node_1;
 
 /* setup (post-init): the executor handle is passed in; create each node +
  * configure its component on the real executor. */
@@ -29,11 +32,35 @@ static int32_t __nros_entry_setup(void* executor) {
     if (executor == NULL) {
         return (int32_t)NROS_CPP_RET_NOT_INIT;
     }
+    /* issue 1283 — per-tier sched contexts on the single executor (RFC-0047),
+     * the C spelling of the C++ pack's block: one context per tier, then the
+     * node-name and callback-group tables, all seeded BEFORE any node exists
+     * so its entities pick the binding up at register time. */
+    uint8_t __nros_sc_ids[2] = {0};
     {
-        nros_cpp_ret_t nrc = nros_cpp_node_create(executor, "talker", "/", &__nros_node_0);
+        nros_cpp_ret_t scr = nros_cpp_create_sched_context_from_policy(executor, NULL, 0ull, 0ull, 0ull, NULL, 80u, &__nros_sc_ids[0]);
+        if (scr != NROS_CPP_RET_OK) return (int32_t)scr;
+    }
+    {
+        nros_cpp_ret_t scr = nros_cpp_create_sched_context_from_policy(executor, NULL, 0ull, 0ull, 0ull, NULL, 10u, &__nros_sc_ids[1]);
+        if (scr != NROS_CPP_RET_OK) return (int32_t)scr;
+    }
+    nros_cpp_bind_node_name_sched(executor, "ctrl", "/", __nros_sc_ids[0]);
+    nros_cpp_bind_node_name_sched(executor, "telem", "/", __nros_sc_ids[1]);
+    nros_cpp_bind_group_sched(executor, "ctrl", "/", "ctrl_grp", __nros_sc_ids[0]);
+    nros_cpp_bind_group_sched(executor, "telem", "/", "telem_grp", __nros_sc_ids[1]);
+    {
+        nros_cpp_ret_t nrc = nros_cpp_node_create(executor, "ctrl", "/", &__nros_node_0);
         if (nrc != NROS_CPP_RET_OK) return (int32_t)nrc;
-        void* self = __nros_c_component_c_talker_pkg_create();
-        int32_t crc = __nros_c_component_c_talker_pkg_configure(&__nros_node_0, executor, self);
+        void* self = __nros_c_component_ctrl_pkg_create();
+        int32_t crc = __nros_c_component_ctrl_pkg_configure(&__nros_node_0, executor, self);
+        if (crc != 0) return crc;
+    }
+    {
+        nros_cpp_ret_t nrc = nros_cpp_node_create(executor, "telem", "/", &__nros_node_1);
+        if (nrc != NROS_CPP_RET_OK) return (int32_t)nrc;
+        void* self = __nros_c_component_telem_pkg_create();
+        int32_t crc = __nros_c_component_telem_pkg_configure(&__nros_node_1, executor, self);
         if (crc != 0) return crc;
     }
     return 0;
@@ -47,9 +74,9 @@ __attribute__((section(".nros_boot_config"), used))
 = {
 .magic      = NROS_BOOT_CONFIG_MAGIC,
 .version    = NROS_BOOT_CONFIG_VERSION,
-.set_flags  = NROS_BOOT_SET_NODE_NAME,
+.set_flags  = 0,
 .domain_id  = 0,
-.node_name  = "talker",
+.node_name  = "",
 .locator    = "",
 .namespace_ = "",
 .rmw        = "",

--- a/packages/cli/nros-entry-lower/src/lib.rs
+++ b/packages/cli/nros-entry-lower/src/lib.rs
@@ -114,12 +114,21 @@ impl BoardFamily {
     ///   NuttX pthread are three different things. The three are
     ///   `nros_board_{freertos,zephyr,nuttx}_run_tiers`, in each board crate's
     ///   `c/<rtos>_run_tiers.c`.
-    /// - `Threadx` — none. It has no `run_tiers` either, so it stays
-    ///   C++-entry-only, and the routing is REPORTED rather than refused.
+    /// - `Threadx` — the same shared `nros_board_rtos_run_components`, and NO
+    ///   `run_tiers` (issue 1286). ThreadX's C++ `run_components` is the
+    ///   FreeRTOS one line for line, and the shared runner already has no
+    ///   per-tick yield off Zephyr, so there was nothing ThreadX-specific to
+    ///   write. The CMake lane compiles the TU into the app target (both
+    ///   `cmake/board/nano-ros-board-*threadx*.cmake`). The cargo lane does
+    ///   not: `nros-board-threadx-linux`'s glue is `+whole-archive`
+    ///   (issue 0582), so the runner there would pull `nros_cpp_*` into every
+    ///   Rust ThreadX image.
     ///
     /// Each half is its own `Option` because the two land independently.
-    /// Issue 1286 gives ThreadX a `run_components` with no `run_tiers`, and
-    /// that is a `Some` with one `None` in it, not a lie in either direction.
+    /// ThreadX is the family that uses that: a `Some` with one `None` in it.
+    /// A multi-tier ThreadX plan therefore takes the single-executor
+    /// sched-context path in the C pack, exactly as it does in the C++ one
+    /// (`Plan::executor_shape` reads the `run_tiers` half).
     ///
     /// `nros-cli-core/tests/board_key_table.rs` checks that every name here is
     /// defined in the tree.
@@ -141,7 +150,10 @@ impl BoardFamily {
                 run_components: Some("nros_board_rtos_run_components"),
                 run_tiers: Some("nros_board_nuttx_run_tiers"),
             }),
-            BoardFamily::Threadx => None,
+            BoardFamily::Threadx => Some(CAbiRunners {
+                run_components: Some("nros_board_rtos_run_components"),
+                run_tiers: None,
+            }),
         }
     }
 
@@ -210,7 +222,7 @@ impl BoardFamily {
 /// [`BoardFamily::c_abi_runners`].
 ///
 /// Each half is independently optional. A family may ship `run_components`
-/// without `run_tiers`: ThreadX will, issue 1286.
+/// without `run_tiers`: ThreadX does (issue 1286).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct CAbiRunners {
     /// The single-executor runner: `(…, setup) -> int32_t`.
@@ -377,13 +389,32 @@ mod tests {
         }
     }
 
-    /// Where issue 1285 left the surface. ThreadX has NO C-ABI runner, so a C
-    /// entry for it is still routed to the C++ pack. Issue 1286 is the change
-    /// that moves it, and it must edit this test to do so.
+    /// Issue 1286. ThreadX has the shared `run_components` and NO `run_tiers`.
+    /// So a C entry renders as C, and a multi-tier plan takes the
+    /// sched-context path, not `run_tiers`. Both halves are pinned: a
+    /// `run_tiers` named here would be a symbol defined nowhere, which is the
+    /// defect issue 1285 removed.
     #[test]
-    fn threadx_has_no_c_abi_runner_yet() {
-        assert_eq!(BoardFamily::Threadx.c_abi_runners(), None);
-        assert!(!BoardFamily::Threadx.has_c_run_components());
+    fn threadx_has_run_components_and_no_run_tiers() {
+        assert_eq!(
+            BoardFamily::Threadx.c_abi_runners(),
+            Some(CAbiRunners {
+                run_components: Some("nros_board_rtos_run_components"),
+                run_tiers: None,
+            })
+        );
+        assert!(BoardFamily::Threadx.has_c_run_components());
+    }
+
+    /// Every family now has a C-ABI `run_components` (issue 1286 closed the
+    /// last one), so a `--lang c` entry renders as C on every board. A new
+    /// family without one fails here and must decide, rather than silently
+    /// routing to the C++ pack.
+    #[test]
+    fn every_family_has_a_c_run_components() {
+        for f in BoardFamily::ALL {
+            assert!(f.has_c_run_components(), "{}", f.as_str());
+        }
     }
 
     /// `freertos-posix` is the trap this table exists to hold. It is a host


### PR DESCRIPTION
Closes issue 1286 (filed and resolved in this PR: `docs/issues/archived/1286-threadx-c-entry-needs-cpp-runtime.md`). With this, every RTOS has a C runner. It builds on #903 (issue 1283: the C pack's sched-context path) and #908 (issue 1285: `c_abi_runners()`), both merged.

## What changes

A `--lang c` ThreadX entry used to go through the C++ pack and link libstdc++. It now takes the shared C runner and is a pure C image.

- **Routing:** ThreadX's `c_abi_runners()` is `run_components = nros_board_rtos_run_components`, with `run_tiers = None`. A multi-tier ThreadX plan therefore takes `ExecutorShape::SchedContexts` in both packs, the same wiring C++ always used. Routing can't depend on the plan, because CMake asks `entry-pack` before any plan exists. That is why ThreadX was held back until the C pack had sched contexts.
- **Boot shape:** checked in the board C, not assumed.
  - threadx-linux: the weak `main` calls `tx_kernel_enter()`; `threadx_hooks.c` creates the app thread, which calls the weak `app_main`.
  - rv-virt: `main` registers `app_main` explicitly.

  Both reach the `app_main` that `NROS_APP_MAIN_REGISTER_VOID()` defines.
- **CMake:**
  - threadx-linux: `THREADX_APP_DEFINE_SOURCE` gains the runner.
  - rv-virt: the runner goes in `THREADX_STARTUP_SOURCE`, **not** `_glue_srcs`. The `threadx_glue` library's compile has no nros-cpp include path, so there the runner would silently use its 81920-byte fallback. It is also an archive that links after `libnros_cpp.a`.
- **Cargo lane: unchanged, deliberately.** `nros-board-threadx-linux`'s glue is `+whole-archive` (issue 0582), so putting the runner there would drag `nros_cpp_*` references into every Rust ThreadX image.

## The storage-size risk was real, and is closed

The per-build size is **90424** bytes on both boards; the runner's fallback is 81920. On both boards the per-build header's directory comes before the in-tree stub on the runner's include line. A missing header therefore hits the stub's `#error` rather than falling back to the smaller size, which is the existing mechanism, so nothing new was added.

## Evidence

- **threadx-linux** (`workspace-c-threadx-linux`):
  - `entry-pack` reports `pack=c`; the build has 0 C++ objects.
  - NEEDED libraries are only `libgcc_s.so.1`, `libc.so.6` and `ld-linux`. The only `__cxa` symbols left are glibc's weak `__cxa_finalize` and `__cxa_thread_atexit_impl`.
  - `nros_board_rtos_run_components`, `nros_app_main` and `app_main` are defined.
- **Runtime:** `entry_matrix` printed `1 ran, 15 skipped, 0 failed`. The one that ran is `threadx-linux/c/entry_pubsub`: the pure-C image publishes `/chatter` to a native C listener. The 15 skips are fixtures the worktree did not build.
- **rv-virt-threadx:** no C workspace fixture row exists. The plain C talker, built with the lane's settings, compiles the runner against the per-build header and links with the unused runner dropped. A C workspace entry on rv-virt is unmeasured, and so is its runtime.
- **Goldens:** `c_threadx_one` changed from the refusal text to a real C entry. `c_threadx_tiers` is new and emits the three sched-context calls. `both_entry_packs_take_the_plans_executor_branch` now covers ThreadX (20 rows, up from 16).
- **Tests and gates:** CLI workspace 1965 passed, 0 failed; CLI clippy `-D warnings` clean. `just ci gate` passed, run on the pre-rebase base:
  - check fast: 296 ran, 2 skipped;
  - check build: 21/21;
  - test-unit: 1295 passed, 3 skipped, and the one red is a reclassified capability precondition;
  - test-lane-contracts: 17/17.
- **After the rebase onto main** (#908's cherry-pick dropped by patch-id, leaving one commit): `cargo test -p nros-cli-core --lib codegen::entry` passed 107, failed 0. The full gate was not re-run on the rebased tree.

## Docs

- RFC-0091: the surface table, §11's open question (answered) and a §12 note.
- phase-432: its three ThreadX rationales.
- The entry-pack comments and the CLI's stderr routing message.

**Not changed:** the C template's header comment still names `nros_board_native_run_components` in every C golden, which has been wrong for the RTOS boards since W3.1. Fixing it rewrites 14 goldens, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zw1nseWJBSTRqVQzRAZcg
