### PR TITLE
fix(#1269, phase-444 W7): Cyclone announced one node per session — one NodeEntitiesInfo per node now

### DIFF
--- a/docs/issues/1292-xrce-graph-shows-no-nano-ros-nodes.md
+++ b/docs/issues/1292-xrce-graph-shows-no-nano-ros-nodes.md
@@ -1,0 +1,65 @@
+---
+id: 1292
+title: "XRCE images publish no `ros_discovery_info`, so `ros2 node list` shows
+  none of their nodes"
+status: open
+type: bug
+area: rmw
+severity: medium
+related: [issue-1269, issue-0105]
+---
+
+## Requirement
+
+Issue 1269's: the same image presents the same node set to ROS 2 whichever
+RMW it is built with. Issue 1269 made Cyclone match zenoh (one graph node per
+component). This is the XRCE third of it.
+
+## What XRCE does today (from the source — NOT measured live)
+
+`nros-rmw-xrce` never writes `ros_discovery_info`. `grep -rn
+'ros_discovery_info\|ParticipantEntitiesInfo' packages/rmw/xrce` finds
+nothing. Its session creates ONE DDS participant on the Agent, named after the
+session's open-time node name (`uxr_buffer_create_participant_bin(...,
+name_buf, ...)` in `session.c`), and its `create_node` / `destroy_node` vtable
+slots are NULL.
+
+A stock `rmw_fastrtps_cpp` / `rmw_cyclonedds_cpp` graph cache
+(`rmw_dds_common::GraphCache`) learns node names ONLY from
+`ParticipantEntitiesInfo` samples on `ros_discovery_info`; a bare DDS
+participant's name is not a node. So the expected reading of `ros2 node list`
+against an XRCE image is **zero** of its nodes, and its topics' endpoints are
+attributed to no node — reasoned from the code above, not observed. The
+Micro-XRCE-DDS Agent does not publish the topic on a client's behalf (micro-ROS
+does it in the CLIENT library, `rmw_microxrcedds`'s graph manager, which we do
+not use).
+
+The issue 1269 table recorded XRCE as "not measured" and guessed the zenoh-era
+collapse to one node; the code says it is worse than that. Measure before
+fixing: the cell below is where the measurement goes.
+
+## Fix shape
+
+- Declare a `ros_discovery_info` DataWriter through the Agent (XML or binary
+  representation) once per session, with the rmw_dds_common type and the
+  stock QoS (RELIABLE, TRANSIENT_LOCAL, KEEP_LAST 1).
+- Fill `create_node` / `destroy_node` and keep one record per node, each with
+  its readers' and writers' GIDs — the Agent assigns the DDS GUIDs, so this
+  needs the entities' GUIDs back from the Agent, which the XRCE protocol does
+  not return by default. That is the hard part and why this is not a copy of
+  Cyclone's `graph.cpp`.
+- Republish on every node/endpoint change, as Cyclone does since 1269.
+
+## Test
+
+`native-multinode-rust-xrce-CARVED` in `interop::CELLS` records the lane as
+absent, citing this issue. The fixture it would run already exists
+(`workspace-rust-native-xrce`, `[image.native_xrce]` in
+`examples/workspaces/rust`); turning the carve-out into a Runtime cell of
+`rust_multi_node_per_node_graph` is the acceptance test.
+
+## Acceptance
+
+`rust_multi_node_per_node_graph` gains an XRCE case asserting the same node set
+(`/talker`, `/listener`) its zenoh and Cyclone cases assert, and it passes
+against a live Agent + ROS 2 peer.

--- a/docs/issues/archived/1269-graph-node-set-differs-across-rmws.md
+++ b/docs/issues/archived/1269-graph-node-set-differs-across-rmws.md
@@ -2,12 +2,45 @@
 id: 1269
 title: "The ROS graph shows a different node set for the same image on each
   RMW: zenoh announces every node, Cyclone announces one per session"
-status: open
+status: resolved
 type: bug
 area: rmw
 severity: medium
-related: [issue-0105, issue-1268]
+related: [issue-0105, issue-1268, issue-1292]
 ---
+
+## Resolution (phase-444 W7)
+
+**Cyclone: fixed.** `graph.cpp` now keeps one record per NODE, fed by the
+`create_node` / `destroy_node` vtable slots (both were NULL; the runtime
+already called `create_node` once per distinct `(name, namespace)`). Every
+endpoint is attributed to the node that created it (`graph_node_of`), and the
+latched `ParticipantEntitiesInfo` carries one `NodeEntitiesInfo` per node with
+that node's own reader/writer GIDs, republished on every node or endpoint
+change. The session's open-time name is no longer published as a node, which
+is what produced the phantom `/node`. Two siblings of the same class fixed in
+the same change: destroying an endpoint now removes its GID (nothing ever
+called `graph_untrack_*`, so a destroyed publisher stayed listed for the
+session's life), and ThreadX's `SessionState` is placement-new'd so the graph
+state is never read uninitialised.
+
+Evidence: the backend CTest `nros_rmw_cyclonedds_graph_node_set` reads the
+sample back from a separate participant and asserts four entries for four
+nodes, each publisher's GID under its own node only, an endpoint-less node
+present, no session-named entry, and a republish after `destroy_publisher`
+and `destroy_node`. Negative control: capping the published sequence at one
+entry (the pre-fix shape) makes it fail four assertions.
+
+**Test the issue asked for:** `rust_multi_node_per_node_graph` runs the same
+`examples/workspaces/rust` image on zenoh and on Cyclone and asserts one shared
+`EXPECTED_NODES` set by equality; cell `native-multinode-rust-cyclone` in
+`interop::CELLS`. It needs a live ROS 2 peer and has NOT been run here — it
+starts life with no verdict, as every new live-peer cell does.
+
+**XRCE: split out as issue 1292.** The backend writes no
+`ros_discovery_info` at all, so the expected reading is zero nodes, not the
+one-node collapse this issue guessed — reasoned from `session.c`, not
+measured. Recorded as the carve-out `native-multinode-rust-xrce-CARVED`.
 
 ## Requirement
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.cpp
@@ -9,9 +9,11 @@
 // every hosted target and failed only on threadx-riscv64.
 #include <stdio.h>
 
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 
+#include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "descriptors.hpp"
 #include "rmw_dds_common_graph.h" // idlc-generated typed structs + descriptor
@@ -33,6 +35,16 @@ namespace {
 constexpr const char* kGraphTopic = "ros_discovery_info";
 constexpr const char* kGraphType = "rmw_dds_common::msg::dds_::ParticipantEntitiesInfo_";
 
+// The published sequences point STRAIGHT into GraphState's `uint8_t[24]` GID
+// storage, typed as the generated `Gid_`. That is only sound while the two have
+// one layout, so it is checked rather than assumed.
+static_assert(sizeof(rmw_dds_common_msg_dds__Gid_) == 24, "Gid_ must be 24 bytes");
+static_assert(alignof(rmw_dds_common_msg_dds__Gid_) == 1, "Gid_ must be byte-aligned");
+static_assert(offsetof(rmw_dds_common_msg_dds__Gid_, data) == 0, "Gid_::data must lead");
+
+// `string<256>` in the IDL: idlc emits a fixed `char[257]`.
+constexpr std::size_t kNameCap = sizeof(rmw_dds_common_msg_dds__NodeEntitiesInfo_::node_name);
+
 // rmw_dds_common Gid is 24 bytes; a DDS GUID is 16. Stock derives the gid by
 // copying the 16-byte GUID into the first 16 bytes (rest zero) and matches the
 // same bytes from SEDP, so endpoints associate with the node. (Distinct from
@@ -53,18 +65,83 @@ int find_entity(const dds_entity_t* arr, int n, dds_entity_t e) {
     return -1;
 }
 
+/// A namespace as it goes on the wire: an absent or empty one is the root.
+const char* wire_ns(const char* ns) {
+    return (ns != nullptr && ns[0] != '\0') ? ns : "/";
+}
+
+bool same_node(const GraphNode& n, const char* name, const char* ns) {
+    return n.used && std::strcmp(n.name, name) == 0 && std::strcmp(wire_ns(n.ns), wire_ns(ns)) == 0;
+}
+
+/// Insert `e` into one endpoint table, keeping it grouped by node. Returns
+/// false if already tracked or full.
+bool insert_grouped(dds_entity_t* ents, uint8_t (*gids)[24], uint8_t* owner, int* n, int node,
+                    dds_entity_t e) {
+    if (find_entity(ents, *n, e) >= 0) return false;
+    if (*n >= GraphState::kMaxEndpoints) return false;
+    // After the last entry whose node is <= this one: stable within a node.
+    int pos = *n;
+    while (pos > 0 && owner[pos - 1] > static_cast<uint8_t>(node))
+        --pos;
+    for (int j = *n; j > pos; --j) {
+        ents[j] = ents[j - 1];
+        std::memcpy(gids[j], gids[j - 1], 24);
+        owner[j] = owner[j - 1];
+    }
+    ents[pos] = e;
+    entity_gid_24(e, gids[pos]);
+    owner[pos] = static_cast<uint8_t>(node);
+    ++*n;
+    return true;
+}
+
+void erase_at(dds_entity_t* ents, uint8_t (*gids)[24], uint8_t* owner, int* n, int i) {
+    for (int j = i; j < *n - 1; ++j) {
+        ents[j] = ents[j + 1];
+        std::memcpy(gids[j], gids[j + 1], 24);
+        owner[j] = owner[j + 1];
+    }
+    --*n;
+}
+
+void erase_node(dds_entity_t* ents, uint8_t (*gids)[24], uint8_t* owner, int* n, int node) {
+    for (int i = *n - 1; i >= 0; --i) {
+        if (owner[i] == static_cast<uint8_t>(node)) erase_at(ents, gids, owner, n, i);
+    }
+}
+
+/// The contiguous run of `node`'s endpoints in one grouped table.
+void node_run(const uint8_t* owner, int n, int node, int* start, int* len) {
+    int s = 0;
+    while (s < n && owner[s] < static_cast<uint8_t>(node))
+        ++s;
+    int e = s;
+    while (e < n && owner[e] == static_cast<uint8_t>(node))
+        ++e;
+    *start = s;
+    *len = e - s;
+}
+
+rmw_dds_common_msg_dds__Gid_* as_gids(uint8_t (*gids)[24], int start) {
+    return reinterpret_cast<rmw_dds_common_msg_dds__Gid_*>(gids[start]);
+}
+
 } // namespace
 
-void graph_init(GraphState* g, dds_entity_t participant, const char* node_name,
-                const char* node_namespace) {
-    if (g == nullptr || participant <= 0) return;
+void graph_init(GraphState* g, dds_entity_t participant) {
+    if (g == nullptr) return;
+    // A clean slate regardless of how the enclosing state was allocated —
+    // node records and endpoint counts are read on every later call. memset,
+    // not `*g = GraphState{}`: that builds a ~5 KiB temporary on the caller's
+    // stack, which is an RTOS app task. All-zero IS the default state (null
+    // pointers, false flags, zero counts), and the type is trivially copyable.
+    std::memset(static_cast<void*>(g), 0, sizeof(*g));
+    if (participant <= 0) return;
 
     register_rmw_dds_common_graph_0();
 
     entity_gid_24(participant, g->participant_gid);
-    ddsrt_strlcpy(g->node_name, node_name ? node_name : "", sizeof(g->node_name));
-    ddsrt_strlcpy(g->node_namespace, (node_namespace && node_namespace[0]) ? node_namespace : "/",
-                  sizeof(g->node_namespace));
 
     const dds_topic_descriptor_t* desc = find_descriptor(kGraphType);
     if (desc == nullptr) return; // graph stays inactive — interop degrades gracefully
@@ -100,90 +177,145 @@ void graph_fini(GraphState* g) {
     g->active = false;
     g->n_readers = 0;
     g->n_writers = 0;
+    for (GraphNode& n : g->nodes)
+        n = GraphNode{};
 }
 
-void graph_track_writer(GraphState* g, dds_entity_t writer) {
-    if (g == nullptr || !g->active || writer <= 0) return;
-    if (find_entity(g->writer_ent, g->n_writers, writer) >= 0) return;
-    if (g->n_writers >= GraphState::kMaxEndpoints) return;
-    g->writer_ent[g->n_writers] = writer;
-    entity_gid_24(writer, g->writer_gid[g->n_writers]);
-    g->n_writers++;
+int graph_add_node(GraphState* g, const char* name, const char* ns) {
+    if (g == nullptr || name == nullptr || name[0] == '\0') return kGraphNodeInvalid;
+    // Refuse rather than truncate — see graph.hpp.
+    if (std::strlen(name) >= kNameCap || std::strlen(wire_ns(ns)) >= kNameCap) {
+        return kGraphNodeInvalid;
+    }
+    int free_slot = -1;
+    for (int i = 0; i < GraphState::kMaxNodes; ++i) {
+        if (same_node(g->nodes[i], name, ns)) return i;
+        if (!g->nodes[i].used && free_slot < 0) free_slot = i;
+    }
+    if (free_slot < 0) return kGraphNodeFull;
+    g->nodes[free_slot].name = name;
+    g->nodes[free_slot].ns = ns;
+    g->nodes[free_slot].used = true;
+    // A node with no endpoints is still a node: `ros2 node list` shows it the
+    // moment it exists, which is also when zenoh declares its token.
+    graph_publish(g);
+    return free_slot;
+}
+
+int graph_node_index(const GraphState* g, const void* rec) {
+    if (g == nullptr || rec == nullptr) return -1;
+    for (int i = 0; i < GraphState::kMaxNodes; ++i) {
+        if (rec == static_cast<const void*>(&g->nodes[i])) return g->nodes[i].used ? i : -1;
+    }
+    return -1;
+}
+
+void graph_remove_node(GraphState* g, int node) {
+    if (g == nullptr || node < 0 || node >= GraphState::kMaxNodes || !g->nodes[node].used) return;
+    erase_node(g->reader_ent, g->reader_gid, g->reader_node, &g->n_readers, node);
+    erase_node(g->writer_ent, g->writer_gid, g->writer_node, &g->n_writers, node);
+    g->nodes[node] = GraphNode{};
     graph_publish(g);
 }
 
-void graph_track_reader(GraphState* g, dds_entity_t reader) {
-    if (g == nullptr || !g->active || reader <= 0) return;
-    if (find_entity(g->reader_ent, g->n_readers, reader) >= 0) return;
-    if (g->n_readers >= GraphState::kMaxEndpoints) return;
-    g->reader_ent[g->n_readers] = reader;
-    entity_gid_24(reader, g->reader_gid[g->n_readers]);
-    g->n_readers++;
-    graph_publish(g);
+void graph_track_writer(GraphState* g, int node, dds_entity_t writer) {
+    if (g == nullptr || writer <= 0 || node < 0 || node >= GraphState::kMaxNodes ||
+        !g->nodes[node].used) {
+        return;
+    }
+    if (insert_grouped(g->writer_ent, g->writer_gid, g->writer_node, &g->n_writers, node, writer)) {
+        graph_publish(g);
+    }
+}
+
+void graph_track_reader(GraphState* g, int node, dds_entity_t reader) {
+    if (g == nullptr || reader <= 0 || node < 0 || node >= GraphState::kMaxNodes ||
+        !g->nodes[node].used) {
+        return;
+    }
+    if (insert_grouped(g->reader_ent, g->reader_gid, g->reader_node, &g->n_readers, node, reader)) {
+        graph_publish(g);
+    }
 }
 
 void graph_untrack_writer(GraphState* g, dds_entity_t writer) {
-    if (g == nullptr || !g->active) return;
+    if (g == nullptr) return;
     int i = find_entity(g->writer_ent, g->n_writers, writer);
     if (i < 0) return;
-    for (int j = i; j < g->n_writers - 1; ++j) {
-        g->writer_ent[j] = g->writer_ent[j + 1];
-        std::memcpy(g->writer_gid[j], g->writer_gid[j + 1], 24);
-    }
-    g->n_writers--;
+    erase_at(g->writer_ent, g->writer_gid, g->writer_node, &g->n_writers, i);
     graph_publish(g);
 }
 
 void graph_untrack_reader(GraphState* g, dds_entity_t reader) {
-    if (g == nullptr || !g->active) return;
+    if (g == nullptr) return;
     int i = find_entity(g->reader_ent, g->n_readers, reader);
     if (i < 0) return;
-    for (int j = i; j < g->n_readers - 1; ++j) {
-        g->reader_ent[j] = g->reader_ent[j + 1];
-        std::memcpy(g->reader_gid[j], g->reader_gid[j + 1], 24);
-    }
-    g->n_readers--;
+    erase_at(g->reader_ent, g->reader_gid, g->reader_node, &g->n_readers, i);
     graph_publish(g);
 }
 
 void graph_publish(GraphState* g) {
     if (g == nullptr || !g->active || g->writer <= 0) return;
 
-    // Build the sample entirely on the stack: dds_write serializes synchronously
-    // (copies), so pointing the sequence `_buffer`s at stack arrays with
-    // `_release = false` needs no heap and no free.
-    rmw_dds_common_msg_dds__Gid_ rgids[GraphState::kMaxEndpoints];
-    rmw_dds_common_msg_dds__Gid_ wgids[GraphState::kMaxEndpoints];
-    for (int i = 0; i < g->n_readers; ++i)
-        std::memcpy(rgids[i].data, g->reader_gid[i], 24);
-    for (int i = 0; i < g->n_writers; ++i)
-        std::memcpy(wgids[i].data, g->writer_gid[i], 24);
+    int n_nodes = 0;
+    for (const GraphNode& n : g->nodes)
+        n_nodes += n.used ? 1 : 0;
 
-    rmw_dds_common_msg_dds__NodeEntitiesInfo_ node;
-    std::memset(&node, 0, sizeof(node));
-    // Bounded `string<256>` → idlc fixed `char[257]` array, so copy (not assign).
-    ddsrt_strlcpy(node.node_namespace, g->node_namespace, sizeof(node.node_namespace));
-    ddsrt_strlcpy(node.node_name, g->node_name, sizeof(node.node_name));
-    node.reader_gid_seq._length = static_cast<uint32_t>(g->n_readers);
-    node.reader_gid_seq._maximum = static_cast<uint32_t>(g->n_readers);
-    node.reader_gid_seq._buffer = g->n_readers ? rgids : nullptr;
-    node.reader_gid_seq._release = false;
-    node.writer_gid_seq._length = static_cast<uint32_t>(g->n_writers);
-    node.writer_gid_seq._maximum = static_cast<uint32_t>(g->n_writers);
-    node.writer_gid_seq._buffer = g->n_writers ? wgids : nullptr;
-    node.writer_gid_seq._release = false;
+    // One `NodeEntitiesInfo_` per node. Each carries two `char[257]` arrays, so
+    // a stack array sized for the table would be ~35 KiB — beyond what an RTOS
+    // app task can give. It is a TRANSIENT sample, so it comes from
+    // `ddsrt_malloc` (never libc: the RTOS heap is separate, see
+    // cyclonedds-known-limitations.md), sized to the nodes that exist, and is
+    // freed once `dds_write` has serialised it. The GID sequences need no
+    // allocation at all: they point into the grouped tables.
+    rmw_dds_common_msg_dds__NodeEntitiesInfo_* infos = nullptr;
+    if (n_nodes > 0) {
+        infos = static_cast<rmw_dds_common_msg_dds__NodeEntitiesInfo_*>(
+            ddsrt_malloc(static_cast<std::size_t>(n_nodes) * sizeof(*infos)));
+        if (infos == nullptr) {
+            // Keep the last published snapshot rather than publish one that
+            // drops every node. Say so: a stale graph is otherwise silent.
+            fprintf(stderr,
+                    "nros-rmw-cyclonedds: ros_discovery_info not republished "
+                    "(out of memory for %d node entries)\n",
+                    n_nodes);
+            return;
+        }
+        std::memset(infos, 0, static_cast<std::size_t>(n_nodes) * sizeof(*infos));
+    }
 
-    rmw_dds_common_msg_dds__NodeEntitiesInfo_ nodes[1] = {node};
+    int k = 0;
+    for (int i = 0; i < GraphState::kMaxNodes; ++i) {
+        const GraphNode& n = g->nodes[i];
+        if (!n.used) continue;
+        rmw_dds_common_msg_dds__NodeEntitiesInfo_& info = infos[k++];
+        // Lengths were checked in graph_add_node, so these never truncate.
+        ddsrt_strlcpy(info.node_namespace, wire_ns(n.ns), sizeof(info.node_namespace));
+        ddsrt_strlcpy(info.node_name, n.name, sizeof(info.node_name));
+
+        int rs = 0, rl = 0, ws = 0, wl = 0;
+        node_run(g->reader_node, g->n_readers, i, &rs, &rl);
+        node_run(g->writer_node, g->n_writers, i, &ws, &wl);
+        info.reader_gid_seq._length = static_cast<uint32_t>(rl);
+        info.reader_gid_seq._maximum = static_cast<uint32_t>(rl);
+        info.reader_gid_seq._buffer = rl ? as_gids(g->reader_gid, rs) : nullptr;
+        info.reader_gid_seq._release = false;
+        info.writer_gid_seq._length = static_cast<uint32_t>(wl);
+        info.writer_gid_seq._maximum = static_cast<uint32_t>(wl);
+        info.writer_gid_seq._buffer = wl ? as_gids(g->writer_gid, ws) : nullptr;
+        info.writer_gid_seq._release = false;
+    }
 
     rmw_dds_common_msg_dds__ParticipantEntitiesInfo_ sample;
     std::memset(&sample, 0, sizeof(sample));
     std::memcpy(sample.gid.data, g->participant_gid, 24);
-    sample.node_entities_info_seq._length = 1;
-    sample.node_entities_info_seq._maximum = 1;
-    sample.node_entities_info_seq._buffer = nodes;
+    sample.node_entities_info_seq._length = static_cast<uint32_t>(n_nodes);
+    sample.node_entities_info_seq._maximum = static_cast<uint32_t>(n_nodes);
+    sample.node_entities_info_seq._buffer = infos;
     sample.node_entities_info_seq._release = false;
 
     (void)dds_write(g->writer, &sample);
+    ddsrt_free(infos);
 }
 
 /// phase-381 W5 — the READER half. Contract in graph.hpp.
@@ -235,7 +367,7 @@ bool graph_visit_nodes(GraphState* g, void* ctx,
     // Env-gated and permanent, same convention as the zenoh shim's
     // `NROS_GRAPH_DUMP`: the first time this was wanted it was patched in by
     // hand, and the next person had to re-derive it.
-    // `fprintf`, NOT `fprintf` — the crate's other TU (descriptors.cpp)
+    // `fprintf`, NOT `std::fprintf` — the crate's other TU (descriptors.cpp)
     // already spells it this way and compiles everywhere. `<cstdio>` is only
     // REQUIRED to declare the name in namespace `std`; putting it in the global
     // namespace too is permitted, not guaranteed, and the minimal C++ library on
@@ -258,9 +390,8 @@ bool graph_visit_nodes(GraphState* g, void* ctx,
         // this distinguishes "incompatible" from "not there" in one number.
         dds_requested_incompatible_qos_status_t iq = {};
         if (dds_get_requested_incompatible_qos_status(g->graph_reader, &iq) == DDS_RETCODE_OK) {
-            fprintf(stderr,
-                         "GRAPH_CYCLONE incompatible_qos total=%u last_policy_id=%u\n",
-                         iq.total_count, iq.last_policy_id);
+            fprintf(stderr, "GRAPH_CYCLONE incompatible_qos total=%u last_policy_id=%u\n",
+                    iq.total_count, iq.last_policy_id);
         }
     }
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.hpp
@@ -7,7 +7,18 @@
 // but stock graph introspection (`ros2 node list/info`, `ros2 action info`, and
 // crucially an action client's `wait_for_server`) sees the endpoints associated
 // with NO node unless we publish this message. This tracks each node's
-// reader/writer GIDs and (re)publishes the message on every endpoint change.
+// reader/writer GIDs and (re)publishes the message on every change.
+//
+// Issue 1269 — ONE participant, MANY nodes. This used to publish exactly one
+// `NodeEntitiesInfo`, named after the SESSION, and attributed every endpoint in
+// the image to it: a four-node image showed `/node` in `ros2 node list` and
+// `ros2 param list /mrm_handler` answered "Node not found". zenoh had shown one
+// graph node per component since phase-268, so the node set a user saw
+// depended on the RMW. Now the graph holds one record per NODE (fed by the
+// `create_node` slot, which the runtime calls once per distinct
+// `(name, namespace)`), every endpoint is attributed to the node that created
+// it, and the sample carries one `NodeEntitiesInfo` per node. The session's own
+// open-time name is not a node — exactly as on zenoh.
 #ifndef NROS_RMW_CYCLONEDDS_GRAPH_HPP
 #define NROS_RMW_CYCLONEDDS_GRAPH_HPP
 
@@ -17,10 +28,30 @@
 
 namespace nros_rmw_cyclonedds {
 
-// Per-session (≈ per-participant ≈ per-node) graph state. Fixed-capacity, no
-// heap (matches the backend's alloc-light style + embedded constraints).
+/// One graph node on this participant.
+///
+/// The strings are BORROWED, not copied: `rmw_node_t` promises its `name` and
+/// `namespace_` outlive the node ("Borrowed; outlives the node",
+/// `rmw_entity.h`), and the runtime hands them out of its static node table.
+/// Copying them would cost 2 x 257 bytes per record for a bound
+/// (`string<256>`) nothing in the image comes near, and would make the table
+/// too expensive to size for the runtime's largest `NROS_RMW_MAX_NODES`.
+struct GraphNode {
+    const char* name{nullptr};
+    const char* ns{nullptr}; // NULL or "" publishes as "/"
+    bool used{false};
+};
+
+// Per-session (= per-participant) graph state. Fixed-capacity, no heap
+// (matches the backend's alloc-light style + embedded constraints).
 struct GraphState {
+    /// Reader and writer capacity for the WHOLE participant, shared by every
+    /// node on it — the same total the one-node table had.
     static constexpr int kMaxEndpoints = 32;
+    /// The upper bound `nros-rmw-cffi`'s `build.rs` accepts for
+    /// `NROS_RMW_MAX_NODES` ([1, 64]), so the runtime's own node table always
+    /// fills before this one does. A record is two pointers and a flag.
+    static constexpr int kMaxNodes = 64;
 
     dds_entity_t topic{0};
     dds_entity_t writer{0}; // latched ros_discovery_info writer
@@ -32,33 +63,62 @@ struct GraphState {
     /// nothing, which matters because most embedded images never ask.
     dds_entity_t graph_reader{0};
     uint8_t participant_gid[24]{};
-    char node_namespace[256]{};
-    char node_name[256]{};
 
+    /// Slots are STABLE: a released record is marked unused and never moved,
+    /// because `rmw_node_t::backend_data` points at it.
+    GraphNode nodes[kMaxNodes]{};
+
+    /// Endpoints are kept GROUPED BY NODE (ascending `*_node`), so each node's
+    /// GIDs are one contiguous run and the published sequence can point
+    /// straight into this storage — no per-publish copy, no stack array.
     dds_entity_t reader_ent[kMaxEndpoints]{};
     uint8_t reader_gid[kMaxEndpoints][24]{};
+    uint8_t reader_node[kMaxEndpoints]{};
     int n_readers{0};
 
     dds_entity_t writer_ent[kMaxEndpoints]{};
     uint8_t writer_gid[kMaxEndpoints][24]{};
+    uint8_t writer_node[kMaxEndpoints]{};
     int n_writers{0};
 
     bool active{false}; // false if the descriptor/topic/writer wasn't created
 };
 
-// Capture the participant GID + node identity, register + create the latched
-// `ros_discovery_info` writer, and publish the (empty) initial sample. If the
-// ParticipantEntitiesInfo descriptor or the writer can't be created the graph
-// stays inactive and every other call is a no-op (interop degrades gracefully
-// to the pre-177.36 behaviour).
-void graph_init(GraphState* g, dds_entity_t participant, const char* node_name,
-                const char* node_namespace);
+/// `graph_add_node` results that are not a slot index.
+constexpr int kGraphNodeInvalid = -1; ///< no name, or a name longer than `string<256>`
+constexpr int kGraphNodeFull = -2;    ///< every slot is taken
+
+// Reset the state, capture the participant GID, register + create the latched
+// `ros_discovery_info` writer, and publish the initial sample (no nodes yet).
+// If the ParticipantEntitiesInfo descriptor or the writer can't be created the
+// graph stays inactive: node records are still kept (they are the node's
+// identity), but nothing is published and interop degrades gracefully to the
+// pre-177.36 behaviour.
+void graph_init(GraphState* g, dds_entity_t participant);
 void graph_fini(GraphState* g);
 
-// Track/untrack an endpoint by its DDS entity (GID derived via dds_get_guid).
-// Each mutation re-publishes the full ParticipantEntitiesInfo.
-void graph_track_writer(GraphState* g, dds_entity_t writer);
-void graph_track_reader(GraphState* g, dds_entity_t reader);
+/// Find the record for `(name, ns)`, adding it if absent, and republish when a
+/// record is added. Returns the slot index, or `kGraphNodeInvalid` /
+/// `kGraphNodeFull`. A name is never truncated: two long names sharing a
+/// prefix would MERGE into one node, which is the defect this table exists to
+/// remove. `name` and `ns` must outlive the record (see `GraphNode`).
+int graph_add_node(GraphState* g, const char* name, const char* ns);
+
+/// The slot index of a record `graph_add_node` handed out as a pointer
+/// (`&g->nodes[i]`, the form `rmw_node_t::backend_data` carries), or -1 if
+/// `rec` is not one of this graph's live records.
+int graph_node_index(const GraphState* g, const void* rec);
+
+/// Release a node record and every endpoint still attributed to it, then
+/// republish. The slot becomes reusable; no other slot moves.
+void graph_remove_node(GraphState* g, int node);
+
+// Track/untrack an endpoint by its DDS entity (GID derived via dds_get_guid),
+// attributed to node slot `node`. A negative `node` is a no-op, so a caller
+// that could not resolve its node records nothing rather than guessing an
+// owner. Each mutation re-publishes the full ParticipantEntitiesInfo.
+void graph_track_writer(GraphState* g, int node, dds_entity_t writer);
+void graph_track_reader(GraphState* g, int node, dds_entity_t reader);
 void graph_untrack_writer(GraphState* g, dds_entity_t writer);
 void graph_untrack_reader(GraphState* g, dds_entity_t reader);
 
@@ -81,8 +141,7 @@ void graph_publish(GraphState* g);
 /// Returns `false` if the graph is inactive (no descriptor / no reader), which
 /// the caller reports as `UNSUPPORTED` — distinct from an empty graph.
 bool graph_visit_nodes(GraphState* g, void* ctx,
-                       bool (*visit)(void* ctx, const char* node_name,
-                                     const char* node_namespace));
+                       bool (*visit)(void* ctx, const char* node_name, const char* node_namespace));
 
 } // namespace nros_rmw_cyclonedds
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
@@ -122,6 +122,18 @@ dds_entity_t session_participant(const rmw_session_t *session);
  *  GIDs via graph_track_*. */
 GraphState *session_graph(rmw_session_t *session);
 
+/** Issue 1269 — the graph slot an endpoint created on `node` belongs to, or -1.
+ *  The record `create_node` stored in `backend_data` when there is one;
+ *  otherwise the node is recorded by its name + namespace (a direct vtable
+ *  caller that never declared it). */
+int graph_node_of(const rmw_node_t *node);
+
+/** Issue 1269 — the `create_node` / `destroy_node` slots: one graph record per
+ *  node, so each shows in `ros2 node list` with its own endpoints. */
+rmw_ret_t node_create(rmw_session_t *session, const char *name, const char *namespace_,
+                      rmw_node_t *out);
+rmw_ret_t node_destroy(rmw_node_t *node);
+
 /* ---- publisher.cpp / subscriber.cpp helpers ---- */
 /** Return the Cyclone writer handle for a publisher created by
  *  this backend, or 0 if the publisher is uninitialised. Used by

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/publisher.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/publisher.cpp
@@ -63,6 +63,9 @@ struct PubState {
     // allocation on a keepalive path. Same shape as the zenoh shim's
     // `liveliness_kind` field.
     bool manual_liveliness{false};
+    /// Issue 1269 — the graph this writer is listed in, so destroying the
+    /// publisher takes its GID back out of `ros_discovery_info`.
+    GraphState* graph{nullptr};
 };
 
 inline PubState* as_state(const rmw_publisher_t* p) {
@@ -189,7 +192,9 @@ rmw_ret_t publisher_create(const rmw_node_t* node, const rmw_message_type_suppor
     state->writer = writer;
 
     out->backend_data = state;
-    graph_track_writer(session_graph(session), writer); // Phase 177.36
+    // Phase 177.36 / issue 1269 — listed under the node that created it.
+    state->graph = session_graph(session);
+    graph_track_writer(state->graph, graph_node_of(node), writer);
     return NROS_RMW_RET_OK;
 }
 
@@ -204,6 +209,14 @@ rmw_ret_t publisher_destroy(rmw_publisher_t* publisher) {
     // refuses to delete is the leak the caller now gets to hear about; the
     // teardown still runs to completion either way, because leaving the C++
     // state behind would turn one leak into two.
+    //
+    // Issue 1269 — out of the graph first. Nothing ever untracked, so a
+    // destroyed publisher stayed in `ros_discovery_info` for the life of the
+    // session. Only while the writer is still a live entity: that implies its
+    // participant is, and so the session state `graph` points into.
+    if (state->graph != nullptr && state->writer > 0 && dds_get_participant(state->writer) > 0) {
+        graph_untrack_writer(state->graph, state->writer);
+    }
     dds_return_t writer_rc = state->writer > 0 ? dds_delete(state->writer) : DDS_RETCODE_OK;
     dds_return_t topic_rc = state->topic > 0 ? dds_delete(state->topic) : DDS_RETCODE_OK;
     delete state;

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/service.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/service.cpp
@@ -286,6 +286,8 @@ struct ServerState {
     const dds_topic_descriptor_t* req_desc{nullptr};
     const dds_topic_descriptor_t* rep_desc{nullptr};
     RequestSlot slots[kRequestSlots];
+    /// Issue 1269 — the graph both endpoints are listed in.
+    GraphState* graph{nullptr};
 };
 
 struct ClientState {
@@ -316,7 +318,18 @@ struct ClientState {
     uint8_t pending_request[kWireScratch]{};
     std::size_t pending_request_len{0};
     int64_t pending_request_seq{-1};
+    /// Issue 1269 — the graph both endpoints are listed in.
+    GraphState* graph{nullptr};
 };
+
+/// Issue 1269 — take a service/client pair back out of the graph on destroy.
+/// Only while each entity is live, which implies its participant — and so the
+/// session state `graph` points into — still is.
+void untrack_pair(GraphState* graph, dds_entity_t reader, dds_entity_t writer) {
+    if (graph == nullptr) return;
+    if (reader > 0 && dds_get_participant(reader) > 0) graph_untrack_reader(graph, reader);
+    if (writer > 0 && dds_get_participant(writer) > 0) graph_untrack_writer(graph, writer);
+}
 
 bool service_topic_name(const char* service_name, const char* prefix, const char* suffix, char* out,
                         std::size_t out_cap) {
@@ -803,8 +816,13 @@ rmw_ret_t service_create(const rmw_node_t* node, const rmw_service_type_support_
     out->backend_data = state;
     // Phase 177.36 — register both endpoints with the node graph (server:
     // request reader + reply writer; client: request writer + reply reader).
-    graph_track_reader(session_graph(session), state->reader);
-    graph_track_writer(session_graph(session), state->writer);
+    // Issue 1269 — both listed under the node that created the pair.
+    state->graph = session_graph(session);
+    {
+        const int owner = graph_node_of(node);
+        graph_track_reader(state->graph, owner, state->reader);
+        graph_track_writer(state->graph, owner, state->writer);
+    }
     return NROS_RMW_RET_OK;
 }
 
@@ -813,6 +831,7 @@ rmw_ret_t service_destroy(rmw_service_t* server) {
         return NROS_RMW_RET_INVALID_ARGUMENT;
     }
     auto* state = static_cast<ServerState*>(server->backend_data);
+    untrack_pair(state->graph, state->reader, state->writer);
     dds_return_t rc = DDS_RETCODE_OK;
     if (state->reader > 0 && dds_delete(state->reader) < 0) rc = DDS_RETCODE_ERROR;
     if (state->writer > 0 && dds_delete(state->writer) < 0) rc = DDS_RETCODE_ERROR;
@@ -1108,8 +1127,13 @@ rmw_ret_t client_create(const rmw_node_t* node, const rmw_service_type_support_t
     out->backend_data = state;
     // Phase 177.36 — register both endpoints with the node graph (server:
     // request reader + reply writer; client: request writer + reply reader).
-    graph_track_reader(session_graph(session), state->reader);
-    graph_track_writer(session_graph(session), state->writer);
+    // Issue 1269 — both listed under the node that created the pair.
+    state->graph = session_graph(session);
+    {
+        const int owner = graph_node_of(node);
+        graph_track_reader(state->graph, owner, state->reader);
+        graph_track_writer(state->graph, owner, state->writer);
+    }
     return NROS_RMW_RET_OK;
 }
 
@@ -1118,6 +1142,7 @@ rmw_ret_t client_destroy(rmw_client_t* client) {
         return NROS_RMW_RET_INVALID_ARGUMENT;
     }
     auto* state = static_cast<ClientState*>(client->backend_data);
+    untrack_pair(state->graph, state->reader, state->writer);
     dds_return_t rc = DDS_RETCODE_OK;
     if (state->writer > 0 && dds_delete(state->writer) < 0) rc = DDS_RETCODE_ERROR;
     if (state->reader > 0 && dds_delete(state->reader) < 0) rc = DDS_RETCODE_ERROR;

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/session.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/session.cpp
@@ -68,10 +68,13 @@ SessionState* alloc_session_state() {
     if (mem == nullptr) {
         return nullptr;
     }
-    auto* state = static_cast<SessionState*>(mem);
-    state->domain = 0;
-    state->participant = 0;
-    return state;
+    // Placement-new, so EVERY member gets its initialiser. This used to set
+    // `domain` and `participant` by hand and leave the rest as whatever the
+    // allocator returned — the wake pair and `listener` included, which
+    // `session_destroy` reads (`listener != nullptr` -> dds_delete_listener).
+    // `SessionState`'s destructor is trivial, so `free_session_state`'s plain
+    // dealloc stays correct.
+    return new (mem) SessionState();
 #else
     return new (std::nothrow) SessionState();
 #endif
@@ -350,10 +353,19 @@ if (NROS_CYC_COMPOSE_DOMAIN || has_user_cyclone_config()) {
     out->backend_data = state;
 
     // Phase 177.36 — stand up the ros_discovery_info graph publisher so stock
-    // ROS 2 sees this participant as a node. Best-effort: if the descriptor /
+    // ROS 2 sees this participant's nodes. Best-effort: if the descriptor /
     // writer can't be created the graph stays inactive and interop degrades to
     // endpoint-only (pre-177.36) behaviour.
-    graph_init(&state->graph, pp, node_name, "/");
+    //
+    // Issue 1269 — `node_name` is NOT registered as a node here. It is the
+    // session's open-time name, and in a multi-node image it names no
+    // component: publishing it is what put a phantom `/node` in
+    // `ros2 node list` beside (in fact instead of) the image's real nodes.
+    // Nodes arrive through `node_create`, once per distinct node; a caller that
+    // never names one still gets its endpoints attributed, via
+    // `graph_node_of`'s fallback.
+    (void)node_name;
+    graph_init(&state->graph, pp);
     return NROS_RMW_RET_OK;
 }
 
@@ -362,6 +374,57 @@ if (NROS_CYC_COMPOSE_DOMAIN || has_user_cyclone_config()) {
 GraphState* session_graph(rmw_session_t* session) {
     if (session == nullptr || session->backend_data == nullptr) return nullptr;
     return &as_state(session)->graph;
+}
+
+int graph_node_of(const rmw_node_t* node) {
+    if (node == nullptr) return -1;
+    GraphState* g = session_graph(node->session);
+    if (g == nullptr) return -1;
+    // The runtime's path: `create_node` ran and `backend_data` is our record.
+    const int idx = graph_node_index(g, node->backend_data);
+    if (idx >= 0) return idx;
+    // A caller that drives the vtable directly may hand an endpoint a node it
+    // never declared (NULL `backend_data` is what the ABI calls a pure
+    // identity carrier). The node's name and namespace are still its identity,
+    // so record it by them rather than attribute the endpoint to nobody.
+    return graph_add_node(g, node->name, node->namespace_);
+}
+
+/* Issue 1269 — the `create_node` slot. The runtime calls it once per distinct
+ * `(name, namespace_)` (`nros-rmw-cffi`'s node table), BEFORE handing the node
+ * to any `create_*`, so this is where a node becomes visible on the graph. */
+rmw_ret_t node_create(rmw_session_t* session, const char* name, const char* namespace_,
+                      rmw_node_t* out) {
+    if (session == nullptr || out == nullptr || name == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    GraphState* g = session_graph(session);
+    if (g == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
+    const int idx = graph_add_node(g, name, namespace_);
+    if (idx == kGraphNodeInvalid) return NROS_RMW_RET_INVALID_ARGUMENT;
+    // Refused, not dropped: a node the graph cannot hold is a node
+    // `ros2 node list` would silently lack, which is the defect itself. The
+    // table is sized to the runtime's largest node count, so reaching this
+    // means a caller outside the runtime declared more nodes than it can.
+    if (idx == kGraphNodeFull) return NROS_RMW_RET_BAD_ALLOC;
+    out->backend_data = &g->nodes[idx];
+    return NROS_RMW_RET_OK;
+}
+
+/* The `destroy_node` slot — the pair `create_node` requires (`rmw_vtable.h`:
+ * a backend that fills `backend_data` in create must fill this too). Called
+ * from `close()`, before `destroy_session`, so the session is still open. */
+rmw_ret_t node_destroy(rmw_node_t* node) {
+    if (node == nullptr || node->backend_data == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    GraphState* g = session_graph(node->session);
+    if (g == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
+    const int idx = graph_node_index(g, node->backend_data);
+    if (idx < 0) return NROS_RMW_RET_INVALID_ARGUMENT;
+    graph_remove_node(g, idx);
+    node->backend_data = nullptr;
+    return NROS_RMW_RET_OK;
 }
 
 rmw_ret_t session_destroy(rmw_session_t* session) {

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/subscriber.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/subscriber.cpp
@@ -68,6 +68,8 @@ struct SubState {
     /// take — check the flag first, clear it, return the error, take nothing —
     /// moved one call later, because that is where the contract leaves room.
     bool pending_too_small{false};
+    /// Issue 1269 — the graph this reader is listed in (see PubState::graph).
+    GraphState* graph{nullptr};
 };
 
 inline SubState* as_state(const rmw_subscription_t* s) {
@@ -185,7 +187,9 @@ rmw_ret_t subscription_create(const rmw_node_t* node,
     state->reader = reader;
 
     out->backend_data = state;
-    graph_track_reader(session_graph(session), reader); // Phase 177.36
+    // Phase 177.36 / issue 1269 — listed under the node that created it.
+    state->graph = session_graph(session);
+    graph_track_reader(state->graph, graph_node_of(node), reader);
     return NROS_RMW_RET_OK;
 }
 
@@ -193,6 +197,10 @@ rmw_ret_t subscription_destroy(rmw_subscription_t* subscriber) {
     if (subscriber == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
     SubState* state = as_state(subscriber);
     if (state == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
+    // Issue 1269 — see `publisher_destroy`: out of the graph while live.
+    if (state->graph != nullptr && state->reader > 0 && dds_get_participant(state->reader) > 0) {
+        graph_untrack_reader(state->graph, state->reader);
+    }
     dds_return_t reader_rc = state->reader > 0 ? dds_delete(state->reader) : DDS_RETCODE_OK;
     dds_return_t topic_rc = state->topic > 0 ? dds_delete(state->topic) : DDS_RETCODE_OK;
     delete state;

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
@@ -416,8 +416,11 @@ const nros_rmw_vtable_t kVtable = {
     /*count_publishers*/ nullptr,
     /*count_subscribers*/ nullptr,
     /*node_get_graph_guard_condition*/ nullptr,
-    /*create_node*/ nullptr,
-    /*destroy_node*/ nullptr,
+    /* Issue 1269 — one `ros_discovery_info` NodeEntitiesInfo per node. NULL
+     * here made every endpoint in the image belong to the session's one
+     * record, so a four-node image showed a single `/node`. */
+    /*create_node*/ node_create,
+    /*destroy_node*/ node_destroy,
     /*set_log_severity*/ cyclone_set_log_severity,
 };
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
@@ -153,6 +153,25 @@ add_test(
     COMMAND nros_rmw_cyclonedds_graph_counts
 )
 
+# Issue 1269 — one `ros_discovery_info` NodeEntitiesInfo per node, each with its
+# own gids, republished on change. Reads the sample back from a separate
+# participant, so it needs the generated graph wire type the backend compiles.
+add_executable(nros_rmw_cyclonedds_graph_node_set
+    graph_node_set.cpp
+    ${_test_string_sources}
+)
+target_link_libraries(nros_rmw_cyclonedds_graph_node_set PRIVATE nros_rmw_cyclonedds)
+target_include_directories(nros_rmw_cyclonedds_graph_node_set
+    PRIVATE
+        ${NROS_RMW_CFFI_DIR}
+        "${CMAKE_CURRENT_BINARY_DIR}/types"
+        "${_NROS_GRAPH_TYPES_DIR}"
+)
+add_test(
+    NAME nros_rmw_cyclonedds_graph_node_set
+    COMMAND nros_rmw_cyclonedds_graph_node_set
+)
+
 # Issue 0823 — the QoS read-back. Pre-loads the out-struct with values the
 # entity cannot have, so an echoing or zeroing implementation is visible.
 add_executable(nros_rmw_cyclonedds_actual_qos

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/graph_node_set.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/graph_node_set.cpp
@@ -1,0 +1,341 @@
+// Issue 1269 — what Cyclone PUBLISHES on `ros_discovery_info` for a
+// multi-node session.
+//
+// The requirement is that one image presents the same node set to ROS 2
+// whichever RMW it is built with. zenoh declared one liveliness token per node
+// (phase-268); Cyclone published ONE `NodeEntitiesInfo`, named after the
+// session, carrying every endpoint in the image — so a four-node image showed a
+// single `/node` in `ros2 node list`.
+//
+// This test reads the published sample back from a SEPARATE participant, i.e.
+// after it has crossed the wire as CDR, and asserts its content entry by entry:
+//
+//   * one entry per declared node, and only those — the session's own name,
+//     which names no node, must not appear (the phantom `/node`);
+//   * each node carries its OWN endpoints: a publisher's gid appears under the
+//     node that created it, byte-identical to `get_gid_for_publisher`, and
+//     under no other node;
+//   * a node with no endpoints is still a node;
+//   * the snapshot is REPUBLISHED on change: a destroyed publisher leaves its
+//     node's writer list, and a destroyed node leaves the set;
+//   * a node handed to `create_publisher` without `create_node` (a direct
+//     vtable caller) is still recorded under its own name.
+//
+// The live half — `ros2 node list` against the same image on each RMW — is
+// `native-multinode-rust-cyclone` in `interop::CELLS`; this is what can be
+// asserted with no ROS 2 on the host.
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <dds/dds.h>
+
+#include "nros/rmw_entity.h"
+#include "nros/rmw_ret.h"
+#include "nros/rmw_vtable.h"
+#include "nros_rmw_cyclonedds.h"
+#include "nros_test_domain.h"
+#include "rmw_dds_common_graph.h" // the generated wire type the backend publishes
+
+namespace {
+const nros_rmw_vtable_t* g_vt = nullptr;
+int g_bad = 0;
+
+void expect(bool ok, const char* what) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        g_bad = 1;
+    }
+}
+
+/// One decoded `NodeEntitiesInfo`.
+struct NodeView {
+    std::string ns;
+    std::string name;
+    std::vector<std::string> readers; // gids as 24-byte strings
+    std::vector<std::string> writers;
+};
+
+std::string gid_str(const uint8_t* p) {
+    return std::string(reinterpret_cast<const char*>(p), 24);
+}
+
+/// The newest `ros_discovery_info` snapshot the session's participant latched.
+bool read_snapshot(dds_entity_t reader, std::vector<NodeView>* out) {
+    void* raw[1] = {nullptr};
+    dds_sample_info_t info[1];
+    const int32_t n = dds_read(reader, raw, info, 1, 1);
+    if (n <= 0) return false;
+    bool ok = false;
+    if (info[0].valid_data) {
+        auto* s = static_cast<rmw_dds_common_msg_dds__ParticipantEntitiesInfo_*>(raw[0]);
+        out->clear();
+        for (uint32_t i = 0; i < s->node_entities_info_seq._length; ++i) {
+            const auto& e = s->node_entities_info_seq._buffer[i];
+            NodeView v;
+            v.ns = e.node_namespace;
+            v.name = e.node_name;
+            for (uint32_t r = 0; r < e.reader_gid_seq._length; ++r)
+                v.readers.push_back(gid_str(e.reader_gid_seq._buffer[r].data));
+            for (uint32_t w = 0; w < e.writer_gid_seq._length; ++w)
+                v.writers.push_back(gid_str(e.writer_gid_seq._buffer[w].data));
+            out->push_back(v);
+        }
+        ok = true;
+    }
+    (void)dds_return_loan(reader, raw, n);
+    return ok;
+}
+
+const NodeView* find(const std::vector<NodeView>& v, const char* ns, const char* name) {
+    for (const auto& n : v) {
+        if (n.ns == ns && n.name == name) return &n;
+    }
+    return nullptr;
+}
+
+/// Poll until `pred` holds for the latest snapshot. The graph writer is
+/// TRANSIENT_LOCAL + KEEP_LAST(1), so the newest sample is the current state,
+/// but it still has to cross discovery to reach our participant.
+template <typename Pred>
+bool await_snapshot(dds_entity_t reader, std::vector<NodeView>* snap, Pred pred) {
+    for (int i = 0; i < 100; ++i) {
+        if (read_snapshot(reader, snap) && pred(*snap)) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return false;
+}
+
+void dump(const char* when, const std::vector<NodeView>& snap) {
+    std::fprintf(stderr, "  snapshot %s: %zu node(s)\n", when, snap.size());
+    for (const auto& n : snap) {
+        std::fprintf(stderr, "    ns=%s name=%s readers=%zu writers=%zu\n", n.ns.c_str(),
+                     n.name.c_str(), n.readers.size(), n.writers.size());
+    }
+}
+
+bool create_pub(rmw_node_t* node, const char* topic, uint32_t domain, rmw_publisher_t* out) {
+    static const rmw_qos_profile_t qos = [] {
+        rmw_qos_profile_t q{};
+        q.reliability = NROS_RMW_RELIABILITY_RELIABLE;
+        q.durability = NROS_RMW_DURABILITY_VOLATILE;
+        q.history = NROS_RMW_HISTORY_KEEP_LAST;
+        q.depth = 5;
+        return q;
+    }();
+    out->topic_name = topic;
+    out->type_name = "nros_test::msg::TestString";
+    const rmw_message_type_support_t ts{out->type_name, ""};
+    return g_vt->create_publisher(node, &ts, topic, domain, &qos, nullptr, out) == NROS_RMW_RET_OK;
+}
+
+bool create_sub(rmw_node_t* node, const char* topic, uint32_t domain, rmw_subscription_t* out) {
+    rmw_qos_profile_t qos{};
+    qos.reliability = NROS_RMW_RELIABILITY_RELIABLE;
+    qos.durability = NROS_RMW_DURABILITY_VOLATILE;
+    qos.history = NROS_RMW_HISTORY_KEEP_LAST;
+    qos.depth = 5;
+    out->topic_name = topic;
+    out->type_name = "nros_test::msg::TestString";
+    const rmw_message_type_support_t ts{out->type_name, ""};
+    return g_vt->create_subscription(node, &ts, topic, domain, &qos, nullptr, out) ==
+           NROS_RMW_RET_OK;
+}
+
+std::string pub_gid(rmw_publisher_t* p) {
+    rmw_gid_t g{};
+    if (g_vt->get_gid_for_publisher(p, &g) != NROS_RMW_RET_OK) return std::string();
+    return gid_str(g.data);
+}
+
+bool contains(const std::vector<std::string>& v, const std::string& x) {
+    for (const auto& e : v)
+        if (e == x) return true;
+    return false;
+}
+} // namespace
+
+extern "C" rmw_ret_t nros_rmw_cffi_register_named(const char* /*name*/,
+                                                  const nros_rmw_vtable_t* vt) {
+    g_vt = vt;
+    return NROS_RMW_RET_OK;
+}
+
+int main() {
+    if (nros_rmw_cyclonedds_register() != NROS_RMW_RET_OK || g_vt == nullptr) {
+        return 1;
+    }
+    // Precondition, not a skip: without the node slots there is nothing to
+    // attribute an endpoint to, and every assertion below would be about the
+    // one session-named record this test exists to rule out.
+    if (g_vt->create_node == nullptr || g_vt->destroy_node == nullptr ||
+        g_vt->get_gid_for_publisher == nullptr) {
+        std::fprintf(stderr, "FAIL: create_node / destroy_node / get_gid slots are NULL\n");
+        return 2;
+    }
+
+    const uint32_t domain = nros_test_domain(96);
+    constexpr const char* kSessionName = "graph_node_set_session";
+
+    rmw_session_t s{};
+    s.node_name = kSessionName;
+    s.namespace_ = "/";
+    if (g_vt->create_session(nullptr, 0, domain, s.node_name, nullptr, &s) != NROS_RMW_RET_OK) {
+        return 3;
+    }
+
+    // Four nodes, the way the runtime declares them: `create_node` once each,
+    // on the one session. One is namespaced, one never gets an endpoint.
+    struct Decl {
+        const char* name;
+        const char* ns;
+    };
+    const Decl decls[4] = {{"alpha", "/"}, {"bravo", "/"}, {"charlie", "/robot"}, {"delta", "/"}};
+    rmw_node_t nodes[4]{};
+    for (int i = 0; i < 4; ++i) {
+        nodes[i].name = decls[i].name;
+        nodes[i].namespace_ = decls[i].ns;
+        nodes[i].session = &s;
+        const rmw_ret_t r = g_vt->create_node(&s, decls[i].name, decls[i].ns, &nodes[i]);
+        expect(r == NROS_RMW_RET_OK, "create_node must accept a fresh node");
+        expect(nodes[i].backend_data != nullptr, "create_node must record the node");
+    }
+    // The runtime deduplicates, but the backend must not MERGE or duplicate
+    // either: re-declaring a node is the same record.
+    {
+        rmw_node_t again{};
+        again.name = "alpha";
+        again.namespace_ = "/";
+        again.session = &s;
+        expect(g_vt->create_node(&s, "alpha", "/", &again) == NROS_RMW_RET_OK &&
+                   again.backend_data == nodes[0].backend_data,
+               "re-declaring (alpha, /) must return the same record, not a second node");
+    }
+    // A name longer than `string<256>` would have to be truncated, and a
+    // truncated name can collide with another node's — refused instead.
+    {
+        std::string long_name(300, 'x');
+        rmw_node_t too_long{};
+        expect(g_vt->create_node(&s, long_name.c_str(), "/", &too_long) ==
+                   NROS_RMW_RET_INVALID_ARGUMENT,
+               "a node name that would not fit string<256> must be refused, not truncated");
+    }
+
+    rmw_publisher_t pa{}, pb{};
+    rmw_subscription_t sb{}, sc{};
+    const bool made = create_pub(&nodes[0], "rt/gns_a", domain, &pa) &&
+                      create_pub(&nodes[1], "rt/gns_b", domain, &pb) &&
+                      create_sub(&nodes[1], "rt/gns_a", domain, &sb) &&
+                      create_sub(&nodes[2], "rt/gns_b", domain, &sc);
+    if (!made) {
+        std::fprintf(stderr, "FAIL: could not create the endpoints\n");
+        (void)g_vt->destroy_session(&s);
+        return 4;
+    }
+    const std::string gid_a = pub_gid(&pa);
+    const std::string gid_b = pub_gid(&pb);
+    expect(gid_a.size() == 24 && gid_b.size() == 24 && gid_a != gid_b,
+           "the two publishers must have distinct gids");
+
+    // The observer: its own participant, so what it reads is the CDR sample
+    // a stock `rmw_dds_common` graph cache would receive, not our structs.
+    const dds_entity_t pp = dds_create_participant(domain, nullptr, nullptr);
+    const dds_entity_t topic =
+        dds_create_topic(pp, &rmw_dds_common_msg_dds__ParticipantEntitiesInfo__desc,
+                         "ros_discovery_info", nullptr, nullptr);
+    dds_qos_t* q = dds_create_qos();
+    dds_qset_reliability(q, DDS_RELIABILITY_RELIABLE, DDS_SECS(1));
+    dds_qset_durability(q, DDS_DURABILITY_TRANSIENT_LOCAL);
+    dds_qset_history(q, DDS_HISTORY_KEEP_LAST, 1);
+    const dds_entity_t reader = dds_create_reader(pp, topic, q, nullptr);
+    dds_delete_qos(q);
+    if (pp < 0 || topic < 0 || reader < 0) {
+        std::fprintf(stderr, "FAIL: could not create the observer\n");
+        (void)g_vt->destroy_session(&s);
+        return 5;
+    }
+
+    std::vector<NodeView> snap;
+
+    // ---- 1. one entry per node, each with its own endpoints --------------
+    const bool settled = await_snapshot(reader, &snap, [&](const std::vector<NodeView>& v) {
+        const NodeView* a = find(v, "/", "alpha");
+        const NodeView* b = find(v, "/", "bravo");
+        const NodeView* c = find(v, "/robot", "charlie");
+        return v.size() == 4 && a && b && c && find(v, "/", "delta") && a->writers.size() == 1 &&
+               b->writers.size() == 1 && b->readers.size() == 1 && c->readers.size() == 1;
+    });
+    if (!settled) dump("after setup", snap);
+    expect(settled, "the snapshot must list exactly the four declared nodes, each with its "
+                    "own endpoints (issue 1269: was one session-named entry)");
+    expect(find(snap, "/", kSessionName) == nullptr,
+           "the session's open-time name is not a node and must not be published");
+    if (settled) {
+        const NodeView* a = find(snap, "/", "alpha");
+        const NodeView* b = find(snap, "/", "bravo");
+        const NodeView* c = find(snap, "/robot", "charlie");
+        const NodeView* d = find(snap, "/", "delta");
+        expect(a->writers[0] == gid_a, "alpha's writer gid must be its publisher's gid");
+        expect(b->writers[0] == gid_b, "bravo's writer gid must be its publisher's gid");
+        expect(!contains(b->writers, gid_a) && !contains(c->writers, gid_a) &&
+                   !contains(d->writers, gid_a),
+               "a publisher must be listed under the node that created it and no other");
+        expect(a->readers.empty() && c->writers.empty(),
+               "a node must not inherit another node's endpoints");
+        expect(d->readers.empty() && d->writers.empty(),
+               "a node with no endpoints is still a node, with empty lists");
+        expect(b->readers[0] != c->readers[0], "two readers must have two gids");
+    }
+
+    // ---- 2. destroying a publisher republishes without its gid ------------
+    expect(g_vt->destroy_publisher(&pb) == NROS_RMW_RET_OK, "destroy_publisher(pb)");
+    const bool untracked = await_snapshot(reader, &snap, [&](const std::vector<NodeView>& v) {
+        const NodeView* b = find(v, "/", "bravo");
+        return v.size() == 4 && b && b->writers.empty() && b->readers.size() == 1;
+    });
+    if (!untracked) dump("after destroy_publisher", snap);
+    expect(untracked, "a destroyed publisher must leave its node's writer list");
+
+    // ---- 3. destroying a node republishes without it ----------------------
+    expect(g_vt->destroy_node(&nodes[3]) == NROS_RMW_RET_OK, "destroy_node(delta)");
+    expect(nodes[3].backend_data == nullptr, "destroy_node must clear backend_data");
+    const bool dropped = await_snapshot(reader, &snap, [&](const std::vector<NodeView>& v) {
+        return v.size() == 3 && find(v, "/", "delta") == nullptr;
+    });
+    if (!dropped) dump("after destroy_node", snap);
+    expect(dropped, "a destroyed node must leave the published set");
+
+    // ---- 4. a node never declared through create_node --------------------
+    rmw_node_t undeclared{};
+    undeclared.name = "echo";
+    undeclared.namespace_ = "/";
+    undeclared.session = &s; // backend_data stays NULL: a pure identity carrier
+    rmw_publisher_t pe{};
+    expect(create_pub(&undeclared, "rt/gns_e", domain, &pe), "create_publisher on undeclared");
+    const std::string gid_e = pub_gid(&pe);
+    const bool fallback = await_snapshot(reader, &snap, [&](const std::vector<NodeView>& v) {
+        const NodeView* e = find(v, "/", "echo");
+        return v.size() == 4 && e && e->writers.size() == 1 && e->writers[0] == gid_e;
+    });
+    if (!fallback) dump("after the undeclared node's publisher", snap);
+    expect(fallback, "an endpoint on an undeclared node must be listed under that node's name");
+
+    (void)g_vt->destroy_publisher(&pe);
+    (void)g_vt->destroy_subscription(&sc);
+    (void)g_vt->destroy_subscription(&sb);
+    (void)g_vt->destroy_publisher(&pa);
+    for (int i = 0; i < 3; ++i)
+        (void)g_vt->destroy_node(&nodes[i]);
+    (void)g_vt->destroy_session(&s);
+    (void)dds_delete(pp);
+
+    if (g_bad == 0) {
+        std::printf("graph_node_set: OK (one NodeEntitiesInfo per node, own gids, "
+                    "republished on change)\n");
+    }
+    return g_bad;
+}

--- a/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
@@ -218,6 +218,7 @@ static C_XRCE_LISTENER_BINARY: OnceCell<PathBuf> = OnceCell::new();
 
 /// Cached path to the native Rust workspace Entry pkg binary.
 static NATIVE_WORKSPACE_RUST_ENTRY_BINARY: OnceCell<PathBuf> = OnceCell::new();
+static NATIVE_WORKSPACE_RUST_CYCLONEDDS_ENTRY_BINARY: OnceCell<PathBuf> = OnceCell::new();
 
 /// Phase 264 W4c — cached path to the parameterised workspace Entry pkg binary.
 static NATIVE_WORKSPACE_RUST_PARAMS_ENTRY_BINARY: OnceCell<PathBuf> = OnceCell::new();
@@ -2085,6 +2086,23 @@ pub fn build_native_workspace_rust_entry() -> TestResult<&'static Path> {
     NATIVE_WORKSPACE_RUST_ENTRY_BINARY
         .get_or_try_init(|| {
             build_workspace_rust_entry("workspace-rust-native", "rust", "native_entry")
+        })
+        .map(|p| p.as_path())
+}
+
+/// Issue 1269 — the SAME `examples/workspaces/rust` image as
+/// [`build_native_workspace_rust_entry`] (default launch, talker + listener),
+/// built on CycloneDDS: `[image.native_cyclonedds]`, row
+/// `workspace-rust-native-cyclonedds`. The multi-node graph test runs both, so
+/// the node set `ros2 node list` shows is compared across RMWs on one image.
+pub fn build_native_workspace_rust_cyclonedds_entry() -> TestResult<&'static Path> {
+    NATIVE_WORKSPACE_RUST_CYCLONEDDS_ENTRY_BINARY
+        .get_or_try_init(|| {
+            build_workspace_rust_entry(
+                "workspace-rust-native-cyclonedds",
+                "rust",
+                "native_cyclonedds_entry",
+            )
         })
         .map(|p| p.as_path())
 }

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -462,6 +462,25 @@ pub const CELLS: &[InteropCell] = &[
     ic("native-multinode-rust-zenoh",
        c(Linux, Rust, Zenoh, EntryPubsub, Interop, Runtime),
        NativeFixtures, RosEdition(Zenoh), NanoToRos, "rust_multi_node_per_node_graph"),
+    // Issue 1269 — the SAME image on Cyclone (`[image.native_cyclonedds]`,
+    // row `workspace-rust-native-cyclonedds`), asserting the SAME node set.
+    // Cyclone announces nodes through `ros_discovery_info`, not liveliness
+    // tokens, and published one session-named node for the whole image until
+    // 1269 — so a green zenoh case says nothing about it.
+    ic("native-multinode-rust-cyclone",
+       c(Linux, Rust, Cyclonedds, EntryPubsub, Interop, Runtime),
+       NativeFixtures, RosEdition(Cyclonedds), NanoToRos, "rust_multi_node_per_node_graph"),
+    // And XRCE's third, carved: the backend publishes no `ros_discovery_info`
+    // at all, so a stock graph cache learns none of its nodes. The fixture
+    // exists (`workspace-rust-native-xrce`); the missing piece is the backend.
+    ic("native-multinode-rust-xrce-CARVED",
+       c(Linux, Rust, Xrce, EntryPubsub, Interop,
+         CarveOut("nros-rmw-xrce writes no `ros_discovery_info` and leaves \
+                   `create_node` NULL, so `ros2 node list` has no source for \
+                   an XRCE image's nodes — reasoned from session.c, not yet \
+                   measured. A live Agent + peer would only confirm the gap. \
+                   Issue 1292.")),
+       NativeFixtures, XrceAgent, NanoToRos, NO_TEST),
     // tests/cpp_multi_node_entry.rs — the C++ typed multi-node entry's pubsub +
     // per-node graph visibility against a stock ROS 2 peer (phase-257/268).
     ic("native-multinode-cpp-zenoh",
@@ -637,6 +656,14 @@ pub const CASE_CELLS: &[CaseOwner] = &[
     // (`require_ros2()` vs `require_ros2_cyclonedds()`), not only in the name.
     co("graph_interop", "nano_ros_enumerates_a_stock_ros2_node", "native-graph-rust-zenoh-r2n"),
     co("graph_interop", "cyclone_enumerates_a_stock_ros2_node",  "native-graph-rust-cyclone-r2n"),
+
+    // ── rust_multi_node_per_node_graph — one image, one case per RMW ────
+    // Issue 1269. Each case names its backend in the body (the fixture it
+    // resolves and the `ros2` env it lists through), not only in the name.
+    co("rust_multi_node_per_node_graph", "rust_multi_node_entry_per_node_graph_nodes",
+       "native-multinode-rust-zenoh"),
+    co("rust_multi_node_per_node_graph", "rust_multi_node_entry_per_node_graph_nodes_cyclonedds",
+       "native-multinode-rust-cyclone"),
 
     // ── ros2_action_e2e — ONE coordinate, two directions ────────────────
     // The pair no coordinate can separate: which side drives is the whole

--- a/packages/testing/nros-tests/src/ros2.rs
+++ b/packages/testing/nros-tests/src/ros2.rs
@@ -871,6 +871,27 @@ pub fn ros2_node_list(locator: &str, distro: &str) -> TestResult<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Run `ros2 node list` over a DDS RMW (`rmw_cyclonedds_cpp`, …) on `domain_id`
+/// and return the output — the DDS sibling of [`ros2_node_list`], which dials a
+/// zenoh router instead. The bus is pinned to loopback by
+/// [`ros2_env_setup_rmw_with_domain`] (issue 1009), so the nano-ros side must
+/// be pinned too (`dds_isolation::apply_to_command`) or the two never meet.
+pub fn ros2_node_list_rmw_with_domain(
+    distro: &str,
+    rmw: &str,
+    domain_id: u8,
+) -> TestResult<String> {
+    let env_setup = ros2_env_setup_rmw_with_domain(distro, rmw, domain_id);
+    let cmd = format!("{env_setup} && timeout --foreground 10 ros2 node list --no-daemon 2>&1");
+
+    let output = Command::new("bash")
+        .args(["-c", &cmd])
+        .output()
+        .map_err(|e| TestError::ProcessFailed(format!("Failed to run ros2 node list: {e}")))?;
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 /// Run `ros2 topic list` and return the output
 pub fn ros2_topic_list(locator: &str, distro: &str) -> TestResult<String> {
     let (env_setup, _config_dir) = ros2_env_setup_with_locator(distro, locator);

--- a/packages/testing/nros-tests/tests/rust_multi_node_per_node_graph.rs
+++ b/packages/testing/nros-tests/tests/rust_multi_node_per_node_graph.rs
@@ -1,47 +1,99 @@
-//! phase-268 W3 — e2e proof (Rust path) that a multi-node Rust entry shows
-//! one graph node per launch component in `ros2 node list`, named from the
-//! launch, with the #104 primary `/node` gated off.
+//! A multi-node Rust entry shows one graph node per launch component in
+//! `ros2 node list` — and the SAME set on every RMW (issue 1269).
 //!
-//! The `workspace-rust-native` fixture bakes `native_entry` from
-//! `examples/workspaces/rust`, whose `nros::main!(launch =
-//! "demo_bringup:system.launch.xml")` resolves a 2-node topology:
+//! The image is `examples/workspaces/rust`'s default launch,
+//! `demo_bringup:system.launch.xml`, a 2-node topology:
 //!   `<node name="talker"/>` + `<node name="listener"/>`
+//! built once per RMW from the same sources: `[image.native]` (zenoh, row
+//! `workspace-rust-native`) and `[image.native_cyclonedds]` (row
+//! `workspace-rust-native-cyclonedds`). Each case asserts [`EXPECTED_NODES`],
+//! the one set every RMW must present, so a divergence between backends fails
+//! a test rather than a user.
 //!
-//! The W2 gate lives in the shared zenoh shim
-//! (`ensure_node_liveliness` in `zpico/nros-rmw-zenoh/src/shim/session.rs`),
-//! so this test exercises the same code path as the C++ proof in
-//! `cpp_multi_node_entry.rs` — proving the gate is language-agnostic.
+//! The two backends announce nodes through unrelated mechanisms, which is why
+//! each needs its own live case:
+//!
+//! * zenoh — one liveliness token per node (`ensure_node_liveliness` in the
+//!   shared zenoh shim, phase-268 W2; the same gate the C++ proof in
+//!   `cpp_multi_node_entry.rs` exercises);
+//! * Cyclone — one `NodeEntitiesInfo` per node in the participant's
+//!   `ros_discovery_info` sample (issue 1269; it used to publish ONE,
+//!   session-named). The self-contained half of that claim is the backend's
+//!   `graph_node_set` CTest, which reads the published sample back.
+//!
+//! XRCE publishes no node at all yet: `native-multinode-rust-xrce-CARVED`,
+//! issue 1292.
 
-use nros_tests::fixtures::{
-    DEFAULT_ROS_DISTRO, ManagedProcess, ZenohRouter, build_native_workspace_rust_entry,
-    is_rmw_zenoh_available, is_ros2_available, require_zenohd, ros2_node_list, zenohd_unique,
+use nros_tests::{
+    fixtures::{
+        DEFAULT_ROS_DISTRO, ManagedProcess, ZenohRouter,
+        build_native_workspace_rust_cyclonedds_entry, build_native_workspace_rust_entry,
+        is_rmw_zenoh_available, is_ros2_available, require_zenohd, ros2_node_list, zenohd_unique,
+    },
+    ros2::{require_ros2_cyclonedds, ros2_node_list_rmw_with_domain},
 };
 use rstest::rstest;
 use std::{
+    collections::BTreeSet,
     process::Command,
     time::{Duration, Instant},
 };
 
-fn poll_until_contains<F>(timeout: Duration, marker: &str, mut poll: F) -> String
+/// The node set the image composes — the launch file's two `<node name=…/>`,
+/// in the root namespace. Every RMW must present exactly this: the #104 / 1269
+/// phantom `/node` (the SESSION's name, which names no component) is excluded
+/// by construction, since equality admits nothing extra.
+const EXPECTED_NODES: [&str; 2] = ["/listener", "/talker"];
+
+/// The fully qualified node names a `ros2 node list` printed. Hidden nodes are
+/// already filtered by the CLI (it needs `--all` to show them), so every
+/// `/`-prefixed line is a node the graph attributes to someone.
+fn node_set(listing: &str) -> BTreeSet<String> {
+    listing
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with('/'))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn expected_set() -> BTreeSet<String> {
+    EXPECTED_NODES.iter().map(|s| (*s).to_owned()).collect()
+}
+
+/// Poll until the listing shows exactly [`EXPECTED_NODES`], or the deadline.
+/// Discovery is asynchronous on both backends, so one sample right after
+/// start-up legitimately shows a partial graph.
+fn poll_for_expected_set<F>(timeout: Duration, mut poll: F) -> String
 where
     F: FnMut() -> String,
 {
+    let want = expected_set();
     let deadline = Instant::now() + timeout;
     let mut output = String::new();
     while Instant::now() < deadline {
         output = poll();
-        if output.contains(marker) {
+        if node_set(&output) == want {
             return output;
         }
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(Duration::from_millis(200));
     }
     output
 }
 
-/// W3 e2e proof (Rust path): `workspace-rust-native` `native_entry` bakes
-/// `demo_bringup:system.launch.xml` (talker + listener) and exposes both as
-/// distinct graph nodes in `ros2 node list`, with the #104 primary `/node`
-/// gated off by W2 `ensure_node_liveliness`.
+/// The shared verdict, so the two cases cannot drift into asking different
+/// questions: the set must EQUAL [`EXPECTED_NODES`].
+fn assert_node_set(rmw: &str, listing: &str) {
+    let got = node_set(listing);
+    assert_eq!(
+        got,
+        expected_set(),
+        "{rmw}: `ros2 node list` must show exactly the image's launch nodes {EXPECTED_NODES:?} \
+         (issue 1269: the node set must not depend on the RMW). Full listing:\n{listing}"
+    );
+}
+
+/// zenoh: `workspace-rust-native` `native_entry`, through a unique router.
 #[rstest]
 fn rust_multi_node_entry_per_node_graph_nodes(
     zenohd_unique: ZenohRouter,
@@ -73,40 +125,73 @@ fn rust_multi_node_entry_per_node_graph_nodes(
     let mut deploy = ManagedProcess::spawn_command(cmd, "rust-native-entry")
         .expect("failed to start native_entry");
 
-    let node_list = poll_until_contains(Duration::from_secs(15), "listener", || {
+    let node_list = poll_for_expected_set(Duration::from_secs(15), || {
         ros2_node_list(&locator, DEFAULT_ROS_DISTRO).unwrap_or_default()
     });
     deploy.kill();
 
-    eprintln!("Node list:\n{node_list}");
-    // W1: both launch-named graph nodes must appear.
-    assert!(
-        node_list.contains("talker"),
-        "Expected '/talker' in ros2 node list (W1 Rust launch name), got:\n{node_list}"
-    );
-    assert!(
-        node_list.contains("listener"),
-        "Expected '/listener' in ros2 node list (W1 Rust launch name), got:\n{node_list}"
-    );
-    // W2 gate: the #104 primary /node token must be absent when per-node tokens
-    // with different names are active. Match the whole trimmed line so prefixes
-    // like /node_factory or /node0 do not cause a false failure.
-    assert!(
-        !node_list.lines().any(|l| l.trim() == "/node"),
-        "W2 gate broken: bare '/node' in ros2 node list (issue #104):\n{node_list}"
-    );
+    eprintln!("Node list (zenoh):\n{node_list}");
+    assert_node_set("zenoh", &node_list);
+    Ok(())
+}
+
+/// Cyclone: `workspace-rust-native-cyclonedds` `native_cyclonedds_entry`, on a
+/// domain of its own and pinned to loopback on BOTH sides (issue 1137 — the
+/// `ros2` side is pinned by its env string, ours by `apply_to_command`; half a
+/// pin is no discovery, and reads as an empty graph).
+#[test]
+fn rust_multi_node_entry_per_node_graph_nodes_cyclonedds() -> nros_tests::TestResult<()> {
+    if !require_ros2_cyclonedds() {
+        nros_tests::skip!("ROS 2 + rmw_cyclonedds_cpp not available");
+    }
+
+    let entry = match build_native_workspace_rust_cyclonedds_entry() {
+        Ok(p) => p.to_path_buf(),
+        Err(e) => nros_tests::skip!(
+            "workspace-rust-native-cyclonedds native_cyclonedds_entry fixture not built: {e}"
+        ),
+    };
+
+    // A domain of our own: Cyclone discovers by SPDP, so a shared domain would
+    // let another test's nodes into this listing and break the equality below.
+    let domain = nros_tests::unique_ros_domain_id();
+
+    let mut cmd = Command::new(&entry);
+    cmd.env("ROS_DOMAIN_ID", domain.to_string())
+        .env("NROS_DOMAIN_ID", domain.to_string())
+        // The registered backend name, never an ambient lane token (AGENTS.md
+        // "`NROS_RMW` footgun").
+        .env("NROS_RMW", "cyclonedds")
+        .env("NROS_ENTRY_SPIN_MS", "20000")
+        .env("NROS_ENTRY_SPIN_STEP_MS", "10");
+    nros_tests::dds_isolation::apply_to_command(&mut cmd);
+    let mut deploy = ManagedProcess::spawn_command(cmd, "rust-native-cyclonedds-entry")
+        .expect("failed to start native_cyclonedds_entry");
+
+    let node_list = poll_for_expected_set(Duration::from_secs(20), || {
+        ros2_node_list_rmw_with_domain(DEFAULT_ROS_DISTRO, "rmw_cyclonedds_cpp", domain)
+            .unwrap_or_default()
+    });
+    deploy.kill();
+
+    eprintln!("Node list (cyclonedds):\n{node_list}");
+    assert_node_set("cyclonedds", &node_list);
     Ok(())
 }
 
 // phase-329 W3 — bind this test to `interop::CELLS` (the pattern from
-// xrce_ros2_interop). The coordinate below must equal what the list declares
-// for `rust_multi_node_per_node_graph`; drift turns this RED. Needs no fixtures — runs in tier 1.
+// xrce_ros2_interop). The coordinates below must equal what the list declares
+// for `rust_multi_node_per_node_graph` — one per Runtime cell; drift turns this
+// RED. Needs no fixtures — runs in tier 1.
 #[test]
 fn cases_bound_to_interop_cells() {
     #[allow(unused_imports)]
     use nros_tests::matrix::{Lang::*, PlatformId::*, Rmw::*, Workload::*};
     nros_tests::interop::assert_test_bound(
         "rust_multi_node_per_node_graph",
-        &[(Linux, Rust, Zenoh, EntryPubsub)],
+        &[
+            (Linux, Rust, Zenoh, EntryPubsub),
+            (Linux, Rust, Cyclonedds, EntryPubsub),
+        ],
     );
 }


### PR DESCRIPTION
phase-444 W7 — issue #1269: the same image must present the same node set to ROS 2 whichever RMW it is built with. zenoh has declared one liveliness token per node since phase-268; Cyclone published ONE `NodeEntitiesInfo`, named after the SESSION, carrying every endpoint in the image — so a four-node image showed a single `/node` in `ros2 node list`, and `ros2 param list /mrm_handler` answered "Node not found".

## What changed

**Cyclone backend (`packages/rmw/cyclonedds/nros-rmw-cyclonedds`)**

- `create_node` / `destroy_node` vtable slots filled — both were NULL, while the runtime (`nros-rmw-cffi`'s node table) has called `create_node` once per distinct `(name, namespace)` since phase-376 W5. The graph keeps one record per node: stable slots (a record's address is `rmw_node_t::backend_data`), borrowed name pointers (the ABI promises they outlive the node), sized to the runtime's largest `NROS_RMW_MAX_NODES`, and a name too long to fit `string<256>` is refused rather than truncated — two truncated names would MERGE into one node.
- Every endpoint is attributed to the node that created it (`graph_node_of`). A node handed to a create slot without `create_node` — a direct vtable caller, `backend_data` NULL — is recorded under its own name rather than attributed to nobody.
- `ros_discovery_info` now carries one entry per node with that node's own reader/writer GIDs, republished on every node or endpoint change. Endpoints are kept grouped by node so each GID sequence points straight into fixed tables (no per-publish copy); the per-node entries are a transient `ddsrt_malloc` sample, because `char[257]` x 2 per node would be ~35 KiB of stack on an RTOS app task.
- The session's open-time name is no longer published as a node — that is the phantom `/node`.

**Two siblings of the same class, fixed in the same change** (the graph misrepresenting what the image composes):

- Nothing in the tree ever called `graph_untrack_*`, so a destroyed publisher/subscription/service stayed listed for the session's life. Every destroy path now untracks, guarded on the entity still being live (which implies its participant, and so the session state, still is).
- ThreadX's `SessionState` was hand-initialised two fields deep and is now placement-new'd, so the graph state — and the wake/listener pair `session_destroy` reads — is never read uninitialised.

## Tests

- **New CTest `nros_rmw_cyclonedds_graph_node_set`** reads the published sample back from a SEPARATE participant (i.e. after it crossed the wire as CDR) and asserts: four entries for four declared nodes and only those; each publisher's GID under its own node and no other, byte-identical to `get_gid_for_publisher`; a node with no endpoints still present; no session-named entry; republish after `destroy_publisher` and after `destroy_node`; and the undeclared-node fallback.
  **Negative control (run):** capping the published sequence at one entry — the pre-fix shape — fails four of its assertions.
- **`rust_multi_node_per_node_graph`** now runs the SAME `examples/workspaces/rust` image on zenoh and on Cyclone (`[image.native_cyclonedds]`, existing row `workspace-rust-native-cyclonedds`) and asserts one shared `EXPECTED_NODES` set by equality, so a divergence between backends fails a test rather than a user. New interop cell `native-multinode-rust-cyclone` + `CASE_CELLS` rows. The zenoh case keeps its function name, so the recorded verdict in `.config/interop-verdicts.toml` still resolves.

## XRCE

Measured by READING, not running: `nros-rmw-xrce` writes no `ros_discovery_info` at all and leaves `create_node` NULL, so a stock `rmw_dds_common` graph cache has no source for its nodes and the expected reading is ZERO nodes — not the one-node collapse issue 1269 guessed. Filed as **issue 1292** and recorded as the carve-out `native-multinode-rust-xrce-CARVED`.

## Not verified live

This host has no ROS 2. `native-multinode-rust-cyclone` is a live-peer cell and has NOT been run — it starts with no ledger entry, which is the default for a new cell. The lane that would verify it is `just native test-ros2-multinode-rust` (binary `rust_multi_node_per_node_graph`) in `live-peer.yml`. Everything asserted above about what Cyclone PUBLISHES is covered by the CTest, which does run here.

## Local gates (this worktree)

- `just ci gate` — **passed**: "CI gate passed (compile + unit; no fixtures were built or needed)".
- `just check rmw-cyclonedds` — **passed**: "100% tests passed out of 29", including the new `graph_node_set`.
- `just check rmw-slot-producers` — **passed**: cyclonedds 41 slots (was 39). `graph 1/12` is unchanged on purpose: the graph-READ family is W3, not this PR.

Issue 1269 resolved and archived; issue 1292 filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7tie7AFCdqoRkxphQcqRx
