### PR TITLE
docs(issues): file 1306 (worktree CLI stamp) and 1307 (NuttX Cargo.lock rewrite)

### DIFF
--- a/docs/issues/1306-cli-build-rs-misses-worktree-git-index.md
+++ b/docs/issues/1306-cli-build-rs-misses-worktree-git-index.md
@@ -1,0 +1,61 @@
+---
+id: 1306
+title: "In a linked git worktree the `nros` CLI's source stamp never re-runs on a
+  commit: `build.rs` watches `<root>/.git/index`, which is not a file there"
+status: open
+type: bug
+area: cli, build
+severity: low
+related: [issue-0466, issue-0627, issue-1285]
+---
+
+## What happens
+
+`packages/cli/nros-cli-core/build.rs` stamps the CLI with a hash of its sources
+(`NROS_CLI_SOURCE_STAMP`), and `source_stamp` reads index blob SHAs. So the
+stamp must be recomputed whenever the index moves (commit, rebase, branch
+switch), and build.rs registers the index for that:
+
+```rust
+let index = root.join(".git/index");
+if index.exists() {
+    println!("cargo:rerun-if-changed={}", index.display());
+}
+```
+
+In a LINKED worktree (`git worktree add`, which is how every parallel agent
+session here works), `<root>/.git` is a FILE (`gitdir: …/.git/worktrees/<name>`)
+and the worktree's real index is `<main>/.git/worktrees/<name>/index`. So
+`root.join(".git/index")` does not exist, the `if` is false, and nothing watches
+the index at all.
+
+Result: after a commit in a worktree, the source files are unchanged on disk, so
+none of the `rerun-if-changed` paths fire, build.rs does not re-run, and the
+baked-in stamp is the pre-commit one. `nros source-stamp` / `just check
+cli-fresh` then report the CLI stale against the tree, and `just setup-cli`
+rebuilding does not help, because cargo sees nothing to rebuild.
+
+## How it was found
+
+Issue 1285's agent (2026-09-11) hit `CI GATE FAILED at step 1 of 6. FAILED
+check::cli-fresh` in its worktree right after committing. It confirmed the cause
+by touching `build.rs`, which forced a re-run, after which the stamp read fresh.
+The agent working on PR #919 (pure-C ThreadX) then needed the same workaround. The main checkout is
+unaffected, because there `.git` is a directory.
+
+## Fix
+
+Resolve the index through git rather than by joining a path:
+`git rev-parse --git-path index` (run in `root`) returns the right file in a
+main checkout, in a linked worktree, and under `GIT_INDEX_FILE`. Watch that path.
+If it cannot be resolved, fall back to watching nothing and say so with a
+`cargo:warning`, so the fallback is visible and does not look like a stamp that
+is fresh. Check the other `.git/`-joined paths in build scripts for the same
+shape (`rg -n '"\.git/' --glob build.rs`) and fix them together.
+
+## Acceptance
+
+In a linked worktree: build the CLI, commit a change to a CLI source file,
+revert the source file's content only (so the tree is back to the pre-commit
+content, but the index SHAs moved), and `just setup-cli` then `nros source-stamp`
+must read fresh with no manual `touch`. Show the same run failing before the fix.

--- a/docs/issues/1307-sizes-build-nested-cargo-rewrites-root-lock.md
+++ b/docs/issues/1307-sizes-build-nested-cargo-rewrites-root-lock.md
@@ -1,0 +1,78 @@
+---
+id: 1307
+title: "Every NuttX build rewrites the root `Cargo.lock` with a `[[patch.unused]]`
+  libc block — `nros-sizes-build`'s nested cargo bypasses the `--locked` shim"
+status: open
+type: bug
+area: build, nuttx
+severity: medium
+related: [issue-0359, issue-0378, issue-0464]
+---
+
+## What happens
+
+After any NuttX build (seen 2026-09-10 and again on 2026-09-11, on the #741
+rebase and on its follow-up PR #898's `tmp/libcxx-probe-a.sh` run), the root
+`Cargo.lock` has a new block appended:
+
+```toml
+[[patch.unused]]
+name = "libc"
+version = "0.2.183"
+```
+
+CLAUDE.md says lockfiles change ONLY when a developer means it (issues
+0359/0378), and `--locked` is injected project-wide by the `scripts/bin/cargo`
+PATH shim (`NROS_CARGO_FLAGS`) exactly so that a lock mismatch FAILS instead of
+rewriting the file. This one gets rewritten anyway, every time, so every NuttX
+build leaves a dirty tracked file that someone has to notice and revert
+(`git checkout -- Cargo.lock`).
+
+## Where it comes from
+
+`packages/tooling/nros-sizes-build/src/lib.rs`, `find_dep_rlib_isolated`.
+For a NuttX target it runs a nested build to probe the executor's sizes:
+
+- the binary is `env::var_os("CARGO")`, which inside a build script is the path
+  of the REAL cargo that cargo exported, not the PATH shim. The shim `exec`s
+  `"$real_cargo"`, so the nested call never passes through it and gets no
+  `--locked`;
+- the args are `build -p <crate> --target <nuttx triple> -Z
+  build-std=std,panic_abort … --config
+  'patch.crates-io.libc.path="…/third-party/nuttx/libc"'`;
+- that `--config` patch is mandatory for std-from-source on NuttX (the
+  crates.io libc lacks `_SC_HOST_NAME_MAX`), but the workspace the nested cargo
+  resolves is the ROOT one, which does not use that libc. Cargo records the
+  patch as unused, in the root lock.
+
+The mechanism above is read from the code. The symptom is measured: the diff is
+exactly the block above, and nothing else in the lock moves.
+
+## Fix — the obvious one does not work alone
+
+Passing `--locked` to the nested call turns the silent rewrite into a hard
+failure, and `find_dep_rlib` has no fallback by design (issue 0464). So
+`--locked` alone would break every NuttX build. The nested build must stop
+writing the root lock at all. Options, to be measured:
+
+1. Give the nested build its own lockfile: the NuttX lane is already nightly
+   (`-Z build-std`), so `-Z unstable-options --lockfile-path <probe dir>/Cargo.lock`,
+   seeded from a copy of the root lock, keeps resolution identical and puts the
+   `[[patch.unused]]` write in the probe dir. Then add `--locked` against THAT
+   copy, if the unused-patch entry can be pre-seeded; otherwise leave it unlocked
+   and state why.
+2. Apply the libc patch only where it is used: build the probe against a
+   manifest/workspace that actually depends on the patched libc, so the patch is
+   not unused.
+
+Whichever is chosen, the nested call should honour `NROS_CARGO_FLAGS`, so the
+project-wide rule reaches it and a future nested cargo cannot bypass it the same
+way. Grep for siblings: every build script that runs `env::var_os("CARGO")`
+bypasses the shim (`rg -n 'var_os\("CARGO"\)' packages`).
+
+## Acceptance
+
+A NuttX build (for example `NROS_CARGO_FRONTENDS=1 bash
+scripts/build/fixtures-build.sh nuttx cpp zenoh`) leaves `git diff --quiet --
+Cargo.lock` true, and the sizes it probes are unchanged (same `__NROS_SIZE_*`
+values as before the fix).


### PR DESCRIPTION
Files two bugs found while landing issues 1283–1286. Docs only; neither is fixed here.

- **1306 — in a linked git worktree, committing never re-runs the `nros` CLI's source stamp.** `nros-cli-core/build.rs` watches `root.join(".git/index")` only if it exists. In a linked worktree `.git` is a FILE, so nothing watches the index at all, and after a commit `check::cli-fresh` reports the CLI stale. `just setup-cli` then rebuilds nothing. Two agents hit this on 2026-09-11 and worked around it by touching `build.rs`. Fix: resolve the index path with `git rev-parse --git-path index`.
- **1307 — every NuttX build rewrites the root `Cargo.lock` with a `[[patch.unused]]` libc block.** `nros-sizes-build`'s nested probe build runs `$CARGO`, which is the real cargo rather than the `--locked` PATH shim. It then injects a NuttX `libc` patch via `--config` into the root workspace, which does not use that libc. Passing `--locked` alone would turn the rewrite into a build failure, because the probe has no fallback (issue 0464). So the issue lists two options to measure: a separate `--lockfile-path` for the probe, or building the probe against a workspace that actually uses the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zw1nseWJBSTRqVQzRAZcg
