### PR TITLE
test(phase-446 F1): pin rlm v0.1.35 and play_launch 07f0461e, prove params: {} end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -2764,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -2776,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/docs/roadmap/phase-446-contract-declares-parameters.md
+++ b/docs/roadmap/phase-446-contract-declares-parameters.md
@@ -250,6 +250,16 @@ treats every launch value for that node as undeclared, by the design rule.
 resolves to a `node_params` entry for all of them, and the image derives its
 store; dropping the `{}` refuses again, naming the node.
 
+**Landed** in ros-launch-manifest v0.1.35 (`803db6b`) and play_launch
+`96a1e3f7`, pinned here at play_launch `07f0461e`. `from_model` needed no
+change, as predicted. Proven two ways in nros-cli-core: a unit test on the
+island's four nodes with one entry emptied (declared, 18 names plus 4 seeds
+gives 22 slots; with no entry, "1 of 4 nodes" refuses, naming it), and
+`tests/param_declarations_resolve.rs`, which runs the pinned resolver over two
+fixture contracts that differ only in `/b`'s `params: {}` (sized at 3 slots
+against a refusal naming `/b`). The downstream island resolves with every node
+carrying an entry and no parameter errors.
+
 ### F2 -- descriptions get their own capacity, and an overflow is not silent
 
 `ParameterDescriptor.description` is a `String<MAX_STRING_VALUE_LEN>`

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -529,7 +529,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -1257,7 +1257,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/cli/nros-cli-core/Cargo.toml
+++ b/packages/cli/nros-cli-core/Cargo.toml
@@ -66,10 +66,10 @@ cargo_metadata = "0.18"
 # built by `just setup-launch-resolve`, invoked by ABSOLUTE path from cmd/ws.rs —
 # never via $PATH, per issue 0285). It is NOT the external `play_launch_parser`
 # this comment used to name; nothing in packages/cli/ spawns that binary any more.
-ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
+ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
 # RFC-0052 / phase-296 W1 — SystemModel ingestion (shared schema, RFC-0050)
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
-ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
+ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
 
 # Phase 228.E — shared per-tier orchestration schema + resolver (RFC-0015),
 # from the runtime workspace at `packages/core/`. Same crate the

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -3322,7 +3322,9 @@ mod from_model_tests {
     }
 
     /// A model running `nodes`, whose contract declares `params` per node.
-    /// A node listed in `nodes` and absent from `params` declares nothing.
+    /// A node listed in `nodes` and absent from `params` has no entry (it
+    /// said nothing); one listed with no names gets `{}`, the empty entry the
+    /// resolver writes for `params: {}` (phase-446 F1).
     fn param_model(nodes: &[&str], params: &[(&str, &[(&str, &str)])]) -> SystemModel {
         let mut y = String::from("meta: { version: 1 }\nstructure:\n  nodes:\n");
         for n in nodes {
@@ -3334,6 +3336,10 @@ mod from_model_tests {
         if !params.is_empty() {
             y.push_str("contracts:\n  node_params:\n");
             for (node, ps) in params {
+                if ps.is_empty() {
+                    y.push_str(&format!("    {node}: {{}}\n"));
+                    continue;
+                }
                 y.push_str(&format!("    {node}:\n"));
                 for (name, ty) in *ps {
                     y.push_str(&format!("      {name}: {{ type: {ty} }}\n"));
@@ -3516,6 +3522,59 @@ mod from_model_tests {
             "{c}"
         );
         assert!(!c.contains("NROS_DERIVED_MAX_PARAMETERS"), "{c}");
+    }
+
+    /// phase-446 F1 -- an EMPTY entry is a declaration of none, not silence.
+    /// The same image with `/system/diag_aggregator: {}` is sized, and that
+    /// node gets only its seeded `use_sim_time`; drop the entry and the image
+    /// refuses again, naming it. (`tests/param_declarations_resolve.rs` makes
+    /// the same pair through the pinned resolver.)
+    #[test]
+    fn an_empty_params_entry_declares_none_and_a_missing_one_refuses() {
+        let none: &[(&str, &str)] = &[];
+        let mut ps = island_params();
+        ps[3] = (ISLAND_NODES[3], none);
+        let m = param_model(&ISLAND_NODES, &ps);
+        assert_eq!(
+            m.contracts
+                .node_params
+                .get(ISLAND_NODES[3])
+                .map(|p| p.len()),
+            Some(0),
+            "the fixture carries the empty entry"
+        );
+        let d = ParamDeclarations::from_model(&m);
+        let ParamDeclarations::Declared { nodes, params } = &d else {
+            panic!("an empty entry counts as declared, got {d:?}");
+        };
+        assert!(nodes.iter().any(|n| n == ISLAND_NODES[3]), "{nodes:?}");
+        assert!(
+            params.iter().all(|p| p.node != ISLAND_NODES[3]),
+            "{params:?}"
+        );
+        let z = d
+            .sizing()
+            .expect("every node declares, so the store is sized");
+        assert_eq!(z.declared, 18, "21 less the three DIAG names");
+        assert_eq!(
+            z.max_parameters, 22,
+            "18 declared + 4 seeded; the empty node's one slot is its seed"
+        );
+        let c = with_params(&m).to_cmake();
+        assert!(
+            c.contains("set(NROS_PARAM_DECLARATION_STATUS \"declared\")\n"),
+            "{c}"
+        );
+        assert!(c.contains("set(NROS_DERIVED_MAX_PARAMETERS 22)\n"), "{c}");
+
+        let m = param_model(&ISLAND_NODES, &ps[..3]);
+        match ParamDeclarations::from_model(&m) {
+            ParamDeclarations::Refused { reason } => {
+                assert!(reason.contains(ISLAND_NODES[3]), "{reason}");
+                assert!(reason.starts_with("1 of 4 nodes"), "{reason}");
+            }
+            other => panic!("no entry must refuse, got {other:?}"),
+        }
     }
 
     /// A contract that names `use_sim_time` itself does not get a second

--- a/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/declared.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/declared.contract.yaml
@@ -1,0 +1,10 @@
+# phase-446 F1: `/b` says it declares NO parameters. Differs from
+# silent.contract.yaml only in that one `params: {}`.
+version: 1
+
+nodes:
+  a:
+    params:
+      rate: { type: integer }
+  b:
+    params: {}

--- a/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/declared.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/declared.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+  <!-- phase-446 F1: `/b` declares no parameters (`params: {}` in
+       declared.contract.yaml), so it carries no launch value. -->
+  <node pkg="demo_pkg" exec="a" name="a">
+    <param name="rate" value="10" />
+  </node>
+  <node pkg="demo_pkg" exec="b" name="b" />
+</launch>

--- a/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/silent.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/silent.contract.yaml
@@ -1,0 +1,9 @@
+# phase-446 F1: `/b` has no `params:` key, so it has not said whether it
+# declares any. Differs from declared.contract.yaml only there.
+version: 1
+
+nodes:
+  a:
+    params:
+      rate: { type: integer }
+  b: {}

--- a/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/silent.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/param_declarations/launch/silent.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+  <!-- phase-446 F1: `/b` states nothing about its parameters
+       (silent.contract.yaml has no `params:` for it). -->
+  <node pkg="demo_pkg" exec="a" name="a">
+    <param name="rate" value="10" />
+  </node>
+  <node pkg="demo_pkg" exec="b" name="b" />
+</launch>

--- a/packages/cli/nros-cli-core/tests/param_declarations_resolve.rs
+++ b/packages/cli/nros-cli-core/tests/param_declarations_resolve.rs
@@ -1,0 +1,125 @@
+//! phase-446 F1 -- `params: {}` survives resolution, end to end.
+//!
+//! The unit tests in `entity_inventory.rs` feed `ParamDeclarations::from_model`
+//! a hand-written model. This one produces the model the way a build does: the
+//! pinned `nros-launch-resolve` over a launch file and its provider-sidecar
+//! contract. The two fixtures differ in one line, `/b`'s `params: {}`, and
+//! that line must decide between a sized store and a refusal. Before F1 the
+//! resolver dropped the empty map, so both fixtures refused.
+//!
+//! Run with: `cargo test --manifest-path packages/cli/Cargo.toml --test param_declarations_resolve`
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use nros_cli_core::entity_inventory::ParamDeclarations;
+use ros_launch_manifest_model::SystemModel;
+
+/// `/b` says `params: {}`: the image declares, and `/b` gets only its seeded
+/// `use_sim_time` slot.
+#[test]
+fn an_empty_params_resolves_to_a_declared_store() {
+    let m = resolve("declared");
+    assert_eq!(
+        m.contracts.node_params.get("/b").map(|p| p.len()),
+        Some(0),
+        "`params: {{}}` must reach the model as an empty entry: {:?}",
+        m.contracts.node_params
+    );
+    let d = ParamDeclarations::from_model(&m);
+    let ParamDeclarations::Declared { nodes, params } = &d else {
+        panic!("every node declares, got {d:?}");
+    };
+    assert_eq!(nodes, &["/a", "/b"]);
+    assert_eq!(
+        params
+            .iter()
+            .map(|p| (p.node.as_str(), p.name.as_str()))
+            .collect::<Vec<_>>(),
+        [("/a", "rate")],
+        "`/b` declares nothing"
+    );
+    let z = d.sizing().expect("a declared image is sized");
+    assert_eq!(z.declared, 1);
+    assert_eq!(
+        z.max_parameters, 3,
+        "/a: rate + use_sim_time, /b: use_sim_time alone"
+    );
+}
+
+/// Without the `{}`, `/b` has said nothing, and the image refuses, naming it.
+#[test]
+fn a_missing_params_resolves_to_a_refusal_naming_the_node() {
+    let m = resolve("silent");
+    assert!(
+        !m.contracts.node_params.contains_key("/b"),
+        "no `params:` must give no entry: {:?}",
+        m.contracts.node_params
+    );
+    let d = ParamDeclarations::from_model(&m);
+    match &d {
+        ParamDeclarations::Refused { reason } => {
+            assert!(
+                reason.contains("/b"),
+                "the refusal names the node: {reason}"
+            );
+            assert!(!reason.contains("/a,"), "`/a` declared: {reason}");
+        }
+        other => panic!("a node with no `params:` must refuse, got {other:?}"),
+    }
+    assert_eq!(d.sizing(), None);
+}
+
+/// Resolve `launch/<stem>.launch.xml` (with its `<stem>.contract.yaml`
+/// sidecar) through the pinned resolver, by ABSOLUTE path (issue 0285).
+fn resolve(stem: &str) -> SystemModel {
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("repo root");
+    let resolver = repo.join("packages/cli/nros-launch-resolve/target/release/nros-launch-resolve");
+    assert!(
+        resolver.is_file(),
+        "nros-launch-resolve not built at {} -- run `just setup-launch-resolve`",
+        resolver.display()
+    );
+    let bringup = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/param_declarations");
+    let out = temp_output(repo, stem);
+    fs::create_dir_all(&out).expect("create model out dir");
+    let model = out.join("system_model.yaml");
+    let output = std::process::Command::new(&resolver)
+        .arg(bringup.join(format!("launch/{stem}.launch.xml")))
+        .arg("--bringup-root")
+        .arg(&bringup)
+        .arg("-o")
+        .arg(&model)
+        .output()
+        .expect("spawn nros-launch-resolve");
+    assert!(
+        output.status.success(),
+        "nros-launch-resolve failed for {stem}:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = fs::read_to_string(&model).expect("read the resolved model");
+    let _ = fs::remove_dir_all(&out);
+    SystemModel::from_yaml_str(&text).expect("the resolved model parses")
+}
+
+/// Unique scratch dir under the repo's gitignored `tmp/` (repo rule: temp
+/// files live in `$project/tmp/`, not the system temp dir).
+fn temp_output(repo: &Path, name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = repo.join("tmp").join(format!(
+        "param-declarations-{name}-{}-{stamp}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    dir
+}

--- a/packages/cli/nros-launch-resolve/Cargo.lock
+++ b/packages/cli/nros-launch-resolve/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-check"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "codespan-reporting",
  "petgraph",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/core/nros-macros/Cargo.toml
+++ b/packages/core/nros-macros/Cargo.toml
@@ -54,7 +54,7 @@ nros-orchestration-ir = { workspace = true }
 # SystemModel at compile time (the canonical bake input). Same vendored crate
 # the CLI uses; path crosses into the cli sub-workspace (host-only proc-macro
 # dep, same rationale as nros-pkg-index / nros-launch-parser above).
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
 
 [lints]
 workspace = true

--- a/packages/core/nros-orchestration-ir/Cargo.toml
+++ b/packages/core/nros-orchestration-ir/Cargo.toml
@@ -40,11 +40,11 @@ thiserror = { workspace = true }
 # depping nros-pkg-index / nros-launch-parser).
 # `[tiers.*]` duration keys accept both the canonical and the deprecated
 # `_us` spelling; the parser is rlm's own, never a second one here.
-ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
-ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
+ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
+ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
 # W5.13 follow-up — `mapper_input` adapts a resolved `SystemModel` into the
 # `MapperInput` the realizer ranks; the model types live in the sibling crate.
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
 # issue 0303 — `qos_override` lowers `qos_overrides.<topic>.<role>.<policy>`
 # params into the codes the entry bakes. The role/policy NUMBERING is
 # `nros-rmw`'s (it owns the decoder every runtime uses), so the lowering must

--- a/packages/testing/nros-tests/Cargo.toml
+++ b/packages/testing/nros-tests/Cargo.toml
@@ -42,7 +42,7 @@ nros-orchestration-ir = { workspace = true }
 # `target/<triple>/<profile>/` from it instead of re-implementing the mapping
 # the builder used.
 nros-cargo-profile = { path = "../../tooling/nros-cargo-profile" }
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.34" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.35" }
 # Phase 212.M.11 + M.12 — TOML parsing for the example-canonical-shape
 # + pre-212-file regression tests. Reads
 # `[package.metadata.nros.{component,entry,deploy.*}]` out of each

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -545,7 +545,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/testing/nros-tests/bins/sim-clock-listener/Cargo.lock
+++ b/packages/testing/nros-tests/bins/sim-clock-listener/Cargo.lock
@@ -797,7 +797,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/testing/nros-tests/bins/sim-clock-publisher/Cargo.lock
+++ b/packages/testing/nros-tests/bins/sim-clock-publisher/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.34#1a50d324271dee2d36d0e47de609502e258811de"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.35#803db6ba840e9a408b93d5b7c7169db292f62ed0"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
Moves the launch-toolchain pins forward and proves phase-446 F1 on this side.

This branch was cut from #872's head while that PR was open, so it carries #872's commits and a cherry-pick of the phase-446 doc commit. Both have since merged; they drop by patch-id when the merge queue rebases.

## chore: pin ros-launch-manifest v0.1.35 and play_launch 07f0461e

- play_launch `155ed78b` -> `07f0461e` (play_launch main). Forward only, checked with `git merge-base --is-ancestor`. It brings F1 (`96a1e3f7`: `params: {}` reaches the model as an empty `contracts.node_params` entry), the wildcard rule (`f5264bf0`: an undeclared launch value under a wildcard key such as `/**` warns instead of refusing, matching rclcpp, while one addressed to the node by name still fails), `8adc52ad` (global parameters reach `.launch.py`, Python ABI 3 to 4, rebuilt together by `just setup-launch-resolve`), and test and formatting fixes.
- ros-launch-manifest `v0.1.34` -> `v0.1.35` (`803db6b`: `NodeDecl.params` is `Option<BTreeMap<..>>`) in every manifest that pinned it: nros-cli-core, nros-macros, nros-orchestration-ir, nros-tests.
- The 16 locks naming the tag moved through `just lock-update`, rlm source lines only.
- The `Option` change breaks nothing here: no nano-ros code reads `NodeDecl.params`, and nros-cli-core reads only `contracts.node_params`, whose type did not change.

## test(phase-446 F1): an empty params entry sizes the store, a missing one refuses

- Unit test in `entity_inventory.rs`: four nodes with one entry emptied are Declared, and that node gets only its `use_sim_time` seed (18 names + 4 seeds = 22 slots). With no entry at all they are Refused ("1 of 4 nodes"), naming the node.
- `tests/param_declarations_resolve.rs` runs the pinned resolver over two fixture contracts differing only in `/b`'s `params: {}`: one gives an empty entry and a 3-slot store, the other a refusal naming `/b`.
- The phase doc's F1 section records it as landed.

## Verification

- `cargo +nightly fmt` clean for nros-cli-core; clippy `-D warnings` clean for nros-cli-core, nros-macros, nros-orchestration-ir and nros-tests.
- `cargo test -p nros-cli-core --lib`: 1085 passed. The new integration test: 2 passed.
- `just setup-launch-resolve` builds at play_launch `07f0461e`; `just check submodule-pinned-locks` OK.
- `just check fast`: all 295 gates pass, through the pre-push hook, with the zenoh-pico submodule and the vendored XRCE trees provisioned rather than skipped.
- End to end: the Autoware Safety Island launch resolves with this resolver to 4 nodes, each carrying its declared parameters (4/3/11/3 names), with no parameter errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPYy9LfvLmiFG6AnZ9nExE
