### PR TITLE
phase-427 W7 [cpp]: the node flips to rclcpp::, and nros::Node is deprecated

### DIFF
--- a/.config/codegen-version-surface.txt
+++ b/.config/codegen-version-surface.txt
@@ -12,8 +12,8 @@
 #
 # Regenerate after a DELIBERATE surface move (bump the constant first):
 #     python3 scripts/check-codegen-version-surface.py --write-baseline
-version 3
-2415963024c63037 cpp|fn|component.hpp|bind_subscription_sized
+version 4
+9a40c1a1fadbae06 cpp|fn|component.hpp|bind_subscription_sized
 4e2616f1497bc854 cpp|struct|fixed_sequence.hpp|FixedSequence
 05b2ecfd67796b30 cpp|struct|fixed_string.hpp|FixedString
 c2bd21803d713aa0 cpp|struct|heap_sequence.hpp|HeapSequence

--- a/book/src/concepts/ros2-comparison.md
+++ b/book/src/concepts/ros2-comparison.md
@@ -291,9 +291,9 @@ node->declare_parameter<double>("ctrl_period", 0.15);
 double v = node->get_parameter("ctrl_period").as_double();
 
 // nano-ros
-nros::Node node;
+rclcpp::Node node;
 nros::ParameterServer<8> params;
-NROS_TRY(nros::Node::create(node, "ctrl"));
+NROS_TRY(rclcpp::Node::create(node, "ctrl"));
 NROS_TRY(params.declare_parameter<double>("ctrl_period", 0.15));
 double v;
 NROS_TRY(params.get_parameter<double>("ctrl_period", v));

--- a/book/src/getting-started/anatomy.md
+++ b/book/src/getting-started/anatomy.md
@@ -15,7 +15,7 @@ If you come from ROS 2, each role is something you already know:
 ## Node packages — the code
 
 A node package is one node as a reusable library. The C++ shape is a
-class with a `configure(nros::Node&)` method that binds real member
+class with a `configure(rclcpp::Node&)` method that binds real member
 callbacks:
 
 ```text

--- a/book/src/getting-started/first-node-cpp.md
+++ b/book/src/getting-started/first-node-cpp.md
@@ -105,7 +105,7 @@ wrappers over the C ABI:
 int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::init("tcp/127.0.0.1:7447", 0), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
 
     nros::Publisher<std_msgs::msg::String> pub;

--- a/book/src/getting-started/porting-a-cpp-node.md
+++ b/book/src/getting-started/porting-a-cpp-node.md
@@ -35,7 +35,7 @@ target_compile_definitions(my_ported_node PRIVATE NROS_CPP_STD=1)
 Two things worth knowing before you reach for it:
 
 * **This is not a host-versus-embedded switch.** Code written against
-  `nros::Node` does not want the flag on a native Linux build either; ported
+  `rclcpp::Node` does not want the flag on a native Linux build either; ported
   rclcpp code wants it on a Cortex-M3 build just as much. The split is *whose
   code it is*, not *what it runs on*. See
   [C++ API — two surfaces](../reference/cpp-api.md#two-surfaces-freestanding-and-nros_cpp_std).
@@ -138,7 +138,7 @@ The compat surface covers the patterns a typical ROS 2 C++ node uses:
 
 | rclcpp surface | nano-ros mapping | Notes |
 |---|---|---|
-| `class MyNode : public rclcpp::Node` | `rclcpp::Node` IS `nros::Node` — one type, both spellings | Ctor takes `(name)`, `(name, options)` or `(name, ns, options)`. |
+| `class MyNode : public rclcpp::Node` | `rclcpp::Node` — ours, and the same name. (`nros::Node` is a deprecated alias for it; write `rclcpp::`.) | Ctor takes `(name)`, `(name, options)` or `(name, ns, options)`. |
 | `std::make_shared<MyNode>()` | works | `shared_from_this()` works too, with one caveat — see "Two things the compiler will not tell you" below. |
 | `create_publisher<M>(topic, qos)` | shared_ptr-returning wrapper | `qos` can be `rclcpp::QoS(10)` or an int. |
 | `create_subscription<M>(topic, qos, callback)` | registered on the executor arena; dispatched by **any** spin verb | **Capturing lambdas + `std::function` all work**. |

--- a/book/src/getting-started/workspace-cpp.md
+++ b/book/src/getting-started/workspace-cpp.md
@@ -16,7 +16,7 @@ changes language-side is the cmake-fn / macro surface.
 
 | Role | Rust | C / C++ |
 |---|---|---|
-| **Node pkg** | `lib.rs` with `nros::node!(MyNode)` + `[package.metadata.nros.node]` in `Cargo.toml` | `Talker.{hpp,cpp}` with a `configure(::nros::Node&)` component method (C++) / `NROS_C_COMPONENT` (C); `CMakeLists.txt` calling `nano_ros_auto_add_library` + `nros_components_register_node` (RFC-0057) |
+| **Node pkg** | `lib.rs` with `nros::node!(MyNode)` + `[package.metadata.nros.node]` in `Cargo.toml` | `Talker.{hpp,cpp}` with a `configure(::rclcpp::Node&)` component method (C++) / `NROS_C_COMPONENT` (C); `CMakeLists.txt` calling `nano_ros_auto_add_library` + `nros_components_register_node` (RFC-0057) |
 | **Bringup pkg** | `package.xml` + `system.toml` + `launch/*.launch.xml` (no `Cargo.toml`) | identical (language-agnostic) |
 | **Image** | `[image.native] board = "native"` in the bringup's `system.toml` | identical (language-agnostic) |
 | **The entry** | GENERATED into `build/<coord>/native_entry/` — a `Cargo.toml` and a `nros::main!(launch = "demo_bringup")` | GENERATED into `build/<coord>/CMakeLists.txt` — a `nano_ros_add_executable(native_entry BOARD … BRINGUP … LAUNCH … LANG cpp TYPED DEPLOY native)` call, plus the `main` TU the verb emits |
@@ -101,7 +101,7 @@ workspace; the per-pkg CMakeLists doesn't change between modes.
 ## Node pkg
 
 A **typed component** (RFC-0043) — no `main()`. The pkg ships a class with a
-`configure(::nros::Node&)` method that creates real entities (a `Publisher`, a
+`configure(::rclcpp::Node&)` method that creates real entities (a `Publisher`, a
 `Timer`) and binds member callbacks **by identity** (member-fn-pointer template
 param, no string callback name, no interpreter). The generated entry constructs
 the object and calls `configure(node)`; the executor dispatches the callbacks.
@@ -206,7 +206,7 @@ class Talker {
     void on_tick();  // real body; bound via &Talker::on_tick (no name)
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::nros::Result configure(::rclcpp::Node& node);
 };
 
 }  // namespace talker_pkg
@@ -224,7 +224,7 @@ void Talker::on_tick() {
     (void)pub_.publish(m);
 }
 
-::nros::Result Talker::configure(::nros::Node& node) {
+::nros::Result Talker::configure(::rclcpp::Node& node) {
     ::nros::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
     // Member-fn-pointer-as-template-param → no-alloc trampoline; `this` is ctx.
@@ -368,7 +368,7 @@ launch.xml / `package.xml` / Node pkg edit re-runs codegen.
 
 | Concern | Lives in |
 |---|---|
-| Node entities + real callbacks | Node pkg `configure(::nros::Node&)` |
+| Node entities + real callbacks | Node pkg `configure(::rclcpp::Node&)` |
 | Topology + launch args + per-target deploy | Bringup pkg `system.toml` + `launch/*.launch.xml` |
 | `int main()` + executor init + spin | Generated TU emitted by the entry's cmake fn |
 | Board + RMW selection | The image's `board` and `rmw`, which become the generated `BOARD` / `DEPLOY` args |

--- a/book/src/getting-started/workspace-node-pkgs.md
+++ b/book/src/getting-started/workspace-node-pkgs.md
@@ -231,7 +231,7 @@ Declare the service in `Node::register` and handle requests in the node body.
   AddTwoInts::Response on_add(const AddTwoInts::Request& req) {
       AddTwoInts::Response r; r.sum = req.a + req.b; return r;
   }
-  ::nros::Result configure(::nros::Node& node) {
+  ::nros::Result configure(::rclcpp::Node& node) {
       return ::nros::bind_service<AddTwoInts, MyServer, &MyServer::on_add>(
           node, "/add_two_ints", this);   // service-type name from AddTwoInts::TYPE_NAME
   }

--- a/book/src/reference/cpp-api.md
+++ b/book/src/reference/cpp-api.md
@@ -15,10 +15,10 @@ public surface a user application needs.
 
 - [`nros/nros.hpp`](../api/cpp/nros_8hpp.html) — convenience umbrella include
 - [`nros::init`](../api/cpp/namespacenros.html) / `nros::shutdown` — session lifetime
-- [`nros::Node`](../api/cpp/classnros_1_1Node.html) — node + create_publisher/subscription/service/client/action_*
-- [`nros::Publisher<M>`](../api/cpp/classnros_1_1Publisher.html) / [`Subscription<M>`](../api/cpp/classnros_1_1Subscription.html)
-- [`nros::Service<S>`](../api/cpp/classnros_1_1Service.html) / [`Client<S>`](../api/cpp/classnros_1_1Client.html)
-- [`nros::ActionServer<A>`](../api/cpp/classnros_1_1ActionServer.html) / [`ActionClient<A>`](../api/cpp/classnros_1_1ActionClient.html) — L2 callback model (executor-arena registered).
+- [`rclcpp::Node`](../api/cpp/classrclcpp_1_1Node.html) — node + create_publisher/subscription/service/client/action_*
+- [`rclcpp::Publisher<M>`](../api/cpp/classrclcpp_1_1Publisher.html) / [`Subscription<M>`](../api/cpp/classrclcpp_1_1Subscription.html)
+- [`rclcpp::Service<S>`](../api/cpp/classrclcpp_1_1Service.html) / [`Client<S>`](../api/cpp/classrclcpp_1_1Client.html)
+- [`rclcpp_action::Server<A>`](../api/cpp/classrclcpp__action_1_1Server.html) / [`Client<A>`](../api/cpp/classrclcpp__action_1_1Client.html) — L2 callback model (executor-arena registered). `nros::ActionServer<A>` / `nros::ActionClient<A>` are the same two types.
 - [`nros::PollingActionServer<A>`](../api/cpp/classnros_1_1PollingActionServer.html) / [`PollingActionClient<A>`](../api/cpp/classnros_1_1PollingActionClient.html) — L1 polling model. Caller drives `take_*` / `accept_goal` / `complete_goal` from a spin loop.
 - [`nros::Future<T>`](../api/cpp/classnros_1_1Future.html) — async result handle
 - [`nros::Executor`](../api/cpp/classnros_1_1Executor.html), [`Timer`](../api/cpp/classnros_1_1Timer.html), [`GuardCondition`](../api/cpp/classnros_1_1GuardCondition.html)
@@ -52,7 +52,7 @@ below for whether you need it.
 One set of headers ships two API shapes, and a build picks one.
 
 **The freestanding surface is the default and it is not a fallback.** It is
-plain C++14 with no standard library, no exceptions and no RTTI: `nros::Node`,
+plain C++14 with no standard library, no exceptions and no RTTI: `rclcpp::Node`,
 `create_*` writing through an out-reference and returning an `nros::Result`,
 `const char*` for names, `uint64_t period_ms` for durations. Every nano-ros
 program in this repository is on it — the native/host examples included.
@@ -73,7 +73,7 @@ than a Cortex-M3 build does; a ported node wants it on both.
 
 | You are… | Flag | Why |
 | --- | --- | --- |
-| writing a new node against `nros::Node` / `nros::Publisher<M>` / `nros::Executor` | **no** | The freestanding surface is the whole API you are using. This is the common case on every platform, native included. |
+| writing a new node against `rclcpp::Node` / `rclcpp::Publisher<M>` / `nros::Executor` | **no** | The freestanding surface is the whole API you are using. This is the common case on every platform, native included. |
 | compiling an upstream ROS 2 `.cpp` unmodified — it says `class MyNode : public rclcpp::Node`, `std::make_shared<MyNode>()`, `create_publisher<M>(...)` returning a `SharedPtr` | **yes** | Those signatures are *spelled in* `std::shared_ptr` and `std::string`. Without the flag they do not exist and you get a compile error naming a missing overload or an unknown `rclcpp::Node`. |
 | passing a `std::string` topic name or a `std::chrono` period into an otherwise nano-ros-native file | **yes** | Those are the `std_compat.hpp` overloads. |
 | building for Zephyr, FreeRTOS, NuttX, ThreadX, or any `-ffreestanding` toolchain | **no** | And here it is not merely unnecessary: asking for the std surface asks the headers to `#include <string>`, which on those toolchains is either absent or a hard `#error`. |

--- a/book/src/user-guide/component-and-entry-pkg.md
+++ b/book/src/user-guide/component-and-entry-pkg.md
@@ -45,7 +45,7 @@ Key rules:
 
 - **No `fn main()`.** A Node pkg builds as `rlib + staticlib` and is *linked into* the entry the build generates. Codegen synthesises the spin driver; you never hand-write one.
 - **`class` must be a namespace-qualified C++ name.** The old 212.L.4 prefix rule (`class` starting with the pkg dir name) is retired by RFC-0057 — `pkg` on the `[[component]]` row is the identity authority, so upstream namespaces (`autoware::x::Node`) port verbatim. `nros check` still rejects an unqualified `class`.
-- **C++ / C analogue:** `nano_ros_auto_add_library(<lib> STATIC <srcs>)` + `nros_components_register_node(<lib> PLUGIN … EXECUTABLE …)` (RFC-0057, rclcpp_components keyword parity) + a typed component in the source — C++ a `configure(::nros::Node&)` method, C a `NROS_C_COMPONENT(StateT, configure_fn)` seam (RFC-0043). Same conceptual shape, no Cargo.toml.
+- **C++ / C analogue:** `nano_ros_auto_add_library(<lib> STATIC <srcs>)` + `nros_components_register_node(<lib> PLUGIN … EXECUTABLE …)` (RFC-0057, rclcpp_components keyword parity) + a typed component in the source — C++ a `configure(::rclcpp::Node&)` method, C a `NROS_C_COMPONENT(StateT, configure_fn)` seam (RFC-0043). Same conceptual shape, no Cargo.toml.
 - **`package.xml` is mandatory.** Even pure-Rust Node pkgs ship one — `<exec_depend>` lines drive ROS 2 launch discovery when the system runs through `ros2 launch` outside the nano-ros toolchain.
 
 ## Bringup pkg

--- a/book/src/user-guide/logging.md
+++ b/book/src/user-guide/logging.md
@@ -83,7 +83,7 @@ int main(void) {
 int main() {
     nros::init("tcp/127.0.0.1:7447", 0);
 
-    nros::Node node;
+    rclcpp::Node node;
     nros::create_node(node, "my_node");
 
     auto logger = node.get_logger();

--- a/changelog.d/929.breaking.md
+++ b/changelog.d/929.breaking.md
@@ -1,0 +1,24 @@
+C++: the node type is `rclcpp::Node`, and `nros::Node` is a **deprecated alias**
+for it. They are one class — `std::is_same<rclcpp::Node, nros::Node>::value` is
+true — so migrating is textual:
+
+    nros::Node node;                       // before, now warns
+    rclcpp::Node node;                     // after
+
+    ::nros::Result configure(::nros::Node& node);      // before
+    ::nros::Result configure(::rclcpp::Node& node);    // after
+
+This is the tenth and last type of the `nros::` → `rclcpp::` move (RFC-0089:
+`rclcpp::` is the home of our C++ API). The other nine — `Clock`, `Duration`,
+`Time`, `Publisher<M>`, `Subscription<M>`, `Client<S>`, `Service<S>` and the two
+action types — moved earlier and their `nros::` aliases are NOT deprecated yet.
+
+The alias stays for at least one release: `nros-v0.5.0` shipped the old spelling
+in the `examples/templates/**` a user copies out, so an existing project gets a
+compiler warning naming its replacement rather than an unknown identifier. Build
+with `-Werror=deprecated-declarations` to find your call sites.
+
+`NROS_CODEGEN_VERSION` moves 3 → 4 because one signature generated code names
+changed spelling. The accepted floor is unchanged, so an already-generated tree
+still compiles; `nros sync` regenerates it if you would rather not see the
+warning.

--- a/cmake/compat/NrosRclcppCompat.cmake
+++ b/cmake/compat/NrosRclcppCompat.cmake
@@ -124,7 +124,7 @@ function(_nros_compat_apply_force_includes target)
     # This target is exactly the right place and nowhere else is: the shim is
     # applied per-target and is deliberately NOT auto-applied on Zephyr (see
     # below), so the opt-in follows the porting surface instead of leaking to
-    # images that use `nros::Node` directly.
+    # images that use `rclcpp::Node` directly.
     #
     # Until now this function set NO compile definition at all, and the whole
     # ported-code path worked only because a hosted compiler happened to find
@@ -139,7 +139,7 @@ endfunction()
 # `<memory>` / `<string>` / `<functional>` / `<vector>` / `<chrono>`
 # — Zephyr's minimal C++ stdlib doesn't ship most of those (only
 # `<chrono>` is shimmed under `zephyr/cxx-compat/`). Existing Zephyr
-# cpp examples use `nros::Node` directly (NOT rclcpp); polluting them
+# cpp examples use OUR `rclcpp::Node` directly (NOT upstream rclcpp); polluting them
 # with rclcpp_compat.hpp would break their build for no benefit.
 #
 # A user who actually ports rclcpp source to Zephyr opts in by adding

--- a/cmake/zephyr/mps2-an385.conf
+++ b/cmake/zephyr/mps2-an385.conf
@@ -74,7 +74,7 @@ CONFIG_NROS_ZENOH_LOCATOR="tcp/10.0.2.2:7456"
 # TWO CORRECTIONS to the first version of this comment, both measured:
 #
 #  - The 88192-byte `NROS_EXECUTOR_SIZE` storage is NOT on this stack. The C/C++
-#    entry template declares it `static ::nros::Node __nros_node;`, i.e. .bss.
+#    entry template declares it `static ::rclcpp::Node __nros_node;`, i.e. .bss.
 #    Cross-check: 65536 was tried and passed all three cells, which an 88 KB
 #    stack object makes impossible. What actually overflows is the executor
 #    CONSTRUCTION path — ~13.4 KB was already consumed at `nros_cpp_init` entry

--- a/docs/design/0018-cpp-api-design.md
+++ b/docs/design/0018-cpp-api-design.md
@@ -23,7 +23,7 @@ embedded systems with no heap allocation. The C++ layer wraps the Rust
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  User code (C++)                                            │
-│  nros::Node, nros::Publisher<M>, nros::Subscription<M>      │
+│  rclcpp::Node, rclcpp::Publisher<M>, rclcpp::Subscription<M>│
 ├─────────────────────────────────────────────────────────────┤
 │  nros-cpp  (header-only, freestanding C++)                  │
 │  Thin wrappers: type safety, RAII, templates                │
@@ -195,8 +195,8 @@ Usage:
 nros::Result init_system() {
     NROS_TRY(nros::init());
 
-    nros::Node node;
-    NROS_TRY(nros::Node::create(node, "my_node"));
+    rclcpp::Node node;
+    NROS_TRY(rclcpp::Node::create(node, "my_node"));
 
     nros::Publisher<std_msgs::msg::Int32> pub;
     NROS_TRY(node.create_publisher(pub, "/chatter"));
@@ -217,7 +217,7 @@ opt-in and never the default.
 
 | rclcpp                     | nros-cpp                | Notes  |
 |----------------------------|-------------------------|--------|
-| `rclcpp::Node`             | `nros::Node`            |        |
+| `rclcpp::Node`             | `rclcpp::Node`          | RFC-0089: ours is DEFINED in `rclcpp::`. `nros::Node` is a deprecated alias. |
 | `rclcpp::Publisher<M>`     | `nros::Publisher<M>`    |        |
 | `rclcpp::Subscription<M>`  | `nros::Subscription<M>` |        |
 | `rclcpp::Service<S>`       | `nros::Service<S>`      | Server |
@@ -839,8 +839,8 @@ void timer_callback(void* ctx) {
 int main() {
     NROS_TRY(nros::init());
 
-    nros::Node node;
-    NROS_TRY(nros::Node::create(node, "talker"));
+    rclcpp::Node node;
+    NROS_TRY(rclcpp::Node::create(node, "talker"));
 
     nros::Publisher<std_msgs::msg::Int32> pub;
     NROS_TRY(node.create_publisher(pub, "/chatter"));

--- a/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -845,7 +845,7 @@ Two consequences of the fix, both stated rather than absorbed:
   12 → 9, `differs` 20 → 21, `ours-only` 354 → 360, `theirs-only` 695 → 651.
   Forty-four names we ship stopped being reported as names only ROS 2 has.
 
-### The flip is DONE for nine of the ten (phase-428, 2026-09-09)
+### The flip is DONE — all ten (nine phase-428 2026-09-09, `Node` phase-427 W7 2026-09-11)
 
 Nothing in the tooling argued for defining a type in `nros::`, and nine of the
 ten have moved. Each definition now sits in the upstream namespace and the
@@ -862,11 +862,61 @@ ten have moved. Each definition now sits in the upstream namespace and the
 | `rclcpp::Service<S>` | `nros::Service<S>` | `service.hpp` |
 | `rclcpp_action::Client<A>` | `nros::ActionClient<A>` | `action_client.hpp` |
 | `rclcpp_action::Server<A>` | `nros::ActionServer<A>` | `action_server.hpp` |
+| **`rclcpp::Node`** | **`nros::Node`** (DEPRECATED) | **`node.hpp`** |
 
-`Node` is the TENTH and is deliberately NOT swept here: PRs #797 and #806 are
-stacked on `node.hpp`, so flipping it in the same change would conflict with two
-landed reviews. It is the one that surfaced the problem, and phase-427 W7 (the
-`nros::Node` deprecation) waits on it.
+`Node` was the TENTH and was held out of phase-428 because PRs #797 and #806
+were stacked on `node.hpp`. Both merged, and phase-427 W7 landed it on
+2026-09-11 together with the deprecation the item was actually about.
+
+**Three mechanics the node needed that the other nine did not**, recorded
+because the next type to move in a header this size will meet them:
+
+* An elaborated `class Node;` in `nros::` declares a SECOND, distinct class once
+  the alias exists, so every forward declaration moves too — twelve headers.
+* A friend declaration inside `namespace rclcpp` must be QUALIFIED or it
+  befriends a `rclcpp::` function that does not exist, and a qualified friend
+  names an EXISTING entity, so `node.hpp` forward-declares the six `nros::` free
+  functions the node befriends. The declarator-id is parenthesized —
+  `friend Result(::nros::init)(...)` — because a nested-name-specifier is parsed
+  greedily and `Result ::nros::init` reads as `Result::nros::init`.
+* Out-of-line member definitions may only be written in a namespace ENCLOSING
+  the class, so all sixteen `Result Node::create_*` bodies moved with it.
+
+**`QoS` was the one place the flip could have changed behaviour silently, and
+that is general.** `rclcpp::QoS` is a SUBCLASS of `nros::QoS`, not an alias, so
+an unqualified `QoS` inside `namespace rclcpp` would have quietly re-typed every
+`create_*` parameter to the derived class — a compiling, non-erroring signature
+change. Every such name in a moved body is `::nros::`-qualified, which is also
+what lets a reader tell an adopted name from an ours-only one. Before moving a
+definition into `rclcpp::`, check each unqualified name for a `rclcpp::`
+homonym: `QoS`, `Logger`, `NodeOptions` and `Rate` are the four that exist here,
+and only `QoS` is a different type.
+
+**`nros::Node` is DEPRECATED, and it is the first of the ten to be** — the
+others are still plain aliases for the reason two paragraphs down. What made it
+affordable is that the same commit migrated all 258 in-tree C++ spellings, so
+the attribute costs no in-tree diagnostic. It is UNCONDITIONAL: every other
+deprecation this API ships is (`nros::Expected<T>`, `nros::bind_timer`,
+`QoS::Liveliness`, the `QoS::*_ms(uint32_t)` family,
+`LifecycleNode::trigger(uint8_t)`), and a macro nothing in-tree defines would
+leave the probe as the only compiler that ever sees it. The reach it is FOR is
+out-of-tree: `nros-v0.5.0` shipped the old spelling in six
+`examples/templates/**` files a user copies out. Probe:
+`tests/compile/node_deprecation_probe.cpp`, greped for the replacement, because
+"it failed" is also what a typo produces.
+
+**One more tool defect the flip surfaced, and it was pre-existing.**
+`correlate.canon_type`'s namespace strips are `^`-anchored, so a LEADING `::`
+made two spellings of one type canonicalise differently: `::std::string` never
+reduced to `string`. Our hosted overloads are spelled `::std::string` and
+upstream's `std::string`, so SEVEN C++ rows — `Node::Node`,
+`Node::create_client`, `Node::create_service`, `Node::declare_parameter`,
+`Node::get_parameter`, `Node::has_parameter`, `QoS::QoS` — reported `systematic`
+over an overload we actually ship. Fixed at the canonicaliser and pinned in
+`--self-test` in both directions (an INNER `::` is not noise). C++ buckets: same
+131 -> 138, systematic 14 -> 7, nothing moved the other way. Same shape as the
+`OUR_CPP_ROOTS` fix above: the instrument was measuring its own spelling
+convention.
 
 **The two action types are a RENAME as well as a move**, and that is where the
 sweep stopped being mechanical. `rclcpp_action` already says "action", so the
@@ -896,13 +946,24 @@ consequences, each of which the gates caught rather than the author:
   named in `KEY_OVERRIDES`, with the service client's own members asserted in the
   self-test so a widened pattern cannot quietly claim them.
 
-**The aliases are NOT deprecated.** They are ours-only names with in-tree reach,
-so they can eventually be removed — unlike an upstream name we lack, where the
-alias is load-bearing — but a bare deprecation attribute warns at every in-tree
-site at once in a workspace that denies warnings. Measured at the flip: **444
-qualified `nros::<Type>` spellings** across `packages/`, `examples/`, `zephyr/`,
-`cmake/`, `book/` and `docs/` (147 of them outside the nine headers themselves).
-Migrating them is its own wave.
+**The other nine aliases are NOT deprecated** (`nros::Node` is — see above).
+They are ours-only names with in-tree reach, so they can eventually be removed —
+unlike an upstream name we lack, where the alias is load-bearing — but a bare
+deprecation attribute warns at every in-tree site at once in a workspace that
+denies warnings. Measured at the flip: **444 qualified `nros::<Type>`
+spellings** across `packages/`, `examples/`, `zephyr/`, `cmake/`, `book/` and
+`docs/` (147 of them outside the nine headers themselves). Migrating them is its
+own wave.
+
+**What the `Node` wave measured, for whoever takes the other nine.** The
+deprecation is affordable exactly when the migration lands in the same commit,
+and the migration is a smaller job than the raw count suggests: of `Node`'s 561
+tree-wide spellings only **258 were C++ code**, because `nros::Node` also names
+a RUST TRAIT (`nros-macros`, every `impl nros::Node for …`) that the C++
+deprecation does not touch and must not be swept, and because `docs/roadmap`,
+`docs/issues` and the dated paragraphs of the ledger are historical record that
+would be FALSIFIED by rewriting. The split that matters is code vs prose, then
+C++ vs Rust — not a grep total.
 
 **What the flip does NOT do is make our headers coexist with upstream's.**
 Measured deliberately, a TU that includes both `<rclcpp/rclcpp.hpp>` and

--- a/docs/guides/cpp-api.md
+++ b/docs/guides/cpp-api.md
@@ -97,7 +97,7 @@ NROS_TRY(nros::Executor::create(executor, "tcp/127.0.0.1:7447"));
 ### Node
 
 ```cpp
-nros::Node node;
+rclcpp::Node node;
 NROS_TRY(nros::create_node(node, "my_node"));
 
 // Or with explicit executor:
@@ -309,7 +309,7 @@ guard.trigger();
 nros::Executor executor;
 NROS_TRY(nros::Executor::create(executor));
 
-nros::Node node;
+rclcpp::Node node;
 NROS_TRY(executor.create_node(node, "my_node"));
 
 // Create publishers, subscriptions, etc. on node...
@@ -371,7 +371,7 @@ below, plus `rclcpp::Node` and its `std::shared_ptr`-returning factories.
 
 **Ask for it when you are compiling ported rclcpp code; do not ask for it
 otherwise.** The split is *whose code it is*, not *what it runs on* — a native
-Linux build of a node written against `nros::Node` stays on the freestanding
+Linux build of a node written against `rclcpp::Node` stays on the freestanding
 surface, and a ported upstream node wants this flag on a Cortex-M3 build just
 as much as on a host. Nothing detects it for you: the headers do not probe the
 include path, because no probe answers correctly on both embedded lanes (the
@@ -473,7 +473,7 @@ int main(void)
     nros::Result ret = nros::init(CONFIG_NROS_ZENOH_LOCATOR, CONFIG_NROS_DOMAIN_ID);
     if (!ret.ok()) return 1;
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY(nros::create_node(node, "my_node"));
 
     // ... create publishers, subscriptions, etc.

--- a/docs/guides/creating-examples.md
+++ b/docs/guides/creating-examples.md
@@ -667,7 +667,7 @@ int main() {
     nros::Result ret = nros::init("tcp/127.0.0.1:7447", 0);
     if (!ret.ok()) return 1;
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY(nros::create_node(node, "my_node"));
 
     nros::Publisher<std_msgs::msg::Int32> pub;

--- a/docs/reference/api-parity-ledger/exec.json
+++ b/docs/reference/api-parity-ledger/exec.json
@@ -599,10 +599,6 @@
     "verdict": "extension",
     "why": "the `NROS_CPP_STD` `std::chrono::milliseconds` overload of `Executor::spin_once`, spelled as a free function taking the executor first for the reason given at `cpp:create_executor` -- `std_compat.hpp` cannot add a member to `Executor`. It is a UNIT overload, not a new operation: the method it forwards to correlates as `same` against rclcpp's `Executor::spin_once`. rclcpp needs no equivalent because it takes `std::chrono` natively; ours takes `int32_t` milliseconds so the method is reachable from a freestanding build with no `<chrono>`. A `no_std` consumer does not get this spelling. Note the naming caveat at `cpp:spin_once`: our one-cycle verb has rclcpp's `spin_some` semantics."
   },
-  "cpp:spin_once": {
-    "verdict": "divergence",
-    "why": "rclcpp's free spin functions take the node to spin (`rclcpp::spin(node)`); ours take no node, because a node is not a unit of dispatch (see `cpp:Executor::spin_node_once`) and the global session is singular (see `cpp:Context`). `nros::spin_once(timeout_ms)` drives the one global executor `nros::init()` created. rclcpp has no free `spin_once` at all -- and note this one has `spin_some` semantics, not rclcpp's `spin_once` semantics; see `cpp:Executor::spin_some`. OUR LANGUAGES DISAGREE: the one-cycle verb is `spin_once` in C++ and Rust and `nros_executor_spin_some` in C (matching rclc), so a reader moving between our own surfaces meets the same operation under rclcpp's name for a different operation."
-  },
   "cpp:spin_some": {
     "verdict": "rename",
     "why": "the free form of `cpp:Executor::spin_some`; ours is `nros::spin_once(0)`. RE-VERDICTED 2026-09-04 (phase-417), declined -> rename, for the same reason and with the same blocker -- the capability is present under another word, which is not what `declined` means. See that row.",

--- a/docs/reference/api-parity-ledger/node.json
+++ b/docs/reference/api-parity-ledger/node.json
@@ -222,6 +222,10 @@
     "verdict": "declined",
     "why": "the free function behind `create_sub_node`."
   },
+  "cpp:global_handle": {
+    "verdict": "extension",
+    "why": "the executor handle behind the free-function `nros::init()` / `nros::spin_once()` convenience path, so a caller using it can still hand an executor to `Future::wait` / `Stream::wait_next` -- which they must, because RFC-0021 makes every blocking helper take the executor. rclcpp needs no equivalent: `spin_until_future_complete` takes a node or executor the caller already holds. Returns `nullptr` before `init()`."
+  },
   "cpp:init_with_launch": {
     "verdict": "extension",
     "why": "initialises from a resolved launch SystemModel rather than from arguments (RFC-0046: launch is authoritative for node identity). rclcpp reads the same information from argv, which a device does not have."
@@ -237,6 +241,10 @@
   "cpp:make_node": {
     "verdict": "extension",
     "why": "the value-returning spelling of `create_node`, kept for entry points that can take the move."
+  },
+  "cpp:spin_once": {
+    "verdict": "divergence",
+    "why": "rclcpp's free spin functions take the node to spin (`rclcpp::spin(node)`); ours take no node, because a node is not a unit of dispatch (see `cpp:Executor::spin_node_once`) and the global session is singular (see `cpp:Context`). `nros::spin_once(timeout_ms)` drives the one global executor `nros::init()` created. rclcpp has no free `spin_once` at all -- and note this one has `spin_some` semantics, not rclcpp's `spin_once` semantics; see `cpp:Executor::spin_some`. OUR LANGUAGES DISAGREE: the one-cycle verb is `spin_once` in C++ and Rust and `nros_executor_spin_some` in C (matching rclc), so a reader moving between our own surfaces meets the same operation under rclcpp's name for a different operation."
   },
   "rust:ActionExecutor": {
     "verdict": "extension",

--- a/docs/reference/api-parity-ledger/other.json
+++ b/docs/reference/api-parity-ledger/other.json
@@ -219,10 +219,6 @@
     "verdict": "divergence",
     "why": "the same adapter for `std::vector<std::string>` -> `std::vector<const char *>`; neither header is available in the freestanding profile, and the return value allocates. See `cpp:get_c_string`."
   },
-  "cpp:global_handle": {
-    "verdict": "extension",
-    "why": "the executor handle behind the free-function `nros::init()` / `nros::spin_once()` convenience path, so a caller using it can still hand an executor to `Future::wait` / `Stream::wait_next` -- which they must, because RFC-0021 makes every blocking helper take the executor. rclcpp needs no equivalent: `spin_until_future_complete` takes a node or executor the caller already holds. Returns `nullptr` before `init()`."
-  },
   "cpp:has_derived_size_bound": {
     "verdict": "extension",
     "why": "phase-408 / issue 0964. Asks whether a message type carries a DERIVED serialized-size bound, as opposed to the estimate `SERIALIZED_SIZE_MAX` states for every type including unbounded ones. It is the predicate the receive buffers branch on: derived -> use it, not derived -> keep today's behaviour. rclcpp has nothing to compare because with an allocator the question does not arise."

--- a/docs/roadmap/phase-427-one-node-type.md
+++ b/docs/roadmap/phase-427-one-node-type.md
@@ -1,8 +1,9 @@
 # Phase 427 — one node type, named `rclcpp::Node`, compiling freestanding
 
-**Status (2026-09-09). W1, W2, W3, W4, W5, W6 and W8 LANDED (W5's runtime half
-and W6's book page closed 2026-09-09; W4's freestanding acceptance split out as
-issue 1247); W7 blocked and re-scoped — see "What landed, and what it measured" below.** Implements RFC-0089 §"The node API, proposed
+**Status (2026-09-11). W1, W2, W3, W4, W5, W6, W7 and W8 LANDED (W5's runtime
+half and W6's book page closed 2026-09-09; W4's freestanding acceptance split
+out as issue 1247; W7 landed 2026-09-11 once its blocker cleared — see "W7
+LANDED" below).** Implements RFC-0089 §"The node API, proposed
 under the governing principle". Preconditions are met by phase-417: the
 `pump()` blocker is gone, `check-cpp-capability-layout` measures the layout
 rule, and the `-nostdinc++` lane can see a freestanding regression.
@@ -95,7 +96,13 @@ missed (`book/src/getting-started/workspace-cpp.md`, the model-1 slides)
 migrated too: a book page teaching a deprecated call is a call site with extra
 reach.
 
-### The namespace direction is the opposite of the RFC's end state, and it is measured
+### The namespace direction was the opposite of the RFC's end state — RESOLVED by W7, 2026-09-11
+
+**Superseded.** Everything below was true of the node-type merge and is kept as
+the record of why the direction was inverted for two days; W7 flipped it, the
+class is `rclcpp::Node`, and both blockers named here are gone (phase-428 fixed
+the extractor's roots; PRs #797 and #806 merged). Read it for the reasoning, not
+for the current shape.
 
 RFC-0089 describes `rclcpp::Node` as the class and `nros::Node` as the migration
 alias. **It is the other way round here, because of the parity tool's own
@@ -121,7 +128,61 @@ The alias is UNCONDITIONAL, which the shim class was not: it lived inside
 node and not its ROS 2 name — the two vocabularies split exactly where the port
 matters most.
 
-### W7 cannot mean what it says, and the blocker is the line above
+### W7 LANDED 2026-09-11 — the flip first, then the deprecation
+
+Both blockers below cleared, and W7 landed as one branch in two commits: the
+namespace flip, then the migration and the attribute together.
+
+**The flip.** `class Node` is DEFINED in `rclcpp::` now and `nros::Node` is the
+alias, the tenth and last of RFC-0089's table. PRs #797 and #806 merged, so the
+stacking objection is gone; the extractor objection is gone too, because
+phase-428 made `OUR_CPP_ROOTS` name both halves of the vocabulary we ship. Three
+mechanics the other nine types did not need are recorded in RFC-0089 §"The flip
+is DONE — all ten": forward declarations must move (an elaborated `class Node;`
+in `nros::` would declare a second class), friend declarations must be qualified
+AND parenthesized (`friend Result(::nros::init)(...)`, because a
+nested-name-specifier is parsed greedily), and all sixteen out-of-line
+`Node::create_*` bodies move with the class. The near-miss worth repeating is
+`QoS`: `rclcpp::QoS` is a SUBCLASS of `nros::QoS`, so a bare `QoS` inside
+`namespace rclcpp` would have re-typed every `create_*` parameter to the derived
+class — compiling, non-erroring, and wrong.
+
+**The deprecation, and the migration in the same commit** — which is what the
+paragraph below demanded. 258 in-tree C++ spellings migrated; the attribute is
+`NROS_CPP_DEPRECATED_MSG` and UNCONDITIONAL, not feature-armed. The evidence for
+that choice, since PR #753 set the armed precedent in Rust: #753 armed BECAUSE
+its tree had not migrated (65 hard errors across 47 files), and that argument
+inverts here. Every other C++ deprecation this API ships is unconditional. And a
+macro nothing in-tree defines leaves the probe as the only compiler that ever
+sees the attribute, which is a gate whose subject disappears. The reach it is
+for is out-of-tree and it is real: `nros-v0.5.0` (2026-06-08) shipped
+`nros::Node` in six `examples/templates/**` files a user copies out.
+
+**What did NOT migrate, and why.** The raw grep is 561 sites; 258 are C++ code.
+The rest split three ways, each deliberate:
+
+* **`nros::Node` also names a RUST TRAIT** (`nros-macros`, `impl nros::Node for
+  Talker`, 58 `.rs` sites). Different symbol, different language, untouched.
+* **`docs/roadmap`, `docs/issues` and the dated paragraphs of the api-parity
+  ledger are historical record.** "`nros::Node` WAS the definition" is true as
+  written; rewriting it would turn a record into a falsehood. Left alone, this
+  file's own history included.
+* **`book/src`, `docs/guides`, the example READMEs and RFC-0018's code
+  blocks teach the name a reader should WRITE**, so those migrated — 28 sites.
+  RFC-0044 did not: its subject is `ComponentNode`, which is deleted, so it is
+  history too.
+
+**One pre-existing tool defect fell out of it.** `correlate.canon_type`'s
+namespace strips are `^`-anchored, so a LEADING `::` made one type canonicalise
+two ways — `::std::string` never reduced to `string`. Our hosted overloads are
+spelled `::std::string` and upstream's `std::string`, so SEVEN C++ rows reported
+`systematic` over an overload we actually ship. same 131 -> 138, systematic
+14 -> 7, nothing the other way. Two ledger rows also changed shard,
+`cpp:spin_once` and `cpp:global_handle` (`exec`/`other` -> `node`): their
+declarations genuinely live in `node.hpp` now, which is what the qualified
+friendship requires, and the taxonomy files a top-level name by its header.
+
+### What blocked it, recorded as it stood before the flip
 
 W7 is "`nros::Node` deprecated with `NROS_DEPRECATED_MSG`, not deleted". A
 deprecation attaches to the ALIAS, and after the merge the alias is
@@ -735,15 +796,21 @@ moved with the template.
   question to ask. Also in `Node`'s constructor doc and the ledger row
   `cpp:Node::ok`. A compiler cannot force a hand-written `main` to ask.
 
-* **W7 [migration] — `nros::Node` deprecated, then deleted. BLOCKED, and the
-  item does not mean what it says.** After the merge `nros::Node` is the
-  DEFINITION and `rclcpp::Node` the alias (see the namespace-direction section
-  above), so a deprecation would land on the name a user is supposed to write.
-  What shipped: `NROS_CPP_DEPRECATED_MSG` exists and is used on the one
-  ours-only name this phase retired, `nros::bind_timer`. The `Node` half waits
-  on phase-428's namespace flip, and whoever lands it must migrate the 218
-  in-tree `nros::Node` sites in the same commit — a bare attribute warns at all
-  of them at once, which this doc's own "Not in scope" forbids.
+* **W7 [migration] — `nros::Node` deprecated. LANDED 2026-09-11.** The item
+  could not mean what it said until the namespace flipped, because a
+  deprecation attaches to the ALIAS and the alias was `rclcpp::Node` — the name
+  a user is supposed to write. Both halves landed together: the flip (the class
+  is `rclcpp::Node`, `nros::Node` is the alias, the tenth of RFC-0089's table)
+  and then the deprecation WITH the migration in one commit, which is what this
+  doc's "Not in scope" requires. 258 in-tree C++ spellings migrated; the
+  attribute is unconditional, and the evidence for not arming it is in the "W7
+  LANDED" section above. Probe:
+  `packages/api/nros-cpp/tests/compile/node_deprecation_probe.cpp`, greped for
+  the replacement. `one_node_type.cpp` is the one TU deliberately left
+  un-migrated — its subject IS both spellings naming one type — and its lane
+  line carries `-Wno-deprecated-declarations` saying so.
+  DELETION is a later wave: the alias stays for at least one release, for the
+  out-of-tree copies of `examples/templates/**` that `nros-v0.5.0` shipped.
 
 * **W11 [rust] — the `spin` family takes upstream's names. LANDED 2026-09-09.**
   Queued here as W12 while it was still work; `main` landed it as W11 before
@@ -1274,7 +1341,7 @@ cost are unchanged, but it becomes a hosted-only method over a `weak_ptr` behind
 
 Remaining here after the move: W2 (construction), W3 (one name, two signatures —
 now four, see the conciliation section), W4 (`ComponentNode` deleted), W5
-(`get_logger`), W7 (the `nros::Node` alias). W0 and W8 are landed.
+(`get_logger`). W0, W7 and W8 are landed.
 
 
 ## W11 [rust] — the spin family takes upstream's names — LANDED 2026-09-09
@@ -1428,6 +1495,7 @@ hosted/freestanding split phase-442 removes:
 * **W5 (`get_logger` follows ROS 2)** — unaffected.
 * **W6 (loudness)** — its `NROS_NODISCARD` half landed as W8. The `ok()` half
   is unaffected.
-* **W7 (`nros::Node` deprecated)** — subsumed: RFC-0089 already settled that
-  `nros::` is phased out entirely and ours-only names take `rclcpp::` too,
-  which RFC-0096 D1 makes structural.
+* **W7 (`nros::Node` deprecated)** — LANDED 2026-09-11, before RFC-0096, and it
+  is what RFC-0096 D1 would otherwise have had to do first: the class is in
+  `rclcpp::` and the `nros::` spelling warns. Nothing here is re-read; the
+  deletion of the alias is the wave RFC-0096 can assume.

--- a/examples/mps2-an385-freertos/cpp/action-client/src/main.cpp
+++ b/examples/mps2-an385-freertos/cpp/action-client/src/main.cpp
@@ -32,7 +32,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/mps2-an385-freertos/cpp/action-server/src/main.cpp
+++ b/examples/mps2-an385-freertos/cpp/action-server/src/main.cpp
@@ -109,7 +109,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/mps2-an385-freertos/cpp/listener/src/main.cpp
+++ b/examples/mps2-an385-freertos/cpp/listener/src/main.cpp
@@ -49,7 +49,7 @@ int nros_app_main(int argc, char** argv) {
     // from `$NROS_LOCATOR` / `$ROS_DOMAIN_ID` at runtime.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/mps2-an385-freertos/cpp/service-client/src/main.cpp
+++ b/examples/mps2-an385-freertos/cpp/service-client/src/main.cpp
@@ -52,7 +52,7 @@ int nros_app_main(int argc, char** argv) {
     }
 #endif
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/mps2-an385-freertos/cpp/service-server/src/main.cpp
+++ b/examples/mps2-an385-freertos/cpp/service-server/src/main.cpp
@@ -46,7 +46,7 @@ int nros_app_main(int argc, char** argv) {
     // (`$NROS_LOCATOR` / `$ROS_DOMAIN_ID`).
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/mps2-an385-freertos/cpp/talker/src/main.cpp
+++ b/examples/mps2-an385-freertos/cpp/talker/src/main.cpp
@@ -79,7 +79,7 @@ int nros_app_main(int argc, char** argv) {
     // defaults match the prior hand-rolled env reads.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/action-client-callback/src/main.cpp
+++ b/examples/native/cpp/action-client-callback/src/main.cpp
@@ -97,7 +97,7 @@ int nros_app_main(int argc, char** argv) {
     // (`$NROS_LOCATOR` / `$ROS_DOMAIN_ID`) active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client_cb"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/action-client/src/main.cpp
+++ b/examples/native/cpp/action-client/src/main.cpp
@@ -32,7 +32,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/action-server/src/main.cpp
+++ b/examples/native/cpp/action-server/src/main.cpp
@@ -109,7 +109,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/component-node-poc/src/main.cpp
+++ b/examples/native/cpp/component-node-poc/src/main.cpp
@@ -1,6 +1,6 @@
 /// @file main.cpp
 /// @brief Phase 242.1 + 242.2 (RFC-0044) proof — the rclcpp-faithful component
-/// model. Each node **IS-A** `nros::Node`; its **constructor** receives
+/// model. Each node **IS-A** `rclcpp::Node`; its **constructor** receives
 /// the executor-bound node handle and creates its entities (a publisher, a typed
 /// member-callback subscription, a typed member timer) as member calls. No
 /// `configure(Node&)`, no callback names, no raw bytes at the authoring surface.
@@ -45,11 +45,11 @@ class Talker : public nros::NodeWithTimers<1> {
 };
 
 // ---- Listener: IS-A node; ctor creates a typed member-callback subscription -
-class Listener : public nros::Node {
+class Listener : public rclcpp::Node {
     int recv_ = 0;
 
   public:
-    explicit Listener(nros::NodeHandle h) : nros::Node(h, "cn_listener") {
+    explicit Listener(nros::NodeHandle h) : rclcpp::Node(h, "cn_listener") {
         // Typed member-callback subscription (242.2). The macro derives Self from
         // `this`; it registers M::TYPE_NAME (DDS-mangled) + deserializes each
         // sample into a typed Int32 before dispatching to on_msg.

--- a/examples/native/cpp/component-poc/src/main.cpp
+++ b/examples/native/cpp/component-poc/src/main.cpp
@@ -34,7 +34,7 @@ class Talker {
     }
 
   public:
-    rclcpp::Result configure(nros::Node& node) {
+    rclcpp::Result configure(rclcpp::Node& node) {
         rclcpp::Result r = node.create_publisher(pub_, "/chatter");
         if (!r.ok()) return r;
         return node.create_wall_timer<Talker, &Talker::on_tick>(timer_, 500, this);
@@ -57,7 +57,7 @@ class Listener {
     }
 
   public:
-    rclcpp::Result configure(nros::Node& node) {
+    rclcpp::Result configure(rclcpp::Node& node) {
         // NB: the wire keyexpr uses the DDS-mangled type name the typed
         // `Publisher<Int32>` registers (`std_msgs::msg::dds_::Int32_`), not the
         // ROS slash form — so the raw sub must pass `Int32::TYPE_NAME` to match.
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
     // spin loop (which runs inside `run_components` and holds `&member` as the
     // dispatch context). The codegen Entry (240.2b) will own them in static
     // storage; the lifetime contract is the same.
-    nros::Node node;
+    rclcpp::Node node;
     Talker talker;
     Listener listener;
 

--- a/examples/native/cpp/listener/src/main.cpp
+++ b/examples/native/cpp/listener/src/main.cpp
@@ -49,7 +49,7 @@ int nros_app_main(int argc, char** argv) {
     // from `$NROS_LOCATOR` / `$ROS_DOMAIN_ID` at runtime.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/logging/src/main.cpp
+++ b/examples/native/cpp/logging/src/main.cpp
@@ -1,5 +1,5 @@
 /// @file main.cpp
-/// @brief Phase 88.13 — minimal nros::Node logging demo.
+/// @brief Phase 88.13 — minimal rclcpp::Node logging demo.
 ///
 /// Walks the Phase-88 macros (`NROS_LOG_TRACE` … `NROS_LOG_FATAL`)
 /// against the Node's Logger handle. The first emit auto-installs
@@ -36,7 +36,7 @@ int nros_app_main(int argc, char** argv) {
         return 1;
     }
 
-    nros::Node node;
+    rclcpp::Node node;
     auto created = nros::create_node(node, "demo");
     if (!created.ok()) {
         fprintf(stderr, "create_node failed: %d\n", created.raw());

--- a/examples/native/cpp/safety-listener/src/main.cpp
+++ b/examples/native/cpp/safety-listener/src/main.cpp
@@ -35,7 +35,7 @@ int nros_app_main(int argc, char** argv) {
     // `$NROS_LOCATOR` / `$ROS_DOMAIN_ID` at runtime.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "cpp_safety_listener"), 1);
 
     // Poll-mode subscription — the validated receive path is poll-only.

--- a/examples/native/cpp/service-client-callback/src/main.cpp
+++ b/examples/native/cpp/service-client-callback/src/main.cpp
@@ -71,7 +71,7 @@ int nros_app_main(int argc, char** argv) {
     }
 #endif
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client_cb"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/service-client/src/main.cpp
+++ b/examples/native/cpp/service-client/src/main.cpp
@@ -52,7 +52,7 @@ int nros_app_main(int argc, char** argv) {
     }
 #endif
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/service-server/src/main.cpp
+++ b/examples/native/cpp/service-server/src/main.cpp
@@ -46,7 +46,7 @@ int nros_app_main(int argc, char** argv) {
     // (`$NROS_LOCATOR` / `$ROS_DOMAIN_ID`).
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/talker/src/main.cpp
+++ b/examples/native/cpp/talker/src/main.cpp
@@ -79,7 +79,7 @@ int nros_app_main(int argc, char** argv) {
     // defaults match the prior hand-rolled env reads.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/native/cpp/transform-poc/src/main.cpp
+++ b/examples/native/cpp/transform-poc/src/main.cpp
@@ -43,7 +43,7 @@ class Source {
     }
 
   public:
-    rclcpp::Result configure(nros::Node& node) {
+    rclcpp::Result configure(rclcpp::Node& node) {
         std::setvbuf(stdout, nullptr, _IONBF, 0);
         rclcpp::Result r = node.create_publisher(pub_, "/in");
         if (!r.ok()) return r;
@@ -65,7 +65,7 @@ class Relay {
     }
 
   public:
-    rclcpp::Result configure(nros::Node& node) {
+    rclcpp::Result configure(rclcpp::Node& node) {
         std::setvbuf(stdout, nullptr, _IONBF, 0);
         rclcpp::Result r = node.create_publisher(out_, "/out");
         if (!r.ok()) return r;
@@ -82,7 +82,7 @@ class Sink {
     }
 
   public:
-    rclcpp::Result configure(nros::Node& node) {
+    rclcpp::Result configure(rclcpp::Node& node) {
         std::setvbuf(stdout, nullptr, _IONBF, 0);
         rclcpp::Result r =
             nros::bind_subscription_raw<Sink, &Sink::on_out>(node, "/out", Int32::TYPE_NAME, this);
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
     const char* role = (argc > 1) ? argv[1] : "relay";
     std::printf("transform-poc role=%s\n", role);
 
-    nros::Node node;
+    rclcpp::Node node;
     Source source;
     Relay relay;
     Sink sink;

--- a/examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/NrosUorbBridge.cpp
+++ b/examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/NrosUorbBridge.cpp
@@ -129,8 +129,8 @@ class NrosUorbBridge : public ModuleBase<NrosUorbBridge>, public px4::ScheduledW
   private:
     void Run() override;
 
-    nros::Node _in_node{};
-    nros::Node _out_node{};
+    rclcpp::Node _in_node{};
+    rclcpp::Node _out_node{};
     rclcpp::Subscription<px4_msgs::msg::DebugKeyValue> _in_sub{};
     rclcpp::Publisher<px4_msgs::msg::DebugKeyValue> _out_pub{};
 
@@ -174,7 +174,7 @@ bool NrosUorbBridge::init() {
     PX4_INFO("outward %s locator: %s", NROS_BRIDGE_RMW, out_locator);
     // Issue 0436 — `nros_cpp_init_multi` (NOT `nros_init_multi`/`MultiExecutor`):
     // it opens the sessions into a real `CppContext`, which is the handle type
-    // `nros::Node` / `NodeBuilder` expect. The bridge crate's handle is a different
+    // `rclcpp::Node` / `NodeBuilder` expect. The bridge crate's handle is a different
     // struct behind the same `void*`; both start with an `Executor` so the cast
     // reads fine and then writes over the box's `Vec` — PX4 dumped core.
     //

--- a/examples/px4/cpp/firmware/src/modules/nros_uorb_demo/NrosUorbDemo.cpp
+++ b/examples/px4/cpp/firmware/src/modules/nros_uorb_demo/NrosUorbDemo.cpp
@@ -54,7 +54,7 @@ namespace {
 
 // Type tags, not message definitions.
 //
-// nros::Node::create_publisher<M> needs M::TYPE_NAME and M::TYPE_HASH; the typed
+// rclcpp::Node::create_publisher<M> needs M::TYPE_NAME and M::TYPE_HASH; the typed
 // publish() path would additionally need M::ffi_publish, and we never call it.
 // On uORB both strings are IGNORED — topic identity is the orb_metadata pointer
 // registered below — so the ROS type name is carried for documentation and for
@@ -96,7 +96,7 @@ class NrosUorbDemo : public ModuleBase<NrosUorbDemo>, public px4::ScheduledWorkI
   private:
     void Run() override;
 
-    nros::Node _node{};
+    rclcpp::Node _node{};
     rclcpp::Publisher<DebugKeyValueTag> _debug_pub{};
     rclcpp::Subscription<VehicleStatusTag> _status_sub{};
 

--- a/examples/qemu-armv7a-nuttx/cpp/action-client/src/main.cpp
+++ b/examples/qemu-armv7a-nuttx/cpp/action-client/src/main.cpp
@@ -32,7 +32,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/qemu-armv7a-nuttx/cpp/action-server/src/main.cpp
+++ b/examples/qemu-armv7a-nuttx/cpp/action-server/src/main.cpp
@@ -109,7 +109,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/qemu-armv7a-nuttx/cpp/listener/src/main.cpp
+++ b/examples/qemu-armv7a-nuttx/cpp/listener/src/main.cpp
@@ -49,7 +49,7 @@ int nros_app_main(int argc, char** argv) {
     // from `$NROS_LOCATOR` / `$ROS_DOMAIN_ID` at runtime.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/qemu-armv7a-nuttx/cpp/service-client/src/main.cpp
+++ b/examples/qemu-armv7a-nuttx/cpp/service-client/src/main.cpp
@@ -52,7 +52,7 @@ int nros_app_main(int argc, char** argv) {
     }
 #endif
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/qemu-armv7a-nuttx/cpp/service-server/src/main.cpp
+++ b/examples/qemu-armv7a-nuttx/cpp/service-server/src/main.cpp
@@ -46,7 +46,7 @@ int nros_app_main(int argc, char** argv) {
     // (`$NROS_LOCATOR` / `$ROS_DOMAIN_ID`).
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/qemu-armv7a-nuttx/cpp/talker/src/main.cpp
+++ b/examples/qemu-armv7a-nuttx/cpp/talker/src/main.cpp
@@ -79,7 +79,7 @@ int nros_app_main(int argc, char** argv) {
     // defaults match the prior hand-rolled env reads.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/rv-virt-threadx/cpp/action-client/src/main.cpp
+++ b/examples/rv-virt-threadx/cpp/action-client/src/main.cpp
@@ -32,7 +32,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/rv-virt-threadx/cpp/action-server/src/main.cpp
+++ b/examples/rv-virt-threadx/cpp/action-server/src/main.cpp
@@ -109,7 +109,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/rv-virt-threadx/cpp/listener/src/main.cpp
+++ b/examples/rv-virt-threadx/cpp/listener/src/main.cpp
@@ -49,7 +49,7 @@ int nros_app_main(int argc, char** argv) {
     // from `$NROS_LOCATOR` / `$ROS_DOMAIN_ID` at runtime.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/rv-virt-threadx/cpp/service-client/src/main.cpp
+++ b/examples/rv-virt-threadx/cpp/service-client/src/main.cpp
@@ -52,7 +52,7 @@ int nros_app_main(int argc, char** argv) {
     }
 #endif
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/rv-virt-threadx/cpp/service-server/src/main.cpp
+++ b/examples/rv-virt-threadx/cpp/service-server/src/main.cpp
@@ -46,7 +46,7 @@ int nros_app_main(int argc, char** argv) {
     // (`$NROS_LOCATOR` / `$ROS_DOMAIN_ID`).
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/rv-virt-threadx/cpp/talker/src/main.cpp
+++ b/examples/rv-virt-threadx/cpp/talker/src/main.cpp
@@ -79,7 +79,7 @@ int nros_app_main(int argc, char** argv) {
     // defaults match the prior hand-rolled env reads.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
+++ b/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
@@ -19,7 +19,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_listener_pkg

--- a/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/src/Listener.cpp
+++ b/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::rclcpp::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::rclcpp::Node& node) {
     std::setvbuf(stdout, nullptr, _IONBF, 0);
     // Typed member binding (RFC-0044): keyexpr + deserialize come from the
     // generated `std_msgs::msg::Int32` (issue #218 — hand-decode retired).

--- a/examples/templates/multi-node-workspace-cpp/README.md
+++ b/examples/templates/multi-node-workspace-cpp/README.md
@@ -7,7 +7,7 @@ the same Node pkg / Bringup pkg / Entry pkg shape, built with CMake.
 ## Layout
 
 - `src/talker_pkg/`, `src/listener_pkg/` — typed components (RFC-0043):
-  `Result configure(nros::Node&)`; the talker binds a 500 ms `create_wall_timer<Talker, &Talker::on_tick>`
+  `Result configure(rclcpp::Node&)`; the talker binds a 500 ms `create_wall_timer<Talker, &Talker::on_tick>`
   publishing `std_msgs/Int32` on `/chatter`; the listener uses
   `bind_subscription` (typed member callback on the generated `std_msgs::msg::Int32`).
 - `src/demo_bringup/` — `package.xml` + `system.toml` + `launch/`

--- a/examples/templates/multi-node-workspace-cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
+++ b/examples/templates/multi-node-workspace-cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
@@ -20,7 +20,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace listener_pkg

--- a/examples/templates/multi-node-workspace-cpp/src/listener_pkg/src/Listener.cpp
+++ b/examples/templates/multi-node-workspace-cpp/src/listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::rclcpp::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::rclcpp::Node& node) {
     std::setvbuf(stdout, nullptr, _IONBF, 0);
     // The typed `Publisher<Int32>` registers the DDS-mangled keyexpr, so the
     // raw sub must match on `Int32::TYPE_NAME` (240.1 finding; raw↔typed

--- a/examples/templates/multi-node-workspace-cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
+++ b/examples/templates/multi-node-workspace-cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
@@ -20,7 +20,7 @@ class Talker {
     void on_tick(); // real body; bound via &Talker::on_tick (no callback name)
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace talker_pkg

--- a/examples/templates/multi-node-workspace-cpp/src/talker_pkg/src/Talker.cpp
+++ b/examples/templates/multi-node-workspace-cpp/src/talker_pkg/src/Talker.cpp
@@ -15,7 +15,7 @@ void Talker::on_tick() {
     }
 }
 
-::rclcpp::Result Talker::configure(::nros::Node& node) {
+::rclcpp::Result Talker::configure(::rclcpp::Node& node) {
     std::setvbuf(stdout, nullptr, _IONBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;

--- a/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.cpp
+++ b/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.cpp
@@ -15,7 +15,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
                 ++recv_);
 }
 
-::rclcpp::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::rclcpp::Node& node) {
     // Typed member binding (RFC-0044): keyexpr + deserialize come from the
     // generated `std_msgs::msg::Int32` (issue #218 — hand-decode retired).
     ::rclcpp::Result r =

--- a/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.hpp
+++ b/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.hpp
@@ -22,7 +22,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // real body; bound by identity
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace pkg_cpp_listener

--- a/examples/templates/topic-state-monitor-port/README.md
+++ b/examples/templates/topic-state-monitor-port/README.md
@@ -33,7 +33,7 @@ ZENOH_CONFIG_OVERRIDE='listen/endpoints=["tcp/127.0.0.1:7447"];scouting/multicas
 
 ## Gap surfaced (filed against Phase 209.A)
 
-`nros::Node::create_subscription`'s **callback overload is SFINAE-restricted
+`rclcpp::Node::create_subscription`'s **callback overload is SFINAE-restricted
 to plain `void(*)(const M&)` function pointers** (`std::enable_if<
 std::is_convertible<F, void(*)(const M&)>::value>`). rclcpp accepts capturing
 lambdas / `std::function`. A direct line-for-line port of upstream

--- a/examples/threadx-linux/cpp/action-client/src/main.cpp
+++ b/examples/threadx-linux/cpp/action-client/src/main.cpp
@@ -32,7 +32,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/threadx-linux/cpp/action-server/src/main.cpp
+++ b/examples/threadx-linux/cpp/action-server/src/main.cpp
@@ -109,7 +109,7 @@ int nros_app_main(int argc, char** argv) {
     // Launch-aware init. Env overlay active today.
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/threadx-linux/cpp/listener/src/main.cpp
+++ b/examples/threadx-linux/cpp/listener/src/main.cpp
@@ -49,7 +49,7 @@ int nros_app_main(int argc, char** argv) {
     // from `$NROS_LOCATOR` / `$ROS_DOMAIN_ID` at runtime.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/threadx-linux/cpp/service-client/src/main.cpp
+++ b/examples/threadx-linux/cpp/service-client/src/main.cpp
@@ -52,7 +52,7 @@ int nros_app_main(int argc, char** argv) {
     }
 #endif
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/threadx-linux/cpp/service-server/src/main.cpp
+++ b/examples/threadx-linux/cpp/service-server/src/main.cpp
@@ -46,7 +46,7 @@ int nros_app_main(int argc, char** argv) {
     // (`$NROS_LOCATOR` / `$ROS_DOMAIN_ID`).
     NROS_TRY_RET(nros::init_with_launch_auto(argc, argv), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/threadx-linux/cpp/talker/src/main.cpp
+++ b/examples/threadx-linux/cpp/talker/src/main.cpp
@@ -79,7 +79,7 @@ int nros_app_main(int argc, char** argv) {
     // defaults match the prior hand-rolled env reads.
     NROS_TRY_RET(nros::init(), 1);
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 

--- a/examples/workspaces/cpp/src/action_client_pkg/include/action_client_pkg/FibClient.hpp
+++ b/examples/workspaces/cpp/src/action_client_pkg/include/action_client_pkg/FibClient.hpp
@@ -55,7 +55,7 @@ class FibClient {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace action_client_pkg

--- a/examples/workspaces/cpp/src/action_client_pkg/src/FibClient.cpp
+++ b/examples/workspaces/cpp/src/action_client_pkg/src/FibClient.cpp
@@ -92,7 +92,7 @@ void FibClient::on_tick() {
     }
 }
 
-::rclcpp::Result FibClient::configure(::nros::Node& node) {
+::rclcpp::Result FibClient::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     phase_ = Idle;
     waits_ = 0;

--- a/examples/workspaces/cpp/src/action_server_pkg/include/action_server_pkg/FibServer.hpp
+++ b/examples/workspaces/cpp/src/action_server_pkg/include/action_server_pkg/FibServer.hpp
@@ -35,7 +35,7 @@ class FibServer {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace action_server_pkg

--- a/examples/workspaces/cpp/src/action_server_pkg/src/FibServer.cpp
+++ b/examples/workspaces/cpp/src/action_server_pkg/src/FibServer.cpp
@@ -69,7 +69,7 @@ void FibServer::on_tick() {
     }
 }
 
-::rclcpp::Result FibServer::configure(::nros::Node& node) {
+::rclcpp::Result FibServer::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr picolibc lacks the std:: name.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     executor_ = node.executor_handle();

--- a/examples/workspaces/cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
+++ b/examples/workspaces/cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
@@ -21,7 +21,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace listener_pkg

--- a/examples/workspaces/cpp/src/listener_pkg/src/Listener.cpp
+++ b/examples/workspaces/cpp/src/listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::rclcpp::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr's picolibc <cstdio> does not put
     // setvbuf in namespace std; the C global is available on every platform.
     ::setvbuf(stdout, nullptr, _IONBF, 0);

--- a/examples/workspaces/cpp/src/service_client_pkg/include/service_client_pkg/AddClient.hpp
+++ b/examples/workspaces/cpp/src/service_client_pkg/include/service_client_pkg/AddClient.hpp
@@ -32,7 +32,7 @@ class AddClient {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace service_client_pkg

--- a/examples/workspaces/cpp/src/service_client_pkg/src/AddClient.cpp
+++ b/examples/workspaces/cpp/src/service_client_pkg/src/AddClient.cpp
@@ -41,7 +41,7 @@ void AddClient::on_tick() {
     }
 }
 
-::rclcpp::Result AddClient::configure(::nros::Node& node) {
+::rclcpp::Result AddClient::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     ::rclcpp::Result r =
         ::nros::create_service_client_raw(node, client_.bytes, "/add_two_ints", Svc::TYPE_NAME);

--- a/examples/workspaces/cpp/src/service_server_pkg/include/service_server_pkg/AddServer.hpp
+++ b/examples/workspaces/cpp/src/service_server_pkg/include/service_server_pkg/AddServer.hpp
@@ -18,7 +18,7 @@ class AddServer {
     Svc::Response on_request(const Svc::Request& req);
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace service_server_pkg

--- a/examples/workspaces/cpp/src/service_server_pkg/src/AddServer.cpp
+++ b/examples/workspaces/cpp/src/service_server_pkg/src/AddServer.cpp
@@ -16,7 +16,7 @@ AddServer::on_request(const example_interfaces::srv::AddTwoInts::Request& req) {
     return resp;
 }
 
-::rclcpp::Result AddServer::configure(::nros::Node& node) {
+::rclcpp::Result AddServer::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr picolibc lacks the std:: name.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     ::rclcpp::Result r =

--- a/examples/workspaces/cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
+++ b/examples/workspaces/cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
@@ -21,7 +21,7 @@ class Talker {
     void on_tick(); // real body; bound via &Talker::on_tick (no callback name)
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace talker_pkg

--- a/examples/workspaces/cpp/src/talker_pkg/src/Talker.cpp
+++ b/examples/workspaces/cpp/src/talker_pkg/src/Talker.cpp
@@ -21,7 +21,7 @@ void Talker::on_tick() {
     NROS_LOG_INFO(nros_log_default_logger(), "cpp_talker logging seq=%d", m.data);
 }
 
-::rclcpp::Result Talker::configure(::nros::Node& node) {
+::rclcpp::Result Talker::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr's picolibc <cstdio> does not put
     // setvbuf in namespace std; the C global is available on every platform.
     ::setvbuf(stdout, nullptr, _IONBF, 0);

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
@@ -18,7 +18,7 @@ class LifecycleTalker {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
@@ -33,7 +33,7 @@ class ManagedTalker : public ::nros::LifecycleNode {
     ::nros::CallbackReturn on_deactivate(::nros::LifecycleState previous) override;
 
     // Component install hook.
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
@@ -18,7 +18,7 @@ void LifecycleTalker::on_tick() {
     }
 }
 
-::rclcpp::Result LifecycleTalker::configure(::nros::Node& node) {
+::rclcpp::Result LifecycleTalker::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
@@ -39,7 +39,7 @@ void ManagedTalker::on_tick() {
     }
 }
 
-::rclcpp::Result ManagedTalker::configure(::nros::Node& node) {
+::rclcpp::Result ManagedTalker::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     // Two-phase: bind the executor handle the component install exposes.
     bind(node.executor_handle());

--- a/examples/workspaces/features/src/cpp_param_talker_pkg/include/cpp_param_talker_pkg/ParamTalker.hpp
+++ b/examples/workspaces/features/src/cpp_param_talker_pkg/include/cpp_param_talker_pkg/ParamTalker.hpp
@@ -18,7 +18,7 @@ class ParamTalker {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_param_talker_pkg

--- a/examples/workspaces/features/src/cpp_param_talker_pkg/src/ParamTalker.cpp
+++ b/examples/workspaces/features/src/cpp_param_talker_pkg/src/ParamTalker.cpp
@@ -24,7 +24,7 @@ void ParamTalker::on_tick() {
     }
 }
 
-::rclcpp::Result ParamTalker::configure(::nros::Node& node) {
+::rclcpp::Result ParamTalker::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     executor_handle_ = node.executor_handle();
     ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");

--- a/examples/workspaces/features/src/cpp_qos_listener_pkg/include/cpp_qos_listener_pkg/QosListener.hpp
+++ b/examples/workspaces/features/src/cpp_qos_listener_pkg/include/cpp_qos_listener_pkg/QosListener.hpp
@@ -22,7 +22,7 @@ class QosListener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_qos_listener_pkg

--- a/examples/workspaces/features/src/cpp_qos_listener_pkg/src/QosListener.cpp
+++ b/examples/workspaces/features/src/cpp_qos_listener_pkg/src/QosListener.cpp
@@ -16,7 +16,7 @@ void QosListener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::rclcpp::Result QosListener::configure(::nros::Node& node) {
+::rclcpp::Result QosListener::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `Received:` flushes live.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     // Byte-identical to the talker's profile — both endpoints must declare the same

--- a/examples/workspaces/features/src/cpp_qos_talker_pkg/include/cpp_qos_talker_pkg/QosTalker.hpp
+++ b/examples/workspaces/features/src/cpp_qos_talker_pkg/include/cpp_qos_talker_pkg/QosTalker.hpp
@@ -22,7 +22,7 @@ class QosTalker {
     void on_tick(); // real body; bound via &QosTalker::on_tick (no callback name)
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_qos_talker_pkg

--- a/examples/workspaces/features/src/cpp_qos_talker_pkg/src/QosTalker.cpp
+++ b/examples/workspaces/features/src/cpp_qos_talker_pkg/src/QosTalker.cpp
@@ -19,7 +19,7 @@ void QosTalker::on_tick() {
     }
 }
 
-::rclcpp::Result QosTalker::configure(::nros::Node& node) {
+::rclcpp::Result QosTalker::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `Published:` flushes
     // immediately when piped (the test reads the output live).
     ::setvbuf(stdout, nullptr, _IOLBF, 0);

--- a/examples/workspaces/features/src/cpp_reading_listener_pkg/include/cpp_reading_listener_pkg/ReadingListener.hpp
+++ b/examples/workspaces/features/src/cpp_reading_listener_pkg/include/cpp_reading_listener_pkg/ReadingListener.hpp
@@ -21,7 +21,7 @@ class ReadingListener {
     void on_reading(const ::custom_msgs::msg::Reading& msg); // typed member callback
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_reading_listener_pkg

--- a/examples/workspaces/features/src/cpp_reading_listener_pkg/src/ReadingListener.cpp
+++ b/examples/workspaces/features/src/cpp_reading_listener_pkg/src/ReadingListener.cpp
@@ -14,7 +14,7 @@ void ReadingListener::on_reading(const ::custom_msgs::msg::Reading& msg) {
     ++recv_;
 }
 
-::rclcpp::Result ReadingListener::configure(::nros::Node& node) {
+::rclcpp::Result ReadingListener::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `reading seq=` flushes live.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     // Typed member binding (RFC-0044 §242.2): keyexpr + deserialize come from

--- a/examples/workspaces/features/src/cpp_reading_talker_pkg/include/cpp_reading_talker_pkg/ReadingTalker.hpp
+++ b/examples/workspaces/features/src/cpp_reading_talker_pkg/include/cpp_reading_talker_pkg/ReadingTalker.hpp
@@ -24,7 +24,7 @@ class ReadingTalker {
     void on_tick(); // real body; bound via &ReadingTalker::on_tick
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_reading_talker_pkg

--- a/examples/workspaces/features/src/cpp_reading_talker_pkg/src/ReadingTalker.cpp
+++ b/examples/workspaces/features/src/cpp_reading_talker_pkg/src/ReadingTalker.cpp
@@ -22,7 +22,7 @@ void ReadingTalker::on_tick() {
     count_++;
 }
 
-::rclcpp::Result ReadingTalker::configure(::nros::Node& node) {
+::rclcpp::Result ReadingTalker::configure(::rclcpp::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `sent seq=` flushes live.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/reading");

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
@@ -18,7 +18,7 @@ class LifecycleTalker {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
@@ -33,7 +33,7 @@ class ManagedTalker : public ::nros::LifecycleNode {
     ::nros::CallbackReturn on_deactivate(::nros::LifecycleState previous) override;
 
     // Component install hook.
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
@@ -18,7 +18,7 @@ void LifecycleTalker::on_tick() {
     }
 }
 
-::rclcpp::Result LifecycleTalker::configure(::nros::Node& node) {
+::rclcpp::Result LifecycleTalker::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
@@ -39,7 +39,7 @@ void ManagedTalker::on_tick() {
     }
 }
 
-::rclcpp::Result ManagedTalker::configure(::nros::Node& node) {
+::rclcpp::Result ManagedTalker::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     // Two-phase: bind the executor handle the component install exposes.
     bind(node.executor_handle());

--- a/examples/workspaces/mixed/src/cpp_add_client_pkg/include/cpp_add_client_pkg/AddClient.hpp
+++ b/examples/workspaces/mixed/src/cpp_add_client_pkg/include/cpp_add_client_pkg/AddClient.hpp
@@ -32,7 +32,7 @@ class AddClient {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_add_client_pkg

--- a/examples/workspaces/mixed/src/cpp_add_client_pkg/src/AddClient.cpp
+++ b/examples/workspaces/mixed/src/cpp_add_client_pkg/src/AddClient.cpp
@@ -41,7 +41,7 @@ void AddClient::on_tick() {
     }
 }
 
-::rclcpp::Result AddClient::configure(::nros::Node& node) {
+::rclcpp::Result AddClient::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     ::rclcpp::Result r =
         ::nros::create_service_client_raw(node, client_.bytes, "/add_two_ints", Svc::TYPE_NAME);

--- a/examples/workspaces/mixed/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
+++ b/examples/workspaces/mixed/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
@@ -19,7 +19,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_listener_pkg

--- a/examples/workspaces/mixed/src/cpp_listener_pkg/src/Listener.cpp
+++ b/examples/workspaces/mixed/src/cpp_listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::rclcpp::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::rclcpp::Node& node) {
     // `::setvbuf`, not `std::setvbuf` — Zephyr picolibc declares it only at global scope
     // (phase-263 C2c-zephyr; same fix as the cpp workspace listener).
     ::setvbuf(stdout, nullptr, _IONBF, 0);

--- a/examples/workspaces/realtime-cpp/README.md
+++ b/examples/workspaces/realtime-cpp/README.md
@@ -13,7 +13,7 @@ not in node code.
 
 Tiers live in `src/demo_bringup/system.toml` (`[tiers.high]` / `[tiers.low]` +
 `[[component]].group_tiers`); the components are configure-shape
-(`Result configure(nros::Node&)`).
+(`Result configure(rclcpp::Node&)`).
 
 ## Run
 

--- a/examples/workspaces/realtime-cpp/src/aux_pkg/include/aux_pkg/Aux.hpp
+++ b/examples/workspaces/realtime-cpp/src/aux_pkg/include/aux_pkg/Aux.hpp
@@ -21,7 +21,7 @@ class Aux {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace aux_pkg

--- a/examples/workspaces/realtime-cpp/src/aux_pkg/src/Aux.cpp
+++ b/examples/workspaces/realtime-cpp/src/aux_pkg/src/Aux.cpp
@@ -22,7 +22,7 @@ void Aux::on_tick() {
     count_++;
 }
 
-::rclcpp::Result Aux::configure(::nros::Node& node) {
+::rclcpp::Result Aux::configure(::rclcpp::Node& node) {
     // Line-buffer stdout so each tick flushes immediately when piped.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/aux");

--- a/examples/workspaces/realtime-cpp/src/ctrl_pkg/include/ctrl_pkg/Ctrl.hpp
+++ b/examples/workspaces/realtime-cpp/src/ctrl_pkg/include/ctrl_pkg/Ctrl.hpp
@@ -19,7 +19,7 @@ class Ctrl {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace ctrl_pkg

--- a/examples/workspaces/realtime-cpp/src/ctrl_pkg/src/Ctrl.cpp
+++ b/examples/workspaces/realtime-cpp/src/ctrl_pkg/src/Ctrl.cpp
@@ -21,7 +21,7 @@ void Ctrl::on_tick() {
     count_++;
 }
 
-::rclcpp::Result Ctrl::configure(::nros::Node& node) {
+::rclcpp::Result Ctrl::configure(::rclcpp::Node& node) {
     // Line-buffer stdout so each tick flushes immediately when piped.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/ctrl");

--- a/examples/workspaces/realtime-cpp/src/telem_pkg/include/telem_pkg/Telem.hpp
+++ b/examples/workspaces/realtime-cpp/src/telem_pkg/include/telem_pkg/Telem.hpp
@@ -19,7 +19,7 @@ class Telem {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace telem_pkg

--- a/examples/workspaces/realtime-cpp/src/telem_pkg/src/Telem.cpp
+++ b/examples/workspaces/realtime-cpp/src/telem_pkg/src/Telem.cpp
@@ -20,7 +20,7 @@ void Telem::on_tick() {
     count_++;
 }
 
-::rclcpp::Result Telem::configure(::nros::Node& node) {
+::rclcpp::Result Telem::configure(::rclcpp::Node& node) {
     // Line-buffer stdout so each tick flushes immediately when piped.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/telem");

--- a/examples/workspaces/safety/src/cpp_safety_listener_pkg/include/cpp_safety_listener_pkg/SafetyListener.hpp
+++ b/examples/workspaces/safety/src/cpp_safety_listener_pkg/include/cpp_safety_listener_pkg/SafetyListener.hpp
@@ -28,7 +28,7 @@ class SafetyListener {
     void on_chatter(const std_msgs::msg::Int32& msg, const nros_cpp_integrity_status_t& status);
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_safety_listener_pkg

--- a/examples/workspaces/safety/src/cpp_safety_listener_pkg/src/SafetyListener.cpp
+++ b/examples/workspaces/safety/src/cpp_safety_listener_pkg/src/SafetyListener.cpp
@@ -49,7 +49,7 @@ void SafetyListener::on_chatter(const std_msgs::msg::Int32& msg,
     }
 }
 
-::rclcpp::Result SafetyListener::configure(::nros::Node& node) {
+::rclcpp::Result SafetyListener::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     g_safety_listener_self = this;
 

--- a/examples/workspaces/safety/src/cpp_safety_talker_pkg/include/cpp_safety_talker_pkg/SafetyTalker.hpp
+++ b/examples/workspaces/safety/src/cpp_safety_talker_pkg/include/cpp_safety_talker_pkg/SafetyTalker.hpp
@@ -18,7 +18,7 @@ class SafetyTalker {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace cpp_safety_talker_pkg

--- a/examples/workspaces/safety/src/cpp_safety_talker_pkg/src/SafetyTalker.cpp
+++ b/examples/workspaces/safety/src/cpp_safety_talker_pkg/src/SafetyTalker.cpp
@@ -18,7 +18,7 @@ void SafetyTalker::on_tick() {
     }
 }
 
-::rclcpp::Result SafetyTalker::configure(::nros::Node& node) {
+::rclcpp::Result SafetyTalker::configure(::rclcpp::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;

--- a/examples/zephyr/cpp/action-client/src/FibonacciClient.cpp
+++ b/examples/zephyr/cpp/action-client/src/FibonacciClient.cpp
@@ -53,7 +53,7 @@ void FibonacciClient::on_result(const uint8_t* /*goal_id*/, int32_t /*status*/, 
     print_sequence("Result received: ", data, len);
 }
 
-::rclcpp::Result FibonacciClient::configure(::nros::Node& node) {
+::rclcpp::Result FibonacciClient::configure(::rclcpp::Node& node) {
     // Unbuffered stdout — the callback prints only on transitions, so a
     // full-buffered console would swallow them when the harness kills the QEMU.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc

--- a/examples/zephyr/cpp/action-client/src/FibonacciClient.hpp
+++ b/examples/zephyr/cpp/action-client/src/FibonacciClient.hpp
@@ -26,7 +26,7 @@ class FibonacciClient {
     void on_result(const uint8_t goal_id[16], int32_t status, const uint8_t* data, size_t len);
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace zephyr_cpp_action_client

--- a/examples/zephyr/cpp/action-server/src/FibonacciServer.cpp
+++ b/examples/zephyr/cpp/action-server/src/FibonacciServer.cpp
@@ -89,7 +89,7 @@ void FibonacciServer::on_tick() {
     }
 }
 
-::rclcpp::Result FibonacciServer::configure(::nros::Node& node) {
+::rclcpp::Result FibonacciServer::configure(::rclcpp::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc

--- a/examples/zephyr/cpp/action-server/src/FibonacciServer.hpp
+++ b/examples/zephyr/cpp/action-server/src/FibonacciServer.hpp
@@ -33,7 +33,7 @@ class FibonacciServer {
     void on_tick();
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace zephyr_cpp_action_server

--- a/examples/zephyr/cpp/listener/src/Listener.cpp
+++ b/examples/zephyr/cpp/listener/src/Listener.cpp
@@ -17,7 +17,7 @@ void Listener::on_raw(const uint8_t* data, size_t len) {
     }
 }
 
-::rclcpp::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::rclcpp::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc

--- a/examples/zephyr/cpp/listener/src/Listener.hpp
+++ b/examples/zephyr/cpp/listener/src/Listener.hpp
@@ -22,7 +22,7 @@ class Listener {
     void on_raw(const uint8_t* data, size_t len); // real body; bound by identity
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace zephyr_cpp_listener

--- a/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.cpp
+++ b/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.cpp
@@ -50,7 +50,7 @@ void AddTwoIntsClient::on_tick() {
     }
 }
 
-::rclcpp::Result AddTwoIntsClient::configure(::nros::Node& node) {
+::rclcpp::Result AddTwoIntsClient::configure(::rclcpp::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc

--- a/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.hpp
+++ b/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.hpp
@@ -26,7 +26,7 @@ class AddTwoIntsClient {
     void on_tick(); // send / poll driver, bound by identity
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace zephyr_cpp_service_client

--- a/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.cpp
+++ b/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.cpp
@@ -44,7 +44,7 @@ bool AddTwoIntsServer::handle_add(const uint8_t* req, size_t req_len, uint8_t* r
     return true;
 }
 
-::rclcpp::Result AddTwoIntsServer::configure(::nros::Node& node) {
+::rclcpp::Result AddTwoIntsServer::configure(::rclcpp::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc

--- a/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.hpp
+++ b/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.hpp
@@ -21,7 +21,7 @@ class AddTwoIntsServer {
                     size_t* resp_len);
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace zephyr_cpp_service_server

--- a/examples/zephyr/cpp/talker/src/Talker.cpp
+++ b/examples/zephyr/cpp/talker/src/Talker.cpp
@@ -20,7 +20,7 @@ void Talker::on_tick() {
     }
 }
 
-::rclcpp::Result Talker::configure(::nros::Node& node) {
+::rclcpp::Result Talker::configure(::rclcpp::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc

--- a/examples/zephyr/cpp/talker/src/Talker.hpp
+++ b/examples/zephyr/cpp/talker/src/Talker.hpp
@@ -21,7 +21,7 @@ class Talker {
     void on_tick(); // real body, bound by identity
 
   public:
-    ::rclcpp::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::rclcpp::Node& node);
 };
 
 } // namespace zephyr_cpp_talker

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -940,8 +940,13 @@ cpp: cpp-fmt
     # stops compiling at `declare_parameter`, which is W2 working, not a
     # regression. The freestanding half has its own probe below and correctly
     # takes no flag.
+    # `-Wno-deprecated-declarations`: this TU names `nros::Node` ON PURPOSE --
+    # it is the one file in the tree left un-migrated by phase-427 W7, because
+    # its whole subject is that BOTH spellings name one type. The negative twin
+    # below asserts the attribute fires.
     echo "  - one node type: hosted shape + both create families (c++14, -DNROS_CPP_STD)"
     c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti -DNROS_CPP_STD=1 \
+        -Wno-deprecated-declarations \
         -Itarget/nros-cpp-generated \
         -Itarget/nros-c-generated \
         -Ipackages/api/nros-cpp/include \
@@ -957,6 +962,44 @@ cpp: cpp-fmt
         -Ipackages/api/nros-c/include \
         -Ipackages/platform/nros-platform-api/include \
         packages/api/nros-cpp/tests/compile/one_node_type_freestanding.cpp
+    # phase-427 W7 — ...and the deprecated `nros::Node` spelling WARNS.
+    #
+    # The positive twin is `one_node_type.cpp` above: one type, two names. This
+    # is the other half — one of those names is on its way out, and a
+    # deprecation nobody is told about is just an alias. NEGATIVE assertion,
+    # because a clean compile is exactly what a silently-dropped attribute looks
+    # like, and asserted-present first, because a missing file is also a
+    # non-zero `c++` and reads as a pass.
+    test -f packages/api/nros-cpp/tests/compile/node_deprecation_probe.cpp || { \
+        echo "ERROR: node_deprecation_probe.cpp is MISSING -- the expected-failure" >&2; \
+        echo "       check below would PASS on a missing file." >&2; \
+        exit 1; \
+    }
+    echo "  - ...and the deprecated nros::Node spelling WARNS"
+    mkdir -p tmp
+    if c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti -DNROS_CPP_STD=1 \
+        -Werror=deprecated-declarations \
+        -Itarget/nros-cpp-generated \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-cpp/include \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-cpp/tests/compile/node_deprecation_probe.cpp \
+        > tmp/refuse-nros-node.log 2>&1; then \
+        echo "ERROR: nros::Node no longer warns. RFC-0089 phases the nros:: vocabulary" >&2; \
+        echo "       out, and this attribute is the only thing telling a consumer who" >&2; \
+        echo "       copied examples/templates/** out of nros-v0.5.0 to write" >&2; \
+        echo "       rclcpp::Node instead." >&2; \
+        exit 1; \
+    fi
+    # "It failed" is also what a typo produces: the diagnostic must name the
+    # replacement, because that naming IS the migration.
+    nros_grep_q 'write rclcpp::Node' tmp/refuse-nros-node.log && _rc=0 || _rc=$?
+    if [ "$_rc" -ne 0 ]; then \
+        echo "ERROR: the nros::Node deprecation no longer names its replacement." >&2; \
+        echo "       See tmp/refuse-nros-node.log." >&2; \
+        exit 1; \
+    fi
     # Expected-failure, asserted-present first for the reason every other
     # probe of this shape is: a missing file is also a non-zero c++, and reads
     # as a pass.

--- a/justfile
+++ b/justfile
@@ -5043,7 +5043,7 @@ book:
     #!/usr/bin/env bash
     set -e
     rm -rf target/doc target/doxygen
-    # `nros::Executor`, `nros::Promise`, `nros::Node`, etc. only re-export
+    # `nros::Executor`, `nros::Promise`, `rclcpp::Node`, etc. only re-export
     # under an rmw feature, so pass an rmw + platform combo or the deployed
     # rustdoc omits the public-facing types and the reference stub's
     # `[Executor](struct.Executor.html)` link 404s.

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -127,7 +127,7 @@ packages = ["cmake", "clang"]
 version = "0.5.0-nros1"
 front = ["bin/nros"]
 smoke = [
-    { run = "bin/nros --codegen-version", expect = "3" },
+    { run = "bin/nros --codegen-version", expect = "4" },
 ]
 upstream = "32b0d2efe61ec66a1cb6c0ff4c780c0f0bc8f10c" # = source.ref
 [tool.nros.source]

--- a/packages/api/nros-c/include/nros/nros_config_generated_nuttx.h
+++ b/packages/api/nros-c/include/nros/nros_config_generated_nuttx.h
@@ -25,7 +25,7 @@
  * Fourth recurrence of this file's documented drift class (#167, #464, 0954
  * below are the others), and the first that is a hard compile error rather
  * than a silent under-size. Gated now: `check-nuttx-fallback-config-macros`. */
-#define NROS_CODEGEN_VERSION 3
+#define NROS_CODEGEN_VERSION 4
 #define NROS_CODEGEN_VERSION_MIN 2
 /* #167 — safe upper bound (was 79296, stale): current codegen needs ~80704 on
  * rv-virt; too-small here overflows the executor storage buffer. Keep above the
@@ -96,7 +96,7 @@
  * tree the runtime rejects. Gated by `check-config-fallback-macros`, which
  * requires every macro a generated artifact reads to be defined here AND
  * requires these two to equal the Rust constants. */
-#define NROS_CODEGEN_VERSION 3
+#define NROS_CODEGEN_VERSION 4
 #define NROS_CODEGEN_VERSION_MIN 2
 
 /* Issue 0464 — this file is a hand-maintained SNAPSHOT, so the pairs below can

--- a/packages/api/nros-cpp/docs/error-codes.md
+++ b/packages/api/nros-cpp/docs/error-codes.md
@@ -21,7 +21,7 @@ macro to short-circuit on the first error.
 ## NROS_TRY
 
 ```cpp
-nros::Result init_pubsub(nros::Node& node) {
+nros::Result init_pubsub(rclcpp::Node& node) {
     nros::Publisher<MyMsg> pub;
     NROS_TRY(node.create_publisher(pub, "/topic"));   // early-return on error
     NROS_TRY(pub.publish(seed_msg));

--- a/packages/api/nros-cpp/docs/getting-started.md
+++ b/packages/api/nros-cpp/docs/getting-started.md
@@ -92,7 +92,7 @@ static void on_tick(void* ctx_ptr) {
 int main() {
     NROS_TRY(nros::init("tcp/127.0.0.1:7447"));
 
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY(nros::create_node(node, "cpp_talker"));
 
     nros::Publisher<std_msgs::msg::Int32> pub;

--- a/packages/api/nros-cpp/docs/mainpage.md
+++ b/packages/api/nros-cpp/docs/mainpage.md
@@ -14,7 +14,7 @@ int main() {
     NROS_TRY(nros::init("tcp/127.0.0.1:7447"));
 
     // 2. Create a node.
-    nros::Node node;
+    rclcpp::Node node;
     NROS_TRY(nros::create_node(node, "cpp_talker"));
 
     // 3. Create a typed publisher.
@@ -44,7 +44,7 @@ The C++ API is organised into the following module groups (see the
 | Group | Description |
 |-------|-------------|
 | @ref grp_init "init"           | Library initialisation, global session, `nros::ok()` |
-| @ref grp_node "node"           | Node creation and lifecycle (`nros::Node`) |
+| @ref grp_node "node"           | Node creation and lifecycle (`rclcpp::Node`) |
 | @ref grp_pubsub "pubsub"       | Publishers and subscriptions (`nros::Publisher<M>`, `nros::Subscription<M>`) |
 | @ref grp_service "service"     | Service servers and clients (`nros::Service<S>`, `nros::Client<S>`) |
 | @ref grp_action "action"       | Action servers and clients (`nros::ActionServer<A>`, `nros::ActionClient<A>`) |

--- a/packages/api/nros-cpp/include/nros/action_client.hpp
+++ b/packages/api/nros-cpp/include/nros/action_client.hpp
@@ -51,14 +51,18 @@ nros_cpp_ret_t nros_cpp_action_client_set_callbacks(
     nros_cpp_action_client_result_callback_t result, void* context);
 } // extern "C"
 
-namespace nros {
-// `nros::Node` is named by the friend declaration below and by the out-of-line
-// `Node::create_action_client` body further down. `nros/node.hpp` (included
-// below, after the class) has the definition; a qualified friend needs the name
-// to EXIST first, which an unqualified `friend class Node;` used to supply
-// implicitly.
+/// `rclcpp::Node` is named by the friend declaration below and by the
+/// out-of-line `Node::create_*` bodies further down. `nros/node.hpp` (included
+/// below, after the class, so a consumer pays only for the entities it uses)
+/// has the definition; a qualified friend needs the name to EXIST first, which
+/// an unqualified `friend class Node;` used to supply implicitly.
+///
+/// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
+/// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
+/// class and collide with the `nros::Node` alias.
+namespace rclcpp {
 class Node;
-} // namespace nros
+}
 
 // ============================================================================
 // `rclcpp_action::Client<A>` -- DEFINED here (RFC-0089: rclcpp_action:: is the home)
@@ -516,7 +520,7 @@ template <typename A> class Client {
     Client(const Client&) = delete;
     Client& operator=(const Client&) = delete;
 
-    friend class ::nros::Node;
+    friend class ::rclcpp::Node;
 
     alignas(8) uint8_t storage_[NROS_CPP_ACTION_CLIENT_STORAGE_SIZE];
     void* executor_; // Stashed executor handle (Phase 82) for blocking helpers
@@ -542,12 +546,14 @@ template <typename A> using ActionClient = ::rclcpp_action::Client<A>;
 // Phase 84.G8: out-of-line definition of Node::create_action_client<A>().
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename A>
-Result Node::create_action_client(ActionClient<A>& out, const char* action_name, const QoS& qos) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+Result Node::create_action_client(::nros::ActionClient<A>& out, const char* action_name,
+                                  const ::nros::QoS& qos) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_action_client_create(&handle_, action_name, A::TYPE_NAME,
                                                        A::Goal::TYPE_HASH, ffi_qos, out.storage_);
     if (ret == 0) {
@@ -556,7 +562,8 @@ Result Node::create_action_client(ActionClient<A>& out, const char* action_name,
     }
     return Result(ret);
 }
+} // namespace rclcpp
 
-} // namespace nros
+namespace nros {} // namespace nros
 
 #endif // NROS_CPP_ACTION_CLIENT_HPP

--- a/packages/api/nros-cpp/include/nros/action_client.hpp
+++ b/packages/api/nros-cpp/include/nros/action_client.hpp
@@ -59,7 +59,7 @@ nros_cpp_ret_t nros_cpp_action_client_set_callbacks(
 ///
 /// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
 /// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
-/// class and collide with the `nros::Node` alias.
+/// class and collide with the `rclcpp::Node` alias.
 namespace rclcpp {
 class Node;
 }

--- a/packages/api/nros-cpp/include/nros/action_server.hpp
+++ b/packages/api/nros-cpp/include/nros/action_server.hpp
@@ -178,14 +178,20 @@ enum class GoalStatus : int8_t {
     Aborted = 6,
 };
 
-// `nros::Node` is named by the friend declaration below and by the out-of-line
-// `Node::create_*` bodies further down. `nros/node.hpp` (included below, after
-// the class, so a consumer pays only for the entities it uses) has the
-// definition; a qualified friend needs the name to EXIST first, which an
-// unqualified `friend class Node;` used to supply implicitly.
-class Node;
-
 } // namespace nros
+
+/// `rclcpp::Node` is named by the friend declaration below and by the
+/// out-of-line `Node::create_*` bodies further down. `nros/node.hpp` (included
+/// below, after the class, so a consumer pays only for the entities it uses)
+/// has the definition; a qualified friend needs the name to EXIST first, which
+/// an unqualified `friend class Node;` used to supply implicitly.
+///
+/// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
+/// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
+/// class and collide with the `nros::Node` alias.
+namespace rclcpp {
+class Node;
+}
 
 // ============================================================================
 // `rclcpp_action::Server<A>` -- DEFINED here (RFC-0089: rclcpp_action:: is the home)
@@ -537,7 +543,7 @@ template <typename A> class Server {
     Server(const Server&) = delete;
     Server& operator=(const Server&) = delete;
 
-    friend class ::nros::Node;
+    friend class ::rclcpp::Node;
 
     // ── C trampolines ───────────────────────────────────────────────
     //
@@ -640,13 +646,15 @@ template <typename A> using ActionServer = ::rclcpp_action::Server<A>;
 // Phase 84.G8: out-of-line definition of Node::create_action_server<A>().
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename A>
-Result Node::create_action_server(ActionServer<A>& out, const char* action_name, const QoS& qos,
-                                  const ActionServerOptions& options) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+Result Node::create_action_server(::nros::ActionServer<A>& out, const char* action_name,
+                                  const ::nros::QoS& qos,
+                                  const ::nros::ActionServerOptions& options) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_action_server_create(&handle_, action_name, A::TYPE_NAME,
                                                        A::Goal::TYPE_HASH, ffi_qos, out.storage_);
     if (ret != 0) return Result(ret);
@@ -656,7 +664,7 @@ Result Node::create_action_server(ActionServer<A>& out, const char* action_name,
     // `nros::ActionServer<A>` class, not in the runtime struct).
     // Phase 189.M3.3.c — `sched_context` binds the action's (arena-registered)
     // goal-service handle to a scheduling context. UNSET ⇒ 0 (inherit, no-op).
-    uint8_t sched = (options.sched_context == SCHED_CONTEXT_UNSET)
+    uint8_t sched = (options.sched_context == ::nros::SCHED_CONTEXT_UNSET)
                         ? 0u
                         : static_cast<uint8_t>(options.sched_context);
     ret = nros_cpp_action_server_register(out.storage_, executor_handle_, action_name, A::TYPE_NAME,
@@ -667,7 +675,8 @@ Result Node::create_action_server(ActionServer<A>& out, const char* action_name,
     }
     return Result(ret);
 }
+} // namespace rclcpp
 
-} // namespace nros
+namespace nros {} // namespace nros
 
 #endif // NROS_CPP_ACTION_SERVER_HPP

--- a/packages/api/nros-cpp/include/nros/action_server.hpp
+++ b/packages/api/nros-cpp/include/nros/action_server.hpp
@@ -188,7 +188,7 @@ enum class GoalStatus : int8_t {
 ///
 /// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
 /// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
-/// class and collide with the `nros::Node` alias.
+/// class and collide with the `rclcpp::Node` alias.
 namespace rclcpp {
 class Node;
 }

--- a/packages/api/nros-cpp/include/nros/client.hpp
+++ b/packages/api/nros-cpp/include/nros/client.hpp
@@ -50,7 +50,7 @@ nros_cpp_ret_t nros_cpp_service_client_register(const nros_cpp_node_t* node,
 ///
 /// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
 /// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
-/// class and collide with the `nros::Node` alias.
+/// class and collide with the `rclcpp::Node` alias.
 namespace rclcpp {
 class Node;
 }

--- a/packages/api/nros-cpp/include/nros/client.hpp
+++ b/packages/api/nros-cpp/include/nros/client.hpp
@@ -42,14 +42,18 @@ nros_cpp_ret_t nros_cpp_service_client_register(const nros_cpp_node_t* node,
                                                 size_t* out_handle_id);
 } // extern "C"
 
-namespace nros {
-// `nros::Node` is named by the friend declaration below and by the out-of-line
-// `Node::create_*` bodies further down. `nros/node.hpp` (included below, after
-// the class, so a consumer pays only for the entities it uses) has the
-// definition; a qualified friend needs the name to EXIST first, which an
-// unqualified `friend class Node;` used to supply implicitly.
+/// `rclcpp::Node` is named by the friend declaration below and by the
+/// out-of-line `Node::create_*` bodies further down. `nros/node.hpp` (included
+/// below, after the class, so a consumer pays only for the entities it uses)
+/// has the definition; a qualified friend needs the name to EXIST first, which
+/// an unqualified `friend class Node;` used to supply implicitly.
+///
+/// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
+/// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
+/// class and collide with the `nros::Node` alias.
+namespace rclcpp {
 class Node;
-} // namespace nros
+}
 
 // ============================================================================
 // `rclcpp::Client<S>` -- DEFINED here (RFC-0089: rclcpp:: is the home)
@@ -346,7 +350,7 @@ template <typename S> class Client {
     Client(const Client&) = delete;
     Client& operator=(const Client&) = delete;
 
-    friend class ::nros::Node;
+    friend class ::rclcpp::Node;
 
     /// Phase 189.M3.3.f — raw response trampoline matching `RawResponseCallback`
     /// (`void(data, len, ctx)`). Deserializes the reply, runs the user's typed
@@ -388,12 +392,13 @@ template <typename S> using Client = ::rclcpp::Client<S>;
 // Phase 84.G8: out-of-line definition of Node::create_client<S>().
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename S>
-Result Node::create_client(Client<S>& out, const char* service_name, const QoS& qos) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+Result Node::create_client(Client<S>& out, const char* service_name, const ::nros::QoS& qos) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_service_client_create(
         &handle_, service_name, S::TYPE_NAME, S::Request::TYPE_HASH, ffi_qos, out.storage_);
     if (ret == 0) {
@@ -402,21 +407,27 @@ Result Node::create_client(Client<S>& out, const char* service_name, const QoS& 
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // Phase 189.M3.3.f — callback-style (arena-registered) client. The arena owns
 // the client + dispatches `out`'s response handler during spin_once; requests
 // go through `async_send_request`. `options.sched_context` is functional.
+} // namespace nros
+
+namespace rclcpp {
 template <typename S, typename F, typename>
-Result Node::create_client(Client<S>& out, const char* service_name, F callback, const QoS& qos,
-                           const ClientOptions& options) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+Result Node::create_client(Client<S>& out, const char* service_name, F callback,
+                           const ::nros::QoS& qos, const ::nros::ClientOptions& options) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
 
     out.user_fn_ = typename Client<S>::TypedResponseFn(callback);
     out.user_fn_ctx_ = nullptr;
     out.user_ctx_ = nullptr;
 
-    uint8_t sched = (options.sched_context == SCHED_CONTEXT_UNSET)
+    uint8_t sched = (options.sched_context == ::nros::SCHED_CONTEXT_UNSET)
                         ? 0u
                         : static_cast<uint8_t>(options.sched_context);
     size_t handle = static_cast<size_t>(-1);
@@ -432,7 +443,8 @@ Result Node::create_client(Client<S>& out, const char* service_name, F callback,
     }
     return Result(ret);
 }
+} // namespace rclcpp
 
-} // namespace nros
+namespace nros {} // namespace nros
 
 #endif // NROS_CPP_CLIENT_HPP

--- a/packages/api/nros-cpp/include/nros/component.hpp
+++ b/packages/api/nros-cpp/include/nros/component.hpp
@@ -19,7 +19,7 @@
 ///     int count_ = 0;
 ///     void on_tick() { Int32 m; m.data = count_++; pub_.publish(m); }  // real body
 ///   public:
-///     nros::Result configure(nros::Node& node) {
+///     nros::Result configure(rclcpp::Node& node) {
 ///         NROS_TRY(node.create_publisher(pub_, "/chatter"));
 ///         return node.create_wall_timer<Talker, &Talker::on_tick>(timer_, 1000, this);
 ///     }
@@ -49,7 +49,8 @@ namespace nros {
 /// typed header. `ctx` is carried through to the callback. The executor owns the
 /// subscription (no storage object needed on the caller side); it dispatches the
 /// callback during `spin_once`. (Thin wrapper over `nros_cpp_subscription_register`.)
-inline Result create_subscription_raw(Node& node, const char* topic, const char* type_name,
+inline Result create_subscription_raw(::rclcpp::Node& node, const char* topic,
+                                      const char* type_name,
                                       void (*callback)(const uint8_t* data, size_t len, void* ctx),
                                       void* ctx, const QoS& qos = QoS::default_profile(),
                                       size_t rx_bytes = 0) {
@@ -77,8 +78,8 @@ inline Result create_subscription_raw(Node& node, const char* topic, const char*
 /// parameter, so the trampoline is a non-capturing lambda (decays to a function
 /// pointer — no heap, no `std::function`). `self` is the executor `ctx`.
 template <class C, void (C::*Method)(const uint8_t* data, size_t len)>
-inline Result bind_subscription_raw(Node& node, const char* topic, const char* type_name, C* self,
-                                    const QoS& qos = QoS::default_profile()) {
+inline Result bind_subscription_raw(::rclcpp::Node& node, const char* topic, const char* type_name,
+                                    C* self, const QoS& qos = QoS::default_profile()) {
     return create_subscription_raw(
         node, topic, type_name,
         [](const uint8_t* data, size_t len, void* ctx) {
@@ -105,7 +106,7 @@ inline Result bind_subscription_raw(Node& node, const char* topic, const char* t
 /// `Node::create_subscription_in` member + `NROS_SUBSCRIBE` macro hide the
 /// spelling.
 template <typename M, class C, void (C::*Method)(const M& msg)>
-inline Result bind_subscription(Node& node, const char* topic, C* self,
+inline Result bind_subscription(::rclcpp::Node& node, const char* topic, C* self,
                                 const QoS& qos = QoS::default_profile()) {
     // phase-403 W3 -- `M` is still in scope here, so the type's own bound can be
     // spent on the arena slot. This is the point the type is erased: everything
@@ -143,8 +144,8 @@ inline Result bind_subscription(Node& node, const char* topic, C* self,
 /// larger samples are refused. The C sibling of this is the generated
 /// `{Msg}_subscribe_sized` macro.
 template <typename M, class C, void (C::*Method)(const M& msg)>
-inline Result bind_subscription_sized(Node& node, const char* topic, C* self, size_t rx_bytes,
-                                      const QoS& qos = QoS::default_profile()) {
+inline Result bind_subscription_sized(::rclcpp::Node& node, const char* topic, C* self,
+                                      size_t rx_bytes, const QoS& qos = QoS::default_profile()) {
     return create_subscription_raw(
         node, topic, M::TYPE_NAME,
         [](const uint8_t* data, size_t len, void* ctx) {
@@ -172,7 +173,7 @@ inline Result bind_subscription_sized(Node& node, const char* topic, C* self, si
 template <class C, void (C::*Method)()>
 NROS_CPP_DEPRECATED_MSG("nros::bind_timer is retired (phase-427 W3): write "
                         "node.create_wall_timer<C, &C::method>(out, period_ms, self)")
-inline Result bind_timer(Node& node, Timer& out, uint64_t period_ms, C* self) {
+inline Result bind_timer(::rclcpp::Node& node, Timer& out, uint64_t period_ms, C* self) {
     return node.template create_wall_timer<C, Method>(out, period_ms, self);
 }
 
@@ -182,7 +183,7 @@ inline Result bind_timer(Node& node, Timer& out, uint64_t period_ms, C* self) {
 /// `*resp_len`; return `true` to send the reply, `false` to drop. `ctx` is
 /// carried through. The executor owns the server; it dispatches the handler
 /// during `spin_once`. (Thin wrapper over `nros_cpp_service_server_register`.)
-inline Result create_service_raw(Node& node, const char* service, const char* type_name,
+inline Result create_service_raw(::rclcpp::Node& node, const char* service, const char* type_name,
                                  nros_cpp_service_request_callback_t callback, void* ctx,
                                  const QoS& qos = QoS::services()) {
     const nros_cpp_node_t* h = node.ffi_handle();
@@ -201,8 +202,8 @@ inline Result create_service_raw(Node& node, const char* service, const char* ty
 /// trampoline; `self` is the executor `ctx`.
 template <class C, bool (C::*Method)(const uint8_t* req, size_t req_len, uint8_t* resp,
                                      size_t resp_cap, size_t* resp_len)>
-inline Result bind_service_raw(Node& node, const char* service, const char* type_name, C* self,
-                               const QoS& qos = QoS::services()) {
+inline Result bind_service_raw(::rclcpp::Node& node, const char* service, const char* type_name,
+                               C* self, const QoS& qos = QoS::services()) {
     return create_service_raw(
         node, service, type_name,
         [](const uint8_t* req, size_t req_len, uint8_t* resp, size_t resp_cap, size_t* resp_len,
@@ -229,7 +230,7 @@ inline Result bind_service_raw(Node& node, const char* service, const char* type
 /// `std::function`. A reply larger than `resp_cap`, or a malformed request,
 /// drops the reply (returns `false`).
 template <typename Svc, class C, typename Svc::Response (C::*Method)(const typename Svc::Request&)>
-inline Result bind_service(Node& node, const char* service, C* self,
+inline Result bind_service(::rclcpp::Node& node, const char* service, C* self,
                            const QoS& qos = QoS::services()) {
     return create_service_raw(
         node, service, Svc::TYPE_NAME,
@@ -262,7 +263,7 @@ struct ActionServerStorage {
 /// goal is accepted, complete it with `nros_cpp_action_server_complete_goal(
 /// storage, node.executor_handle(), goal_id, result_cdr, len)` (and feedback via
 /// `nros_cpp_action_server_publish_feedback`).
-inline Result create_action_server_raw(Node& node, void* storage, const char* action_name,
+inline Result create_action_server_raw(::rclcpp::Node& node, void* storage, const char* action_name,
                                        const char* type_name, nros_cpp_goal_callback_t goal_cb,
                                        nros_cpp_cancel_callback_t cancel_cb, void* ctx,
                                        const QoS& qos = QoS::services()) {
@@ -286,7 +287,7 @@ inline Result create_action_server_raw(Node& node, void* storage, const char* ac
 template <class C,
           int32_t (C::*GoalMethod)(const uint8_t goal_id[16], const uint8_t* data, size_t len),
           int32_t (C::*CancelMethod)(const uint8_t goal_id[16])>
-inline Result bind_action_server_raw(Node& node, void* storage, const char* action_name,
+inline Result bind_action_server_raw(::rclcpp::Node& node, void* storage, const char* action_name,
                                      const char* type_name, C* self,
                                      const QoS& qos = QoS::services()) {
     return create_action_server_raw(
@@ -308,7 +309,7 @@ struct ServiceClientStorage {
 };
 
 /// Create a raw poll-style service client into the component-owned `storage`.
-inline Result create_service_client_raw(Node& node, void* storage, const char* service,
+inline Result create_service_client_raw(::rclcpp::Node& node, void* storage, const char* service,
                                         const char* type_name, const QoS& qos = QoS::services()) {
     const nros_cpp_node_t* h = node.ffi_handle();
     if (h == nullptr) return Result(ErrorCode::NotInitialized);
@@ -326,7 +327,7 @@ struct ActionClientStorage {
 /// `nros_cpp_action_client_try_recv_goal_response` /
 /// `nros_cpp_action_client_get_result`. (Poll opt-in — for callback dispatch use
 /// `bind_action_client` below.)
-inline Result create_action_client_raw(Node& node, void* storage, const char* action_name,
+inline Result create_action_client_raw(::rclcpp::Node& node, void* storage, const char* action_name,
                                        const char* type_name, const QoS& qos = QoS::services()) {
     const nros_cpp_node_t* h = node.ffi_handle();
     if (h == nullptr) return Result(ErrorCode::NotInitialized);
@@ -352,9 +353,9 @@ template <class C, void (C::*OnGoalResponse)(bool accepted, const uint8_t goal_i
           void (C::*OnFeedback)(const uint8_t goal_id[16], const uint8_t* data, size_t len),
           void (C::*OnResult)(const uint8_t goal_id[16], int32_t status, const uint8_t* data,
                               size_t len)>
-inline Result bind_action_client(Node& node, ActionClientStorage& storage, Timer& poll_timer,
-                                 const char* action_name, const char* type_name, C* self,
-                                 uint64_t poll_ms = 20, const QoS& qos = QoS::services()) {
+inline Result bind_action_client(::rclcpp::Node& node, ActionClientStorage& storage,
+                                 Timer& poll_timer, const char* action_name, const char* type_name,
+                                 C* self, uint64_t poll_ms = 20, const QoS& qos = QoS::services()) {
     Result r = create_action_client_raw(node, storage.bytes, action_name, type_name, qos);
     if (!r.ok()) return r;
     nros_cpp_ret_t ret = nros_cpp_action_client_set_callbacks(
@@ -598,7 +599,7 @@ inline void operator delete[](void*, void*) noexcept {}
 
 // -- NROS_COMPONENT(Class) ---------------------------------------------------
 //
-// Marks a `nros::Node`-derived class as the pkg's rclcpp-faithful (IS-A-node)
+// Marks a `rclcpp::Node`-derived class as the pkg's rclcpp-faithful (IS-A-node)
 // component. Parallels `NROS_NODE_REGISTER` (node_pkg.hpp), but for the
 // construct-with-handle ctor shape.
 //
@@ -625,22 +626,22 @@ inline void operator delete[](void*, void*) noexcept {}
 #define _NROS_COMP_CLASS_SYM(pkg) _NROS_COMP_CAT(__nros_component_class_, pkg)
 #define _NROS_COMP_SHAPE_SYM(pkg) _NROS_COMP_CAT(__nros_component_shape_, pkg)
 
-/// Register a `nros::Node`-derived class as the pkg's component. Emits:
+/// Register a `rclcpp::Node`-derived class as the pkg's component. Emits:
 ///  - `__nros_component_factory_<pkg>(void* storage, void* node_handle)` — a
 ///    C-ABI factory that placement-news `Class(nros::NodeHandle(node_handle))`
-///    into the entry-owned arena slot and returns it as `nros::Node*`.
+///    into the entry-owned arena slot and returns it as `rclcpp::Node*`.
 ///  - `__nros_component_class_<pkg>` — the `"<pkg>::<Class>"` string for lint.
 ///  - `__nros_component_shape_<pkg>` — the `"rclcpp"` shape marker.
 ///
 /// The derived class MUST have an `explicit Class(nros::NodeHandle)` ctor (it
 /// forwards the handle + the node name to the `Node` base).
 ///
-/// The factory returns `::nros::Node*` — phase-427 W4. It used to return
+/// The factory returns `::rclcpp::Node*` — phase-427 W4. It used to return
 /// `::nros::ComponentNode*`, a type that WRAPPED a node; the merged type IS one,
 /// so the entry's post-construct `ok()` check now reads the node itself.
 #define NROS_COMPONENT(Class)                                                                      \
-    extern "C" ::nros::Node* _NROS_COMP_FACTORY_SYM(NROS_PKG_NAME)(void* storage,                  \
-                                                                   void* node_handle) {            \
+    extern "C" ::rclcpp::Node* _NROS_COMP_FACTORY_SYM(NROS_PKG_NAME)(void* storage,                \
+                                                                     void* node_handle) {          \
         return new (storage) Class(::nros::NodeHandle(node_handle));                               \
     }                                                                                              \
     extern "C" const char _NROS_COMP_CLASS_SYM(NROS_PKG_NAME)[] =                                  \

--- a/packages/api/nros-cpp/include/nros/component.hpp
+++ b/packages/api/nros-cpp/include/nros/component.hpp
@@ -392,8 +392,11 @@ inline Result bind_action_client(Node& node, ActionClientStorage& storage, Timer
 // The second one below is both — a group form of the storage-free shape — and
 // its name says the half a reader cannot infer from the argument list.
 
+} // namespace nros
+
+namespace rclcpp {
 template <typename M, class C, void (C::*Method)(const M& msg)>
-inline void Node::create_subscription_in(const char* topic, const QoS& qos) {
+inline void Node::create_subscription_in(const char* topic, const ::nros::QoS& qos) {
     if (!this->check_declared_depth(M::TYPE_NAME, topic, qos)) {
         return;
     }
@@ -402,10 +405,14 @@ inline void Node::create_subscription_in(const char* topic, const QoS& qos) {
         this->set_error("create_subscription_in", r.raw());
     }
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename M, class C, void (C::*Method)(const M& msg)>
-inline void Node::create_subscription_in_group(const CallbackGroup& group, const char* topic,
-                                               const QoS& qos) {
+inline void Node::create_subscription_in_group(const ::nros::CallbackGroup& group,
+                                               const char* topic, const ::nros::QoS& qos) {
     // phase-403 step 2 — the same boot-time check as the ungrouped form. A
     // grouped subscription costs the arena exactly what an ungrouped one does,
     // so leaving this path out would make the declared depth enforceable
@@ -418,7 +425,7 @@ inline void Node::create_subscription_in_group(const CallbackGroup& group, const
         this->set_error("create_subscription_in_group", -3);
         return;
     }
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
     C* self = static_cast<C*>(this);
     size_t handle = static_cast<size_t>(-1);
     // phase-402: the group name is a FIELD now, not a trailing argument. Start
@@ -438,6 +445,9 @@ inline void Node::create_subscription_in_group(const CallbackGroup& group, const
         this->set_error("create_subscription_in_group", ret);
     }
 }
+} // namespace rclcpp
+
+namespace nros {
 
 namespace detail {
 

--- a/packages/api/nros-cpp/include/nros/executor.hpp
+++ b/packages/api/nros-cpp/include/nros/executor.hpp
@@ -21,7 +21,7 @@
 // phase-427 W7 — `Node` is DEFINED in `rclcpp::` (RFC-0089: that namespace is
 // the home), so the forward declaration has to be there too: an elaborated
 // `class Node;` inside `nros::` would declare a second, distinct class and
-// collide with the `nros::Node` alias `node.hpp` declares.
+// collide with the `rclcpp::Node` alias `node.hpp` declares.
 namespace rclcpp {
 class Node;
 }
@@ -100,7 +100,7 @@ class OnShutdownCallbackHandle : public ShutdownCallbackHandle {
 /// nros::Executor executor;
 /// NROS_TRY(nros::Executor::create(executor));
 ///
-/// nros::Node node;
+/// rclcpp::Node node;
 /// NROS_TRY(executor.create_node(node, "my_node"));
 ///
 /// // Create publishers, subscriptions, etc. on node...

--- a/packages/api/nros-cpp/include/nros/executor.hpp
+++ b/packages/api/nros-cpp/include/nros/executor.hpp
@@ -18,10 +18,17 @@
 
 #include "nros_cpp_ffi.h"
 
+// phase-427 W7 — `Node` is DEFINED in `rclcpp::` (RFC-0089: that namespace is
+// the home), so the forward declaration has to be there too: an elaborated
+// `class Node;` inside `nros::` would declare a second, distinct class and
+// collide with the `nros::Node` alias `node.hpp` declares.
+namespace rclcpp {
+class Node;
+}
+
 namespace nros {
 
 // Forward declarations
-class Node;
 class NodeBuilder;
 
 /// Signature of a shutdown callback: `void callback(void* context)`.
@@ -177,7 +184,7 @@ class Executor {
     /// @param name  Node name (null-terminated).
     /// @param ns    Node namespace (null-terminated), or nullptr for "/".
     /// @return Result indicating success or failure.
-    Result create_node(Node& out, const char* name, const char* ns = nullptr);
+    Result create_node(::rclcpp::Node& out, const char* name, const char* ns = nullptr);
 
     /// Phase 104.C.9 — chainable Node-creation builder.
     ///

--- a/packages/api/nros-cpp/include/nros/graph.hpp
+++ b/packages/api/nros-cpp/include/nros/graph.hpp
@@ -3,7 +3,7 @@
 //
 // The graph QUERIES live on `nros::Executor` (`executor.hpp:205-301`) because
 // one session per image makes the executor the graph's receiver (RFC-0002);
-// `nros::Node` and `nros::LifecycleNode` forward to it so a ported rclcpp file
+// `rclcpp::Node` and `nros::LifecycleNode` forward to it so a ported rclcpp file
 // reaches them where rclcpp puts them, on the node. This header holds the one
 // thing those calls need that the FFI does not already give C++ a name for: a
 // value type for a discovered endpoint.

--- a/packages/api/nros-cpp/include/nros/guard_condition.hpp
+++ b/packages/api/nros-cpp/include/nros/guard_condition.hpp
@@ -23,6 +23,15 @@
 
 #include "nros_cpp_ffi.h"
 
+// phase-427 W7 — `Node` is DEFINED in `rclcpp::` (RFC-0089: that namespace is
+// the home). The friend declaration below is qualified, and a qualified friend
+// names an existing entity rather than introducing one, so the name has to be
+// declared first — and in `rclcpp::`, because an elaborated `class Node;` in
+// `nros::` would declare a second, distinct class.
+namespace rclcpp {
+class Node;
+}
+
 namespace nros {
 
 /// Guard condition for cross-thread signaling.
@@ -114,7 +123,7 @@ class GuardCondition {
     GuardCondition(const GuardCondition&) = delete;
     GuardCondition& operator=(const GuardCondition&) = delete;
 
-    friend class Node;
+    friend class ::rclcpp::Node;
 
     alignas(8) uint8_t storage_[NROS_GUARD_CONDITION_SIZE];
     bool initialized_;

--- a/packages/api/nros-cpp/include/nros/lifecycle.hpp
+++ b/packages/api/nros-cpp/include/nros/lifecycle.hpp
@@ -268,7 +268,7 @@ class LifecycleNode {
     // receiver, because there is one session per image (RFC-0002) — and does
     // nothing else: no state, no loop, no caching, no name construction.
     // RFC-0019 keeps the behaviour in Rust. The bodies are the same one-line
-    // forwards `nros::Node` carries; see `node.hpp` for the per-call
+    // forwards `rclcpp::Node` carries; see `node.hpp` for the per-call
     // documentation.
     //
     // On an UNBOUND node (default-constructed, `bind()` not yet called) they
@@ -323,7 +323,7 @@ class LifecycleNode {
 
     /// What one named node SUBSCRIBES to, with the types. `subscription`, not
     /// `subscriber` — the C++ surface takes rclcpp's vocabulary and this
-    /// matches `nros::Node` / `nros::Executor` rather than adding a third
+    /// matches `rclcpp::Node` / `nros::Executor` rather than adding a third
     /// spelling.
     Result get_subscription_names_and_types_by_node(const char* node_name,
                                                     const char* node_namespace,

--- a/packages/api/nros-cpp/include/nros/log.hpp
+++ b/packages/api/nros-cpp/include/nros/log.hpp
@@ -63,7 +63,7 @@
  * Obtain the handle from a Node via `node.get_logger()`:
  *
  * ```cpp
- * nros::Node node;
+ * rclcpp::Node node;
  * NROS_TRY(nros::create_node(node, "my_node"));
  * auto logger = node.get_logger();
  * NROS_LOG_INFO(logger, "started; domain=%u", 42);
@@ -176,7 +176,8 @@ template <typename T> struct refuse {
     "statistics collector and no /rosout topic, so there is nothing for these knobs to switch. "   \
     "Use: node->declare_parameter<T>(name, default) for parameter overrides; the launch file "     \
     "for remaps; and drop the option chain. `rclcpp::NodeOptions{}` itself still constructs, so "  \
-    "the `Node(name, options)` constructor shape a composable node needs keeps compiling."
+    "the `::rclcpp::Node(name, options)` constructor shape a composable node needs keeps "         \
+    "compiling."
 
 #define NROS_RCLCPP_REFUSE_INIT_ARGV                                                               \
     "rclcpp::init(argc, argv) was given --ros-args, which nano-ros cannot honour "                 \
@@ -255,7 +256,7 @@ class Logger {
     explicit Logger(const char* name = "") : name_(name), handle_(nullptr) {}
 
     /// phase-427 W5 — the name PLUS the opaque `nros_log::Logger` handle the
-    /// `NROS_LOG_*` macros dispatch through. `nros::Node::get_logger()` builds
+    /// `NROS_LOG_*` macros dispatch through. `rclcpp::Node::get_logger()` builds
     /// one of these; `rclcpp::get_logger("free")` leaves the handle null,
     /// because a free-standing name has no node behind it.
     Logger(const char* name, const void* handle) : name_(name), handle_(handle) {}
@@ -266,7 +267,7 @@ class Logger {
     ///
     /// This is what let `get_logger()` become ONE accessor with upstream's
     /// return type without breaking the native call sites. Before the merge
-    /// there were two: `nros::Node::get_logger() -> const void*` for
+    /// there were two: `rclcpp::Node::get_logger() -> const void*` for
     /// `NROS_LOG_INFO(logger, …)`, and the shim's `-> rclcpp::Logger` for
     /// `RCLCPP_INFO(get_logger(), …)`. Two overloads differing only in return
     /// type are ill-formed, so the ported channel won (RFC-0089 clause 2) and

--- a/packages/api/nros-cpp/include/nros/node.hpp
+++ b/packages/api/nros-cpp/include/nros/node.hpp
@@ -4,7 +4,7 @@
 /**
  * @file node.hpp
  * @ingroup grp_node
- * @brief `nros::Node` and global session helpers.
+ * @brief `rclcpp::Node` and global session helpers.
  */
 
 #ifndef NROS_CPP_NODE_HPP
@@ -475,7 +475,7 @@ inline void* global_handle();
 // ============================================================================
 // rclcpp:: — the HOME of the C++ node type (RFC-0089 §"Settled: `rclcpp::` is
 // the HOME, not an alias onto `nros::`"). phase-427 W7 flipped the direction:
-// the class is DEFINED here and `nros::Node` below is the migration alias, the
+// the class is DEFINED here and `rclcpp::Node` below is the migration alias, the
 // same shape the other nine types already carry (`clock.hpp`, `duration.hpp`,
 // `time.hpp`, `publisher.hpp`, `subscription.hpp`, `client.hpp`, `service.hpp`,
 // `action_client.hpp`, `action_server.hpp`).
@@ -495,7 +495,7 @@ inline void* global_handle();
 // re-merged by a using-directive.
 // ============================================================================
 namespace rclcpp {
-/// The node — `rclcpp::Node`, and `nros::Node`, which are ONE TYPE
+/// The node — `rclcpp::Node`, and `rclcpp::Node`, which are ONE TYPE
 /// (phase-427). The primary interface for creating ROS entities: publishers,
 /// subscriptions, services, timers are all created through it, and it holds a
 /// reference to the parent executor session.
@@ -508,12 +508,12 @@ namespace rclcpp {
 ///
 /// Three shapes collapsed here: the freestanding out-ref node, the hosted
 /// `shared_ptr` node that used to be a separate `rclcpp::Node` in `nros.hpp`,
-/// and (from RFC-0044) the derivable component base. `nros::Node` is declared
+/// and (from RFC-0044) the derivable component base. `rclcpp::Node` is declared
 /// as an alias for this class at the bottom of this header, so
-/// `std::is_same<rclcpp::Node, nros::Node>::value` is true and there is exactly
+/// `std::is_same<rclcpp::Node, rclcpp::Node>::value` is true and there is exactly
 /// one set of entities, one arena registration path and one parameter facade.
 ///
-/// THE CLASS IS DEFINED HERE, in `rclcpp::`, and `nros::Node` is the alias —
+/// THE CLASS IS DEFINED HERE, in `rclcpp::`, and `rclcpp::Node` is the alias —
 /// RFC-0089 §"Settled: `rclcpp::` is the HOME, not an alias onto `nros::`", and
 /// the tenth and last type of the phase-428 flip. It was held back for two
 /// reasons, both now gone: two landed reviews (PRs #797, #806) were stacked on
@@ -2019,16 +2019,37 @@ namespace nros {
 /// `std::is_same<rclcpp::Node, nros::Node>::value` is true: one class, one set
 /// of entities, one arena registration path, one parameter facade.
 ///
-/// RFC-0089 §"Settled: `nros::` is phased out entirely" makes `rclcpp::` the
-/// vocabulary a user writes, and this alias is the migration step, not a second
-/// name to choose between. It is UNCONDITIONAL, unlike the shim class it
-/// replaced: that one lived inside `#if defined(NROS_CPP_HAS_SHARED_PTR) && …`,
-/// so a freestanding target had the node and not its ROS 2 name.
-using Node = ::rclcpp::Node;
-
-} // namespace nros
-
-namespace nros {
+/// **DEPRECATED — phase-427 W7.** RFC-0089 §"Settled: `nros::` is phased out
+/// entirely" makes `rclcpp::` the vocabulary a user writes, and this alias is
+/// the migration step, not a second name to choose between. Write
+/// `rclcpp::Node`; the change is textual, because it is the same class.
+///
+/// The attribute is UNCONDITIONAL, and so was the alias before it: the shim
+/// class this replaced lived inside `#if defined(NROS_CPP_HAS_SHARED_PTR) && …`,
+/// so a freestanding target had the node and NOT its ROS 2 name.
+///
+/// WHY IT IS NOT BEHIND A FEATURE MACRO, which is the question PR #753's Rust
+/// `#[cfg_attr(feature = …, deprecated)]` raises. #753 armed its deprecation
+/// because the tree had NOT migrated — 65 hard errors across 47 files — and
+/// `#[allow(deprecated)]` at every one of them would have suppressed the signal
+/// in exactly the code the deprecation was aimed at. That argument does not
+/// apply here: the same commit migrates all 258 in-tree C++ spellings, so the
+/// attribute costs no in-tree diagnostic at all. Every other deprecation this
+/// API ships is unconditional for the same reason (`nros::Expected<T>`,
+/// `nros::bind_timer`, `QoS::Liveliness`, the `QoS::*_ms(uint32_t)` family,
+/// `LifecycleNode::trigger(uint8_t)`). And a macro nothing in-tree defines
+/// would leave the probe as the only compiler that ever sees the attribute,
+/// which is a gate whose subject disappears.
+///
+/// OUT-OF-TREE REACH IS THE POINT, not a reason to hide it. `nros-v0.5.0`
+/// (2026-06-08) shipped `nros::Node` in six `examples/templates/**` files a
+/// user copies out, so copies of it exist that this checkout cannot reach. A
+/// warning naming `rclcpp::Node` is what those copies get; silence is what a
+/// feature-armed attribute would give them.
+using Node NROS_CPP_DEPRECATED_MSG(
+    "nros::Node is deprecated (phase-427 W7): write rclcpp::Node. Same type, so "
+    "the change is textual -- nros:: is the vocabulary RFC-0089 phases out and "
+    "rclcpp:: is the home.") = ::rclcpp::Node;
 
 // ==== phase-427 W4 — the timer pool, as a TEMPLATE PARAMETER ================
 //
@@ -2045,7 +2066,7 @@ namespace nros {
 // Why a derived template and not `template <size_t N> class Node` — measured,
 // not preferred. `Node` has to stay ONE non-template type: `rclcpp::Node` is an
 // alias for it and `tests/compile/one_node_type.cpp` asserts
-// `std::is_same<rclcpp::Node, nros::Node>`; 218 in-tree sites spell `Node` with
+// `std::is_same<rclcpp::Node, rclcpp::Node>`; 218 in-tree sites spell `Node` with
 // no argument list, which a class template with a defaulted parameter does not
 // permit; and every `Node&` parameter in the tree — `create_node(Node&)`,
 // `Executor`, `spin` — would otherwise accept only ONE depth, so a component
@@ -2092,12 +2113,14 @@ namespace nros {
 ///     void on_tick();
 /// };
 /// ```
-template <::size_t MaxTimers = NROS_COMPONENT_MAX_TIMERS> class NodeWithTimers : public Node {
-    static_assert(MaxTimers >= 1, "NodeWithTimers<0> has no pool -- derive Node directly, or use "
-                                  "the out-ref create_wall_timer(Timer&, ...) family");
+template <::size_t MaxTimers = NROS_COMPONENT_MAX_TIMERS>
+class NodeWithTimers : public ::rclcpp::Node {
+    static_assert(MaxTimers >= 1,
+                  "NodeWithTimers<0> has no pool -- derive ::rclcpp::Node directly, or use "
+                  "the out-ref create_wall_timer(Timer&, ...) family");
 
   public:
-    using Node::Node;
+    using ::rclcpp::Node::Node;
 
     /// Create a **typed member** repeating wall timer parked in the pool.
     ///
@@ -2161,8 +2184,8 @@ template <::size_t MaxTimers = NROS_COMPONENT_MAX_TIMERS> class NodeWithTimers :
     // The out-ref forms on `Node` share these names; bring them in so a derived
     // node can still spell `create_timer_in_group(group, my_timer_, 100, cb, ctx)`
     // without the pool overloads hiding the base by name lookup.
-    using Node::create_timer_in_group;
-    using Node::create_wall_timer;
+    using ::rclcpp::Node::create_timer_in_group;
+    using ::rclcpp::Node::create_wall_timer;
 
   private:
     /// The next free pool slot, or `nullptr` after latching an exhaustion
@@ -2264,8 +2287,8 @@ inline Result init(const char* locator, uint8_t domain_id, const char* session_n
 #else
     const char* rmw = nullptr;
 #endif
-    nros_cpp_ret_t ret =
-        nros_cpp_init_rmw(rmw, locator, domain_id, session_name, nullptr, Node::global_storage());
+    nros_cpp_ret_t ret = nros_cpp_init_rmw(rmw, locator, domain_id, session_name, nullptr,
+                                           ::rclcpp::Node::global_storage());
     // No flag to set: `nros_cpp_init_rmw` stamps the context tag, and
     // `global_initialized()` reads it.
     return Result(ret);
@@ -2291,20 +2314,20 @@ inline Result init_with_rmw(const char* rmw, const char* locator, uint8_t domain
     // No `NROS_ENTRY_RMW` fallback here: an explicit argument that resolves to
     // nullptr is the caller saying "no selector", and quietly substituting the
     // bake would make this overload unable to express that.
-    nros_cpp_ret_t ret =
-        nros_cpp_init_rmw(rmw, locator, domain_id, session_name, nullptr, Node::global_storage());
+    nros_cpp_ret_t ret = nros_cpp_init_rmw(rmw, locator, domain_id, session_name, nullptr,
+                                           ::rclcpp::Node::global_storage());
     // No flag to set: `nros_cpp_init_rmw` stamps the context tag, and
     // `global_initialized()` reads it.
     return Result(ret);
 }
 
 inline Result shutdown() {
-    if (!Node::global_initialized()) {
+    if (!::rclcpp::Node::global_initialized()) {
         return Result::success();
     }
     // No flag to clear: `nros_cpp_fini` unstamps the tag, which is what
     // `global_initialized()` reads. One owner of the fact.
-    return Result(nros_cpp_fini(Node::global_storage()));
+    return Result(nros_cpp_fini(::rclcpp::Node::global_storage()));
 }
 
 // -- Phase 212.L.5 launch-aware init --
@@ -2353,7 +2376,7 @@ inline Result init_with_launch(const char* path, int argc, char** argv, const ch
 
 /// Check if the nros session is initialized.
 inline bool ok() {
-    return Node::global_initialized();
+    return ::rclcpp::Node::global_initialized();
 }
 
 /// Create a node (convenience — uses the global executor).
@@ -2363,12 +2386,12 @@ inline bool ok() {
 /// @param out   Receives the initialized node.
 /// @param name  Node name.
 /// @param ns    Node namespace, or nullptr for "/".
-inline Result create_node(Node& out, const char* name, const char* ns = nullptr) {
-    if (!Node::global_initialized()) {
+inline Result create_node(::rclcpp::Node& out, const char* name, const char* ns = nullptr) {
+    if (!::rclcpp::Node::global_initialized()) {
         return Result(ErrorCode::NotInitialized);
     }
-    out.executor_handle_ = Node::global_storage();
-    return Node::create(out, name, ns);
+    out.executor_handle_ = ::rclcpp::Node::global_storage();
+    return ::rclcpp::Node::create(out, name, ns);
 }
 
 /// Phase 274.W2 — create a node on an explicit executor handle.
@@ -2382,31 +2405,31 @@ inline Result create_node(Node& out, const char* name, const char* ns = nullptr)
 /// @param executor_handle  Explicit executor handle (from a tier setup param).
 /// @param name             Node name.
 /// @param ns               Node namespace, or nullptr for "/".
-inline Result create_node_on(Node& out, void* executor_handle, const char* name,
+inline Result create_node_on(::rclcpp::Node& out, void* executor_handle, const char* name,
                              const char* ns = nullptr) {
     if (executor_handle == nullptr) {
         return Result(ErrorCode::NotInitialized);
     }
     out.executor_handle_ = executor_handle;
-    return Node::create(out, name, ns);
+    return ::rclcpp::Node::create(out, name, ns);
 }
 
 /// Phase 123.B.4 — value-returning factory. Wraps `create_node`
 /// in the `ResultOf<Node>` envelope so users can write
 /// `auto n = nros::make_node("foo");` in the rclcpp-style.
-inline ResultOf<Node> make_node(const char* name, const char* ns = nullptr) {
-    Node n;
+inline ResultOf<::rclcpp::Node> make_node(const char* name, const char* ns = nullptr) {
+    ::rclcpp::Node n;
     Result r = create_node(n, name, ns);
-    if (!r.ok()) return ResultOf<Node>::error(r);
-    return ResultOf<Node>::ok(::std::move(n));
+    if (!r.ok()) return ResultOf<::rclcpp::Node>::error(r);
+    return ResultOf<::rclcpp::Node>::ok(::std::move(n));
 }
 
 // -- Executor::create_node implementation (requires full Node definition) --
 
-inline Result Executor::create_node(Node& out, const char* name, const char* ns) {
+inline Result Executor::create_node(::rclcpp::Node& out, const char* name, const char* ns) {
     if (!initialized_) return Result(ErrorCode::NotInitialized);
     out.executor_handle_ = storage_;
-    return Node::create(out, name, ns);
+    return ::rclcpp::Node::create(out, name, ns);
 }
 
 // -- Phase 104.C.9 — NodeBuilder ----------------------------------------
@@ -2419,7 +2442,7 @@ inline Result Executor::create_node(Node& out, const char* name, const char* ns)
 //
 // Usage:
 // ```cpp
-// nros::Node node;
+// rclcpp::Node node;
 // NROS_TRY(executor.node_builder("egress")
 //              .rmw("cyclonedds")
 //              .domain_id(0)
@@ -2470,7 +2493,7 @@ class NodeBuilder {
     }
 
     /// Materialize the Node.
-    Result build(Node& out) const {
+    Result build(::rclcpp::Node& out) const {
         if (!executor_handle_) return Result(ErrorCode::NotInitialized);
         out.executor_handle_ = executor_handle_;
         nros_cpp_ret_t ret =

--- a/packages/api/nros-cpp/include/nros/node.hpp
+++ b/packages/api/nros-cpp/include/nros/node.hpp
@@ -156,6 +156,11 @@ static_assert(NROS_CPP_RET_NOT_FOUND == -4 && NROS_CPP_RET_ALREADY_EXISTS == -5 
 // declaration sites, and `api-parity` attributes a name to the header it is
 // first seen in.
 namespace rclcpp {
+// phase-427 W7 — the node itself, defined further down in this header. Forward
+// declared up here because the `nros::` free functions BELOW take it by
+// reference and are named by `Node`'s own qualified friend declarations, which
+// require a prior declaration of the function AND of its parameter type.
+class Node;
 template <typename M> class Publisher;
 template <typename M> class Subscription;
 template <typename S> class Service;
@@ -449,41 +454,73 @@ inline Result init_with_launch(const char* path, int argc = 0, char** argv = nul
 /// Closes the middleware connection and frees all resources.
 inline Result shutdown();
 
-/// Node — the primary interface for creating ROS entities.
-///
-/// Mirrors `rclcpp::Node`. Entities (publishers, subscriptions, services,
-/// etc.) are created through the node. The node holds a reference to the
-/// parent executor session.
+// phase-427 W7 — the remaining `nros::` free functions `Node` befriends. A
+// QUALIFIED friend declaration (`friend Result(::nros::ok)();`) names an
+// existing entity; it cannot introduce one. These four live in `nros.hpp`,
+// which includes this header, so without these declarations the friendship
+// would be unresolvable and the private `executor_handle_` unreachable from the
+// functions whose whole job is to set it. Default arguments stay on the
+// definitions — a default may be added by a later declaration, never repeated.
+inline bool ok();
+inline Result create_node(::rclcpp::Node& out, const char* name, const char* ns);
+inline Result create_node_on(::rclcpp::Node& out, void* executor_handle, const char* name,
+                             const char* ns);
+inline Result spin_once(int32_t timeout_ms);
+inline Result spin();
+inline Result spin(uint32_t duration_ms, int32_t poll_ms);
+inline void* global_handle();
+
+} // namespace nros
+
+// ============================================================================
+// rclcpp:: — the HOME of the C++ node type (RFC-0089 §"Settled: `rclcpp::` is
+// the HOME, not an alias onto `nros::`"). phase-427 W7 flipped the direction:
+// the class is DEFINED here and `nros::Node` below is the migration alias, the
+// same shape the other nine types already carry (`clock.hpp`, `duration.hpp`,
+// `time.hpp`, `publisher.hpp`, `subscription.hpp`, `client.hpp`, `service.hpp`,
+// `action_client.hpp`, `action_server.hpp`).
+//
+// `Node` was the TENTH and was held back because PRs #797 and #806 were stacked
+// on this header. Both merged. The measurement that blocked it before — the
+// parity extractor rooting our native surface at `{"nros"}` alone, so a class
+// defined here re-bucketed ~60 members to `theirs-only` — is gone too:
+// `scripts/api-parity.py` roots every C++ TU at `OUR_CPP_ROOTS`, both halves of
+// the vocabulary we ship.
+//
+// The body below is written in the `rclcpp::` vocabulary, so the `nros::`-only
+// names it reaches (`ErrorCode`, `detail::*`, `NodeHandle`, `SchedContext`, the
+// polling entity templates) are spelled `::nros::`-qualified. That is
+// deliberate and not noise: it is what a reader needs to tell an adopted name
+// from an ours-only one, and it is what keeps the two vocabularies from being
+// re-merged by a using-directive.
+// ============================================================================
+namespace rclcpp {
+/// The node — `rclcpp::Node`, and `nros::Node`, which are ONE TYPE
+/// (phase-427). The primary interface for creating ROS entities: publishers,
+/// subscriptions, services, timers are all created through it, and it holds a
+/// reference to the parent executor session.
 ///
 /// Usage:
 /// ```cpp
-/// nros::Node node;
-/// NROS_TRY(nros::Node::create(node, "my_node"));
+/// rclcpp::Node node;
+/// NROS_TRY(rclcpp::Node::create(node, "my_node"));
 /// ```
-/// The node — `rclcpp::Node`, and `nros::Node`, which are ONE TYPE
-/// (phase-427).
 ///
 /// Three shapes collapsed here: the freestanding out-ref node, the hosted
 /// `shared_ptr` node that used to be a separate `rclcpp::Node` in `nros.hpp`,
-/// and (from RFC-0044) the derivable component base. `rclcpp::Node` is declared
+/// and (from RFC-0044) the derivable component base. `nros::Node` is declared
 /// as an alias for this class at the bottom of this header, so
 /// `std::is_same<rclcpp::Node, nros::Node>::value` is true and there is exactly
 /// one set of entities, one arena registration path and one parameter facade.
 ///
-/// WHY THE CLASS IS DEFINED IN `nros::` AND ALIASED INTO `rclcpp::`, rather
-/// than the other way round as RFC-0089's end state describes. It is measured,
-/// not stylistic: `scripts/api-parity.py` extracts the NATIVE C++ surface with
-/// namespace root `{"nros"}` and the PORTED surface with `{"rclcpp", ...}`,
-/// and only the native bucket is gated by `just check api-parity`. Moving the
-/// class definition into `rclcpp` empties `nros::Node::*` from the native
-/// surface, so every one of its ~60 members re-buckets to `theirs-only` with no
-/// ledger row and the gate goes red — a namespace question answered by a
-/// measurement tool's roots. Every other type in this API is already spelled
-/// this way (`rclcpp::Publisher`, `rclcpp::QoS`, `rclcpp::Timer`,
-/// `rclcpp::Clock` are all aliases of `nros::` definitions), so this is the
-/// consistent shape as well as the affordable one. Flipping it is the same
-/// change as phase-428's whole-tree `nros::` -> `rclcpp::` migration, and
-/// belongs with it.
+/// THE CLASS IS DEFINED HERE, in `rclcpp::`, and `nros::Node` is the alias —
+/// RFC-0089 §"Settled: `rclcpp::` is the HOME, not an alias onto `nros::`", and
+/// the tenth and last type of the phase-428 flip. It was held back for two
+/// reasons, both now gone: two landed reviews (PRs #797, #806) were stacked on
+/// this header, and `scripts/api-parity.py` rooted our NATIVE C++ surface at
+/// `{"nros"}` alone, so a class defined here re-bucketed ~60 members to
+/// `theirs-only` with no ledger row. The tool was the thing that had to change
+/// and did: `OUR_CPP_ROOTS` now names both halves of the vocabulary we ship.
 ///
 /// LAYOUT IS PROBE-INDEPENDENT (phase-427 W1, gate
 /// `check-cpp-capability-layout`). Every member below is unconditional; the
@@ -529,8 +566,8 @@ class Node {
     /// Re-initialising an already-initialised node is `AlreadyExists` rather
     /// than a silent re-open.
     Result init(const char* name, const char* ns = nullptr) {
-        if (initialized_) return Result(ErrorCode::AlreadyExists);
-        if (!Node::global_initialized()) return Result(ErrorCode::NotInitialized);
+        if (initialized_) return Result(::nros::ErrorCode::AlreadyExists);
+        if (!Node::global_initialized()) return Result(::nros::ErrorCode::NotInitialized);
         executor_handle_ = Node::global_storage();
         return Node::create(*this, name, ns);
     }
@@ -540,8 +577,8 @@ class Node {
     /// `NodeHandle` constructor used to be (RFC-0089 §"What this means for the
     /// merge": construction is not identity).
     Result init_on(void* executor_handle, const char* name, const char* ns = nullptr) {
-        if (initialized_) return Result(ErrorCode::AlreadyExists);
-        if (executor_handle == nullptr) return Result(ErrorCode::NotInitialized);
+        if (initialized_) return Result(::nros::ErrorCode::AlreadyExists);
+        if (executor_handle == nullptr) return Result(::nros::ErrorCode::NotInitialized);
         executor_handle_ = executor_handle;
         return Node::create(*this, name, ns);
     }
@@ -553,7 +590,7 @@ class Node {
     /// This is the SECOND of the type's two constructors. On a null handle or a
     /// creation failure it latches the error rather than aborting: the entry
     /// checks `ok()` post-construct and halts naming this node (RFC-0044 Q2).
-    explicit Node(NodeHandle handle, const char* name, const char* ns = nullptr)
+    explicit Node(::nros::NodeHandle handle, const char* name, const char* ns = nullptr)
         : handle_(), initialized_(false), executor_handle_(nullptr), clock_(NROS_CLOCK_ROS_TIME),
           hosted_(nullptr) {
         if (!handle.valid()) {
@@ -677,7 +714,7 @@ class Node {
     /// `create_publisher<M>(topic, qos)` — upstream's shape.
     template <typename M>
     ::std::shared_ptr<::rclcpp::Publisher<M>> create_publisher(const ::std::string& topic,
-                                                               const QoS& qos);
+                                                               const ::nros::QoS& qos);
 
     /// `create_publisher<M>(topic, depth)` — the integer-depth spelling.
     template <typename M>
@@ -688,7 +725,7 @@ class Node {
     /// Accepts ANY callable; the executor dispatches it.
     template <typename M, typename Cb>
     ::std::shared_ptr<::rclcpp::Subscription<M>> create_subscription(const ::std::string& topic,
-                                                                     const QoS& qos, Cb cb);
+                                                                     const ::nros::QoS& qos, Cb cb);
 
     /// `create_subscription<M>(topic, depth, callback)`.
     template <typename M, typename Cb>
@@ -705,15 +742,16 @@ class Node {
     /// upstream signature — upstream requires a callback — so it claims
     /// nothing. Drain with `service->take_request(...)`.
     template <typename S>
-    ::std::shared_ptr<::rclcpp::Service<S>> create_service(const ::std::string& name,
-                                                           const QoS& qos = QoS::services());
+    ::std::shared_ptr<::rclcpp::Service<S>>
+    create_service(const ::std::string& name, const ::nros::QoS& qos = ::nros::QoS::services());
 
     /// Callback-style service server (`void(const S::Request&, S::Response&)`).
     template <typename S, typename F,
               typename = typename std::enable_if<std::is_convertible<
                   F, void (*)(const typename S::Request&, typename S::Response&)>::value>::type>
-    ::std::shared_ptr<::rclcpp::Service<S>> create_service(const ::std::string& name, F callback,
-                                                           const QoS& qos = QoS::services());
+    ::std::shared_ptr<::rclcpp::Service<S>>
+    create_service(const ::std::string& name, F callback,
+                   const ::nros::QoS& qos = ::nros::QoS::services());
 
     /// **REFUSED** — upstream's `shared_ptr` handler shape. See
     /// `NROS_RCLCPP_REFUSE_SHARED_PTR_SERVICE_CALLBACK`.
@@ -723,20 +761,21 @@ class Node {
                   !std::is_convertible<F, void (*)(const typename S::Request&,
                                                    typename S::Response&)>::value>::type,
               typename = void>
-    ::std::shared_ptr<::rclcpp::Service<S>> create_service(const ::std::string&, F,
-                                                           const QoS& = QoS::services());
+    ::std::shared_ptr<::rclcpp::Service<S>>
+    create_service(const ::std::string&, F, const ::nros::QoS& = ::nros::QoS::services());
 
     /// Future-style service client — pair with `spin_until_future_complete`.
     template <typename S>
-    ::std::shared_ptr<::rclcpp::Client<S>> create_client(const ::std::string& name,
-                                                         const QoS& qos = QoS::services());
+    ::std::shared_ptr<::rclcpp::Client<S>>
+    create_client(const ::std::string& name, const ::nros::QoS& qos = ::nros::QoS::services());
 
     /// Callback-style service client (`void(const S::Response&)`).
     template <typename S, typename F,
               typename = typename std::enable_if<
                   std::is_convertible<F, void (*)(const typename S::Response&)>::value>::type>
-    ::std::shared_ptr<::rclcpp::Client<S>> create_client(const ::std::string& name, F callback,
-                                                         const QoS& qos = QoS::services());
+    ::std::shared_ptr<::rclcpp::Client<S>>
+    create_client(const ::std::string& name, F callback,
+                  const ::nros::QoS& qos = ::nros::QoS::services());
 
     /// **REFUSED** — upstream's `shared_ptr` handler shape.
     template <typename S, typename F,
@@ -744,8 +783,8 @@ class Node {
                   !::rclcpp::detail::is_qos_arg<F>::value &&
                   !std::is_convertible<F, void (*)(const typename S::Response&)>::value>::type,
               typename = void>
-    ::std::shared_ptr<::rclcpp::Client<S>> create_client(const ::std::string&, F,
-                                                         const QoS& = QoS::services());
+    ::std::shared_ptr<::rclcpp::Client<S>>
+    create_client(const ::std::string&, F, const ::nros::QoS& = ::nros::QoS::services());
 
     // -- parameters (bodies in `nros.hpp`) ----------------------------------
     //
@@ -817,7 +856,7 @@ class Node {
     /// @return Result indicating success or failure.
     static Result create(Node& out, const char* name, const char* ns = nullptr) {
         if (!out.executor_handle_) {
-            return Result(ErrorCode::NotInitialized);
+            return Result(::nros::ErrorCode::NotInitialized);
         }
 
         nros_cpp_ret_t ret = nros_cpp_node_create(out.executor_handle_, name, ns, &out.handle_);
@@ -855,7 +894,7 @@ class Node {
     ///        or, when the buffer is too small, the length that WOULD be
     ///        written, so a caller can size a second attempt. May be nullptr.
     Result get_fully_qualified_name(char* buf, size_t buf_len, size_t* out_len = nullptr) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_node_get_fully_qualified_name(&handle_, buf, buf_len, out_len));
     }
 
@@ -1007,7 +1046,7 @@ class Node {
     /// `ErrorCode::Unsupported` from a backend with no graph stays distinct
     /// from it.
     Result get_node_names(nros_cpp_node_visit_fn visit, void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_node_names(executor_handle_, visit, ctx));
     }
 
@@ -1019,7 +1058,7 @@ class Node {
     /// `types_count` may legitimately be 0 on a partially discovered graph.
     /// Same discovery envelope as [`get_node_names`].
     Result get_topic_names_and_types(nros_cpp_names_and_types_visit_fn visit, void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_topic_names_and_types(executor_handle_, visit, ctx));
     }
 
@@ -1027,7 +1066,7 @@ class Node {
     /// `Node::get_service_names_and_types()`. As
     /// [`get_topic_names_and_types`], over servers and clients.
     Result get_service_names_and_types(nros_cpp_names_and_types_visit_fn visit, void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_service_names_and_types(executor_handle_, visit, ctx));
     }
 
@@ -1040,14 +1079,14 @@ class Node {
     /// DISCOVERED, so it can be low right after startup and a zero is never a
     /// proof of absence.
     Result count_publishers(const char* topic_name, size_t* out_count) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_count_publishers(executor_handle_, topic_name, out_count));
     }
 
     /// How many subscribers are visible on `topic_name` — rclcpp's
     /// `Node::count_subscribers()`. See [`count_publishers`] for the caveats.
     Result count_subscribers(const char* topic_name, size_t* out_count) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_count_subscribers(executor_handle_, topic_name, out_count));
     }
 
@@ -1057,7 +1096,7 @@ class Node {
     Result get_publisher_names_and_types_by_node(const char* node_name, const char* node_namespace,
                                                  nros_cpp_names_and_types_visit_fn visit,
                                                  void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_publisher_names_and_types_by_node(
             executor_handle_, node_name, node_namespace, visit, ctx));
     }
@@ -1076,7 +1115,7 @@ class Node {
                                                     const char* node_namespace,
                                                     nros_cpp_names_and_types_visit_fn visit,
                                                     void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_subscription_names_and_types_by_node(
             executor_handle_, node_name, node_namespace, visit, ctx));
     }
@@ -1087,7 +1126,7 @@ class Node {
     Result get_service_names_and_types_by_node(const char* node_name, const char* node_namespace,
                                                nros_cpp_names_and_types_visit_fn visit,
                                                void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_service_names_and_types_by_node(
             executor_handle_, node_name, node_namespace, visit, ctx));
     }
@@ -1098,7 +1137,7 @@ class Node {
     Result get_client_names_and_types_by_node(const char* node_name, const char* node_namespace,
                                               nros_cpp_names_and_types_visit_fn visit,
                                               void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_client_names_and_types_by_node(
             executor_handle_, node_name, node_namespace, visit, ctx));
     }
@@ -1119,7 +1158,7 @@ class Node {
     /// Same discovery envelope as [`get_node_names`].
     Result get_publishers_info_by_topic(const char* topic_name,
                                         nros_cpp_endpoint_info_visit_fn visit, void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_publishers_info_by_topic(executor_handle_, topic_name,
                                                                      visit, ctx));
     }
@@ -1132,12 +1171,12 @@ class Node {
     /// `endpoint_gid()`) instead of the raw C struct. Every caveat of the
     /// `nros_cpp_endpoint_info_visit_fn` overload applies unchanged, including
     /// the absent QoS profile and the borrowed strings.
-    Result get_publishers_info_by_topic(const char* topic_name, TopicEndpointInfoVisitFn visit,
-                                        void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
-        detail::EndpointInfoTrampoline tramp{visit, ctx};
+    Result get_publishers_info_by_topic(const char* topic_name,
+                                        ::nros::TopicEndpointInfoVisitFn visit, void* ctx) const {
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+        ::nros::detail::EndpointInfoTrampoline tramp{visit, ctx};
         return Result(nros_cpp_executor_get_publishers_info_by_topic(
-            executor_handle_, topic_name, &detail::EndpointInfoTrampoline::thunk, &tramp));
+            executor_handle_, topic_name, &::nros::detail::EndpointInfoTrampoline::thunk, &tramp));
     }
 
     /// The subscriptions discovered on `topic_name`, one visit each —
@@ -1146,7 +1185,7 @@ class Node {
     /// envelopes.
     Result get_subscriptions_info_by_topic(const char* topic_name,
                                            nros_cpp_endpoint_info_visit_fn visit, void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         return Result(nros_cpp_executor_get_subscriptions_info_by_topic(executor_handle_,
                                                                         topic_name, visit, ctx));
     }
@@ -1154,12 +1193,13 @@ class Node {
     /// The subscriptions on `topic_name`, visited as
     /// [`nros::TopicEndpointInfo`] — the rclcpp-shaped overload of the call
     /// above.
-    Result get_subscriptions_info_by_topic(const char* topic_name, TopicEndpointInfoVisitFn visit,
+    Result get_subscriptions_info_by_topic(const char* topic_name,
+                                           ::nros::TopicEndpointInfoVisitFn visit,
                                            void* ctx) const {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
-        detail::EndpointInfoTrampoline tramp{visit, ctx};
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+        ::nros::detail::EndpointInfoTrampoline tramp{visit, ctx};
         return Result(nros_cpp_executor_get_subscriptions_info_by_topic(
-            executor_handle_, topic_name, &detail::EndpointInfoTrampoline::thunk, &tramp));
+            executor_handle_, topic_name, &::nros::detail::EndpointInfoTrampoline::thunk, &tramp));
     }
 
     /// Create a publisher for a topic.
@@ -1170,7 +1210,7 @@ class Node {
     /// @param qos    QoS profile (default: reliable, keep-last(10)).
     template <typename M>
     Result create_publisher(::rclcpp::Publisher<M>& out, const char* topic,
-                            const QoS& qos = QoS::default_profile());
+                            const ::nros::QoS& qos = ::nros::QoS::default_profile());
 
     /// Create a publisher with rclcpp-style named options (Phase 189.M3.1).
     ///
@@ -1185,8 +1225,8 @@ class Node {
     /// @param qos      QoS profile.
     /// @param options  Named publisher options.
     template <typename M>
-    Result create_publisher(::rclcpp::Publisher<M>& out, const char* topic, const QoS& qos,
-                            const PublisherOptions& options);
+    Result create_publisher(::rclcpp::Publisher<M>& out, const char* topic, const ::nros::QoS& qos,
+                            const ::nros::PublisherOptions& options);
 
     /// Create a subscription for a topic.
     ///
@@ -1196,7 +1236,7 @@ class Node {
     /// @param qos    QoS profile (default: reliable, keep-last(10)).
     template <typename M>
     Result create_subscription(::rclcpp::Subscription<M>& out, const char* topic,
-                               const QoS& qos = QoS::default_profile());
+                               const ::nros::QoS& qos = ::nros::QoS::default_profile());
 
     /// Create a subscription with rclcpp-style named options (Phase 189.M3.1).
     ///
@@ -1211,8 +1251,8 @@ class Node {
     /// @param qos      QoS profile.
     /// @param options  Named subscription options.
     template <typename M>
-    Result create_subscription(::rclcpp::Subscription<M>& out, const char* topic, const QoS& qos,
-                               const SubscriptionOptions& options);
+    Result create_subscription(::rclcpp::Subscription<M>& out, const char* topic,
+                               const ::nros::QoS& qos, const ::nros::SubscriptionOptions& options);
 
     /// Create a **callback-style** subscription (rclcpp dispatch model; Phase
     /// 189.M3.x). The executor arena owns the subscriber and invokes `callback`
@@ -1236,8 +1276,8 @@ class Node {
         typename M, typename F,
         typename = typename std::enable_if<std::is_convertible<F, void (*)(const M&)>::value>::type>
     Result create_subscription(::rclcpp::Subscription<M>& out, const char* topic, F callback,
-                               const QoS& qos = QoS::default_profile(),
-                               const SubscriptionOptions& options = {});
+                               const ::nros::QoS& qos = ::nros::QoS::default_profile(),
+                               const ::nros::SubscriptionOptions& options = {});
 
     /// Create a **callback-style** subscription that also delivers each sample's
     /// wire **attachment** (Phase 189.M3.4 — the callback analogue of
@@ -1250,8 +1290,9 @@ class Node {
               typename = typename std::enable_if<
                   std::is_convertible<F, void (*)(const M&, const uint8_t*, size_t)>::value>::type>
     Result create_subscription_with_info(::rclcpp::Subscription<M>& out, const char* topic,
-                                         F callback, const QoS& qos = QoS::default_profile(),
-                                         const SubscriptionOptions& options = {});
+                                         F callback,
+                                         const ::nros::QoS& qos = ::nros::QoS::default_profile(),
+                                         const ::nros::SubscriptionOptions& options = {});
 
 #if defined(NANO_ROS_SAFETY_E2E)
     /// Phase 269 W3 — Create a **callback-style** subscription that surfaces the
@@ -1272,8 +1313,9 @@ class Node {
               typename = typename std::enable_if<std::is_convertible<
                   F, void (*)(const M&, const nros_cpp_integrity_status_t&)>::value>::type>
     Result create_subscription_with_safety(::rclcpp::Subscription<M>& out, const char* topic,
-                                           F callback, const QoS& qos = QoS::default_profile(),
-                                           const SubscriptionOptions& options = {});
+                                           F callback,
+                                           const ::nros::QoS& qos = ::nros::QoS::default_profile(),
+                                           const ::nros::SubscriptionOptions& options = {});
 #endif // NANO_ROS_SAFETY_E2E
 
     /// Create a service server.
@@ -1284,7 +1326,7 @@ class Node {
     /// @param qos           QoS profile (default: services preset).
     template <typename S>
     Result create_service(::rclcpp::Service<S>& out, const char* service_name,
-                          const QoS& qos = QoS::services());
+                          const ::nros::QoS& qos = ::nros::QoS::services());
 
     /// Create a **callback-style** service server (rclcpp dispatch model;
     /// Phase 189.M3.3.e). Unlike the poll-style overload above, this
@@ -1302,7 +1344,8 @@ class Node {
               typename = typename std::enable_if<std::is_convertible<
                   F, void (*)(const typename S::Request&, typename S::Response&)>::value>::type>
     Result create_service(::rclcpp::Service<S>& out, const char* service_name, F callback,
-                          const QoS& qos = QoS::services(), const ServiceOptions& options = {});
+                          const ::nros::QoS& qos = ::nros::QoS::services(),
+                          const ::nros::ServiceOptions& options = {});
 
     /// Create a service client.
     ///
@@ -1312,7 +1355,7 @@ class Node {
     /// @param qos           QoS profile (default: services preset).
     template <typename S>
     Result create_client(::rclcpp::Client<S>& out, const char* service_name,
-                         const QoS& qos = QoS::services());
+                         const ::nros::QoS& qos = ::nros::QoS::services());
 
     /// Create a **callback-style** service client (rclcpp async dispatch;
     /// Phase 189.M3.3.f). Arena-registered, so it owns a real executor handle and
@@ -1328,7 +1371,8 @@ class Node {
               typename = typename std::enable_if<
                   std::is_convertible<F, void (*)(const typename S::Response&)>::value>::type>
     Result create_client(::rclcpp::Client<S>& out, const char* service_name, F callback,
-                         const QoS& qos = QoS::services(), const ClientOptions& options = {});
+                         const ::nros::QoS& qos = ::nros::QoS::services(),
+                         const ::nros::ClientOptions& options = {});
 
     /// Create an action server.
     ///
@@ -1342,8 +1386,8 @@ class Node {
     ///                     the goal-service dispatch onto a scheduling context.
     template <typename A>
     Result create_action_server(::rclcpp_action::Server<A>& out, const char* action_name,
-                                const QoS& qos = QoS::services(),
-                                const ActionServerOptions& options = {});
+                                const ::nros::QoS& qos = ::nros::QoS::services(),
+                                const ::nros::ActionServerOptions& options = {});
 
     /// Create an action client.
     ///
@@ -1353,17 +1397,19 @@ class Node {
     /// @param qos          QoS profile (default: services preset).
     template <typename A>
     Result create_action_client(::rclcpp_action::Client<A>& out, const char* action_name,
-                                const QoS& qos = QoS::services());
+                                const ::nros::QoS& qos = ::nros::QoS::services());
 
     /// Phase 122.3.d.b — Create an L1 polling-mode action server.
     /// Caller drives the lifecycle (no executor callback). See
     /// `polling_action_server.hpp` for usage.
     template <typename A>
-    Result create_polling_action_server(PollingActionServer<A>& out, const char* action_name);
+    Result create_polling_action_server(::nros::PollingActionServer<A>& out,
+                                        const char* action_name);
 
     /// Phase 122.3.d.b — Create an L1 polling-mode action client.
     template <typename A>
-    Result create_polling_action_client(PollingActionClient<A>& out, const char* action_name);
+    Result create_polling_action_client(::nros::PollingActionClient<A>& out,
+                                        const char* action_name);
 
     /// Issue 0278 — Create a latest-value polling subscription (the nano-ros
     /// analog of `autoware_utils::InterProcessPollingSubscriber`): a poll-mode
@@ -1371,8 +1417,8 @@ class Node {
     /// `PollingSubscription<M>::take_data()` / `take_new_data()`. See
     /// `polling_subscription.hpp`.
     template <typename M>
-    Result create_polling_subscription(PollingSubscription<M>& out, const char* topic,
-                                       const QoS& qos = QoS::default_profile());
+    Result create_polling_subscription(::nros::PollingSubscription<M>& out, const char* topic,
+                                       const ::nros::QoS& qos = ::nros::QoS::default_profile());
 
     /// Create a repeating timer on a CLOCK — `rclcpp::create_timer(node, clock,
     /// period, callback)`, phase-425 W4.
@@ -1399,7 +1445,7 @@ class Node {
     /// @param context    User context passed to the callback (may be nullptr).
     Result create_timer(Timer& out, const Clock& clock, uint64_t period_ms,
                         nros_cpp_timer_callback_t callback, void* context = nullptr) {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         size_t handle_id = 0;
         nros_cpp_ret_t ret = nros_cpp_timer_create_on_clock(
             executor_handle_, static_cast<uint8_t>(clock.get_clock_type()), period_ms, callback,
@@ -1424,7 +1470,7 @@ class Node {
     /// @param context    User context passed to the callback (may be nullptr).
     Result create_wall_timer(Timer& out, uint64_t period_ms, nros_cpp_timer_callback_t callback,
                              void* context = nullptr) {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         size_t handle_id = 0;
         nros_cpp_ret_t ret =
             nros_cpp_timer_create(executor_handle_, period_ms, callback, context, &handle_id);
@@ -1475,7 +1521,7 @@ class Node {
     /// Bind a member `void C::on_tick()` as a timer IN a callback group
     /// (RFC-0047) — the member-binding half of `create_timer_in_group`.
     template <class C, void (C::*Method)()>
-    Result create_timer_in_group(const CallbackGroup& group, Timer& out, uint64_t period_ms,
+    Result create_timer_in_group(const ::nros::CallbackGroup& group, Timer& out, uint64_t period_ms,
                                  C* self) {
         return this->create_timer_in_group(
             group, out, period_ms, [](void* ctx) { (static_cast<C*>(ctx)->*Method)(); }, self);
@@ -1491,7 +1537,7 @@ class Node {
     /// @param context   User context passed to the callback (may be nullptr).
     Result create_timer_oneshot(Timer& out, uint64_t delay_ms, nros_cpp_timer_callback_t callback,
                                 void* context = nullptr) {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         size_t handle_id = 0;
         nros_cpp_ret_t ret = nros_cpp_timer_create_oneshot(executor_handle_, delay_ms, callback,
                                                            context, &handle_id);
@@ -1513,7 +1559,9 @@ class Node {
     ///
     /// @param name  Group name — must be a string literal or static-lifetime
     ///              string; the pointer is stored directly (no copy).
-    CallbackGroup create_callback_group(const char* name) { return CallbackGroup{name}; }
+    ::nros::CallbackGroup create_callback_group(const char* name) {
+        return ::nros::CallbackGroup{name};
+    }
 
     /// Create a repeating timer **in** a callback group (RFC-0047).
     ///
@@ -1526,9 +1574,9 @@ class Node {
     /// @param period_ms  Timer period in milliseconds.
     /// @param callback   C function pointer invoked on each tick.
     /// @param context    User context passed to the callback (may be nullptr).
-    Result create_timer_in_group(const CallbackGroup& group, Timer& out, uint64_t period_ms,
+    Result create_timer_in_group(const ::nros::CallbackGroup& group, Timer& out, uint64_t period_ms,
                                  nros_cpp_timer_callback_t callback, void* context = nullptr) {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         size_t handle_id = 0;
         nros_cpp_ret_t ret = nros_cpp_timer_create_in_group(
             executor_handle_, &handle_, period_ms, callback, context, group.get_name(), &handle_id);
@@ -1557,10 +1605,11 @@ class Node {
     template <
         typename M, typename F,
         typename = typename std::enable_if<std::is_convertible<F, void (*)(const M&)>::value>::type>
-    Result create_subscription_in_group(const CallbackGroup& group, ::rclcpp::Subscription<M>& out,
-                                        const char* topic, F callback,
-                                        const QoS& qos = QoS::default_profile(),
-                                        const SubscriptionOptions& options = {});
+    Result create_subscription_in_group(const ::nros::CallbackGroup& group,
+                                        ::rclcpp::Subscription<M>& out, const char* topic,
+                                        F callback,
+                                        const ::nros::QoS& qos = ::nros::QoS::default_profile(),
+                                        const ::nros::SubscriptionOptions& options = {});
 
     /// Create a publisher **in** a callback group (API symmetry; RFC-0047).
     ///
@@ -1574,8 +1623,9 @@ class Node {
     /// @param topic  Topic name.
     /// @param qos    QoS profile.
     template <typename M>
-    Result create_publisher_in_group(const CallbackGroup& /* group */, ::rclcpp::Publisher<M>& out,
-                                     const char* topic, const QoS& qos = QoS::default_profile()) {
+    Result create_publisher_in_group(const ::nros::CallbackGroup& /* group */,
+                                     ::rclcpp::Publisher<M>& out, const char* topic,
+                                     const ::nros::QoS& qos = ::nros::QoS::default_profile()) {
         return create_publisher<M>(out, topic, qos);
     }
 
@@ -1586,9 +1636,9 @@ class Node {
     /// @param out       Receives the initialized guard condition.
     /// @param callback  C function pointer invoked when triggered.
     /// @param context   User context passed to the callback (may be nullptr).
-    Result create_guard_condition(GuardCondition& out, nros_cpp_guard_callback_t callback,
+    Result create_guard_condition(::nros::GuardCondition& out, nros_cpp_guard_callback_t callback,
                                   void* context = nullptr) {
-        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
         nros_cpp_ret_t ret =
             nros_cpp_guard_condition_create(executor_handle_, callback, context, out.storage_);
         if (ret == 0) {
@@ -1634,8 +1684,9 @@ class Node {
     /// member: `pub_ = create_publisher_in<M>("/topic")`. Latches `ok()=false`
     /// on failure instead of throwing.
     template <typename M>
-    ::rclcpp::Publisher<M> create_publisher_in(const char* topic,
-                                               const QoS& qos = QoS::default_profile()) {
+    ::rclcpp::Publisher<M>
+    create_publisher_in(const char* topic,
+                        const ::nros::QoS& qos = ::nros::QoS::default_profile()) {
         ::rclcpp::Publisher<M> pub;
         Result r = this->create_publisher(pub, topic, qos);
         if (!r.ok()) {
@@ -1658,13 +1709,14 @@ class Node {
     /// `nros.hpp` pulls in `component.hpp`, so the definition is visible
     /// wherever the umbrella is.
     template <typename M, class C, void (C::*Method)(const M& msg)>
-    void create_subscription_in(const char* topic, const QoS& qos = QoS::default_profile());
+    void create_subscription_in(const char* topic,
+                                const ::nros::QoS& qos = ::nros::QoS::default_profile());
 
     /// The same, **in** a callback group (RFC-0047) — the group's SchedContext
     /// is resolved via `group_sched_table`. Also defined in `component.hpp`.
     template <typename M, class C, void (C::*Method)(const M& msg)>
-    void create_subscription_in_group(const CallbackGroup& group, const char* topic,
-                                      const QoS& qos = QoS::default_profile());
+    void create_subscription_in_group(const ::nros::CallbackGroup& group, const char* topic,
+                                      const ::nros::QoS& qos = ::nros::QoS::default_profile());
 
     /// phase-403 step 2 — the BOOT-TIME half of the declared-depth check.
     ///
@@ -1682,7 +1734,7 @@ class Node {
     /// did not declare is exactly the arena mis-sizing this step prevents.
     ///
     /// Returns true when the subscription may be created.
-    bool check_declared_depth(const char* type_name, const char* topic, const QoS& qos) {
+    bool check_declared_depth(const char* type_name, const char* topic, const ::nros::QoS& qos) {
         const int declared = ::nros::declared_depth(type_name, topic);
         // Nobody declared this endpoint. Not an error: the image has not opted
         // in, and anything sizing from depth refuses rather than defaulting.
@@ -1694,11 +1746,13 @@ class Node {
         }
         // The two NUMBERS and the TOPIC go out first: `set_error` records one
         // `const char*`, which cannot carry them.
-        detail::report_declared_depth_mismatch(this->get_name(), topic, declared, qos.depth());
-        this->set_error("create_subscription_in: QoS depth disagrees with the depth declared for "
-                        "this topic in the contract sidecar. Depth multiplies the arena, so the "
-                        "declaration and the code must state one number, not two.",
-                        detail::DECLARED_DEPTH_MISMATCH);
+        ::nros::detail::report_declared_depth_mismatch(this->get_name(), topic, declared,
+                                                       qos.depth());
+        this->set_error(
+            "create_subscription_in: ::nros::QoS depth disagrees with the depth declared for "
+            "this topic in the contract sidecar. Depth multiplies the arena, so the "
+            "declaration and the code must state one number, not two.",
+            ::nros::detail::DECLARED_DEPTH_MISMATCH);
         return false;
     }
 
@@ -1762,7 +1816,7 @@ class Node {
             // RELEASE publishes the two plain writes above: a reader that
             // acquire-observes has_error_ == true is guaranteed to see them.
             __atomic_store_n(&has_error_, true, __ATOMIC_RELEASE);
-            detail::report_component_failure(this->get_name(), what, code);
+            ::nros::detail::report_component_failure(this->get_name(), what, code);
         }
     }
 
@@ -1775,7 +1829,8 @@ class Node {
     /// the defect the layout rule exists to prevent.
     ~Node() {
         if (hosted_ != nullptr) {
-            detail::NodeHostedBase* h = static_cast<detail::NodeHostedBase*>(hosted_);
+            ::nros::detail::NodeHostedBase* h =
+                static_cast<::nros::detail::NodeHostedBase*>(hosted_);
             hosted_ = nullptr;
             h->destroy(h);
         }
@@ -1802,7 +1857,8 @@ class Node {
     Node& operator=(Node&& other) {
         if (this != &other) {
             if (hosted_ != nullptr) {
-                detail::NodeHostedBase* h = static_cast<detail::NodeHostedBase*>(hosted_);
+                ::nros::detail::NodeHostedBase* h =
+                    static_cast<::nros::detail::NodeHostedBase*>(hosted_);
                 hosted_ = nullptr;
                 h->destroy(h);
             }
@@ -1842,12 +1898,13 @@ class Node {
     /// `create_*` family never calls `operator new` either. `const` reads go
     /// through the same allocation because `get_node_options()` and
     /// `parameters() const` must answer on a node nobody has written to yet.
-    detail::NodeHosted& hosted() const {
+    ::nros::detail::NodeHosted& hosted() const {
         if (hosted_ == nullptr) {
             const_cast<Node*>(this)->hosted_ =
-                static_cast<detail::NodeHostedBase*>(new detail::NodeHosted());
+                static_cast<::nros::detail::NodeHostedBase*>(new ::nros::detail::NodeHosted());
         }
-        return *static_cast<detail::NodeHosted*>(static_cast<detail::NodeHostedBase*>(hosted_));
+        return *static_cast<::nros::detail::NodeHosted*>(
+            static_cast<::nros::detail::NodeHostedBase*>(hosted_));
     }
 #endif
 
@@ -1879,21 +1936,36 @@ class Node {
     const char* error_what_ = nullptr;
     int32_t error_code_ = 0;
 
-    friend class Executor;
-    friend class NodeBuilder;
-    friend Result init(const char* locator, uint8_t domain_id);
-    friend Result init(const char* locator, uint8_t domain_id, const char* session_name);
-    friend Result init_with_rmw(const char* rmw, const char* locator, uint8_t domain_id,
-                                const char* session_name);
-    friend Result shutdown();
-    friend bool ok();
-    friend Result create_node(Node& out, const char* name, const char* ns);
-    friend Result create_node_on(Node& out, void* executor_handle, const char* name,
-                                 const char* ns);
-    friend Result spin_once(int32_t timeout_ms);
-    friend Result spin();
-    friend Result spin(uint32_t duration_ms, int32_t poll_ms);
-    friend void* global_handle();
+    // phase-427 W7 — the class moved to `rclcpp::`; its friends did not. Every
+    // one of these is an `nros::` name, so each is QUALIFIED: an unqualified
+    // `friend Result init(...)` inside this namespace would befriend a
+    // `rclcpp::init` that does not exist and leave the real one locked out.
+    // phase-427 W7 — the class moved to `rclcpp::`; its friends did not. Every
+    // one of these is an `nros::` free function, so each is QUALIFIED: an
+    // unqualified `friend Result init(...)` inside this namespace would
+    // befriend a `rclcpp::init` that does not exist and leave the real one
+    // locked out.
+    //
+    // The declarator-id is PARENTHESIZED, and that is not style. A
+    // nested-name-specifier is parsed greedily, so `friend Result ::nros::init`
+    // reads as `Result::nros::init` and fails with `'nros' in 'using Result ='
+    // does not name a type` — a diagnostic that names neither the friend nor
+    // the namespace. `(::nros::init)` closes the return type first.
+    friend class ::nros::Executor;
+    friend class ::nros::NodeBuilder;
+    friend Result(::nros::init)(const char* locator, uint8_t domain_id);
+    friend Result(::nros::init)(const char* locator, uint8_t domain_id, const char* session_name);
+    friend Result(::nros::init_with_rmw)(const char* rmw, const char* locator, uint8_t domain_id,
+                                         const char* session_name);
+    friend Result(::nros::shutdown)();
+    friend bool(::nros::ok)();
+    friend Result(::nros::create_node)(Node& out, const char* name, const char* ns);
+    friend Result(::nros::create_node_on)(Node& out, void* executor_handle, const char* name,
+                                          const char* ns);
+    friend Result(::nros::spin_once)(int32_t timeout_ms);
+    friend Result(::nros::spin)();
+    friend Result(::nros::spin)(uint32_t duration_ms, int32_t poll_ms);
+    friend void*(::nros::global_handle)();
 
     // Global executor inline storage for init/shutdown free functions.
     //
@@ -1938,6 +2010,25 @@ class Node {
 // including this header all collapse to a single .bss allocation.
 template <int N>
 alignas(8) uint8_t Node::GlobalStorageHolder<N>::storage[NROS_CPP_EXECUTOR_STORAGE_SIZE] = {};
+
+} // namespace rclcpp
+
+namespace nros {
+
+/// `nros::Node` — the historical spelling of `rclcpp::Node`, and the SAME TYPE.
+/// `std::is_same<rclcpp::Node, nros::Node>::value` is true: one class, one set
+/// of entities, one arena registration path, one parameter facade.
+///
+/// RFC-0089 §"Settled: `nros::` is phased out entirely" makes `rclcpp::` the
+/// vocabulary a user writes, and this alias is the migration step, not a second
+/// name to choose between. It is UNCONDITIONAL, unlike the shim class it
+/// replaced: that one lived inside `#if defined(NROS_CPP_HAS_SHARED_PTR) && …`,
+/// so a freestanding target had the node and not its ROS 2 name.
+using Node = ::rclcpp::Node;
+
+} // namespace nros
+
+namespace nros {
 
 // ==== phase-427 W4 — the timer pool, as a TEMPLATE PARAMETER ================
 //
@@ -2417,31 +2508,9 @@ inline NodeBuilder Executor::node_builder(const char* name) {
 
 } // namespace nros
 
-// ============================================================================
-// rclcpp:: — the ROS 2 spelling (RFC-0089 stage 6; phase-427 W1-W3, W7)
-// ============================================================================
-
-namespace rclcpp {
-
-/// `rclcpp::Node` — the ROS 2 spelling, and the SAME TYPE as `nros::Node`.
-/// `std::is_same<rclcpp::Node, nros::Node>::value` is true: one class, one set
-/// of entities, one arena registration path, one parameter facade. See the
-/// class above for why the definition lives in `nros::` and the alias here
-/// rather than the other way round (it is a measurement about
-/// `scripts/api-parity.py`'s namespace roots, not a preference).
-///
-/// UNCONDITIONAL, unlike the shim class it replaces. That class was declared
-/// only where `<memory>`/`<string>`/`<vector>`/`<functional>` were, so a
-/// freestanding target had the node and NOT its ROS 2 name — the two
-/// vocabularies split exactly where the port matters most. The hosted-shape
-/// METHODS are still gated; the NAME is not.
-using Node = ::nros::Node;
-
-/// The process-level verbs — `rclcpp::init()`, `rclcpp::ok()`,
-/// `rclcpp::shutdown()`, `rclcpp::spin_once()` — are declared in `nros.hpp`,
-/// which is where the free functions they name live. This header carries only
-/// what the node itself needs.
-
-} // namespace rclcpp
+// The process-level verbs — `rclcpp::init()`, `rclcpp::ok()`,
+// `rclcpp::shutdown()`, `rclcpp::spin_once()` — are declared in `nros.hpp`,
+// which is where the free functions they name live. This header carries only
+// what the node itself needs.
 
 #endif // NROS_CPP_NODE_HPP

--- a/packages/api/nros-cpp/include/nros/node.hpp
+++ b/packages/api/nros-cpp/include/nros/node.hpp
@@ -1789,13 +1789,13 @@ class Node {
         if (declared == passed_type) {
             return true;
         }
-        detail::report_declared_param_mismatch(declaring->fqn, name, declaring->contract, declared,
-                                               passed_type);
+        ::nros::detail::report_declared_param_mismatch(declaring->fqn, name, declaring->contract,
+                                                       declared, passed_type);
         this->set_error("declare_parameter: the code does not declare this parameter the way "
                         "its contract does (see the line above for the node, the parameter and "
                         "the contract). The parameter store is sized from the contract's "
                         "`params:`, so the two must state one name and one type.",
-                        detail::DECLARED_PARAM_MISMATCH);
+                        ::nros::detail::DECLARED_PARAM_MISMATCH);
         return false;
     }
 

--- a/packages/api/nros-cpp/include/nros/node_parameters.hpp
+++ b/packages/api/nros-cpp/include/nros/node_parameters.hpp
@@ -30,7 +30,7 @@
  * The `nros_cpp_node_t*` — its `node_id` IS the key (phase-426 W1). So two
  * nodes on one executor may declare the same name with different values, and
  * `ros2 param list` enumerates per node. Pass a node's `ffi_handle()`; a null
- * handle (an `nros::Node` that was never opened) is an error, never a silent
+ * handle (an `rclcpp::Node` that was never opened) is an error, never a silent
  * write to some other node's parameters.
  *
  * ## Freestanding

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -60,7 +60,7 @@
 // phase-427 W4 — `nros/component_node.hpp` IS GONE. `nros::ComponentNode` was a
 // type that WRAPPED a node (RFC-0044 Q1's "wrap, not derive"), so a component
 // was not a `Node` and every verb had to be forwarded. Its members are on
-// `nros::Node` now, its pool is the opt-in `nros::NodeWithTimers<N>`, and its
+// `rclcpp::Node` now, its pool is the opt-in `nros::NodeWithTimers<N>`, and its
 // macros are in `component.hpp` below. The rclcpp-shaped, value-returning
 // parameter facade phase-417 W2.b pulled in here for is `Node`'s own.
 // phase-417 stage 6 step A — `nros::create_subscription_raw`, the
@@ -77,8 +77,8 @@ namespace nros {
 ///
 /// @return Executor handle, or nullptr if not initialized.
 inline void* global_handle() {
-    if (!Node::global_initialized()) return nullptr;
-    return Node::global_storage();
+    if (!::rclcpp::Node::global_initialized()) return nullptr;
+    return ::rclcpp::Node::global_storage();
 }
 
 /// Drive transport I/O and dispatch callbacks.
@@ -89,10 +89,10 @@ inline void* global_handle() {
 /// @param timeout_ms  Maximum time to block waiting for I/O (default: 10ms).
 /// @return Result indicating success or failure.
 inline Result spin_once(int32_t timeout_ms = 10) {
-    if (!Node::global_initialized()) {
+    if (!::rclcpp::Node::global_initialized()) {
         return Result(ErrorCode::NotInitialized);
     }
-    return Result(nros_cpp_spin_once(Node::global_storage(), timeout_ms));
+    return Result(nros_cpp_spin_once(::rclcpp::Node::global_storage(), timeout_ms));
 }
 
 /// Register a callback to run BEFORE the global session's entities are torn
@@ -171,12 +171,12 @@ inline bool remove_on_shutdown_callback(OnShutdownCallbackHandle handle) {
 /// Returns the first non-success `spin_once` result, or
 /// `Result::success()` after a clean shutdown.
 inline Result spin() {
-    if (!Node::global_initialized()) {
+    if (!::rclcpp::Node::global_initialized()) {
         return Result(ErrorCode::NotInitialized);
     }
     Result last = Result::success();
     while (ok()) {
-        last = Result(nros_cpp_spin_once(Node::global_storage(), 10));
+        last = Result(nros_cpp_spin_once(::rclcpp::Node::global_storage(), 10));
         if (!last.ok()) return last;
     }
     return last;
@@ -191,7 +191,7 @@ inline Result spin() {
 /// @param poll_ms      Individual spin_once timeout (default: 10ms).
 /// @return Result from the last spin_once call.
 inline Result spin(uint32_t duration_ms, int32_t poll_ms = 10) {
-    if (!Node::global_initialized()) {
+    if (!::rclcpp::Node::global_initialized()) {
         return Result(ErrorCode::NotInitialized);
     }
     // Issue 0329 — forward to the single budgeted-spin CFFI entry point. This
@@ -199,7 +199,7 @@ inline Result spin(uint32_t duration_ms, int32_t poll_ms = 10) {
     // collapsed to milliseconds when `spin_once` returned early on a signaled
     // wake — the exact bug `Executor::spin` fixed in Phase 118.C. The correct
     // wall-clock budget now lives once, Rust-side, in `nros_cpp_spin_for`.
-    return Result(nros_cpp_spin_for(Node::global_storage(), duration_ms, poll_ms));
+    return Result(nros_cpp_spin_for(::rclcpp::Node::global_storage(), duration_ms, poll_ms));
 }
 
 } // namespace nros
@@ -283,7 +283,7 @@ constexpr bool argv_has_ros_args(int argc, char const* const* argv, int i = 0) {
 
 /// What upstream's `throw` becomes here — phase-428 W5 finding 9.
 ///
-/// The `create_*` verbs on `nros::Node` (reached as `rclcpp::Node`, which is an
+/// The `create_*` verbs on `rclcpp::Node` (reached as `rclcpp::Node`, which is an
 /// alias for it since phase-427 W1-W3) used to write
 /// `(void)this->create_…(…)` and return the `shared_ptr` regardless. The
 /// `(void)` was not incidental: `nros::Result` carries `[[nodiscard]]`
@@ -318,7 +318,7 @@ constexpr bool argv_has_ros_args(int argc, char const* const* argv, int i = 0) {
 /// is what an uncaught upstream throw actually does to a tutorial `main` —
 /// terminate with a diagnostic, rather than continue with a dead object.
 ///
-/// The failure is still HANDLEABLE: the underlying out-ref `nros::Node` verbs
+/// The failure is still HANDLEABLE: the underlying out-ref `rclcpp::Node` verbs
 /// return `nros::Result` into caller-owned storage, and the message names them.
 [[noreturn]] inline void abort_failed_create(const char* verb, const char* name, int32_t code) {
     NROS_ERROR("rclcpp::Node::%s(\"%s\") failed with nros::ErrorCode %d. %s", verb, name,
@@ -466,7 +466,7 @@ namespace detail {
 // --- Node ---------------------------------------------------------------------
 //
 // phase-427 W1-W3 — THE NODE TYPES ARE MERGED. `rclcpp::Node` is not a class
-// here any more; it is an ALIAS for `nros::Node`, and the hosted call shape
+// here any more; it is an ALIAS for `rclcpp::Node`, and the hosted call shape
 // that used to be a separate adapter class in this file is now a set of
 // overloads on that one type (declared in `node.hpp`, defined below).
 //
@@ -483,7 +483,7 @@ namespace detail {
 //     merge forced the decision W5 records.
 //   * THE TWO-VOCABULARY SPLIT. A ported file wrote `rclcpp::Node` and got a
 //     type with no graph queries, no lifecycle, no callback groups, no action
-//     entities and no out-ref creators; a native file wrote `nros::Node` and
+//     entities and no out-ref creators; a native file wrote `rclcpp::Node` and
 //     got no `shared_ptr` creators and no parameters. Neither list was a
 //     design; both were what the other file happened to have.
 //
@@ -500,7 +500,7 @@ namespace detail {
 
 namespace nros {
 
-// The HOSTED half of `nros::Node`, defined here rather than in `node.hpp`
+// The HOSTED half of `rclcpp::Node`, defined here rather than in `node.hpp`
 // because every body below needs a complete entity type (`Publisher<M>`,
 // `Subscription<M>`, `Service<S>`, `Client<S>`) or a helper the umbrella pulls
 // in (`create_subscription_raw` from `component.hpp`, the callback cells from
@@ -683,7 +683,7 @@ namespace nros {
 // `declare_parameter` returns the code default. The loud half USED to be
 // `nros::ComponentNode`, whose own facade recorded the failure on an `ok()`
 // flag and made it boot-fatal; phase-427 W4 deleted that type, so no C++ path
-// is boot-fatal on a missing store any more. `nros::Node` still carries the
+// is boot-fatal on a missing store any more. `rclcpp::Node` still carries the
 // flag (`set_error` / `ok()`); routing the parameter path back onto it is a
 // separate decision, because it changes what an upstream-shaped
 // `declare_parameter` does.
@@ -914,13 +914,13 @@ namespace detail {
 /// `NodeT` in upstream's signature is anything node-shaped — `this`, a
 /// `shared_ptr`, a reference. One overload set, so the free function does not
 /// need three copies.
-inline ::nros::Node& as_node_ref(::nros::Node& n) {
+inline ::rclcpp::Node& as_node_ref(::rclcpp::Node& n) {
     return n;
 }
-inline ::nros::Node& as_node_ref(::nros::Node* n) {
+inline ::rclcpp::Node& as_node_ref(::rclcpp::Node* n) {
     return *n;
 }
-inline ::nros::Node& as_node_ref(const ::std::shared_ptr<::nros::Node>& n) {
+inline ::rclcpp::Node& as_node_ref(const ::std::shared_ptr<::rclcpp::Node>& n) {
     return *n;
 }
 
@@ -933,7 +933,7 @@ inline ::nros::Node& as_node_ref(const ::std::shared_ptr<::nros::Node>& n) {
 template <typename NodeT, typename CallbackT>
 inline ::std::shared_ptr<::nros::Timer>
 create_timer(NodeT&& node, ::nros::Clock* clock, ::nros::Duration period, CallbackT&& callback) {
-    ::nros::Node& n = detail::as_node_ref(node);
+    ::rclcpp::Node& n = detail::as_node_ref(node);
     auto t = ::std::make_shared<detail::WallTimer>();
     t->callback = ::std::forward<CallbackT>(callback);
     const int64_t ns = period.nanoseconds();

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -515,9 +515,12 @@ namespace nros {
 
 // -- publishers ---------------------------------------------------------------
 
+} // namespace nros
+
+namespace rclcpp {
 template <typename M>
 inline ::std::shared_ptr<Publisher<M>> Node::create_publisher(const ::std::string& topic,
-                                                              const QoS& qos) {
+                                                              const ::nros::QoS& qos) {
     auto p = ::std::make_shared<Publisher<M>>();
     ::rclcpp::detail::require_created(this->create_publisher<M>(*p, topic.c_str(), qos),
                                       "create_publisher", topic.c_str());
@@ -527,12 +530,19 @@ inline ::std::shared_ptr<Publisher<M>> Node::create_publisher(const ::std::strin
     this->hosted().owned_entities.push_back(p);
     return p;
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename M>
 inline ::std::shared_ptr<Publisher<M>> Node::create_publisher(const ::std::string& topic,
                                                               ::size_t depth) {
-    return this->create_publisher<M>(topic, QoS(static_cast<uint32_t>(depth)));
+    return this->create_publisher<M>(topic, ::nros::QoS(static_cast<uint32_t>(depth)));
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // -- subscriptions ------------------------------------------------------------
 //
@@ -566,9 +576,12 @@ inline ::std::shared_ptr<Publisher<M>> Node::create_publisher(const ::std::strin
 // with it (`rclcpp::Subscription<M>::SharedPtr sub_;`). The executor owns the
 // real subscriber, so `sub->take(msg)` on it answers `NotInitialized` — the
 // sample went to your callback.
+} // namespace nros
+
+namespace rclcpp {
 template <typename M, typename Cb>
 inline ::std::shared_ptr<Subscription<M>> Node::create_subscription(const ::std::string& topic,
-                                                                    const QoS& qos, Cb cb) {
+                                                                    const ::nros::QoS& qos, Cb cb) {
     auto cell = ::std::make_shared<::rclcpp::detail::SubscriptionCallback<M>>();
     cell->fn = ::std::move(cb);
     ::rclcpp::detail::require_created(
@@ -579,12 +592,20 @@ inline ::std::shared_ptr<Subscription<M>> Node::create_subscription(const ::std:
     this->hosted().owned_entities.push_back(cell);
     return ::std::shared_ptr<Subscription<M>>(cell, &cell->handle);
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename M, typename Cb>
 inline ::std::shared_ptr<Subscription<M>> Node::create_subscription(const ::std::string& topic,
                                                                     ::size_t depth, Cb cb) {
-    return this->create_subscription<M>(topic, QoS(static_cast<uint32_t>(depth)), ::std::move(cb));
+    return this->create_subscription<M>(topic, ::nros::QoS(static_cast<uint32_t>(depth)),
+                                        ::std::move(cb));
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // -- wall timer ---------------------------------------------------------------
 
@@ -604,9 +625,12 @@ inline ::std::shared_ptr<Subscription<M>> Node::create_subscription(const ::std:
 /// `detail::WallTimer` cell, pointing at its `timer` member — the same shape
 /// `create_subscription` returns, which is why the cell needs no base class to
 /// be handed out.
+} // namespace nros
+
+namespace rclcpp {
 template <typename Rep, typename Period, typename Cb>
-inline ::std::shared_ptr<Timer> Node::create_wall_timer(::std::chrono::duration<Rep, Period> period,
-                                                        Cb cb) {
+inline ::std::shared_ptr<::nros::Timer>
+Node::create_wall_timer(::std::chrono::duration<Rep, Period> period, Cb cb) {
     auto t = ::std::make_shared<::rclcpp::detail::WallTimer>();
     t->callback = ::std::move(cb);
     const auto ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(period).count();
@@ -623,8 +647,11 @@ inline ::std::shared_ptr<Timer> Node::create_wall_timer(::std::chrono::duration<
     // `pump()` could iterate it, and it was the member that broke the
     // capability-layout rule.
     this->hosted().owned_entities.push_back(t);
-    return ::std::shared_ptr<Timer>(t, &t->timer);
+    return ::std::shared_ptr<::nros::Timer>(t, &t->timer);
 }
+} // namespace rclcpp
+
+namespace nros {
 #endif // NROS_CPP_HAS_STD_CHRONO
 
 // -- parameters ---------------------------------------------------------------
@@ -669,6 +696,9 @@ inline ::std::shared_ptr<Timer> Node::create_wall_timer(::std::chrono::duration<
 /// override. That adoption is now the store's own `ALREADY_EXISTS` answer
 /// followed by the read-back below, rather than a helper that copied a value
 /// between two stores. On any other failure the code default is returned.
+} // namespace nros
+
+namespace rclcpp {
 template <typename T> inline T Node::declare_parameter(const char* name, T default_value) {
     // phase-446 W6 -- a declaration the contract's `params:` does not make, or
     // makes with another type, refuses the boot through `set_error` before
@@ -687,28 +717,49 @@ template <typename T> inline T Node::declare_parameter(const char* name, T defau
     }
     return out;
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename T> inline bool Node::get_parameter(const char* name, T& out) const {
     return ::nros::detail::node_param_get(this->ffi_handle(), name, out).ok();
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename T> inline T Node::get_parameter(const char* name) const {
     T out = T();
     (void)::nros::detail::node_param_get(this->ffi_handle(), name, out);
     return out;
 }
+} // namespace rclcpp
+
+namespace nros {
 
 /// phase-426 W4 — `set_parameter` now goes through the SAME
 /// `ParameterServer::apply` a remote `ros2 param set` does, so a read-only
 /// parameter is refused here exactly as it is on the wire, and the value a
 /// service reports back is the value this wrote.
+} // namespace nros
+
+namespace rclcpp {
 template <typename T> inline Result Node::set_parameter(const char* name, T value) {
     return ::nros::detail::node_param_set(this->ffi_handle(), name, value);
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 inline bool Node::has_parameter(const char* name) const {
     return ::nros::detail::node_param_has(this->ffi_handle(), name);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // `parameters()` IS GONE (phase-426 W4). It handed out a reference to the node's
 // own `nros::ParameterServer`, described as the escape hatch for "the C-API
@@ -727,19 +778,26 @@ inline bool Node::has_parameter(const char* name) const {
 // per-request heap allocation on the delivery path, which is a second delivery
 // path, not a spelling.
 
+} // namespace nros
+
+namespace rclcpp {
 template <typename S>
 inline ::std::shared_ptr<Service<S>> Node::create_service(const ::std::string& name,
-                                                          const QoS& qos) {
+                                                          const ::nros::QoS& qos) {
     auto s = ::std::make_shared<Service<S>>();
     ::rclcpp::detail::require_created(this->template create_service<S>(*s, name.c_str(), qos),
                                       "create_service", name.c_str());
     this->hosted().owned_entities.push_back(s);
     return s;
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename S, typename F, typename>
 inline ::std::shared_ptr<Service<S>> Node::create_service(const ::std::string& name, F callback,
-                                                          const QoS& qos) {
+                                                          const ::nros::QoS& qos) {
     auto s = ::std::make_shared<Service<S>>();
     this->hosted().owned_entities.push_back(s);
     ::rclcpp::detail::require_created(
@@ -747,26 +805,40 @@ inline ::std::shared_ptr<Service<S>> Node::create_service(const ::std::string& n
         name.c_str());
     return s;
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename S, typename F, typename, typename>
-inline ::std::shared_ptr<Service<S>> Node::create_service(const ::std::string&, F, const QoS&) {
+inline ::std::shared_ptr<Service<S>> Node::create_service(const ::std::string&, F,
+                                                          const ::nros::QoS&) {
     static_assert(::rclcpp::detail::refuse<F>::value,
                   NROS_RCLCPP_REFUSE_SHARED_PTR_SERVICE_CALLBACK);
     return ::std::shared_ptr<Service<S>>();
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename S>
-inline ::std::shared_ptr<Client<S>> Node::create_client(const ::std::string& name, const QoS& qos) {
+inline ::std::shared_ptr<Client<S>> Node::create_client(const ::std::string& name,
+                                                        const ::nros::QoS& qos) {
     auto c = ::std::make_shared<Client<S>>();
     ::rclcpp::detail::require_created(this->template create_client<S>(*c, name.c_str(), qos),
                                       "create_client", name.c_str());
     this->hosted().owned_entities.push_back(c);
     return c;
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename S, typename F, typename>
 inline ::std::shared_ptr<Client<S>> Node::create_client(const ::std::string& name, F callback,
-                                                        const QoS& qos) {
+                                                        const ::nros::QoS& qos) {
     auto c = ::std::make_shared<Client<S>>();
     this->hosted().owned_entities.push_back(c);
     ::rclcpp::detail::require_created(
@@ -774,13 +846,21 @@ inline ::std::shared_ptr<Client<S>> Node::create_client(const ::std::string& nam
         name.c_str());
     return c;
 }
+} // namespace rclcpp
 
+namespace nros {} // namespace nros
+
+namespace rclcpp {
 template <typename S, typename F, typename, typename>
-inline ::std::shared_ptr<Client<S>> Node::create_client(const ::std::string&, F, const QoS&) {
+inline ::std::shared_ptr<Client<S>> Node::create_client(const ::std::string&, F,
+                                                        const ::nros::QoS&) {
     static_assert(::rclcpp::detail::refuse<F>::value,
                   NROS_RCLCPP_REFUSE_SHARED_PTR_SERVICE_CALLBACK);
     return ::std::shared_ptr<Client<S>>();
 }
+} // namespace rclcpp
+
+namespace nros {
 
 #endif // NROS_CPP_NODE_HOSTED
 

--- a/packages/api/nros-cpp/include/nros/nros_cpp_config_generated_nuttx.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_config_generated_nuttx.h
@@ -66,7 +66,7 @@
  *
  * EXACT values, not upper bounds — a version range has no bound to be safe on.
  * Gated by `check-config-fallback-macros`. */
-#define NROS_CODEGEN_VERSION 3
+#define NROS_CODEGEN_VERSION 4
 #define NROS_CODEGEN_VERSION_MIN 2
 
 /* Issue 0464 — the generator computes

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -788,7 +788,7 @@ nros_cpp_ret_t nros_cpp_init_rmw(const char *rmw,
  *
  * The two surfaces need ONE handle type. This is that: same storage contract as
  * [`nros_cpp_init`] (caller owns the buffer, executor carved in place), so every
- * existing C++ path — `nros::Node`, `NodeBuilder().rmw(name)`, publishers,
+ * existing C++ path — `rclcpp::Node`, `NodeBuilder().rmw(name)`, publishers,
  * subscriptions — works against a multi-session executor unchanged.
  *
  * `specs[0]` is the primary session; the rest become extras, each findable by its

--- a/packages/api/nros-cpp/include/nros/polling_action_client.hpp
+++ b/packages/api/nros-cpp/include/nros/polling_action_client.hpp
@@ -31,6 +31,15 @@
 
 #include "nros_cpp_ffi.h"
 
+// phase-427 W7 — `Node` is DEFINED in `rclcpp::` (RFC-0089: that namespace is
+// the home). The friend declaration below is qualified, and a qualified friend
+// names an existing entity rather than introducing one, so the name has to be
+// declared first — and in `rclcpp::`, because an elaborated `class Node;` in
+// `nros::` would declare a second, distinct class.
+namespace rclcpp {
+class Node;
+}
+
 namespace nros {
 
 /// Typed L1 polling-mode action client.
@@ -241,7 +250,7 @@ template <typename A> class PollingActionClient {
     }
 
   private:
-    friend class Node;
+    friend class ::rclcpp::Node;
 
     static constexpr size_t kStorageU64s = NROS_CPP_RAW_ACTION_CLIENT_OPAQUE_U64S;
     alignas(8) uint64_t storage_[kStorageU64s];
@@ -253,11 +262,13 @@ template <typename A> class PollingActionClient {
 
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename A>
-Result Node::create_polling_action_client(PollingActionClient<A>& out, const char* action_name) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
+Result Node::create_polling_action_client(::nros::PollingActionClient<A>& out,
+                                          const char* action_name) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
     nros_cpp_ret_t ret =
         nros_cpp_action_client_init_polling(&handle_, action_name, A::TYPE_NAME, A::Goal::TYPE_HASH,
                                             reinterpret_cast<void*>(out.storage_));
@@ -271,7 +282,8 @@ Result Node::create_polling_action_client(PollingActionClient<A>& out, const cha
     out.initialized_ = true;
     return Result::success();
 }
+} // namespace rclcpp
 
-} // namespace nros
+namespace nros {} // namespace nros
 
 #endif // NROS_CPP_POLLING_ACTION_CLIENT_HPP

--- a/packages/api/nros-cpp/include/nros/polling_action_server.hpp
+++ b/packages/api/nros-cpp/include/nros/polling_action_server.hpp
@@ -30,6 +30,15 @@
 
 #include "nros_cpp_ffi.h"
 
+// phase-427 W7 — `Node` is DEFINED in `rclcpp::` (RFC-0089: that namespace is
+// the home). The friend declaration below is qualified, and a qualified friend
+// names an existing entity rather than introducing one, so the name has to be
+// declared first — and in `rclcpp::`, because an elaborated `class Node;` in
+// `nros::` would declare a second, distinct class.
+namespace rclcpp {
+class Node;
+}
+
 namespace nros {
 
 /// Typed L1 polling-mode action server.
@@ -311,7 +320,7 @@ template <typename A> class PollingActionServer {
     }
 
   private:
-    friend class Node;
+    friend class ::rclcpp::Node;
 
     static constexpr size_t kStorageU64s = NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S;
     alignas(8) uint64_t storage_[kStorageU64s];
@@ -323,11 +332,13 @@ template <typename A> class PollingActionServer {
 
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename A>
-Result Node::create_polling_action_server(PollingActionServer<A>& out, const char* action_name) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
+Result Node::create_polling_action_server(::nros::PollingActionServer<A>& out,
+                                          const char* action_name) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
     nros_cpp_ret_t ret =
         nros_cpp_action_server_init_polling(&handle_, action_name, A::TYPE_NAME, A::Goal::TYPE_HASH,
                                             reinterpret_cast<void*>(out.storage_));
@@ -341,7 +352,8 @@ Result Node::create_polling_action_server(PollingActionServer<A>& out, const cha
     out.initialized_ = true;
     return Result::success();
 }
+} // namespace rclcpp
 
-} // namespace nros
+namespace nros {} // namespace nros
 
 #endif // NROS_CPP_POLLING_ACTION_SERVER_HPP

--- a/packages/api/nros-cpp/include/nros/polling_subscription.hpp
+++ b/packages/api/nros-cpp/include/nros/polling_subscription.hpp
@@ -34,6 +34,15 @@
 // (issues 0112, 1187, 1240) is stated there.
 #include "nros/std_detect.hpp"
 
+// phase-427 W7 — `Node` is DEFINED in `rclcpp::` (RFC-0089: that namespace is
+// the home). The friend declaration below is qualified, and a qualified friend
+// names an existing entity rather than introducing one, so the name has to be
+// declared first — and in `rclcpp::`, because an elaborated `class Node;` in
+// `nros::` would declare a second, distinct class.
+namespace rclcpp {
+class Node;
+}
+
 namespace nros {
 
 /// Latest-value polling subscription.
@@ -120,7 +129,7 @@ template <typename M> class PollingSubscription {
     const M* peek() const { return has_ever_ ? &latest_ : nullptr; }
 
   private:
-    friend class Node;
+    friend class ::rclcpp::Node;
 
     /// Consume every pending sample, keeping the newest in `latest_`. Returns
     /// `true` iff at least one new sample was taken this call. `take`
@@ -144,16 +153,18 @@ template <typename M> class PollingSubscription {
 
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename M>
-Result Node::create_polling_subscription(PollingSubscription<M>& out, const char* topic,
-                                         const QoS& qos) {
+Result Node::create_polling_subscription(::nros::PollingSubscription<M>& out, const char* topic,
+                                         const ::nros::QoS& qos) {
     // Reuse the existing poll-mode subscription factory to own storage/init/
     // destroy; the wrapper only adds the retained-latest cache (issue 0278).
     return create_subscription(out.sub_, topic, qos);
 }
+} // namespace rclcpp
 
-} // namespace nros
+namespace nros {} // namespace nros
 
 #endif // NROS_CPP_POLLING_SUBSCRIPTION_HPP

--- a/packages/api/nros-cpp/include/nros/publisher.hpp
+++ b/packages/api/nros-cpp/include/nros/publisher.hpp
@@ -55,7 +55,7 @@ static constexpr size_t PUBLISHER_TOPIC_NAME_MAX = 256;
 ///
 /// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
 /// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
-/// class and collide with the `nros::Node` alias.
+/// class and collide with the `rclcpp::Node` alias.
 namespace rclcpp {
 class Node;
 }
@@ -391,7 +391,7 @@ namespace nros {
 /// `auto pub = nros::create_publisher<Int32>(node, "/chatter");`
 /// in the rclcpp-style.
 template <typename M>
-inline ResultOf<Publisher<M>> create_publisher(Node& node, const char* topic,
+inline ResultOf<Publisher<M>> create_publisher(::rclcpp::Node& node, const char* topic,
                                                const QoS& qos = QoS::default_profile()) {
     Publisher<M> p;
     Result r = node.create_publisher<M>(p, topic, qos);

--- a/packages/api/nros-cpp/include/nros/publisher.hpp
+++ b/packages/api/nros-cpp/include/nros/publisher.hpp
@@ -45,14 +45,20 @@ namespace nros {
 /// implementation bound of one of them, not a name upstream declares.
 static constexpr size_t PUBLISHER_TOPIC_NAME_MAX = 256;
 
-/// `nros::Node` is named by the friend declaration below and by the out-of-line
-/// `Node::create_*` bodies further down. `nros/node.hpp` (included below, after
-/// the class, so a consumer pays only for the entities it uses) has the
-/// definition; a qualified friend needs the name to EXIST first, which an
-/// unqualified `friend class Node;` used to supply implicitly.
-class Node;
-
 } // namespace nros
+
+/// `rclcpp::Node` is named by the friend declaration below and by the
+/// out-of-line `Node::create_*` bodies further down. `nros/node.hpp` (included
+/// below, after the class, so a consumer pays only for the entities it uses)
+/// has the definition; a qualified friend needs the name to EXIST first, which
+/// an unqualified `friend class Node;` used to supply implicitly.
+///
+/// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
+/// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
+/// class and collide with the `nros::Node` alias.
+namespace rclcpp {
+class Node;
+}
 
 // ============================================================================
 // `rclcpp::Publisher<M>` -- DEFINED here (RFC-0089: rclcpp:: is the home)
@@ -308,7 +314,7 @@ template <typename M> class Publisher {
     Publisher(const Publisher&) = delete;
     Publisher& operator=(const Publisher&) = delete;
 
-    friend class ::nros::Node;
+    friend class ::rclcpp::Node;
 
     alignas(8) uint8_t storage_[NROS_PUBLISHER_SIZE];
     char topic_name_[::nros::PUBLISHER_TOPIC_NAME_MAX];
@@ -332,15 +338,16 @@ template <typename M> using Publisher = ::rclcpp::Publisher<M>;
 // every entity's code path.
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename M>
-Result Node::create_publisher(Publisher<M>& out, const char* topic, const QoS& qos) {
+Result Node::create_publisher(Publisher<M>& out, const char* topic, const ::nros::QoS& qos) {
     // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
     // message the linked backend cannot encode never reaches the wire.
     NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_publisher_create(&handle_, topic, M::TYPE_NAME, M::TYPE_HASH,
                                                    ffi_qos, out.storage_);
     if (ret == 0) {
@@ -356,18 +363,27 @@ Result Node::create_publisher(Publisher<M>& out, const char* topic, const QoS& q
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 /// Phase 189.M3.1 — named-options overload. `PublisherOptions` is a
 /// reserved/empty struct (a publisher has no callback ⇒ no sched-context
 /// or message-info axis), so this simply forwards to the qos-only create.
 /// It exists for rclcpp symmetry and as the seam for future intra-process
 /// / loaned-message knobs.
+} // namespace nros
+
+namespace rclcpp {
 template <typename M>
-Result Node::create_publisher(Publisher<M>& out, const char* topic, const QoS& qos,
-                              const PublisherOptions& options) {
+Result Node::create_publisher(Publisher<M>& out, const char* topic, const ::nros::QoS& qos,
+                              const ::nros::PublisherOptions& options) {
     (void)options; // reserved — no live fields today
     return create_publisher<M>(out, topic, qos);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 /// Phase 123.B.4 — value-returning publisher factory. Wraps the
 /// out-param `Node::create_publisher` in `ResultOf<Publisher<M>>`

--- a/packages/api/nros-cpp/include/nros/result.hpp
+++ b/packages/api/nros-cpp/include/nros/result.hpp
@@ -315,7 +315,7 @@ using Result = ResultOf<void>;
 ///
 /// Usage:
 /// ```cpp
-/// auto node_r = nros::Node::make("my_node");
+/// auto node_r = rclcpp::Node::make("my_node");
 /// if (!node_r.ok()) return node_r.error_as_result();
 /// auto& node = node_r.value();
 /// ```

--- a/packages/api/nros-cpp/include/nros/serialization_format.hpp
+++ b/packages/api/nros-cpp/include/nros/serialization_format.hpp
@@ -65,7 +65,7 @@ template <typename M> struct format_of {
 ///
 /// **Only meaningful in a single-backend image.** A bridge image links two
 /// backends and has no single answer; it asks per session instead, with
-/// `nros::Node::serialization_format()`. `check-format-macro-scope` refuses a
+/// `rclcpp::Node::serialization_format()`. `check-format-macro-scope` refuses a
 /// bridge-linked translation unit that reaches the underlying macro.
 constexpr SerializationFormat linked_format() {
     return static_cast<SerializationFormat>(NROS_CPP_SERIALIZATION_FORMAT_ID);

--- a/packages/api/nros-cpp/include/nros/service.hpp
+++ b/packages/api/nros-cpp/include/nros/service.hpp
@@ -51,7 +51,7 @@ nros_cpp_ret_t nros_cpp_service_server_register(const nros_cpp_node_t* node,
 ///
 /// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
 /// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
-/// class and collide with the `nros::Node` alias.
+/// class and collide with the `rclcpp::Node` alias.
 namespace rclcpp {
 class Node;
 }

--- a/packages/api/nros-cpp/include/nros/service.hpp
+++ b/packages/api/nros-cpp/include/nros/service.hpp
@@ -43,14 +43,18 @@ nros_cpp_ret_t nros_cpp_service_server_register(const nros_cpp_node_t* node,
                                                 size_t* out_handle_id);
 } // extern "C"
 
-namespace nros {
-// `nros::Node` is named by the friend declaration below and by the out-of-line
-// `Node::create_*` bodies further down. `nros/node.hpp` (included below, after
-// the class, so a consumer pays only for the entities it uses) has the
-// definition; a qualified friend needs the name to EXIST first, which an
-// unqualified `friend class Node;` used to supply implicitly.
+/// `rclcpp::Node` is named by the friend declaration below and by the
+/// out-of-line `Node::create_*` bodies further down. `nros/node.hpp` (included
+/// below, after the class, so a consumer pays only for the entities it uses)
+/// has the definition; a qualified friend needs the name to EXIST first, which
+/// an unqualified `friend class Node;` used to supply implicitly.
+///
+/// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
+/// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
+/// class and collide with the `nros::Node` alias.
+namespace rclcpp {
 class Node;
-} // namespace nros
+}
 
 // ============================================================================
 // `rclcpp::Service<S>` -- DEFINED here (RFC-0089: rclcpp:: is the home)
@@ -240,7 +244,7 @@ template <typename S> class Service {
     Service(const Service&) = delete;
     Service& operator=(const Service&) = delete;
 
-    friend class ::nros::Node;
+    friend class ::rclcpp::Node;
 
     /// Phase 189.M3.3.e — raw request trampoline matching `RawServiceCallback`
     /// (`bool(req, req_len, resp, resp_cap, resp_len, ctx)`). Deserializes the
@@ -290,12 +294,13 @@ template <typename S> using Service = ::rclcpp::Service<S>;
 // Phase 84.G8: out-of-line definition of Node::create_service<S>().
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename S>
-Result Node::create_service(Service<S>& out, const char* service_name, const QoS& qos) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+Result Node::create_service(Service<S>& out, const char* service_name, const ::nros::QoS& qos) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_service_server_create(
         &handle_, service_name, S::TYPE_NAME, S::Request::TYPE_HASH, ffi_qos, out.storage_);
     if (ret == 0) {
@@ -303,22 +308,28 @@ Result Node::create_service(Service<S>& out, const char* service_name, const QoS
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // Phase 189.M3.3.e — callback-style (arena-registered) service. The arena owns
 // the server + dispatches `out`'s request handler during spin_once, so the
 // handle is real and `options.sched_context` is functional.
+} // namespace nros
+
+namespace rclcpp {
 template <typename S, typename F, typename>
-Result Node::create_service(Service<S>& out, const char* service_name, F callback, const QoS& qos,
-                            const ServiceOptions& options) {
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+Result Node::create_service(Service<S>& out, const char* service_name, F callback,
+                            const ::nros::QoS& qos, const ::nros::ServiceOptions& options) {
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
 
     // Store the user handler (compile error if F isn't convertible).
     out.user_fn_ = typename Service<S>::TypedServiceFn(callback);
     out.user_fn_ctx_ = nullptr;
     out.user_ctx_ = nullptr;
 
-    uint8_t sched = (options.sched_context == SCHED_CONTEXT_UNSET)
+    uint8_t sched = (options.sched_context == ::nros::SCHED_CONTEXT_UNSET)
                         ? 0u
                         : static_cast<uint8_t>(options.sched_context);
     size_t handle = static_cast<size_t>(-1);
@@ -333,7 +344,8 @@ Result Node::create_service(Service<S>& out, const char* service_name, F callbac
     }
     return Result(ret);
 }
+} // namespace rclcpp
 
-} // namespace nros
+namespace nros {} // namespace nros
 
 #endif // NROS_CPP_SERVICE_HPP

--- a/packages/api/nros-cpp/include/nros/std_compat.hpp
+++ b/packages/api/nros-cpp/include/nros/std_compat.hpp
@@ -79,7 +79,7 @@ inline std::string get_fully_qualified_name(const char* node_name, const char* n
 /// @param period    Timer period.
 /// @param callback  Callable invoked on each tick.
 /// @return Result indicating success or failure.
-inline Result create_wall_timer(Node& node, Timer& out, std::chrono::milliseconds period,
+inline Result create_wall_timer(::rclcpp::Node& node, Timer& out, std::chrono::milliseconds period,
                                 std::function<void()> callback) {
     auto fn =
         std::unique_ptr<std::function<void()>>(new std::function<void()>(std::move(callback)));
@@ -108,7 +108,7 @@ inline Result create_wall_timer(Node& node, Timer& out, std::chrono::millisecond
 /// @param period    Timer period, ON THAT CLOCK.
 /// @param callback  Callable invoked on each tick.
 /// @return Result indicating success or failure.
-inline Result create_timer(Node& node, Timer& out, const Clock& clock,
+inline Result create_timer(::rclcpp::Node& node, Timer& out, const Clock& clock,
                            std::chrono::milliseconds period, std::function<void()> callback) {
     auto fn =
         std::unique_ptr<std::function<void()>>(new std::function<void()>(std::move(callback)));
@@ -125,7 +125,8 @@ inline Result create_timer(Node& node, Timer& out, const Clock& clock,
 ///
 /// Same ownership rules as `create_wall_timer`: the closure lives with the
 /// Timer and is freed on destruction.
-inline Result create_timer_oneshot(Node& node, Timer& out, std::chrono::milliseconds delay,
+inline Result create_timer_oneshot(::rclcpp::Node& node, Timer& out,
+                                   std::chrono::milliseconds delay,
                                    std::function<void()> callback) {
     auto fn =
         std::unique_ptr<std::function<void()>>(new std::function<void()>(std::move(callback)));
@@ -141,7 +142,7 @@ inline Result create_timer_oneshot(Node& node, Timer& out, std::chrono::millisec
 /// Create a guard condition with a std::function callback.
 ///
 /// Same ownership rules as `create_wall_timer`.
-inline Result create_guard_condition(Node& node, GuardCondition& out,
+inline Result create_guard_condition(::rclcpp::Node& node, GuardCondition& out,
                                      std::function<void()> callback) {
     auto fn =
         std::unique_ptr<std::function<void()>>(new std::function<void()>(std::move(callback)));
@@ -163,7 +164,7 @@ inline Result init(const std::string& locator, uint8_t domain_id = 0) {
 }
 
 /// Create a node (std::string overload).
-inline Result create_node(Node& out, const std::string& name,
+inline Result create_node(::rclcpp::Node& out, const std::string& name,
                           const std::string& ns = std::string()) {
     return create_node(out, name.c_str(), ns.empty() ? nullptr : ns.c_str());
 }
@@ -172,43 +173,43 @@ inline Result create_node(Node& out, const std::string& name,
 
 /// Create a publisher (std::string topic overload).
 template <typename M>
-Result create_publisher(Node& node, Publisher<M>& out, const std::string& topic,
+Result create_publisher(::rclcpp::Node& node, Publisher<M>& out, const std::string& topic,
                         const QoS& qos = QoS::default_profile()) {
     return node.create_publisher(out, topic.c_str(), qos);
 }
 
 /// Create a subscription (std::string topic overload).
 template <typename M>
-Result create_subscription(Node& node, Subscription<M>& out, const std::string& topic,
+Result create_subscription(::rclcpp::Node& node, Subscription<M>& out, const std::string& topic,
                            const QoS& qos = QoS::default_profile()) {
     return node.create_subscription(out, topic.c_str(), qos);
 }
 
 /// Create a service server (std::string name overload).
 template <typename S>
-Result create_service(Node& node, Service<S>& out, const std::string& service_name,
+Result create_service(::rclcpp::Node& node, Service<S>& out, const std::string& service_name,
                       const QoS& qos = QoS::services()) {
     return node.create_service(out, service_name.c_str(), qos);
 }
 
 /// Create a service client (std::string name overload).
 template <typename S>
-Result create_client(Node& node, Client<S>& out, const std::string& service_name,
+Result create_client(::rclcpp::Node& node, Client<S>& out, const std::string& service_name,
                      const QoS& qos = QoS::services()) {
     return node.create_client(out, service_name.c_str(), qos);
 }
 
 /// Create an action server (std::string name overload).
 template <typename A>
-Result create_action_server(Node& node, ActionServer<A>& out, const std::string& action_name,
-                            const QoS& qos = QoS::services()) {
+Result create_action_server(::rclcpp::Node& node, ActionServer<A>& out,
+                            const std::string& action_name, const QoS& qos = QoS::services()) {
     return node.create_action_server(out, action_name.c_str(), qos);
 }
 
 /// Create an action client (std::string name overload).
 template <typename A>
-Result create_action_client(Node& node, ActionClient<A>& out, const std::string& action_name,
-                            const QoS& qos = QoS::services()) {
+Result create_action_client(::rclcpp::Node& node, ActionClient<A>& out,
+                            const std::string& action_name, const QoS& qos = QoS::services()) {
     return node.create_action_client(out, action_name.c_str(), qos);
 }
 
@@ -220,7 +221,7 @@ inline Result create_executor(Executor& out, const std::string& locator, uint8_t
 }
 
 /// Create a node on an executor (std::string overload).
-inline Result create_node(Executor& exec, Node& out, const std::string& name,
+inline Result create_node(Executor& exec, ::rclcpp::Node& out, const std::string& name,
                           const std::string& ns = std::string()) {
     return exec.create_node(out, name.c_str(), ns.empty() ? nullptr : ns.c_str());
 }

--- a/packages/api/nros-cpp/include/nros/subscription.hpp
+++ b/packages/api/nros-cpp/include/nros/subscription.hpp
@@ -98,7 +98,7 @@ static constexpr size_t SUBSCRIPTION_TOPIC_NAME_MAX = 256;
 ///
 /// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
 /// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
-/// class and collide with the `nros::Node` alias.
+/// class and collide with the `rclcpp::Node` alias.
 namespace rclcpp {
 class Node;
 }
@@ -866,7 +866,7 @@ namespace nros {
 /// with `create_publisher` so the full pub/sub create dance is
 /// expressible as a chain of `auto`-typed factories.
 template <typename M>
-inline ResultOf<Subscription<M>> create_subscription(Node& node, const char* topic,
+inline ResultOf<Subscription<M>> create_subscription(::rclcpp::Node& node, const char* topic,
                                                      const QoS& qos = QoS::default_profile()) {
     Subscription<M> s;
     Result r = node.create_subscription<M>(s, topic, qos);

--- a/packages/api/nros-cpp/include/nros/subscription.hpp
+++ b/packages/api/nros-cpp/include/nros/subscription.hpp
@@ -88,14 +88,20 @@ namespace nros {
 /// implementation bound of one of them, not a name upstream declares.
 static constexpr size_t SUBSCRIPTION_TOPIC_NAME_MAX = 256;
 
-/// `nros::Node` is named by the friend declaration below and by the out-of-line
-/// `Node::create_*` bodies further down. `nros/node.hpp` (included below, after
-/// the class, so a consumer pays only for the entities it uses) has the
-/// definition; a qualified friend needs the name to EXIST first, which an
-/// unqualified `friend class Node;` used to supply implicitly.
-class Node;
-
 } // namespace nros
+
+/// `rclcpp::Node` is named by the friend declaration below and by the
+/// out-of-line `Node::create_*` bodies further down. `nros/node.hpp` (included
+/// below, after the class, so a consumer pays only for the entities it uses)
+/// has the definition; a qualified friend needs the name to EXIST first, which
+/// an unqualified `friend class Node;` used to supply implicitly.
+///
+/// phase-427 W7 — declared in `rclcpp::`, which is where the definition moved.
+/// An elaborated `class Node;` in `nros::` would now declare a SECOND, distinct
+/// class and collide with the `nros::Node` alias.
+namespace rclcpp {
+class Node;
+}
 
 // ============================================================================
 // `rclcpp::Subscription<M>` -- DEFINED here (RFC-0089: rclcpp:: is the home)
@@ -567,7 +573,7 @@ template <typename M> class Subscription {
     Subscription(const Subscription&) = delete;
     Subscription& operator=(const Subscription&) = delete;
 
-    friend class ::nros::Node;
+    friend class ::rclcpp::Node;
 
     /// Phase 189.M3.x — raw message trampoline matching `RawSubscriptionCallback`
     /// (`void(data, len, ctx)`). Deserializes the CDR sample into `M` and runs
@@ -657,15 +663,16 @@ template <typename M> using Subscription = ::rclcpp::Subscription<M>;
 // Phase 84.G8: out-of-line definition of Node::create_subscription<M>().
 #include "nros/node.hpp"
 
-namespace nros {
+namespace nros {} // namespace nros
 
+namespace rclcpp {
 template <typename M>
-Result Node::create_subscription(Subscription<M>& out, const char* topic, const QoS& qos) {
+Result Node::create_subscription(Subscription<M>& out, const char* topic, const ::nros::QoS& qos) {
     // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
     // message the linked backend cannot encode never reaches the wire.
     NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_subscription_create(&handle_, topic, M::TYPE_NAME, M::TYPE_HASH,
                                                       ffi_qos, out.storage_);
     if (ret == 0) {
@@ -680,6 +687,9 @@ Result Node::create_subscription(Subscription<M>& out, const char* topic, const 
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 /// Phase 189.M3.1 — named-options overload. Delegates to the qos-only
 /// create, then lowers the non-QoS axes:
@@ -693,15 +703,18 @@ Result Node::create_subscription(Subscription<M>& out, const char* topic, const 
 ///    until a handle-returning create FFI lands (tracked with M3.4); the
 ///    field is honoured transparently once that exists.
 ///  * `message_info` — reserved (M3.4); ignored today.
+} // namespace nros
+
+namespace rclcpp {
 template <typename M>
-Result Node::create_subscription(Subscription<M>& out, const char* topic, const QoS& qos,
-                                 const SubscriptionOptions& options) {
+Result Node::create_subscription(Subscription<M>& out, const char* topic, const ::nros::QoS& qos,
+                                 const ::nros::SubscriptionOptions& options) {
     Result r = create_subscription<M>(out, topic, qos);
     if (!r.ok()) return r;
 
     // TODO(M3.4): honour options.message_info via the with-info arena path.
 
-    if (options.sched_context != SCHED_CONTEXT_UNSET && out.has_sched_handle()) {
+    if (options.sched_context != ::nros::SCHED_CONTEXT_UNSET && out.has_sched_handle()) {
         nros_cpp_ret_t bind = nros_cpp_bind_handle_to_sched_context(
             executor_handle_, out.sched_handle_id(), static_cast<uint8_t>(options.sched_context));
         if (bind != 0) {
@@ -715,19 +728,26 @@ Result Node::create_subscription(Subscription<M>& out, const char* topic, const 
     }
     return Result::success();
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // Phase 189.M3.x — callback-style (arena-registered) subscription. The arena
 // owns the subscriber + dispatches `out`'s message handler during spin_once, so
 // the handle is real and `options.sched_context` is functional. Mirrors the
 // callback-style `create_service` one entity over.
+} // namespace nros
+
+namespace rclcpp {
 template <typename M, typename F, typename>
 Result Node::create_subscription(Subscription<M>& out, const char* topic, F callback,
-                                 const QoS& qos, const SubscriptionOptions& options) {
+                                 const ::nros::QoS& qos,
+                                 const ::nros::SubscriptionOptions& options) {
     // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
     // message the linked backend cannot encode never reaches the wire.
     NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
 
     // Store the user handler (compile error if F isn't convertible to the
     // plain-fn-ptr handler type).
@@ -735,7 +755,7 @@ Result Node::create_subscription(Subscription<M>& out, const char* topic, F call
     out.user_fn_ctx_ = nullptr;
     out.user_ctx_ = nullptr;
 
-    uint8_t sched = (options.sched_context == SCHED_CONTEXT_UNSET)
+    uint8_t sched = (options.sched_context == ::nros::SCHED_CONTEXT_UNSET)
                         ? 0u
                         : static_cast<uint8_t>(options.sched_context);
     size_t handle = static_cast<size_t>(-1);
@@ -753,25 +773,31 @@ Result Node::create_subscription(Subscription<M>& out, const char* topic, F call
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // Phase 273 (RFC-0047) — callback-style subscription **in** a named callback group.
 // Mirrors create_subscription (callback-style) exactly but passes group.get_name()
 // as `callback_group` so the executor binds the slot via group_sched_table.
+} // namespace nros
+
+namespace rclcpp {
 template <typename M, typename F, typename>
-Result Node::create_subscription_in_group(const CallbackGroup& group, Subscription<M>& out,
-                                          const char* topic, F callback, const QoS& qos,
-                                          const SubscriptionOptions& options) {
+Result Node::create_subscription_in_group(const ::nros::CallbackGroup& group, Subscription<M>& out,
+                                          const char* topic, F callback, const ::nros::QoS& qos,
+                                          const ::nros::SubscriptionOptions& options) {
     // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
     // message the linked backend cannot encode never reaches the wire.
     NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
 
     out.user_fn_ = typename Subscription<M>::TypedSubscriptionFn(callback);
     out.user_fn_ctx_ = nullptr;
     out.user_ctx_ = nullptr;
 
-    uint8_t sched = (options.sched_context == SCHED_CONTEXT_UNSET)
+    uint8_t sched = (options.sched_context == ::nros::SCHED_CONTEXT_UNSET)
                         ? 0u
                         : static_cast<uint8_t>(options.sched_context);
     size_t handle = static_cast<size_t>(-1);
@@ -789,26 +815,33 @@ Result Node::create_subscription_in_group(const CallbackGroup& group, Subscripti
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 // Phase 189.M3.4 — callback-style subscription that delivers the wire attachment.
 // Mirrors the callback `create_subscription` one step over, but stores the
 // `(const M&, attachment, att_len)` handler + registers via the with-info arena
 // path so the trampoline receives the attachment.
+} // namespace nros
+
+namespace rclcpp {
 template <typename M, typename F, typename>
 Result Node::create_subscription_with_info(Subscription<M>& out, const char* topic, F callback,
-                                           const QoS& qos, const SubscriptionOptions& options) {
+                                           const ::nros::QoS& qos,
+                                           const ::nros::SubscriptionOptions& options) {
     // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
     // message the linked backend cannot encode never reaches the wire.
     NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
 
     out.user_fn_info_ = typename Subscription<M>::TypedSubscriptionInfoFn(callback);
     out.user_fn_ = nullptr;
     out.user_fn_ctx_ = nullptr;
     out.user_ctx_ = nullptr;
 
-    uint8_t sched = (options.sched_context == SCHED_CONTEXT_UNSET)
+    uint8_t sched = (options.sched_context == ::nros::SCHED_CONTEXT_UNSET)
                         ? 0u
                         : static_cast<uint8_t>(options.sched_context);
     size_t handle = static_cast<size_t>(-1);
@@ -825,6 +858,9 @@ Result Node::create_subscription_with_info(Subscription<M>& out, const char* top
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 
 /// Phase 123.B.4 — value-returning subscription factory. Pairs
 /// with `create_publisher` so the full pub/sub create dance is
@@ -843,14 +879,18 @@ inline ResultOf<Subscription<M>> create_subscription(Node& node, const char* top
 // Mirrors `create_subscription_with_info` one overload over, but routes through
 // `nros_cpp_subscription_register_validated` so the arena dispatches the
 // `message_safety_trampoline` on each new sample.
+} // namespace nros
+
+namespace rclcpp {
 template <typename M, typename F, typename>
 Result Node::create_subscription_with_safety(Subscription<M>& out, const char* topic, F callback,
-                                             const QoS& qos, const SubscriptionOptions& options) {
+                                             const ::nros::QoS& qos,
+                                             const ::nros::SubscriptionOptions& options) {
     // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
     // message the linked backend cannot encode never reaches the wire.
     NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
-    if (!initialized_) return Result(ErrorCode::NotInitialized);
-    nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
+    if (!initialized_) return Result(::nros::ErrorCode::NotInitialized);
+    nros_cpp_qos_t ffi_qos = ::nros::detail::qos_to_ffi(qos);
 
     out.user_fn_safety_ = typename Subscription<M>::TypedSubscriptionSafetyFn(callback);
     out.user_fn_ = nullptr;
@@ -858,7 +898,7 @@ Result Node::create_subscription_with_safety(Subscription<M>& out, const char* t
     out.user_fn_info_ = nullptr;
     out.user_ctx_ = nullptr;
 
-    uint8_t sched = (options.sched_context == SCHED_CONTEXT_UNSET)
+    uint8_t sched = (options.sched_context == ::nros::SCHED_CONTEXT_UNSET)
                         ? 0u
                         : static_cast<uint8_t>(options.sched_context);
     size_t handle = static_cast<size_t>(-1);
@@ -875,6 +915,9 @@ Result Node::create_subscription_with_safety(Subscription<M>& out, const char* t
     }
     return Result(ret);
 }
+} // namespace rclcpp
+
+namespace nros {
 #endif // NANO_ROS_SAFETY_E2E
 
 } // namespace nros

--- a/packages/api/nros-cpp/include/nros/timer.hpp
+++ b/packages/api/nros-cpp/include/nros/timer.hpp
@@ -28,6 +28,15 @@
 
 #include "nros_cpp_ffi.h"
 
+// phase-427 W7 — `Node` is DEFINED in `rclcpp::` (RFC-0089: that namespace is
+// the home). The friend declaration below is qualified, and a qualified friend
+// names an existing entity rather than introducing one, so the name has to be
+// declared first — and in `rclcpp::`, because an elaborated `class Node;` in
+// `nros::` would declare a second, distinct class.
+namespace rclcpp {
+class Node;
+}
+
 namespace nros {
 
 /// Repeating or one-shot timer registered with the executor.
@@ -151,7 +160,7 @@ class Timer {
     Timer(const Timer&) = delete;
     Timer& operator=(const Timer&) = delete;
 
-    friend class Node;
+    friend class ::rclcpp::Node;
 
     void* executor_;
     size_t handle_id_;

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -1119,7 +1119,7 @@ pub(crate) fn node_error_to_cpp_ret(err: nros_node::NodeError) -> nros_cpp_ret_t
 ///
 /// The two surfaces need ONE handle type. This is that: same storage contract as
 /// [`nros_cpp_init`] (caller owns the buffer, executor carved in place), so every
-/// existing C++ path — `nros::Node`, `NodeBuilder().rmw(name)`, publishers,
+/// existing C++ path — `rclcpp::Node`, `NodeBuilder().rmw(name)`, publishers,
 /// subscriptions — works against a multi-session executor unchanged.
 ///
 /// `specs[0]` is the primary session; the rest become extras, each findable by its
@@ -4667,7 +4667,7 @@ fn entry_spin_ms() -> u64 {
 //
 // **Only meaningful in a single-backend image** (RFC-0088 D5). A bridge image
 // links two backends and has no single answer; it asks per session, with
-// `nros::Node::serialization_format()`. `scripts/check-format-macro-scope.py`
+// `rclcpp::Node::serialization_format()`. `scripts/check-format-macro-scope.py`
 // refuses a bridge-linked translation unit that references the macro.
 
 /// Image-local discriminant of the linked backend's serialization format

--- a/packages/api/nros-cpp/src/params_shim.rs
+++ b/packages/api/nros-cpp/src/params_shim.rs
@@ -327,7 +327,7 @@ pub unsafe extern "C" fn nros_cpp_get_param_string(
 ///
 /// `None` for a null handle, a handle whose executor pointer is not one of ours
 /// (the issue 0436 tag check), or a handle carrying no registered node — a
-/// zero-initialised `nros::Node` that was never opened. Guessing
+/// zero-initialised `rclcpp::Node` that was never opened. Guessing
 /// `NodeId::PRIMARY` for the last case would write another node's parameters.
 #[cfg(all(feature = "param-services", feature = "rmw-cffi"))]
 unsafe fn node_param_target<'a>(
@@ -1368,7 +1368,7 @@ mod tests {
         assert!(ParameterValue::from_bool_array(&bools[..cap + 1]).is_none());
     }
 
-    /// A zero-initialised `nros_cpp_node_t`, the shape a C++ `nros::Node` has
+    /// A zero-initialised `nros_cpp_node_t`, the shape a C++ `rclcpp::Node` has
     /// before `nros_cpp_node_create` runs.
     fn zeroed_node_handle() -> crate::nros_cpp_node_t {
         crate::nros_cpp_node_t {

--- a/packages/api/nros-cpp/tests/compile/action_callback_tier.cpp
+++ b/packages/api/nros-cpp/tests/compile/action_callback_tier.cpp
@@ -48,7 +48,7 @@ struct UserState {
     int accepted_count{0};
 };
 
-inline ::nros::Result instantiate_server(::nros::Node& node) {
+inline ::nros::Result instantiate_server(::rclcpp::Node& node) {
     ::nros::ActionServer<Fib> server;
     ::nros::Result r = node.create_action_server(server, "/fib");
 
@@ -72,7 +72,7 @@ inline ::nros::Result instantiate_server(::nros::Node& node) {
     return r;
 }
 
-inline ::nros::Result instantiate_client(::nros::Node& node) {
+inline ::nros::Result instantiate_client(::rclcpp::Node& node) {
     ::nros::ActionClient<Fib> client;
     ::nros::Result r = node.create_action_client(client, "/fib");
 

--- a/packages/api/nros-cpp/tests/compile/action_goal_uuid.cpp
+++ b/packages/api/nros-cpp/tests/compile/action_goal_uuid.cpp
@@ -102,7 +102,7 @@ inline bool comparisons_and_container_use(const uint8_t raw_a[16], const uint8_t
 
 // ── 3. The callback tier: verbs + both id spellings ───────────────────────
 
-inline ::nros::Result callback_tier_server(::nros::Node& node) {
+inline ::nros::Result callback_tier_server(::rclcpp::Node& node) {
     ::nros::ActionServer<Fib> server;
     ::nros::Result r = node.create_action_server(server, "/fib");
 
@@ -136,7 +136,7 @@ inline ::nros::Result callback_tier_server(::nros::Node& node) {
     return r;
 }
 
-inline ::nros::Result callback_tier_client(::nros::Node& node) {
+inline ::nros::Result callback_tier_client(::rclcpp::Node& node) {
     ::nros::ActionClient<Fib> client;
     ::nros::Result r = node.create_action_client(client, "/fib");
 
@@ -169,7 +169,7 @@ inline ::nros::Result callback_tier_client(::nros::Node& node) {
 
 // ── 4. The polling (L1) tier — the same four surfaces ─────────────────────
 
-inline ::nros::Result polling_tier_server(::nros::Node& node) {
+inline ::nros::Result polling_tier_server(::rclcpp::Node& node) {
     ::nros::PollingActionServer<Fib> server;
     ::nros::Result r = node.create_polling_action_server(server, "/fib");
 
@@ -202,7 +202,7 @@ inline ::nros::Result polling_tier_server(::nros::Node& node) {
     return r;
 }
 
-inline ::nros::Result polling_tier_client(::nros::Node& node) {
+inline ::nros::Result polling_tier_client(::rclcpp::Node& node) {
     ::nros::PollingActionClient<Fib> client;
     ::nros::Result r = node.create_polling_action_client(client, "/fib");
 

--- a/packages/api/nros-cpp/tests/compile/bind_service.cpp
+++ b/packages/api/nros-cpp/tests/compile/bind_service.cpp
@@ -44,14 +44,14 @@ class Server {
         resp.sum = req.a + req.b;
         return resp;
     }
-    ::nros::Result configure(::nros::Node& node) {
+    ::nros::Result configure(::rclcpp::Node& node) {
         return ::nros::bind_service<AddTwoInts, Server, &Server::on_add>(node, "/add_two_ints",
                                                                          this);
     }
 };
 
 // Force template instantiation (body type-checked at compile).
-inline ::nros::Result instantiate(::nros::Node& node, Server* s) {
+inline ::nros::Result instantiate(::rclcpp::Node& node, Server* s) {
     return s->configure(node);
 }
 

--- a/packages/api/nros-cpp/tests/compile/bind_timer_deprecation_probe.cpp
+++ b/packages/api/nros-cpp/tests/compile/bind_timer_deprecation_probe.cpp
@@ -22,7 +22,7 @@ struct Component {
     nros::Timer timer;
     void on_tick() {}
 
-    nros::Result the_retired_spelling(nros::Node& node) {
+    nros::Result the_retired_spelling(rclcpp::Node& node) {
         return nros::bind_timer<Component, &Component::on_tick>(node, timer, 100, this);
     }
 };

--- a/packages/api/nros-cpp/tests/compile/declared_qos_depth.cpp
+++ b/packages/api/nros-cpp/tests/compile/declared_qos_depth.cpp
@@ -89,9 +89,9 @@ static_assert(::nros::detail::qos_from_declared_depth(::nros::declared_depth(Boo
 
 // -- The macro, in the shape a component ctor actually writes ---------------
 
-class Listener : public ::nros::Node {
+class Listener : public ::rclcpp::Node {
   public:
-    explicit Listener(::nros::NodeHandle h) : ::nros::Node(h, "listener") {
+    explicit Listener(::nros::NodeHandle h) : ::rclcpp::Node(h, "listener") {
         // Mode 1: the code states the QoS and the declaration agrees.
         NROS_SUBSCRIBE(Int32, on_int, "/chatter", ::nros::QoS(1));
         // Mode 2: the code states no QoS, and the declared depth fills in.

--- a/packages/api/nros-cpp/tests/compile/declared_qos_depth_probe.cpp
+++ b/packages/api/nros-cpp/tests/compile/declared_qos_depth_probe.cpp
@@ -34,9 +34,9 @@ struct Int32 {
     }
 };
 
-class Listener : public ::nros::Node {
+class Listener : public ::rclcpp::Node {
   public:
-    explicit Listener(::nros::NodeHandle h) : ::nros::Node(h, "listener") {
+    explicit Listener(::nros::NodeHandle h) : ::rclcpp::Node(h, "listener") {
         // DECLARED @depth=1. PASSED depth 10. This line is the whole test.
         NROS_SUBSCRIBE(Int32, on_int, "/chatter", ::nros::QoS(10));
     }

--- a/packages/api/nros-cpp/tests/compile/node_deprecation_probe.cpp
+++ b/packages/api/nros-cpp/tests/compile/node_deprecation_probe.cpp
@@ -1,0 +1,29 @@
+// EXPECTED-FAILURE probe — phase-427 W7.
+//
+// `nros::Node` is DEPRECATED. `rclcpp::Node` is the class (RFC-0089 §"Settled:
+// `rclcpp::` is the HOME") and `nros::` is the spelling that phases out; the
+// alias survives so an out-of-tree consumer — `nros-v0.5.0` shipped the old
+// spelling in six `examples/templates/**` files a user copies out — gets the
+// migration in the compiler's own words rather than as an unknown identifier.
+//
+// A deprecation nobody is told about is just an alias, so this probe asserts the
+// attribute FIRES: under `-Werror=deprecated-declarations` the old spelling must
+// fail to compile, and the lane greps the diagnostic for the replacement,
+// because "it failed" is also what a typo produces.
+//
+// Same shape as `bind_timer_deprecation_probe.cpp`, `qos_deprecation_probe.cpp`,
+// `receive_deprecation_probe.cpp` and `expected_deprecation_probe.cpp`. The
+// POSITIVE twin — both spellings still naming ONE type — is
+// `one_node_type.cpp`, which is the one TU in the tree deliberately left
+// un-migrated, because its subject IS the old spelling.
+
+#include <nros/nros.hpp>
+
+namespace nros_cpp_node_deprecation_probe {
+
+// The deprecated spelling in the shape a ported file writes it: a parameter
+// type. `[[deprecated]]` on an alias fires where the NAME is used, so this is
+// enough and it needs no definition.
+::rclcpp::Result the_retired_spelling(::nros::Node& node);
+
+} // namespace nros_cpp_node_deprecation_probe

--- a/packages/api/nros-cpp/tests/compile/node_graph_forwarders.cpp
+++ b/packages/api/nros-cpp/tests/compile/node_graph_forwarders.cpp
@@ -1,5 +1,5 @@
 // phase-417 stage 2b (RFC-0089) — the graph surface must be reachable on
-// `nros::Node` and `nros::LifecycleNode`, not only on `nros::Executor`.
+// `rclcpp::Node` and `nros::LifecycleNode`, not only on `nros::Executor`.
 //
 // Why this probe exists: rclcpp puts the graph calls on the NODE, and 18
 // ledger rows were open purely because ours were only on the executor. The
@@ -184,14 +184,14 @@ template <typename N> bool graph_surface_calls(N& node) {
 }
 
 int main() {
-    graph_surface_exists<nros::Node>();
+    graph_surface_exists<rclcpp::Node>();
     graph_surface_exists<nros::LifecycleNode>();
 
-    nros::Node node;
+    rclcpp::Node node;
     nros::LifecycleNode lifecycle;
 
     // `const` reachability: a ported file often holds a `const Node &`.
-    const nros::Node& const_node = node;
+    const rclcpp::Node& const_node = node;
     const nros::LifecycleNode& const_lifecycle = lifecycle;
 
     bool ok = graph_surface_calls(const_node);

--- a/packages/api/nros-cpp/tests/compile/one_node_type_ours_only_names.cpp
+++ b/packages/api/nros-cpp/tests/compile/one_node_type_ours_only_names.cpp
@@ -141,12 +141,12 @@ class PooledNode : public ::nros::NodeWithTimers<2> {
     ::nros::Publisher<CounterMsg> pub_;
 };
 
-static_assert(::std::is_base_of<::nros::Node, PooledNode>::value,
+static_assert(::std::is_base_of<::rclcpp::Node, PooledNode>::value,
               "a component IS-A Node now -- ComponentNode only ever wrapped one");
 
 // The pool is opt-in, and that is the whole point of making its depth a
 // template parameter: a plain `Node` must not carry the bytes.
-static_assert(sizeof(::nros::NodeWithTimers<2>) > sizeof(::nros::Node),
+static_assert(sizeof(::nros::NodeWithTimers<2>) > sizeof(::rclcpp::Node),
               "NodeWithTimers<N> is the node PLUS a pool");
 
 // --- (3) NEGATIVE CONTROL — the pre-rename shape binds the wrong overload ----
@@ -195,7 +195,7 @@ void pre_rename_negative_control(MergedBeforeRename& n) {
 //
 // phase-427 follow-on. Two suffixes had collapsed into one: `_in` meant "in a
 // callback group" from phase 273 (RFC-0047) and, after W4, also "ours-only /
-// storage-free". Both meanings sat on `nros::Node`, and one overload —
+// storage-free". Both meanings sat on `rclcpp::Node`, and one overload —
 // `create_subscription_in<M, C, &C::method>(group, topic, qos)` — was in both.
 //
 // The compiler was never confused: `const CallbackGroup&` and `const char*` do
@@ -231,11 +231,11 @@ struct pub_has_group_verb<
            ::std::declval<const ::nros::CallbackGroup&>(),
            ::std::declval<::nros::Publisher<CounterMsg>&>(), "t"))>> : ::std::true_type {};
 
-static_assert(!pub_short_name_takes_group<::nros::Node>::value,
+static_assert(!pub_short_name_takes_group<::rclcpp::Node>::value,
               "`create_publisher_in` must be the OURS-ONLY form only. A callback group as the "
               "first parameter is spelled `create_publisher_in_group` -- one suffix, one meaning "
               "(RFC-0089, \"The `_in` rule, amended\")");
-static_assert(pub_has_group_verb<::nros::Node>::value,
+static_assert(pub_has_group_verb<::rclcpp::Node>::value,
               "`create_publisher_in_group` must exist: the split renamed the group form, it did "
               "not delete the capability");
 
@@ -270,7 +270,7 @@ static_assert(timer_has_group_verb<::nros::NodeWithTimers<2>>::value,
 // split.
 
 struct PreSplitPublisherNode {
-    // The group form, under the SHORT name -- what `nros::Node` carried before.
+    // The group form, under the SHORT name -- what `rclcpp::Node` carried before.
     template <typename M>
     ::nros::Result create_publisher_in(const ::nros::CallbackGroup&, ::nros::Publisher<M>&,
                                        const char*,
@@ -289,7 +289,7 @@ struct PreSplitTimerNode {
 static_assert(pub_short_name_takes_group<PreSplitPublisherNode>::value,
               "NEGATIVE CONTROL: on the pre-split shape the SHORT publisher name must accept a "
               "group. If this fires the detector is broken, not the header, and the assertion "
-              "that `nros::Node` no longer accepts one is proving nothing");
+              "that `rclcpp::Node` no longer accepts one is proving nothing");
 static_assert(!pub_has_group_verb<PreSplitPublisherNode>::value,
               "NEGATIVE CONTROL: the pre-split shape had no `_in_group` spelling at all");
 static_assert(timer_short_name_takes_group<PreSplitTimerNode>::value,

--- a/packages/api/nros-cpp/tests/compile/param_hosted_overloads.cpp
+++ b/packages/api/nros-cpp/tests/compile/param_hosted_overloads.cpp
@@ -59,7 +59,7 @@ inline void rclcpp_node_string_values(rclcpp::Node& node) {
     (void)node.has_parameter(key);
 }
 
-// --- nros::Node, subclassed --------------------------------------------------
+// --- rclcpp::Node, subclassed --------------------------------------------------
 //
 // The value-returning facade, including the `std::vector<T>` overloads that had
 // never been compiled. Written as a derived ctor because that is where a
@@ -67,14 +67,14 @@ inline void rclcpp_node_string_values(rclcpp::Node& node) {
 // instantiated when something calls it.
 //
 // phase-427 W4 — this said `nros::ComponentNode`, the type that WRAPPED a node.
-// It is deleted; a component IS-A `nros::Node` now, and the facade this probe
+// It is deleted; a component IS-A `rclcpp::Node` now, and the facade this probe
 // compiles is the same one `rclcpp::Node` above wears, because they are one
 // type. So the two halves of this file are no longer two facades that could
 // disagree — they are two call SHAPES (a free function taking a `Node&`, and a
 // ctor on a subclass of it) over one.
-class HostedParamNode : public ::nros::Node {
+class HostedParamNode : public ::rclcpp::Node {
   public:
-    explicit HostedParamNode(::nros::NodeHandle h) : ::nros::Node(h, "hosted_params") {
+    explicit HostedParamNode(::nros::NodeHandle h) : ::rclcpp::Node(h, "hosted_params") {
         // Scalars, `const char*` keyed and `std::string` keyed.
         const double period = this->declare_parameter<double>("ctrl_period", 0.15);
         const int64_t depth = this->declare_parameter<int64_t>("queue_depth", 10);

--- a/packages/api/nros-cpp/tests/compile/polling_subscription.cpp
+++ b/packages/api/nros-cpp/tests/compile/polling_subscription.cpp
@@ -29,7 +29,7 @@ struct Int32 {
 };
 
 // Force template instantiation (bodies type-checked at compile).
-inline ::nros::Result instantiate(::nros::Node& node) {
+inline ::nros::Result instantiate(::rclcpp::Node& node) {
     ::nros::PollingSubscription<Int32> sub;
     ::nros::Result r = node.create_polling_subscription(sub, "/count");
 

--- a/packages/api/nros-cpp/tests/compile/rclcpp_node_freestanding_surface.cpp
+++ b/packages/api/nros-cpp/tests/compile/rclcpp_node_freestanding_surface.cpp
@@ -1,8 +1,8 @@
 // phase-438 W4 — `rclcpp::Node`'s UNCONDITIONAL surface, instantiated.
 //
-// phase-427 W1-W3/W5 made `rclcpp::Node` one class (`= ::nros::Node`) with a
+// phase-427 W1-W3/W5 made `rclcpp::Node` one class (`= ::rclcpp::Node`) with a
 // fixed layout on every target, and made the std-flavoured factories ADDITIVE
-// overloads beside out-ref forms that mirror `nros::Node`.
+// overloads beside out-ref forms that mirror `rclcpp::Node`.
 // `check-cpp-capability-layout` measures the layout half; nothing measured the
 // method half, and it could not have:
 //
@@ -100,7 +100,7 @@ inline ::nros::Result instantiate() {
     (void)node.get_clock();
 
     // The out-ref factories — caller-owned storage, `Result` channel, `const
-    // char*` names. Exactly `nros::Node`'s shape, which is what 27 of the 28
+    // char*` names. Exactly `rclcpp::Node`'s shape, which is what 27 of the 28
     // in-tree `create_*` call sites already write.
     ::nros::Publisher<Int32> pub;
     ::nros::Result r = node.create_publisher(pub, "/count", ::nros::QoS(10));

--- a/packages/api/nros-cpp/tests/compile/ros2_api_adoption.cpp
+++ b/packages/api/nros-cpp/tests/compile/ros2_api_adoption.cpp
@@ -79,7 +79,7 @@ class PortedNode : public rclcpp::Node {
         publisher_ = this->create_publisher<StringMsg>("topic", 10);
         timer_ = this->create_wall_timer(std::chrono::milliseconds(500), [this]() { tick(); });
 
-        // W1.d — identity and clock, forwarded to `nros::Node`.
+        // W1.d — identity and clock, forwarded to `rclcpp::Node`.
         const char* name = this->get_name();
         const char* ns = this->get_namespace();
         rclcpp::Time stamp = this->now();
@@ -197,7 +197,7 @@ static_assert(std::is_same<rclcpp::Duration, ::nros::Duration>::value,
 static_assert(std::is_same<rclcpp::Clock, ::nros::Clock>::value,
               "rclcpp::Clock must BE nros::Clock");
 
-// The shim's accessors have the shapes `nros::Node` has, since they forward.
+// The shim's accessors have the shapes `rclcpp::Node` has, since they forward.
 static_assert(
     std::is_same<decltype(std::declval<const rclcpp::Node&>().get_name()), const char*>::value,
     "rclcpp::Node::get_name() must return const char*, as upstream does");

--- a/packages/api/nros-cpp/tests/compile/rx_size_bound.cpp
+++ b/packages/api/nros-cpp/tests/compile/rx_size_bound.cpp
@@ -105,7 +105,7 @@ class Listener {
   public:
     // Instantiates the changed template BODY: the hint reaching
     // `create_subscription_raw` is the derived bound.
-    ::nros::Result configure(::nros::Node& node) {
+    ::nros::Result configure(::rclcpp::Node& node) {
         ::nros::Result r =
             ::nros::bind_subscription<Bounded, Listener, &Listener::on_msg>(node, "/chatter", this);
         if (!r.ok()) return r;
@@ -115,7 +115,7 @@ class Listener {
     }
 };
 
-inline ::nros::Result instantiate(::nros::Node& node) {
+inline ::nros::Result instantiate(::rclcpp::Node& node) {
     static Listener listener;
     (void)sizeof(Unbounded); // included, never asked for its bound
     return listener.configure(node);

--- a/packages/api/nros-cpp/tests/compile/serialization_format.cpp
+++ b/packages/api/nros-cpp/tests/compile/serialization_format.cpp
@@ -63,7 +63,7 @@ static_assert(::nros::format_of<Unspecialized>::value == ::nros::SerializationFo
 
 // Force instantiation of the entity creators, so the `static_assert` inside
 // their bodies is evaluated rather than merely parsed.
-inline ::nros::Result instantiate(::nros::Node& node) {
+inline ::nros::Result instantiate(::rclcpp::Node& node) {
     ::nros::Publisher<Int32> pub;
     ::nros::Result rp = node.create_publisher(pub, "/count");
 

--- a/packages/api/nros-cpp/tests/compile/serialization_format_mismatch_probe.cpp
+++ b/packages/api/nros-cpp/tests/compile/serialization_format_mismatch_probe.cpp
@@ -50,7 +50,7 @@ static_assert(::nros::linked_format() == ::nros::SerializationFormat::Cdr,
 // THIS is what must not compile: a typed entity created over a uORB message in
 // a CDR image. The assertion lives in `Node::create_publisher`'s body, so the
 // instantiation below is what evaluates it.
-inline ::nros::Result instantiate(::nros::Node& node) {
+inline ::nros::Result instantiate(::rclcpp::Node& node) {
     ::nros::Publisher<VehicleStatus> pub;
     return node.create_publisher(pub, "/fmu/out/vehicle_status");
 }

--- a/packages/cli/cargo-nano-ros/src/scaffold.rs
+++ b/packages/cli/cargo-nano-ros/src/scaffold.rs
@@ -353,7 +353,7 @@ pub struct ComponentScaffoldConfig {
     /// Source language. `rust` lands the planned-mode `nros::Component` shape;
     /// `c` / `cpp` land the typed component shape (RFC-0043) in the RFC-0048
     /// ament spelling: `find_package(nano_ros REQUIRED)` +
-    /// `nano_ros_add_node(...)` + a `configure(::nros::Node&)` (C++) /
+    /// `nano_ros_add_node(...)` + a `configure(::rclcpp::Node&)` (C++) /
     /// `NROS_C_COMPONENT` (C) seam.
     pub lang: String,
     pub force: bool,
@@ -534,7 +534,7 @@ source_metadata = "metadata/{module}.json"
 
 /// Scaffold a **C++ Node pkg** — typed component (RFC-0043). Emits the
 /// RFC-0048 ament surface (`find_package(nano_ros)` + `nano_ros_add_node`) and a
-/// `<UserClass>::configure(::nros::Node&)` real-callback body in the
+/// `<UserClass>::configure(::rclcpp::Node&)` real-callback body in the
 /// `<pkg>::` namespace per §212.L.4 (class prefix must equal `PROJECT_NAME`).
 /// `configure` creates a `Publisher` + binds a member timer callback by
 /// identity (no string descriptor, no interpreter) — the typed Entry
@@ -641,7 +641,7 @@ class {class_name} {{
     void on_tick(); // real body; bound via &{class_name}::on_tick (no name)
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::nros::Result configure(::rclcpp::Node& node);
 }};
 
 }} // namespace {pkg_sym}
@@ -675,7 +675,7 @@ void {class_name}::on_tick() {{
     }}
 }}
 
-::nros::Result {class_name}::configure(::nros::Node& node) {{
+::nros::Result {class_name}::configure(::rclcpp::Node& node) {{
     std::setvbuf(stdout, nullptr, _IONBF, 0);
     ::nros::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
@@ -1350,7 +1350,7 @@ int main(int argc, char** argv) {{
         return 1;
     }}
 
-    nros::Node node;
+    rclcpp::Node node;
     if (auto r = nros::create_node(node, "{name}"); !r.ok()) {{
         std::fprintf(stderr, "create_node failed: %d\n", r.raw());
         return 1;

--- a/packages/cli/cargo-nano-ros/tests/integration_tests.rs
+++ b/packages/cli/cargo-nano-ros/tests/integration_tests.rs
@@ -853,7 +853,7 @@ mod component_scaffold {
 
         // Header at include/<pkg>/<Class>.hpp (typed Entry includes it by that path).
         let hpp = fs::read_to_string(dir.join("include/cpp_talker/Talker.hpp")).unwrap();
-        assert!(hpp.contains("::nros::Result configure(::nros::Node& node);"));
+        assert!(hpp.contains("::nros::Result configure(::rclcpp::Node& node);"));
         assert!(hpp.contains("#include <nros/component.hpp>"));
         assert!(
             !hpp.contains("register_node") && !hpp.contains("NodeContext"),
@@ -861,7 +861,7 @@ mod component_scaffold {
         );
 
         let cpp = fs::read_to_string(dir.join("src/Talker.cpp")).unwrap();
-        assert!(cpp.contains("::nros::Result Talker::configure(::nros::Node& node)"));
+        assert!(cpp.contains("::nros::Result Talker::configure(::rclcpp::Node& node)"));
         assert!(cpp.contains("create_wall_timer<Talker, &Talker::on_tick>"));
         assert!(
             !cpp.contains("NROS_NODE_REGISTER") && !cpp.contains("DeclaredNode"),

--- a/packages/cli/nros-cli-core/src/codegen/entry/emit_cpp.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/emit_cpp.rs
@@ -202,7 +202,7 @@ struct CppEntryView {
 struct CppStorageView {
     index: usize,
     /// `"rclcpp"` gets an aligned arena slot; anything else gets a
-    /// `::nros::Node`, plus a component object when `class` is set (a C node
+    /// `::rclcpp::Node`, plus a component object when `class` is set (a C node
     /// keeps its state in its own TU, so it has none).
     shape: &'static str,
     class: Option<String>,
@@ -365,7 +365,7 @@ pub fn emit_typed_with_tail(plan: &Plan, tail: &EntryTail<'_>) -> Result<String,
     }
 
     // Static per-node storage. Shape-branched (RFC-0044): an rclcpp component
-    // OWNS its node, so it gets an arena slot and no `::nros::Node`; a C node
+    // OWNS its node, so it gets an arena slot and no `::rclcpp::Node`; a C node
     // keeps its state in its own TU, so it gets no component object; a Rust
     // node self-creates and gets nothing at all.
     let storage: Vec<CppStorageView> = plan
@@ -543,7 +543,7 @@ fn is_c_node(n: &super::PlanNode) -> bool {
 
 /// Phase 257 (W0-B) — a `lang == "rust"` node is installed via the uniform
 /// `__nros_component_<pkg>_install` seam onto the shared executor; it self-creates
-/// its node (no entry-created `::nros::Node`, no C++ class, no qos-override — D7
+/// its node (no entry-created `::rclcpp::Node`, no C++ class, no qos-override — D7
 /// Option C).
 fn is_rust_node(n: &super::PlanNode) -> bool {
     n.lang.as_deref() == Some("rust")
@@ -722,7 +722,7 @@ mod tests {
         assert!(src.contains("#include \"listener_pkg/Listener.hpp\""));
         assert!(src.contains("#include <nros/component.hpp>"));
         // static component + node storage
-        assert!(src.contains("static ::nros::Node __nros_node_0;"));
+        assert!(src.contains("static ::rclcpp::Node __nros_node_0;"));
         assert!(src.contains("static ::talker_pkg::Talker __nros_comp_0;"));
         assert!(src.contains("static ::listener_pkg::Listener __nros_comp_1;"));
         // setup constructs the node + configures the component
@@ -877,7 +877,7 @@ mod tests {
         assert!(src.contains("if (!__nros_comp_0->ok()) {"));
         assert!(src.contains("report_component_failure(\"controller\""));
         // The rclcpp shape does NOT default-construct a Node or call configure.
-        assert!(!src.contains("static ::nros::Node __nros_node_0;"));
+        assert!(!src.contains("static ::rclcpp::Node __nros_node_0;"));
         assert!(!src.contains("__nros_comp_0.configure"));
         assert!(!src.contains("create_node(__nros_node_0"));
         // still routes to the real executor via the named overload (phase 266)
@@ -914,9 +914,9 @@ mod tests {
         assert!(
             src.contains("__nros_comp_0 = new (__nros_comp_buf_0) ::ctrl_pkg::Controller(__h);")
         );
-        assert!(!src.contains("static ::nros::Node __nros_node_0;"));
+        assert!(!src.contains("static ::rclcpp::Node __nros_node_0;"));
         // node 1 = configure: Node + configure, no arena slot.
-        assert!(src.contains("static ::nros::Node __nros_node_1;"));
+        assert!(src.contains("static ::rclcpp::Node __nros_node_1;"));
         assert!(src.contains("static ::legacy_pkg::Legacy __nros_comp_1;"));
         assert!(src.contains("__nros_comp_1.configure(__nros_node_1)"));
         assert!(!src.contains("__nros_comp_buf_1"));

--- a/packages/cli/nros-cli-core/src/codegen/entry/packs/entry/cpp/entry.cpp.jinja
+++ b/packages/cli/nros-cli-core/src/codegen/entry/packs/entry/cpp/entry.cpp.jinja
@@ -80,7 +80,7 @@ extern "C" {
 alignas(::{{ s.class }}) static unsigned char __nros_comp_buf_{{ s.index }}[sizeof(::{{ s.class }})];
 static ::{{ s.class }}* __nros_comp_{{ s.index }} = nullptr;
 {%- else %}
-static ::nros::Node __nros_node_{{ s.index }};
+static ::rclcpp::Node __nros_node_{{ s.index }};
 {%- if s.class %}
 static ::{{ s.class }} __nros_comp_{{ s.index }};
 {%- endif %}

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_freertos_one.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_freertos_one.cpp.golden
@@ -17,7 +17,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_freertos_tiers.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_freertos_tiers.cpp.golden
@@ -18,9 +18,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::ctrl_pkg::CTRL __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::telem_pkg::TELEM __nros_comp_1;
 
 /* Phase 274.W2 — tier[0] (high) setup: creates only this tier's nodes. */

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_freertos_two.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_freertos_two.cpp.golden
@@ -18,9 +18,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::listener_pkg::LISTENER __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_group_split.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_group_split.cpp.golden
@@ -17,9 +17,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::ctrl_pkg::CTRL __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::telem_pkg::TELEM __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_one.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_one.cpp.golden
@@ -16,7 +16,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_probe.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_probe.cpp.golden
@@ -16,7 +16,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_rich.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_rich.cpp.golden
@@ -17,9 +17,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::listener_pkg::LISTENER __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_services.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_services.cpp.golden
@@ -16,7 +16,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_shapes.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_shapes.cpp.golden
@@ -32,12 +32,12 @@ extern "C" {
 }
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::talker_pkg::TALKER2 __nros_comp_1;
-static ::nros::Node __nros_node_2;
-static ::nros::Node __nros_node_3;
+static ::rclcpp::Node __nros_node_2;
+static ::rclcpp::Node __nros_node_3;
 alignas(::rclcpp_pkg::RCL_ONE) static unsigned char __nros_comp_buf_6[sizeof(::rclcpp_pkg::RCL_ONE)];
 static ::rclcpp_pkg::RCL_ONE* __nros_comp_6 = nullptr;
 

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_tiers.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_tiers.cpp.golden
@@ -17,9 +17,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::ctrl_pkg::CTRL __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::telem_pkg::TELEM __nros_comp_1;
 
 /* Phase 274.W2 — tier[0] (high) setup: creates only this tier's nodes. */

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_tiers_services.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_tiers_services.cpp.golden
@@ -17,9 +17,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::ctrl_pkg::CTRL __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::telem_pkg::TELEM __nros_comp_1;
 
 /* Phase 274.W2 — tier[0] (high) setup: creates only this tier's nodes. */

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_native_two.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_native_two.cpp.golden
@@ -17,9 +17,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::listener_pkg::LISTENER __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_nuttx_one.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_nuttx_one.cpp.golden
@@ -17,7 +17,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_nuttx_tiers.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_nuttx_tiers.cpp.golden
@@ -18,9 +18,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::ctrl_pkg::CTRL __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::telem_pkg::TELEM __nros_comp_1;
 
 /* Phase 274.W2 — tier[0] (high) setup: creates only this tier's nodes. */

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_nuttx_two.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_nuttx_two.cpp.golden
@@ -18,9 +18,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::listener_pkg::LISTENER __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_threadx_one.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_threadx_one.cpp.golden
@@ -17,7 +17,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_threadx_tiers.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_threadx_tiers.cpp.golden
@@ -18,9 +18,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::ctrl_pkg::CTRL __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::telem_pkg::TELEM __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_threadx_two.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_threadx_two.cpp.golden
@@ -18,9 +18,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::listener_pkg::LISTENER __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_zephyr_one.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_zephyr_one.cpp.golden
@@ -16,7 +16,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_zephyr_tiers.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_zephyr_tiers.cpp.golden
@@ -17,9 +17,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::ctrl_pkg::CTRL __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::telem_pkg::TELEM __nros_comp_1;
 
 /* Phase 274.W2 — tier[0] (high) setup: creates only this tier's nodes. */

--- a/packages/cli/nros-cli-core/testdata/entry/cpp_zephyr_two.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/cpp_zephyr_two.cpp.golden
@@ -17,9 +17,9 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::TALKER __nros_comp_0;
-static ::nros::Node __nros_node_1;
+static ::rclcpp::Node __nros_node_1;
 static ::listener_pkg::LISTENER __nros_comp_1;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_freertos_c.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_freertos_c.cpp.golden
@@ -24,7 +24,7 @@ extern "C" {
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 
 static int32_t __nros_entry_setup() {
     {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_freertos_cpp.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_freertos_cpp.cpp.golden
@@ -17,7 +17,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::Talker __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_native_c.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_native_c.cpp.golden
@@ -23,7 +23,7 @@ extern "C" {
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 
 static int32_t __nros_entry_setup() {
     {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_native_cpp.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_native_cpp.cpp.golden
@@ -16,7 +16,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::Talker __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_nuttx_c.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_nuttx_c.cpp.golden
@@ -24,7 +24,7 @@ extern "C" {
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 
 static int32_t __nros_entry_setup() {
     {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_nuttx_cpp.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_nuttx_cpp.cpp.golden
@@ -17,7 +17,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::Talker __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_threadx_c.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_threadx_c.cpp.golden
@@ -24,7 +24,7 @@ extern "C" {
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 
 static int32_t __nros_entry_setup() {
     {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_threadx_cpp.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_threadx_cpp.cpp.golden
@@ -17,7 +17,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::Talker __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_zephyr_c.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_zephyr_c.cpp.golden
@@ -23,7 +23,7 @@ extern "C" {
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 
 static int32_t __nros_entry_setup() {
     {

--- a/packages/cli/nros-cli-core/testdata/entry/node_register_zephyr_cpp.cpp.golden
+++ b/packages/cli/nros-cli-core/testdata/entry/node_register_zephyr_cpp.cpp.golden
@@ -16,7 +16,7 @@
 
 
 // Static per-node storage (outlives the spin loop; no heap).
-static ::nros::Node __nros_node_0;
+static ::rclcpp::Node __nros_node_0;
 static ::talker_pkg::Talker __nros_comp_0;
 
 static int32_t __nros_entry_setup() {

--- a/packages/cli/rosidl-codegen/packs/cpp/message.hpp.jinja
+++ b/packages/cli/rosidl-codegen/packs/cpp/message.hpp.jinja
@@ -195,7 +195,7 @@ static constexpr {{ constant.c_type }} {{ message_name }}_{{ constant.name }} = 
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
@@ -19,8 +19,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -120,7 +120,7 @@ struct Bounded {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
@@ -19,8 +19,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -116,7 +116,7 @@ struct Capped {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.hpp
@@ -20,8 +20,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -129,7 +129,7 @@ struct Nested {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Probe.action.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Probe.action.h
@@ -17,8 +17,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Probe.srv.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Probe.srv.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.h
@@ -16,8 +16,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.hpp
@@ -20,8 +20,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -177,7 +177,7 @@ struct ShapesView {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
@@ -19,8 +19,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -120,7 +120,7 @@ struct Bounded {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.hpp
@@ -19,8 +19,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -129,7 +129,7 @@ struct Capped {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.hpp
@@ -20,8 +20,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -129,7 +129,7 @@ struct Nested {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Probe.action.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Probe.action.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Probe.srv.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Probe.srv.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.h
@@ -15,8 +15,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.hpp
@@ -19,8 +19,8 @@
 
 #include <nros/nros_config_generated.h>
 
-/* RFC-0090 — emitted by nano-ros codegen version 3. */
-#define NROS_EMITTED_CODEGEN_VERSION 3
+/* RFC-0090 — emitted by nano-ros codegen version 4. */
+#define NROS_EMITTED_CODEGEN_VERSION 4
 
 #ifndef NROS_CODEGEN_VERSION
 #error "nros: the generated config header did not define NROS_CODEGEN_VERSION. This generated artifact cannot tell whether the runtime accepts it; rebuild the nano-ros runtime so its config header is regenerated."
@@ -143,7 +143,7 @@ struct Shapes {
 // which is a fact about the GENERATOR, and a future non-CDR pack specializes the
 // same slot instead of silently riding the default.
 //
-// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// `rclcpp::Node::create_publisher` / `create_subscription` static_assert on this
 // against the format the linked backend speaks — one image, one backend, one
 // encoding.
 namespace nros {

--- a/packages/core/nros-core/src/codegen_version.rs
+++ b/packages/core/nros-core/src/codegen_version.rs
@@ -35,7 +35,7 @@
 ///
 /// Gated by `check-codegen-version-surface`, which fails when the surface
 /// generated code names changes and this constant does not.
-pub const NROS_CODEGEN_VERSION: u32 = 3;
+pub const NROS_CODEGEN_VERSION: u32 = 4;
 
 /// The oldest codegen version this runtime still accepts.
 ///
@@ -63,6 +63,22 @@ pub const NROS_CODEGEN_VERSION: u32 = 3;
 /// was withdrawn: it compiles against the corrected `nros/view.h` and picks the
 /// fix up for free, because the view helpers are `static inline` in the header
 /// rather than symbols the generated code defines.
+///
+/// Still 2 while [`NROS_CODEGEN_VERSION`] moved to 4 (phase-427 W7). That move
+/// is a SPELLING change and nothing else: `nros::bind_subscription_sized` — the
+/// one demanded C++ signature that names the node type — now writes its
+/// parameter `::rclcpp::Node&` where it wrote `Node&`, because the class moved
+/// to `rclcpp::` and `nros::Node` became a deprecated alias for it. The two
+/// spellings are ONE TYPE (`std::is_same<rclcpp::Node, nros::Node>` is asserted
+/// by `tests/compile/one_node_type.cpp`), so a version-3 tree — which declares
+/// its node `static ::nros::Node __nros_node_0;` — still compiles and still
+/// links, with a deprecation warning naming its replacement. Nothing it names
+/// was withdrawn, which is the window the doc above describes.
+///
+/// The version moves anyway because the gate is fail-closed on the TEXT of a
+/// demanded declaration and should stay that way: it cannot know that two
+/// spellings are one type, and a gate that tried to would be one that misses a
+/// real rename.
 ///
 /// The range `[NROS_CODEGEN_VERSION_MIN, NROS_CODEGEN_VERSION]` is expressed to
 /// C and C++ as a SET OF DEFINED SYMBOLS rather than as a comparison — see

--- a/packages/testing/nros-tests/fixtures/cpp_compat_snippets/subscription_with_info.cpp
+++ b/packages/testing/nros-tests/fixtures/cpp_compat_snippets/subscription_with_info.cpp
@@ -32,7 +32,7 @@ struct FakeString {
 } // namespace
 
 int main() {
-    nros::Node node;
+    rclcpp::Node node;
     rclcpp::Subscription<FakeString> info_sub;
     (void)node.create_subscription_with_info<FakeString>(
         info_sub, "/chatter_info",

--- a/scripts/api-parity.py
+++ b/scripts/api-parity.py
@@ -1618,6 +1618,20 @@ def self_test():
         "same",
     )
     check("type noise", correlate.canon_type("const std::string &"), "string&")
+    # phase-427 W7 -- a LEADING `::` is the same type. The namespace strips are
+    # `^`-anchored, so before this the two spellings canonicalised differently
+    # and SEVEN C++ rows read `systematic` for nothing but a `::`: our hosted
+    # overloads are written `::std::string` and upstream's are `std::string`, so
+    # `Node::declare_parameter` and five siblings reported `rule:cstr-not-string`
+    # over an overload we actually ship. Both directions pinned, because a fix
+    # that stripped `::` from EVERY position would also erase the difference
+    # between `A::B` and `B`.
+    check("leading :: is the same type",
+          correlate.canon_type("const ::std::string &"), "string&")
+    check("leading :: on our namespace",
+          correlate.canon_type("const ::nros::QoS &"), "QoS&")
+    check("an inner :: is not noise",
+          correlate.canon_type("Node::SharedPtr"), "Node::SharedPtr")
 
     ours = correlate.flatten(
         [

--- a/scripts/api_parity/correlate.py
+++ b/scripts/api_parity/correlate.py
@@ -300,6 +300,10 @@ _TYPE_NOISE = [
     (re.compile(r"\s*&\s*"), "&"),
     (re.compile(r"\s*\*\s*"), "*"),
     (re.compile(r"\s+"), " "),
+    # phase-427 W7 -- a LEADING `::` is the same type, and the namespace strips
+    # below are `^`-anchored, so without this `::nros::QoS` and `nros::QoS`
+    # canonicalise to two different strings.
+    (re.compile(r"^::"), ""),
     (re.compile(r"^rclcpp::"), ""),
     (re.compile(r"^rclcpp_action::"), ""),
     (re.compile(r"^rclrs::"), ""),

--- a/scripts/check-cpp-capability-layout.py
+++ b/scripts/check-cpp-capability-layout.py
@@ -584,7 +584,7 @@ def run(include_args, workdir, baseline, subjects=None):
 # honestly while the real types were being compared against themselves, so the
 # control has to reach a real type in a real header. It copies the whole
 # `nros-cpp` include tree to a temp dir, injects a capability-gated member into
-# `nros::Node`, and runs the SAME `run()` the gate runs. No tracked header is
+# `rclcpp::Node`, and runs the SAME `run()` the gate runs. No tracked header is
 # touched.
 #
 # Cases 4 and 5 are issue 1225's: a RATCHET that tolerates a stale entry has
@@ -672,11 +672,12 @@ def selftest(baseline):
         # of 2 x 90, which is the difference between a gate that runs on the
         # fast lane and one that doubles its wall clock.
         #
-        # The subject is `::nros::Node` and not `rclcpp::Node` for the reason
-        # in the header comment: `rclcpp::Node` is an ALIAS of it, so the two
-        # are one layout, and a mutation there would be measuring the alias.
+        # The subject is `::rclcpp::Node`, which is where the CLASS is
+        # (phase-427 W7 flipped the direction; `::nros::Node` is the alias now).
+        # The two are one layout either way, so this narrows the mutation to the
+        # DEFINITION rather than to a name that resolves to it.
         before, subjects, _base = run(
-            args, workdir, baseline, subjects=["::nros::Node"]
+            args, workdir, baseline, subjects=["::rclcpp::Node"]
         )
         if before:
             fail.append(
@@ -699,11 +700,12 @@ def selftest(baseline):
                 after, _s, _b = run(args, workdir, baseline, subjects=subjects)
                 if not after:
                     fail.append(
-                        "case 3: a capability-gated MEMBER injected into ::nros::Node did\n"
+                        "case 3: a capability-gated MEMBER injected into ::rclcpp::Node\n"
+                        "    did\n"
                         "    not fail the gate. This is issue 1204 exactly -- the\n"
                         "    measurement is comparing a configuration against itself."
                     )
-                elif not any("::nros::Node" in e for e in after):
+                elif not any("::rclcpp::Node" in e for e in after):
                     fail.append(
                         "case 3: the gate failed on the injected member but its message\n"
                         f"    does not name the type. Reported: {after[0]}"
@@ -810,7 +812,7 @@ def selftest(baseline):
         raise SystemExit(1)
     print(
         "check-cpp-capability-layout --selftest: 7 case(s) OK (gated member diverges, "
-        "gated method does not, real ::nros::Node caught when mutated, a fixed "
+        "gated method does not, real ::rclcpp::Node caught when mutated, a fixed "
         "baseline entry fails, a stale one fails, an unbaselined divergence fails, "
         "a layout that moves with -DNROS_CPP_STD fails, hosted-only does not excuse "
         "it, and a stale std-only entry fails)"

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -30,7 +30,7 @@ config NROS_CPP_API
     select CPP
     help
       Build and link the nros C++ API library (libnros_cpp.a).
-      Uses nros::init(), nros::Node, nros::Publisher<M>, etc.
+      Uses nros::init(), rclcpp::Node, rclcpp::Publisher<M>, etc.
       Requires C++ support (automatically selected).
 
 config NROS_RUST_API


### PR DESCRIPTION
phase-427 **W7** — the node takes RFC-0089's namespace, and the old spelling
starts warning. Two commits: the flip, then the migration and the attribute
together (they must be one commit, or a bare `[[deprecated]]` is a flag day
wearing a migration's clothes).

## 1. The flip — `Node` is the tenth and last

RFC-0089 §"Settled: `rclcpp::` is the HOME" puts the class in `rclcpp::` with
`nros::` holding the migration alias. Nine types already read that way; `Node`
was excluded because PRs #797 and #806 were stacked on `node.hpp` and because
`api-parity` rooted our native surface at `{"nros"}` alone. Both blockers are
gone — the PRs merged, and phase-428 widened `OUR_CPP_ROOTS`.

Three mechanics the other nine did not need:

* **Forward declarations move too.** `class Node;` in `nros::` is an
  elaborated-type-specifier, so after the flip it declares a SECOND, distinct
  class and collides with the alias. Twelve headers.
* **Friends are qualified, and the declarator is parenthesized.** An unqualified
  `friend Result init(...)` inside `namespace rclcpp` befriends an `rclcpp::init`
  that does not exist. A qualified friend names an EXISTING entity, so `node.hpp`
  forward-declares the six `nros::` free functions the node befriends — and a
  nested-name-specifier is parsed greedily, so `friend Result ::nros::init` reads
  as `Result::nros::init` and fails naming neither the friend nor the namespace.
  `friend Result(::nros::init)(...)` closes the return type first.
* **Out-of-line member definitions may only live in a namespace ENCLOSING the
  class**, so all sixteen `Result Node::create_*` bodies moved with it.

**The near-miss worth reading.** `rclcpp::QoS` is a SUBCLASS of `nros::QoS`, not
an alias, so a bare `QoS` inside `namespace rclcpp` would have silently re-typed
every `create_*` parameter to the derived class — compiling, non-erroring, wrong.
Every such name in a moved body is `::nros::`-qualified, which is also what tells
a reader an adopted name from an ours-only one. `QoS`, `Logger`, `NodeOptions`
and `Rate` are the four `rclcpp::` homonyms here; only `QoS` is a different type.

## 2. The deprecation — UNCONDITIONAL, and here is the evidence

PR #753 armed its Rust deprecation behind a feature; PR #806 deleted outright.
#753's own argument decides it: it armed BECAUSE its tree had not migrated (65
hard errors across 47 files), and `#[allow(deprecated)]` at each site would have
suppressed the signal in exactly the code it was aimed at. Here the tree migrates
in the same commit, so the attribute costs **zero** in-tree diagnostics —
measured, over every nros-cpp header standalone (c++14 freestanding) and over the
umbrella plus every non-probe compile TU at `-DNROS_CPP_STD=1
-Werror=deprecated-declarations`.

Two structural reasons on top. Every other deprecation this API ships is
unconditional (`nros::Expected<T>`, `nros::bind_timer`, `QoS::Liveliness` + four
enumerators, the `QoS::*_ms(uint32_t)` family, `QoS::*_raw()`,
`LifecycleNode::trigger(uint8_t)`). And a macro nothing in-tree defines leaves
the PROBE as the only compiler that ever sees the attribute — a gate whose
subject disappears.

Out-of-tree reach is why the alias survives, and it is measured: `nros-v0.5.0`
(2026-06-08) shipped `nros::Node` in six `examples/templates/**` files a user
copies out. Those copies get a warning naming `rclcpp::Node`. A feature-armed
attribute would give them silence.

## What migrated — 326 sites, 207 files

| where | sites |
| --- | --- |
| `packages/api` | 92 |
| `packages/cli` (codegen emitters, entry jinja + 31 goldens, scaffold templates, their assertions) | 71 |
| `examples/*` (workspaces 45, native 21, zephyr 12, templates 10, freertos/nuttx/threadx 24, px4 5) | 106 |
| `book/src` | 17 |
| `docs/design` (RFC-0089 + RFC-0018) | 7 |
| `docs/guides` | 5 |
| `scripts/check-cpp-capability-layout.py` | 6 |
| cmake / Kconfig / justfile comments | 5 |

The tree-wide grep is 561. The difference is judgement, not omission:

* **`nros::Node` also names a RUST TRAIT** — `nros-macros`, `impl nros::Node for
  Talker`, 58 `.rs` sites. Different symbol, different language, untouched.
* **`docs/roadmap` (72) and `docs/issues` (26) are historical record.**
  "`nros::Node` WAS the definition" is true as written; rewriting it makes a
  record into a falsehood. Same for the dated paragraphs of the api-parity ledger
  and for RFC-0044, whose subject `ComponentNode` is deleted. Only phase-427's
  own W7 section changes, because it is the item that landed.
* **RFC-0018 DID migrate.** It is `Stable` and its code blocks teach what to
  write, so a stale example there misleads rather than records.
* **`one_node_type.cpp` is the ONE TU left un-migrated** — its subject IS both
  spellings naming one type. Its lane line carries `-Wno-deprecated-declarations`
  saying so.

## Three things the change surfaced

**A pre-existing parity defect: a leading `::` read as a different type.**
`correlate.canon_type`'s namespace strips are `^`-anchored, so `::std::string`
never reduced to `string`. Our hosted overloads are spelled `::std::string` and
upstream's `std::string`, so SEVEN C++ rows — `Node::Node`,
`Node::create_client`, `Node::create_service`, `Node::declare_parameter`,
`Node::get_parameter`, `Node::has_parameter`, `QoS::QoS` — reported `systematic`
over an overload we actually ship. Fixed at the canonicaliser, pinned in
`--self-test` in both directions (an INNER `::` is not noise). C++ buckets: same
131 → 138, systematic 14 → 7; nothing moved the other way and no ledger row's
claim changed.

**Two ledger rows changed shard**, `cpp:spin_once` and `cpp:global_handle`
(`exec` / `other` → `node`). Their declarations genuinely live in `node.hpp` now
— that is what the qualified friendship requires — and the taxonomy files a
top-level name by its header. Neither verb changed.

**`NROS_CODEGEN_VERSION` 3 → 4, `_MIN` held at 2.**
`check-codegen-version-surface` is fail-closed on the TEXT of a demanded
declaration, and `nros::bind_subscription_sized` now writes `::rclcpp::Node&`
where it wrote `Node&`. One type, two spellings, so a version-3 tree still
compiles and links and the floor does not move. The version moves anyway and the
gate should stay fail-closed: it cannot know two spellings are one type, and one
that tried would miss a real rename. Carried to the NuttX fallback config headers
and `nros-sdk-index.toml`'s smoke expectation.

Also fixed, MEASURED not guessed: **seven stale doxygen links** in
`book/src/reference/cpp-api.md`. `just doc-cpp` emits `classrclcpp_1_1Node.html`;
the book linked `classnros_1_1Node.html` and six siblings, all 404 since
phase-428's nine-type flip. Verified against the generated file list.

## Run

| lane | result |
| --- | --- |
| `just check cpp` | **green**, including the new probe and nros-cpp clippy |
| `just check fast` | 297 of 298. The one red is `xrce-source-manifest`, and it is this HOST: its self-test asserts `Path("/nonexistent/xrce-config.txt").exists()`, which raises `PermissionError` in this sandbox instead of returning False. The script is byte-identical to `origin/main`'s and reads nothing this branch touches. |
| `just check api-parity` | **green** — "every divergence carries a ledger entry" |
| `just check api-parity-ledger` | green (0 self-test failures) |
| `just check cpp-capability-layout` | green — 7 self-test cases, 90 derived subjects × 8 macros |
| `just check cbindgen-headers` | green (3 headers match a fresh generation) |
| `just check ffi-struct-mirrors` | green |
| `just check build` | green (21 gates) |
| `just check cli-tests` | green |
| `just test-unit` | **1295 passed**, 1 skip (`ZPICO_MAX_SESSIONS=1` on this host) |
| `cargo test -p nros-tests --test cpp_api_drift` | 4/4, compile-check fixtures rebuilt |
| **`just colcon-parity`** | **green** — the templates still build against real rclcpp under `/opt/ros/humble` |

**The dual-compile hazard was tested deliberately, not hoped at.** A TU that
includes BOTH `<rclcpp/rclcpp.hpp>` and `<nros/nros.hpp>` fails before (1860
errors, 725 distinct — origin/main headers) and after (1706 / 663). No
regression, and slightly fewer: nros-cpp REPLACES upstream rclcpp rather than
sitting beside it, and `colcon-parity`'s `consumer.cpp` compiles against upstream
ALONE, which is why `rclcpp::Node` being ours breaks nothing there.

Tier run: **`just ci gate`** (compile + unit, no fixtures) — `cli-fresh` ok, `fast` 297/298 as above, and `build` / `api-parity` / `test-unit` run separately and green because the lane stops at its first red. Everything was run in this worktree with every vendored submodule initialised (cyclonedds, zenoh-pico, the two XRCE trees, play_launch), so none of the results above is a skip reading as a pass.

One fixture family had to be rebuilt for `cpp_api_drift` (`scripts/build/compile-check-fixtures.sh`); the px4 lane skips, PX4-Autopilot being the one submodule still absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bgWmbrBZbCbYfbKMmzaYy
