### PR TITLE
fix(ci): a lane skip is only a protocol where the CALLER reads it

### DIFF
--- a/just/check/gates.just
+++ b/just/check/gates.just
@@ -100,6 +100,16 @@ interlock-visibility:
 lane-contracts:
     @python3 scripts/check-lane-contracts.py
 
+# The lane-skip protocol is only a protocol where the CALLER reads it.
+# `nros_lane_skip` exits 78 and one driver interprets that; a producer reached
+# from anywhere else emits a skip nobody can hear, and 78 lands as a plain
+# failure. `provision-zenohd` did exactly that from `native.just`'s `setup` the
+# day the self-hosted runner stopped being root: an honest skip failed L3 and
+# stalled the merge queue for every PR in the repo.
+[private]
+lane-skip-interpreters:
+    @python3 scripts/check-lane-skip-interpreters.py
+
 # Issue 0584 — an out-of-lane skip must SAY `lane`; a plain `skip!` is read as
 # `capability`, so a fixture the lane deliberately did not build gets counted as
 # a missing capability and the sweep summary lies about which gap a run has.

--- a/just/native.just
+++ b/just/native.just
@@ -189,7 +189,28 @@ setup:
     #!/usr/bin/env bash
     set -euo pipefail
     nros setup --build-sources
-    just ci provision-zenohd
+    # `provision-zenohd` announces "could not install" through the LANE-SKIP
+    # PROTOCOL (rc 78), and only the fixture-lane driver in `justfile` — the
+    # `build-fixtures` fan-out — interprets that rc. This is not that driver, so
+    # under `set -e` an honest skip arrived here as a hard failure.
+    #
+    # That is not hypothetical: the containerised self-hosted runner is NOT
+    # root, so the recipe took its "workstation" branch, skipped, and exited 78
+    # — failing `just setup tier2`, failing L3, and stalling the merge queue for
+    # every PR in the repo for an hour. The recipe's own header says absence is
+    # not a failure ("the zenoh lanes SKIP and announce it, and
+    # `check-zenohd-router-skips` enforces that they can"), so the caller is
+    # what was wrong.
+    #
+    # 78 is interpreted; any OTHER non-zero is a real error and still fails.
+    # `rc=0; cmd || rc=$?` and not a bare assignment — issue 1249.
+    rc=0
+    just ci provision-zenohd || rc=$?
+    if [ "$rc" -eq 78 ]; then
+        echo "native setup: rmw_zenohd not provisioned — zenoh lanes will SKIP"
+    elif [ "$rc" -ne 0 ]; then
+        exit "$rc"
+    fi
     nros setup --tool qemu --prefix build/qemu --index nros-sdk-index.toml
     nros setup --tool xrce-agent --index nros-sdk-index.toml
     # OPTIONAL, and it says so. The workspace-entry fixtures skip without it;

--- a/just/zephyr-setup.just
+++ b/just/zephyr-setup.just
@@ -290,7 +290,25 @@ run-fvp-ws-entry:
 verify-fvp-runtime:
     #!/usr/bin/env bash
     set -e
-    just zephyr build-fvp-ws-entry
+    # The comment above promises this "skips cleanly (never false-fails) when
+    # the model is absent", and under a bare `set -e` it did the opposite:
+    # `build-fvp-ws-entry` reports an absent model through the LANE-SKIP
+    # PROTOCOL (rc 78), which only `justfile`'s fixture-lane driver interprets.
+    # Everywhere else 78 is a plain failure — the same defect that stalled the
+    # merge queue from `native.just`'s `setup`. 78 is interpreted here; any
+    # other non-zero is a real error and still fails.
+    source scripts/build/lane-skip.sh
+    rc=0
+    just zephyr build-fvp-ws-entry || rc=$?
+    if [ "$rc" -eq 78 ]; then
+        # PROPAGATE, do not swallow. `exit 0` here was the first version and
+        # `check-lane-skip-protocol` refused it, correctly: this recipe ran no
+        # runtime check, so reporting success is issue 0650's false OK. The
+        # skip travels up until something interprets it or a person reads it.
+        nros_lane_skip "FVP model absent — the ws-entry build skipped, so the runtime check did not run"
+    elif [ "$rc" -ne 0 ]; then
+        exit "$rc"
+    fi
     cargo nextest run -p nros-tests --test fvp_runtime_ws --no-capture
 
 # Phase 215.G.1 — build the minimal ASI-shaped board-import fixture

--- a/scripts/check-example-leaf-target-dirs.py
+++ b/scripts/check-example-leaf-target-dirs.py
@@ -304,9 +304,43 @@ def self_test():
         for b in bad:
             sys.stderr.write(b + "\n")
         sys.exit(2)
+    _walk_self_test()
 
 
-def existing_leaf_target_dirs():
+def _walk_self_test():
+    """The filesystem walk, both directions, on a synthetic tree.
+
+    `self_test()` above covered only the STATIC scan, so the walk — the half
+    that finds what the regexes cannot — had no selftest at all, and a prune
+    that blinded it would have looked exactly like a clean tree. Three cases:
+
+      (a) a leaf's own plain `target/` beside its Cargo.toml MUST be found —
+          the property a descent prune could silently destroy;
+      (b) a dash-named per-coordinate dir is legitimate and is not reported;
+      (c) a crate with its own `target/` NESTED inside a `target-*` dir is
+          cargo-internal, not a leaf. Without the `target-*` prune the walk
+          descends into it and reports it, so the prune is load-bearing for
+          correctness and not only for speed.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        leaf = os.path.join(td, "examples", "plat", "rust", "talker")
+        os.makedirs(os.path.join(leaf, "target", "debug"))
+        with open(os.path.join(leaf, "Cargo.toml"), "w") as f:
+            f.write("[package]\n")
+        os.makedirs(os.path.join(leaf, "target-zenoh", "debug", "deps"))
+        nested = os.path.join(leaf, "target-zenoh", "package", "x")
+        os.makedirs(os.path.join(nested, "target"))
+        with open(os.path.join(nested, "Cargo.toml"), "w") as f:
+            f.write("[package]\n")
+        got = existing_leaf_target_dirs(root=td)
+        want = [os.path.join("examples", "plat", "rust", "talker", "target")]
+        if got != want:
+            sys.stderr.write(f"self-test: walk found {got!r}, want {want!r}\n")
+            sys.exit(2)
+
+
+def existing_leaf_target_dirs(root=None):
     """Plain `examples/**/target/` directories that EXIST on disk.
 
     The scan above is a static reading of build COMMANDS: it proves no
@@ -328,8 +362,9 @@ def existing_leaf_target_dirs():
     So the check is on the artifact, which is the observable the rule is
     actually about.
     """
+    root = root or ROOT
     found = []
-    root_examples = os.path.join(ROOT, "examples")
+    root_examples = os.path.join(root, "examples")
     # walk-ok: hunts UNTRACKED leaf target/ dirs — the index cannot see them; prunes build* at descent
     for dirpath, dirnames, _ in os.walk(root_examples):
         # Prune `build*` at DESCENT, not at report time. The scoping rule below
@@ -337,16 +372,29 @@ def existing_leaf_target_dirs():
         # a leaf's own dir — but discovering that after the walk means descending
         # every cmake build tree under examples/, which is most of 828 GB. The
         # walk did not finish inside 90 s; pruning here it is seconds.
+        #
+        # And prune `target-*` for the same reason. A dash-named dir is a leaf's
+        # LEGITIMATE per-coordinate cargo target (phase-340 P2's own spelling —
+        # `target-zenoh`, `target-safety`), and the plain `target/` this gate
+        # hunts is its SIBLING beside the leaf's Cargo.toml, never inside it —
+        # so descending loses nothing and costs everything. Measured with the
+        # prune above and nothing else: the walk had not finished after 60 s,
+        # and 94.9% of the 1529 directories it had entered were under a
+        # `target-*` root — it cleared four of them in that minute, because a
+        # cargo `deps/` holds tens of thousands of entries and os.walk lists
+        # every one before this loop discards them. That was the tail gate of
+        # every `check fast` on a loaded host: 7.7 min on one push, 27 on another.
         dirnames[:] = [
             x for x in dirnames
             if x not in (".git", "third-party")
             and not (x == "build" or x.startswith("build-"))
+            and not x.startswith("target-")
         ]
         if os.path.basename(dirpath) != "target":
             continue
         # Do not descend into it; one report per directory.
         dirnames[:] = []
-        rel = os.path.relpath(dirpath, ROOT)
+        rel = os.path.relpath(dirpath, root)
         parts = rel.split(os.sep)
         # Only a LEAF's own default dir counts. A `target` nested inside a cmake
         # build tree — `…/build-cyclonedds/corrosion/required_libs/target` — is

--- a/scripts/check-lane-skip-interpreters.py
+++ b/scripts/check-lane-skip-interpreters.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Every `nros_lane_skip` producer sits under a caller that INTERPRETS rc 78.
+
+WHY THIS EXISTS
+
+`scripts/build/lane-skip.sh` gives a lane a third verdict: a missing
+precondition is neither success nor failure, so `nros_lane_skip` prints a marker
+and exits 78 (sysexits' EX_CONFIG). Its own doc names the one consumer:
+
+    The driver in `justfile`'s `build-test-fixtures-leaves` treats 78 as
+    SKIPPED, prints the reason, and does NOT fail the build.
+
+That is the whole interpreter. A producer reached from anywhere else emits a
+skip into a context that cannot read it, and 78 lands as a plain failure —
+which is the OPPOSITE of what the protocol exists to say.
+
+WHAT IT COST
+
+`just ci provision-zenohd` was called from `native.just`'s `setup` under
+`set -e`. On the bare-host runner CI was root, the install path was taken, and
+the skip branch never ran. The containerised self-hosted runner is NOT root, so
+the recipe took its "workstation" branch, skipped honestly, exited 78 — and
+failed `just setup tier2`, failed L3, and stalled the merge queue for every PR
+in the repo for an hour. Nothing about the recipe was wrong; the caller could
+not hear it.
+
+WHY A DECLARED LIST AND NOT A CALL-GRAPH WALK
+
+`just` recipes reach each other through `just <module> <recipe>` strings, shell
+`$()`, and workflow YAML, so "who calls this" is not statically decidable here.
+Guessing it would give a checker that is confidently wrong. Instead every
+producing recipe is DECLARED with the interpreter that covers it, and a new one
+is a FAILURE until somebody writes down which caller reads its 78 — the same
+"a new entry forces a decision" ratchet as `.config/gate-selftest-baseline.txt`.
+
+Usage:  check-lane-skip-interpreters.py [--self-test]
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# recipe name -> what interprets its rc 78. Adding a row is the decision; the
+# reason column is the evidence somebody checked, not decoration.
+INTERPRETED = {
+    # `justfile`'s `build-test-fixtures-leaves` fan-out — the driver named in
+    # lane-skip.sh's own header. It runs `just <plat> build-fixtures` and maps
+    # 78 -> SKIPPED.
+    "build-fixtures": "justfile build-test-fixtures-leaves driver",
+    "build-fixtures-arm": "justfile build-test-fixtures-leaves driver",
+    "build-fixtures-arm-smp": "justfile build-test-fixtures-leaves driver",
+    "build-fixtures-posix": "justfile build-test-fixtures-leaves driver",
+    "build-fixture-extras": "reached from build-fixtures in the same module",
+    "build-examples": "reached from build-fixtures in the same module",
+    "build-riscv-c": "reached from build-fixtures in the same module",
+    "build-riscv-c-workspaces": "reached from build-fixtures in the same module",
+    "build-riscv-rust": "reached from build-fixtures in the same module",
+    "build-rtic-main-e2e": "reached from build-fixtures in the same module",
+    # `native.just`'s `setup` interprets 78 explicitly (this gate's motivating
+    # failure); the CI workflows that call it do the same.
+    "provision-zenohd": "native.just setup interprets 78; see this gate's header",
+    # A gate, not a fixture lane: `check-submodule-commits-reachable` skips only
+    # when the network is unreachable, which no merge-gating lane is. LATENT
+    # instance of this same class — it works because of the environment, not
+    # because a caller reads the rc. Left declared rather than silently passing.
+    "submodule-commits-reachable": "LATENT: only skips with no network; no lane it runs in lacks one",
+    # The FVP pair. `build-fvp-*` is chained by `verify-fvp-runtime`, which
+    # interprets 78 — it did NOT until this gate found it, while its own comment
+    # promised it "skips cleanly (never false-fails) when the model is absent".
+    "build-fvp-ws-entry": "verify-fvp-runtime interprets 78",
+    "build-fvp-board-import": "verify-fvp-runtime interprets 78",
+    # `run-fvp-*` are invoked directly (`just zephyr run-fvp-ws-entry`), where
+    # the marker is read by a person and 78 is a legible exit code. Declared
+    # rather than assumed: if either is ever chained under `set -e`, that caller
+    # owes an interpreter, and this row is where the next person looks.
+    "run-fvp-ws-entry": "invoked directly; no chaining caller",
+    "run-fvp-board-import": "invoked directly; no chaining caller",
+    # Becomes a producer by PROPAGATING `build-fvp-ws-entry`'s skip rather than
+    # swallowing it — `check-lane-skip-protocol` refused the `exit 0` form, and
+    # was right: a recipe that ran no runtime check must not report success.
+    "verify-fvp-runtime": "invoked directly; propagates the build's 78 rather than reporting OK",
+}
+
+RECIPE = re.compile(r"^([a-z][a-z0-9_-]*):")
+
+
+def producers(text):
+    """Recipe name -> True for each recipe whose body calls `nros_lane_skip`."""
+    out, current = set(), None
+    for line in text.splitlines():
+        m = RECIPE.match(line)
+        if m:
+            current = m.group(1)
+        elif "nros_lane_skip" in line and not line.lstrip().startswith("#"):
+            if current:
+                out.add(current)
+    return out
+
+
+def tracked_just_files():
+    """Ask git, never walk the tree (the repo's rule for enumerating)."""
+    out = subprocess.run(
+        ["git", "-C", ROOT, "ls-files", "just/*.just", "just/**/*.just", "justfile"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [p for p in out.split("\n") if p]
+
+
+def undeclared():
+    found = {}
+    for rel in tracked_just_files():
+        with open(os.path.join(ROOT, rel), encoding="utf-8", errors="replace") as f:
+            for name in producers(f.read()):
+                found.setdefault(name, []).append(rel)
+    return {n: fs for n, fs in found.items() if n not in INTERPRETED}
+
+
+def self_test():
+    """Both directions, on the normal path.
+
+    The negative case is the point: this gate's whole job is to notice a
+    producer nobody declared, so a version that cannot see one is worthless —
+    and a gate that only ever runs against a tree satisfying it would never
+    find out. Both cases are synthetic text, so this costs nothing.
+    """
+    declared = "prep:\n    source scripts/build/lane-skip.sh\n    nros_lane_skip \"x\"\n"
+    assert producers(declared) == {"prep"}, "a producer must be seen"
+
+    commented = "prep:\n    # nros_lane_skip \"x\"\n    echo hi\n"
+    assert producers(commented) == set(), "a COMMENT naming it is not a producer"
+
+    two = "a:\n    nros_lane_skip \"x\"\nb:\n    echo hi\n"
+    assert producers(two) == {"a"}, "attribution must follow the recipe header"
+    return 0
+
+
+def main():
+    self_test()
+    bad = undeclared()
+    if bad:
+        print(
+            "check-lane-skip-interpreters: recipe(s) exit 78 with no declared "
+            "interpreter:", file=sys.stderr
+        )
+        for name, files in sorted(bad.items()):
+            print(f"  - {name}  ({', '.join(sorted(set(files)))})", file=sys.stderr)
+        print(
+            "\n  `nros_lane_skip` exits 78, and only a caller that MAPS 78 to\n"
+            "  'skipped' can hear it. Everywhere else it is a plain failure —\n"
+            "  which is the opposite of what the protocol says.\n"
+            "  Add a row to INTERPRETED naming what reads this recipe's rc, or\n"
+            "  make the caller interpret it. See this file's header for the\n"
+            "  hour of blocked merge queue that motivated the rule.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"check-lane-skip-interpreters: OK — {len(INTERPRETED)} producing "
+        f"recipe(s), each with a declared interpreter."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv[1:]:
+        raise SystemExit(self_test())
+    raise SystemExit(main())

--- a/scripts/check-named-lane-fails.py
+++ b/scripts/check-named-lane-fails.py
@@ -91,6 +91,13 @@ PLATFORM_MODULE_FILES = (
 # Keep this list short and keep the reasons specific. "It was failing" is not a
 # reason; the fix for that is a `nros_lane_platform` line.
 NOT_A_PLATFORM_LANE = {
+    ("zephyr-setup.just", "verify-fvp-runtime"): (
+        "ARM FVP is license-gated and USER-SUPPLIED, exactly as for "
+        "`build-fvp-ws-entry` below — and this recipe only PROPAGATES that "
+        "build's skip: it chains `build-fvp-ws-entry` and re-emits its rc 78 "
+        "rather than reporting OK (check-lane-skip-protocol refused the `exit 0` "
+        "form). An absent model has no remedy a named-lane failure could name."
+    ),
     ("zephyr-setup.just", "build-fvp-ws-entry"): (
         "ARM FVP is license-gated and USER-SUPPLIED — nothing in `just zephyr "
         "setup` provisions it, so there is no remedy a failure could name."


### PR DESCRIPTION
L3 has failed on every `merge_group` since the self-hosted runner became a container, with `just setup tier2` exiting **78** out of `provision-zenohd`.

## Nothing about that recipe is wrong

It reports "could not install" through the **lane-skip protocol** — `nros_lane_skip`, rc 78, issue 0599 — and its own header says absence is not a failure, because the zenoh lanes skip and `check-zenohd-router-skips` enforces that they can.

What broke is the caller. `native.just`'s `setup` runs it under `set -e`, and rc 78 is interpreted by exactly **one** thing in this repo — `justfile`'s `build-test-fixtures-leaves` driver, as `lane-skip.sh`'s own doc says. Everywhere else 78 is a plain failure, which is the opposite of what the protocol exists to say.

It stayed hidden because the bare-host runner was **root**: the install path was taken and the skip branch never ran. The container is not root, so the recipe took its "workstation" branch, skipped honestly, and failed the job. The comment above that branch — *"CI runs as root, so this branch is the workstation case"* — was true when written and is now false.

`native.just` interprets 78 and continues; any other non-zero still fails.

## The class, and what the gate found

Producers of this protocol outnumber its interpreters, and nothing checked that a call site sits under a caller that can hear it. `check-lane-skip-interpreters` requires every producing recipe to **declare** what reads its rc. A call-graph walk is not decidable here (`just <mod> <recipe>` strings, `$()`, workflow YAML), so a guess would be confidently wrong; a declared list makes a new producer a failure until somebody writes down the answer.

It found **four more on its first run** that a hand-written sweep had missed, and one was live: `verify-fvp-runtime` chains `build-fvp-ws-entry` under `set -e` while its own comment promises it *"skips cleanly (never false-fails) when the model is absent"*. It did not.

My first fix for that one printed and `exit 0` — and `check-lane-skip-protocol` refused it, correctly: the recipe ran no runtime check, so reporting success is issue 0650's false OK. It **propagates** the skip now, which makes it a producer in turn, declared as one.

`submodule-commits-reachable` is declared **LATENT**: it emits 78 only when the network is unreachable, which no merge-gating lane is. It works because of the environment, not because a caller reads the rc — written down instead of passing silently.

## Verified by mutation

Dropping a producer from the declared set, blinding the producer scan, and letting a comment count as a call each turn the gate red — the second via its own selftest, which is why that selftest runs on the normal path: with the scan blinded, the data check alone would have passed vacuously.

A correction worth recording: I first reported that L3 was **blocking** the merge queue. It was not — the only required context is the `CI` aggregator from `gate.yml`; `queue.yml` failing is a red workflow, not a merge blocker. The queue was slow, not stuck.

## This PR carries #911's commit

The first push of this branch was killed by its own `timeout 2400` while the pre-push hook was still inside `check-example-leaf-target-dirs` — the 8–27 minute gate that #911 fixes. So the branch carries #911's commit, and this push ran the 0.5 s version of that gate instead. It is not merged into this change's intent: when #911 lands, the merge queue drops this copy by patch-id.

## Two more gates caught me on the way

**`check-named-lane-fails`** refused `verify-fvp-runtime`'s propagated skip. phase-411 W2: a *named* platform lane must work, so a whole-recipe `nros_lane_skip` in a platform module needs an `nros_lane_platform` declaration — without one, naming the lane would still skip. But for this recipe the skip is correct even when named: ARM FVP is license-gated and user-supplied, so an absent model has no remedy a failure could name. That is exactly why `build-fvp-ws-entry` is already in `NOT_A_PLATFORM_LANE`. Exempted with that reason, rather than a lane declaration that would turn an unfixable absence into a red.

**`check-submodule-pins`** read the branch as a **rewind**: it was cut before `main` advanced `play_launch` 0647131 → 155ed78, so pushing the old base proposed moving the pin backward. Rebased onto `main`; the pin and checkout now agree, and `Cargo.lock` is untouched — the checkout moved, not the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
