### PR TITLE
feat(phase-447 D1+D2): a dist declares a measured floor, and apt learns the release

### DIFF
--- a/.config/dist-floor-baseline.txt
+++ b/.config/dist-floor-baseline.txt
@@ -1,0 +1,17 @@
+# `[tool.*].dist.<host>` rows that do NOT yet declare a `floor = { .. }`.
+# A RATCHET, not an allowlist: this file may only shrink.
+#
+# One row per line, `<tool> <host>`. `check-dist-floors` fails when a row
+# here gains a floor (delete the line), names no dist row (delete it), or
+# when the file holds more rows than `BASELINE_CEILING` in the script — so
+# growing it is a visible edit, and a new dist declares its floor instead.
+#
+# Measure a floor: python3 scripts/sdk/measure-dist-floor.py <tool> --host <host>
+#
+# The three Zephyr SDK 0.16.8 artifacts below are 1.0-1.3 GB each, upstream
+# (sdk-ng), and were still downloading at the measuring host's ~0.12 MB/s when
+# the other 40 rows were measured (phase-447 D1, 2026-09-11). The linux-x86_64
+# row was measured from a local install of the same release instead.
+zephyr-sdk linux-arm64
+zephyr-sdk macos-arm64
+zephyr-sdk macos-x86_64

--- a/.config/dist-floor-baseline.txt
+++ b/.config/dist-floor-baseline.txt
@@ -7,11 +7,3 @@
 # growing it is a visible edit, and a new dist declares its floor instead.
 #
 # Measure a floor: python3 scripts/sdk/measure-dist-floor.py <tool> --host <host>
-#
-# The three Zephyr SDK 0.16.8 artifacts below are 1.0-1.3 GB each, upstream
-# (sdk-ng), and were still downloading at the measuring host's ~0.12 MB/s when
-# the other 40 rows were measured (phase-447 D1, 2026-09-11). The linux-x86_64
-# row was measured from a local install of the same release instead.
-zephyr-sdk linux-arm64
-zephyr-sdk macos-arm64
-zephyr-sdk macos-x86_64

--- a/.config/gate-registry-baseline.txt
+++ b/.config/gate-registry-baseline.txt
@@ -96,6 +96,7 @@ default-gates-run-somewhere
 deferred-call-args
 deploy-board-resolves
 derived-descriptor-fields
+dist-floors
 doc-commit-citations
 doc-recipe-refs
 doc-refs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,6 +596,14 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   who owns a `/lib/...` file, query the RESOLVED path: `/lib` is a symlink to `usr/lib`
   on merged-`/usr`, so `dpkg -S /lib/<f>` says "no path found" for a perfectly
   well-owned file — which is how this entry first called that library a stray.
+- **A dist row carries a MEASURED `floor`, and `apt` may be per-release** (phase-447 D1/D2,
+  RFC-0099 D5/D9). `host_key()` has no OS version, so `nros setup` compares the host with
+  `floor = { glibc/glibcxx/macos }` BEFORE downloading and falls back to source with the
+  reason; read the number off the artifact (`scripts/sdk/measure-dist-floor.py`), never off
+  the runner. Gate `check-dist-floors` (ratchet). `apt = { default = [..], noble = [..] }` —
+  TOML cannot hold `apt = [..]` beside `apt.noble`; `noble = []` means "not packaged there".
+  Python reads it only via `scripts/lib/index_packages.py` (`entry.get("apt")` on a table
+  iterates RELEASE NAMES).
 - **The west manifests are DERIVED — `[zephyr_module.*]` in `nros-sdk-index.toml` is the
   module SSoT** (phase-447 F1, issues 1275/1282). A module is in `west.yml`'s allowlist iff
   its `lines` has `"3.7"`, `west-4.4.yml`'s iff `"4.4"`; `check-zephyr-module-allowlist`

--- a/docs/design/0099-provisioning-is-planned-once-and-prefers-prebuilts.md
+++ b/docs/design/0099-provisioning-is-planned-once-and-prefers-prebuilts.md
@@ -174,6 +174,31 @@ a RANGE, not an identity — a 2.39 host runs a 2.35 binary — so exact-match k
 are wrong, "highest key <= host" is a new resolution mechanism, and it still
 misses the interpreter-linked half.
 
+**Status: move 3 landed (2026-09-11, phase-447 D1).** Every `dist.<host>` row
+carries `floor = { glibc, glibcxx, macos }` or `none = "<why>"`, and
+`plan_install` compares the host with it IN THE PLAN — so a refused prebuilt's
+URL never reaches `execute` — falling back to the source recipe with the reason,
+or refusing outright when there is none. Both halves are covered: the floor
+numbers are the forward half; the backward half is `system = [..]` read against
+D9's per-release names, refusing only when a soname is ABSENT and the index
+says the manager does not package it on this release. A probe that cannot
+answer abstains. `check-dist-floors` is the floor-or-reason ratchet.
+
+Measured with `scripts/sdk/measure-dist-floor.py` (ELF `verneed`/`NEEDED`/
+`INTERP`, Mach-O `minos`, cross-checked against `objdump -T`), and the numbers
+corrected three assumptions this section was written on:
+
+* **No dist needs glibc 2.35.** The runner has 2.35; every `nano-ros-sdk` dist
+  references at most `GLIBC_2.34`. What a runner HAS is not what a binary USES.
+* **The C++ runtime is a real floor.** `riscv-none-elf-gcc` and `xrce-agent`
+  need `GLIBCXX_3.4.30` (GCC 12, jammy) from a libstdc++ they do not bundle.
+* **A dist can bring its own libc.** The Zephyr SDK host tools are a Yocto
+  sysroot on their own `ld.so` + glibc; counting them against the host floor
+  would have been wrong, so the measurement excludes self-hosted ELF and says
+  how many it excluded.
+
+Move 2 (smoke on the install path) is phase-447 C1.
+
 ## D6 — Repeated `nros setup` is made CHEAP rather than restructured away
 
 A bootstrap makes ~24 `nros setup` invocations. The obvious fix — collapse them
@@ -289,6 +314,32 @@ key cannot express the alternative. (It is also stale in a second way:
 `apt = [...]` stays valid and means "every version"; `apt.noble = [...]`
 overrides. Narrower than rosdep's OS-then-version nesting, because the manager is
 what actually installs.
+
+**Status: landed (2026-09-11, phase-447 D2) — with the spelling corrected.**
+The sketch above is unwritable exactly when it is needed: TOML cannot hold
+`apt = [..]` beside `apt.noble = [..]`, since a key is an array or a table,
+never both. So the override table carries its own default:
+
+```toml
+apt = ["libssl3"]                                         # every release, unchanged
+apt = { default = ["libssl3"], noble = ["libssl3t64"] }   # one release renamed it
+```
+
+Release keys are the host's `VERSION_CODENAME`, else `VERSION_ID`
+(`host_os_release`); `validate` refuses one that cannot be a release name.
+An explicitly EMPTY list — `noble = []` — means "not packaged on that
+release", which is a different answer from "not named", and D5's floor probe
+reads exactly that. Python readers go through `scripts/lib/index_packages.py`,
+because `entry.get("apt")` on the table shape iterates RELEASE NAMES.
+
+**`libpython310` was misnamed, not merely stale.** Its only consumer is the
+`play_launch_parser` SOURCE build, and a source build links the host's own
+CPython — so the requirement is "this host's libpython3", and a key naming
+3.10 asked every non-jammy host for something it could not have. It is now
+`[prereq.libpython3]` (`default = libpython3-dev`, `jammy = libpython3.10`,
+`noble = libpython3.12t64`, probe `sharedlib = "libpython3."`). A soname-EXACT
+requirement belongs to a prebuilt that links one minor; it gets its own key the
+day such a dist row exists, and `check-dist-runtime-deps` will demand it.
 
 ## D10 — The provisioner reads manifest/index files — TRUE for Zephyr since phase-447 F1
 

--- a/docs/roadmap/phase-447-provisioning-revision.md
+++ b/docs/roadmap/phase-447-provisioning-revision.md
@@ -116,10 +116,84 @@ remedy, and falls back to source; a floor-or-reason ratchet. Note `nano-ros-sdk`
 already builds on `ubuntu-22.04` and bundles the ldd closure minus libc, so this
 is about interpreter-linked and named deps, not glibc.
 
+**Landed 2026-09-11** (with D2, one branch — both own `sdk_index.rs`).
+`DistArtifact.floor` + `orchestration/host_floor.rs`; the refusal is decided in
+`plan_install`, so the URL never reaches `execute`. Below the floor with a source
+recipe -> `Source { refused: Some(why) }`, printed on the plan line and at
+install; with none -> `InstallAction::Refused`, which bails naming the remedy.
+Ratchet: `check-dist-floors` + `.config/dist-floor-baseline.txt`.
+
+Floors, MEASURED from each released archive (`scripts/sdk/measure-dist-floor.py`
+— ELF version-needs / `DT_NEEDED` / `PT_INTERP`, Mach-O `minos`; parser
+cross-checked against `objdump -T` on `xrce-agent`: both say 2.34 / 3.4.30):
+
+| tool | linux-x86_64 | linux-arm64 | macOS |
+| --- | --- | --- | --- |
+| arm-fvp | glibc 2.17, glibcxx 3.4.26 | — | — |
+| arm-none-eabi-gcc | 2.34, 3.4.19 | 2.34, 3.4.22 | arm64 11.0 |
+| cargo-llvm-cov | 2.34 | 2.34 | — |
+| cargo-nextest | 2.27 | 2.27 | — |
+| clang-format | 2.16, 3.4.19 | 2.17, 3.4.19 | arm64 11.0 |
+| cyclonedds | 2.34 | 2.34 | arm64 14.0 |
+| mdbook | none (static musl) | none (static musl) | arm64 11.0, x86_64 10.12 |
+| ninja | 2.15, 3.4.21 | 2.17, 3.4.21 | arm64 11.0 |
+| openocd | 2.34 | 2.34 | arm64 14.0 |
+| qemu | 2.34 | 2.34 | arm64 14.0 |
+| riscv-none-elf-gcc | 2.27, 3.4.30 | 2.27, 3.4.30 | arm64 11.0 |
+| verus | 2.34, 3.4.26 | — | arm64 11.0, x86_64 11.0 |
+| xrce-agent | 2.34, 3.4.30 | 2.34, 3.4.30 | arm64 14.0 |
+| zephyr-sdk (0.16.8) | 2.27, 3.4.21 | **debt** | **debt** (both) |
+| zephyr-sdk-1-0-1 | none (self-hosted sysroot) | none (self-hosted sysroot) | arm64 14.0 |
+
+Three measurements that reading would have got wrong:
+
+1. **No dist needs 2.35.** The runner's version is not a binary's floor; every
+   `nano-ros-sdk` dist tops out at `GLIBC_2.34`. Ubuntu 20.04 (2.31) is what
+   these floors actually refuse.
+2. **zephyr-sdk-1-0-1 looked floor-less and is not binary-free.** Its
+   `_minimal` archive holds no ELF, but it carries the host tools as a 70 MB
+   Yocto self-extractor. Measured from the payload (after `MARKER:`, never run):
+   109/108 ELF, every one on the sysroot's OWN `ld.so` + glibc — so `none` is
+   the right answer, for a reason the first measurement could not see.
+3. **The Zephyr SDK 0.16.8 install mixes both kinds.** 55 of its 1334 dynamic
+   ELF are self-hosted (the pokysdk sysroot) and would have inflated the floor;
+   the host-linked toolchains alone set 2.27 / 3.4.21. Measured from a local
+   install of the same release (`sdk_version` 0.16.8).
+
+**Debt: 3 rows** — the zephyr-sdk 0.16.8 linux-arm64 / macos-arm64 /
+macos-x86_64 archives are 1.0-1.3 GB upstream assets that were still
+downloading at ~0.12 MB/s. Recorded in the baseline, `BASELINE_CEILING = 3`,
+and may only shrink.
+
+**Not covered, deliberately.** `nros-launch-resolve` links `libpython3.10.so.1.0`
+(issue 0897) but ships INSIDE the release asset via `install.sh`, not as an index
+dist, so `plan_install` never sees it. It is covered the day `[tool.nros]` gains
+`dist.<host>` rows (phase-431 W5): the ratchet then demands a floor, and its
+`system` must name a soname-exact libpython key so the backward half can refuse
+it on noble.
+
+**Side finding, not fixed here.** The `arm-none-eabi-gcc` linux-arm64 dist
+bundles focal's CPython 3.8, whose `lib-dynload/_ssl` module needs
+`libssl.so.1.1`, which jammy does not ship — so `import ssl` fails inside that
+gdb's Python on the host it was built for. gdb itself is unaffected. A
+`nano-ros-sdk` re-cut question.
+
 ### D2 — manager fields gain an OS-version dimension
 
 `apt = [...]` stays valid and means every version; `apt.noble = [...]` overrides.
 Fixes `libpython310` and the t64 renames.
+
+**Landed 2026-09-11.** Spelled `apt = { default = [..], noble = [..] }` — TOML
+cannot hold `apt = [..]` beside `apt.noble`, so the table carries its own
+default (RFC-0099 D9 records why). `ManagerPackages` is the Rust type;
+`scripts/lib/index_packages.py` the one Python reader (two scripts moved onto
+it). An explicitly empty release list means "not packaged there", and D1 reads
+it. `libssl3` gains `noble = ["libssl3t64"]`. `libpython310` was MISNAMED: its
+only consumer is a SOURCE build, which links the host's own CPython, so it is
+`[prereq.libpython3]` now (`jammy = libpython3.10`, `noble = libpython3.12t64`,
+`default = libpython3-dev`) with a minor-independent probe. Every noble name was
+checked against the archive, not assumed — both `libssl3` and `libpython3.12`
+turned out to be t64 renames there.
 
 ### D3 — a pinned rosdep snapshot, as a fallback rung
 

--- a/docs/roadmap/phase-447-provisioning-revision.md
+++ b/docs/roadmap/phase-447-provisioning-revision.md
@@ -135,11 +135,13 @@ cross-checked against `objdump -T` on `xrce-agent`: both say 2.34 / 3.4.30):
 | cargo-nextest | 2.27 | 2.27 | — |
 | clang-format | 2.16, 3.4.19 | 2.17, 3.4.19 | arm64 11.0 |
 | cyclonedds | 2.34 | 2.34 | arm64 14.0 |
+| espflash (C2) | none (static musl) | 2.34 (a `-gnu` build) | arm64 11.0 |
 | mdbook | none (static musl) | none (static musl) | arm64 11.0, x86_64 10.12 |
 | ninja | 2.15, 3.4.21 | 2.17, 3.4.21 | arm64 11.0 |
 | openocd | 2.34 | 2.34 | arm64 14.0 |
 | qemu | 2.34 | 2.34 | arm64 14.0 |
 | riscv-none-elf-gcc | 2.27, 3.4.30 | 2.27, 3.4.30 | arm64 11.0 |
+| sccache (C2) | none (static musl) | none (static musl) | arm64 11.0 |
 | verus | 2.34, 3.4.26 | — | arm64 11.0, x86_64 11.0 |
 | xrce-agent | 2.34, 3.4.30 | 2.34, 3.4.30 | arm64 14.0 |
 | zephyr-sdk (0.16.8) | 2.27, 3.4.21 | 2.27, 3.4.21 | arm64 11.0, x86_64 11.0 |
@@ -169,12 +171,23 @@ cross-check between the two methods. All three needed a resumed download (curl
 92, an HTTP/2 stream reset mid-transfer), which is why the measuring script's
 fetch now resumes (`-C -`, `--retry`).
 
-**Not covered, deliberately.** `nros-launch-resolve` links `libpython3.10.so.1.0`
-(issue 0897) but ships INSIDE the release asset via `install.sh`, not as an index
-dist, so `plan_install` never sees it. It is covered the day `[tool.nros]` gains
+**The ratchet caught its first rows the same day.** C2 (#1273) landed first and
+added six dist rows (`sccache`, `espflash`) with no floor; on the rebase
+`check-dist-floors` named exactly those six and nothing else. Measured and
+stamped in a third commit — `espflash` is the instructive one: its x86_64 asset
+is a static musl build (no floor) while its arm64 asset is `-gnu` (glibc 2.34),
+so two columns of ONE tool need different answers, which a per-tool floor could
+not have said. 49 dist rows across 17 tools, every one floored, debt 0.
+
+**What D1 owes `nros-launch-resolve` (A1's note), and how much of it is paid.**
+It links `libpython3.10.so.1.0` (issue 0897) but ships INSIDE the release asset
+via `install.sh`, not as an index dist, so `plan_install` never sees it. The
+DECLARATION is paid: `[prereq.libpython310]` is now the soname-exact key for that
+binary, with `apt = { jammy = [..], noble = [] }` — the "not packaged there"
+signal the backward half reads. The ENFORCEMENT waits for `[tool.nros]` to gain
 `dist.<host>` rows (phase-431 W5): the ratchet then demands a floor, and its
-`system` must name a soname-exact libpython key so the backward half can refuse
-it on noble.
+`system = ["libpython310"]` makes the backward half refuse it on noble before
+the download.
 
 **Side finding, not fixed here.** The `arm-none-eabi-gcc` linux-arm64 dist
 bundles focal's CPython 3.8, whose `lib-dynload/_ssl` module needs

--- a/docs/roadmap/phase-447-provisioning-revision.md
+++ b/docs/roadmap/phase-447-provisioning-revision.md
@@ -142,7 +142,7 @@ cross-checked against `objdump -T` on `xrce-agent`: both say 2.34 / 3.4.30):
 | riscv-none-elf-gcc | 2.27, 3.4.30 | 2.27, 3.4.30 | arm64 11.0 |
 | verus | 2.34, 3.4.26 | — | arm64 11.0, x86_64 11.0 |
 | xrce-agent | 2.34, 3.4.30 | 2.34, 3.4.30 | arm64 14.0 |
-| zephyr-sdk (0.16.8) | 2.27, 3.4.21 | **debt** | **debt** (both) |
+| zephyr-sdk (0.16.8) | 2.27, 3.4.21 | 2.27, 3.4.21 | arm64 11.0, x86_64 11.0 |
 | zephyr-sdk-1-0-1 | none (self-hosted sysroot) | none (self-hosted sysroot) | arm64 14.0 |
 
 Three measurements that reading would have got wrong:
@@ -160,10 +160,14 @@ Three measurements that reading would have got wrong:
    the host-linked toolchains alone set 2.27 / 3.4.21. Measured from a local
    install of the same release (`sdk_version` 0.16.8).
 
-**Debt: 3 rows** — the zephyr-sdk 0.16.8 linux-arm64 / macos-arm64 /
-macos-x86_64 archives are 1.0-1.3 GB upstream assets that were still
-downloading at ~0.12 MB/s. Recorded in the baseline, `BASELINE_CEILING = 3`,
-and may only shrink.
+**Debt: 0.** The zephyr-sdk 0.16.8 linux-arm64 / macos-arm64 / macos-x86_64
+archives (1.0-1.3 GB, upstream) landed first as recorded debt (ceiling 3), and a
+follow-up commit measured them and took the ceiling to 0 — the ratchet shrinking
+as designed. linux-arm64 measured from the ARCHIVE came out 2.27 / 3.4.21,
+identical to the linux-x86_64 figure measured from an INSTALL, which is the
+cross-check between the two methods. All three needed a resumed download (curl
+92, an HTTP/2 stream reset mid-transfer), which is why the measuring script's
+fetch now resumes (`-C -`, `--retry`).
 
 **Not covered, deliberately.** `nros-launch-resolve` links `libpython3.10.so.1.0`
 (issue 0897) but ships INSIDE the release asset via `install.sh`, not as an index

--- a/just/check/workflows.just
+++ b/just/check/workflows.just
@@ -131,6 +131,18 @@ claim-protocol:
 dist-runtime-deps:
     @python3 scripts/check-dist-runtime-deps.py
 
+# RFC-0099 D5 / phase-447 D1 — every `[tool.*].dist.<host>` row declares a
+# MEASURED floor (`scripts/sdk/measure-dist-floor.py`), or is recorded debt in
+# `.config/dist-floor-baseline.txt`, which may only SHRINK.
+#
+# ON the fast line, unlike its neighbour above: it reads the index and nothing
+# else, so it needs no store. A dist row landing without a floor is offered to
+# every host of its `<os>-<arch>`, including ones it cannot run on — the gap
+# `nros setup` now closes by comparing the host BEFORE downloading.
+[group("checks")]
+dist-floors:
+    @python3 scripts/check-dist-floors.py
+
 [private]
 package-xml-comments:
     @bash packages/testing/nros-tests/tests/package_xml_comment_stripping.sh

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -23,6 +23,18 @@
 # pinned `url` + `sha256` verified before unpack (issue 1273 records the case
 # for it, and why maintainer-side/offline is the only shape that would keep
 # both properties).
+#
+# phase-447 D1 (RFC-0099 D5) — every `dist.<host>` row carries a MEASURED
+# `floor = { glibc = "..", glibcxx = "..", macos = ".." }` (or `none = "<why>"`),
+# the oldest host it runs on. The host key has no OS version in it, so the
+# floor is what stops a host that cannot run a dist from downloading it:
+# `nros setup` compares BEFORE the fetch and falls back to the source recipe
+# with the reason printed. Read the number off the artifact, never off the
+# runner it was built on:
+#   python3 scripts/sdk/measure-dist-floor.py <tool> --host <host>
+# `check-dist-floors` refuses a dist row without one. (Two ratchets, two
+# questions: dist-or-reason asks WHETHER a prebuilt exists; dist-floors asks
+# WHO it runs on.)
 
 # --- the repo's own build-stage source union (issue 0390) ---
 # The `[source.*]` names `just test` (links every RMW's `-sys`) and
@@ -147,9 +159,9 @@ smoke = [
 # check fails with a bare loader error.
 system = ["libselinux1", "libpcre2"]
 upstream = "nano-ros-v11.0.0-patches" # exact upstream rev/branch (SSOT for build-tool.yml)
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/qemu-11.0.0-nros6/qemu-linux-x86_64.tar.zst", sha256 = "1255611e2dd80f040cd3b473583e1d34eaa1e62db00c800662cdc194d05ae916" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/qemu-11.0.0-nros6/qemu-linux-arm64.tar.zst", sha256 = "ce6b11bc0e1b16f81b2a31b73990b4b07e2ead273c29b80c3075b41a018ada86" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/qemu-11.0.0-nros6/qemu-macos-arm64.tar.zst", sha256 = "ac16f10b33cba19f2982381a928d58aeade02defc2cb647e23b23fcb2345046f" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/qemu-11.0.0-nros6/qemu-linux-x86_64.tar.zst", sha256 = "1255611e2dd80f040cd3b473583e1d34eaa1e62db00c800662cdc194d05ae916", floor = { glibc = "2.34" } }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/qemu-11.0.0-nros6/qemu-linux-arm64.tar.zst", sha256 = "ce6b11bc0e1b16f81b2a31b73990b4b07e2ead273c29b80c3075b41a018ada86", floor = { glibc = "2.34" } }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/qemu-11.0.0-nros6/qemu-macos-arm64.tar.zst", sha256 = "ac16f10b33cba19f2982381a928d58aeade02defc2cb647e23b23fcb2345046f", floor = { macos = "14.0" } }
 [tool.qemu.source]
 git = "https://github.com/NEWSLabNTU/qemu"
 ref = "nano-ros-v11.0.0-patches" # patched fork branch (no tags upstream)
@@ -198,9 +210,9 @@ smoke = [
 system = ["libcrypt1"]
 upstream = "13.2.rel1" # ARM release id (SSOT — build script no longer hand-derives)
 # Repackaged from ARM's release; no in-repo source build (binary toolchain).
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "27d5e5f6f9428157df7900c91b000486184f99fbc1a35ea5c3ca219be9068197" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "841e456d571e3f60244652a5ac7287f9e06a9c61f1fc93d2fbbc037b05f5a6ab" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "27d5e5f6f9428157df7900c91b000486184f99fbc1a35ea5c3ca219be9068197", floor = { glibc = "2.34", glibcxx = "3.4.19" } }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "841e456d571e3f60244652a5ac7287f9e06a9c61f1fc93d2fbbc037b05f5a6ab", floor = { glibc = "2.34", glibcxx = "3.4.22" } }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748", floor = { macos = "11.0" } }
 
 [tool.zephyr-sdk]
 # The Zephyr SDK, host-keyed (issue 0610). `scripts/zephyr/setup.sh` used to
@@ -225,7 +237,7 @@ dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/
 # the shell script that already runs it.
 version = "0.16.8"
 upstream = "v0.16.8" # sdk-ng release tag (SSOT for the URLs below)
-dist.linux-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-x86_64.tar.xz", sha256 = "cb4e4012751e4526aaf1ec1e8ab9b4ded5681e2e01711b64f7a1b519ff7dbc6a" }
+dist.linux-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-x86_64.tar.xz", sha256 = "cb4e4012751e4526aaf1ec1e8ab9b4ded5681e2e01711b64f7a1b519ff7dbc6a", floor = { glibc = "2.27", glibcxx = "3.4.21" } }
 dist.linux-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-aarch64.tar.xz", sha256 = "83782b4cf595bb3da8a6c7c1ade01eed00ad03f8ba0c72da6680693192b3668d" }
 dist.macos-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_macos-aarch64.tar.xz", sha256 = "e06138c1e50cc5b4508646640bd08c50f05f0eb3f2949e756d84d3367f581593" }
 dist.macos-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_macos-x86_64.tar.xz", sha256 = "b96c849cc63e0f0218c196be8faba548ed473894fb7fced67311aa39fe97ac21" }
@@ -261,9 +273,9 @@ dist.macos-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releas
 # linux-x86_64 one was additionally verified against a local download.
 version = "1.0.1"
 upstream = "v1.0.1" # sdk-ng release tag (SSOT for the URLs below)
-dist.linux-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.1/zephyr-sdk-1.0.1_linux-x86_64_minimal.tar.xz", sha256 = "ca9bc0ff66fafca1dac9d592a36d953cf16d096a9d09b1c0357f021cf9f6a7eb" }
-dist.linux-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.1/zephyr-sdk-1.0.1_linux-aarch64_minimal.tar.xz", sha256 = "d79c5bfc68e679488659bea289a4026e52a64f03338875c8c9c850fff13cee30" }
-dist.macos-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.1/zephyr-sdk-1.0.1_macos-aarch64_minimal.tar.xz", sha256 = "867063901f39528a6175a80ebc20367bd6cb440593e7e2650eda30392f1f6b65" }
+dist.linux-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.1/zephyr-sdk-1.0.1_linux-x86_64_minimal.tar.xz", sha256 = "ca9bc0ff66fafca1dac9d592a36d953cf16d096a9d09b1c0357f021cf9f6a7eb", floor = { none = "its only binaries are the hosttools installer's Yocto sysroot, and all 109 ELF run on that sysroot's own ld.so + glibc (measured from the .sh payload); the toolchains setup.sh fetches later are not this artifact" } }
+dist.linux-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.1/zephyr-sdk-1.0.1_linux-aarch64_minimal.tar.xz", sha256 = "d79c5bfc68e679488659bea289a4026e52a64f03338875c8c9c850fff13cee30", floor = { none = "its only binaries are the hosttools installer's Yocto sysroot, and all 108 ELF run on that sysroot's own ld.so + glibc (measured from the .sh payload); the toolchains setup.sh fetches later are not this artifact" } }
+dist.macos-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.1/zephyr-sdk-1.0.1_macos-aarch64_minimal.tar.xz", sha256 = "867063901f39528a6175a80ebc20367bd6cb440593e7e2650eda30392f1f6b65", floor = { macos = "14.0" } }
 
 [tool.riscv-none-elf-gcc]
 version = "14.2-nros1"
@@ -271,9 +283,9 @@ smoke = [
     { run = "bin/riscv-none-elf-gcc --version", expect = "riscv-none-elf-gcc" },
 ]
 upstream = "14.2.0-3" # xPack build (SSOT — was hardcoded only in the build script)
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/riscv-none-elf-gcc-14.2-nros1/riscv-none-elf-gcc-linux-x86_64.tar.zst", sha256 = "0f7a938cf5724c6c4ac48af140ede038015d63df1a6460f671d1215fff5ba622" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/riscv-none-elf-gcc-14.2-nros1/riscv-none-elf-gcc-linux-arm64.tar.zst", sha256 = "8eba3c6e8e9dd51ae0583146209100a5e09a670649f1ed0840c26608caa32095" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/riscv-none-elf-gcc-14.2-nros1/riscv-none-elf-gcc-macos-arm64.tar.zst", sha256 = "eb9cd46e48e2196fb13d09112a655b3b926ff18a2350eb7ae79336205165b954" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/riscv-none-elf-gcc-14.2-nros1/riscv-none-elf-gcc-linux-x86_64.tar.zst", sha256 = "0f7a938cf5724c6c4ac48af140ede038015d63df1a6460f671d1215fff5ba622", floor = { glibc = "2.27", glibcxx = "3.4.30" } }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/riscv-none-elf-gcc-14.2-nros1/riscv-none-elf-gcc-linux-arm64.tar.zst", sha256 = "8eba3c6e8e9dd51ae0583146209100a5e09a670649f1ed0840c26608caa32095", floor = { glibc = "2.27", glibcxx = "3.4.30" } }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/riscv-none-elf-gcc-14.2-nros1/riscv-none-elf-gcc-macos-arm64.tar.zst", sha256 = "eb9cd46e48e2196fb13d09112a655b3b926ff18a2350eb7ae79336205165b954", floor = { macos = "11.0" } }
 
 # zenohd — REMOVED (phase-362 / RFC-0075).
 #
@@ -340,9 +352,9 @@ smoke = [
     { run = "bin/openocd --version", expect = "Open On-Chip Debugger" },
 ]
 upstream = "v0.12.0" # upstream tag (SSOT — build script no longer hand-derives)
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/openocd-0.12.0-nros2/openocd-linux-x86_64.tar.zst", sha256 = "0c999015212391add99f0428b2d8401383f3a65ff5cc43157f71c2eb15b5b47c" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/openocd-0.12.0-nros2/openocd-linux-arm64.tar.zst", sha256 = "3235ef67860cc83ac6ac95f940801602683e25ecfed00c968ef01580e5115b6d" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/openocd-0.12.0-nros2/openocd-macos-arm64.tar.zst", sha256 = "33e0131e483e3a00274c2ae7df5939e368d8969df38d7c36101354d74dcaca86" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/openocd-0.12.0-nros2/openocd-linux-x86_64.tar.zst", sha256 = "0c999015212391add99f0428b2d8401383f3a65ff5cc43157f71c2eb15b5b47c", floor = { glibc = "2.34" } }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/openocd-0.12.0-nros2/openocd-linux-arm64.tar.zst", sha256 = "3235ef67860cc83ac6ac95f940801602683e25ecfed00c968ef01580e5115b6d", floor = { glibc = "2.34" } }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/openocd-0.12.0-nros2/openocd-macos-arm64.tar.zst", sha256 = "33e0131e483e3a00274c2ae7df5939e368d8969df38d7c36101354d74dcaca86", floor = { macos = "14.0" } }
 
 # --- the cargo tools (phase-422 W2, second half) ---
 #
@@ -368,8 +380,8 @@ upstream = "cargo-nextest-0.9.143" # = source.ref (nextest-rs/nextest release ta
 smoke = [
     { run = "bin/cargo-nextest --version", expect = "0.9.143" },
 ]
-dist.linux-x86_64 = { url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.143/cargo-nextest-0.9.143-x86_64-unknown-linux-gnu.tar.gz", sha256 = "66786b9abe23920d022a182d1416b1bbc8130dd4872a9553d76985a1708dcd1e", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-nextest && chmod +x {prefix}/bin/cargo-nextest" }
-dist.linux-arm64 = { url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.143/cargo-nextest-0.9.143-aarch64-unknown-linux-gnu.tar.gz", sha256 = "2a64b3566a92508550a7ab29c3e8db25472ca37730ecb4d22100b6aa440c2a68", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-nextest && chmod +x {prefix}/bin/cargo-nextest" }
+dist.linux-x86_64 = { url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.143/cargo-nextest-0.9.143-x86_64-unknown-linux-gnu.tar.gz", sha256 = "66786b9abe23920d022a182d1416b1bbc8130dd4872a9553d76985a1708dcd1e", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-nextest && chmod +x {prefix}/bin/cargo-nextest", floor = { glibc = "2.27" } }
+dist.linux-arm64 = { url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.143/cargo-nextest-0.9.143-aarch64-unknown-linux-gnu.tar.gz", sha256 = "2a64b3566a92508550a7ab29c3e8db25472ca37730ecb4d22100b6aa440c2a68", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-nextest && chmod +x {prefix}/bin/cargo-nextest", floor = { glibc = "2.27" } }
 [tool.cargo-nextest.source]
 git = "https://github.com/nextest-rs/nextest"
 ref = "cargo-nextest-0.9.143"
@@ -388,8 +400,8 @@ upstream = "v0.9.0" # = source.ref (taiki-e/cargo-llvm-cov release tag)
 smoke = [
     { run = "bin/cargo-llvm-cov llvm-cov --version", expect = "0.9.0" },
 ]
-dist.linux-x86_64 = { url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.9.0/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz", sha256 = "b068f7c98841aacb9c4f382b4a0c184ae82f49b56a32d442b429b2961c73be15", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-llvm-cov && chmod +x {prefix}/bin/cargo-llvm-cov" }
-dist.linux-arm64 = { url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.9.0/cargo-llvm-cov-aarch64-unknown-linux-gnu.tar.gz", sha256 = "9af53b273e50d01d8bde8785de8541f6738cc4375248cd7683aec8b5768b9d21", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-llvm-cov && chmod +x {prefix}/bin/cargo-llvm-cov" }
+dist.linux-x86_64 = { url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.9.0/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz", sha256 = "b068f7c98841aacb9c4f382b4a0c184ae82f49b56a32d442b429b2961c73be15", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-llvm-cov && chmod +x {prefix}/bin/cargo-llvm-cov", floor = { glibc = "2.34" } }
+dist.linux-arm64 = { url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.9.0/cargo-llvm-cov-aarch64-unknown-linux-gnu.tar.gz", sha256 = "9af53b273e50d01d8bde8785de8541f6738cc4375248cd7683aec8b5768b9d21", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin cargo-llvm-cov && chmod +x {prefix}/bin/cargo-llvm-cov", floor = { glibc = "2.34" } }
 [tool.cargo-llvm-cov.source]
 git = "https://github.com/taiki-e/cargo-llvm-cov"
 ref = "v0.9.0"
@@ -456,9 +468,9 @@ system = ["unzip"]
 smoke = [
     { run = "bin/clang-format --version", expect = "17.0.6" },
 ]
-dist.linux-x86_64 = { url = "https://files.pythonhosted.org/packages/89/df/5296c3eca534eedef32813cd38b3436c86f0eabcda2238060f73e45ef37d/clang_format-17.0.6-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", sha256 = "2a1323ca5322e0dead521223155fe2ae1ba81d50abab8e20aaac28f6a94f23b9", install = "unzip -q -o {archive} -d {prefix}/.wheel && install -Dm755 {prefix}/.wheel/clang_format/data/bin/clang-format {prefix}/bin/clang-format && rm -rf {prefix}/.wheel" }
-dist.linux-arm64 = { url = "https://files.pythonhosted.org/packages/2e/a5/78fe6b7b6947a1d90dcb451caf9c63895fa84d7fc453865a64d770aae242/clang_format-17.0.6-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", sha256 = "5cda40badfb01818ece739509d9cde678fc02660180cc1a55156782ef203704d", install = "unzip -q -o {archive} -d {prefix}/.wheel && install -Dm755 {prefix}/.wheel/clang_format/data/bin/clang-format {prefix}/bin/clang-format && rm -rf {prefix}/.wheel" }
-dist.macos-arm64 = { url = "https://files.pythonhosted.org/packages/5b/0a/d112aea9f0272e2c5558a2e9cf50229c846892dadf585f2a98fa0ba22385/clang_format-17.0.6-py2.py3-none-macosx_11_0_arm64.whl", sha256 = "195014a589fde9e2bec447ee1f2efd31f8c9f773b10aa66b510beae6997e6bc5", install = "unzip -q -o {archive} -d {prefix}/.wheel && install -Dm755 {prefix}/.wheel/clang_format/data/bin/clang-format {prefix}/bin/clang-format && rm -rf {prefix}/.wheel" }
+dist.linux-x86_64 = { url = "https://files.pythonhosted.org/packages/89/df/5296c3eca534eedef32813cd38b3436c86f0eabcda2238060f73e45ef37d/clang_format-17.0.6-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", sha256 = "2a1323ca5322e0dead521223155fe2ae1ba81d50abab8e20aaac28f6a94f23b9", install = "unzip -q -o {archive} -d {prefix}/.wheel && install -Dm755 {prefix}/.wheel/clang_format/data/bin/clang-format {prefix}/bin/clang-format && rm -rf {prefix}/.wheel", floor = { glibc = "2.16", glibcxx = "3.4.19" } }
+dist.linux-arm64 = { url = "https://files.pythonhosted.org/packages/2e/a5/78fe6b7b6947a1d90dcb451caf9c63895fa84d7fc453865a64d770aae242/clang_format-17.0.6-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", sha256 = "5cda40badfb01818ece739509d9cde678fc02660180cc1a55156782ef203704d", install = "unzip -q -o {archive} -d {prefix}/.wheel && install -Dm755 {prefix}/.wheel/clang_format/data/bin/clang-format {prefix}/bin/clang-format && rm -rf {prefix}/.wheel", floor = { glibc = "2.17", glibcxx = "3.4.19" } }
+dist.macos-arm64 = { url = "https://files.pythonhosted.org/packages/5b/0a/d112aea9f0272e2c5558a2e9cf50229c846892dadf585f2a98fa0ba22385/clang_format-17.0.6-py2.py3-none-macosx_11_0_arm64.whl", sha256 = "195014a589fde9e2bec447ee1f2efd31f8c9f773b10aa66b510beae6997e6bc5", install = "unzip -q -o {archive} -d {prefix}/.wheel && install -Dm755 {prefix}/.wheel/clang_format/data/bin/clang-format {prefix}/bin/clang-format && rm -rf {prefix}/.wheel", floor = { macos = "11.0" } }
 
 # Micro-XRCE-DDS Agent — the host daemon the XRCE-DDS RMW connects to (the
 # counterpart to zenohd for the rmw-xrce path). Source build is a CMake
@@ -467,9 +479,9 @@ dist.macos-arm64 = { url = "https://files.pythonhosted.org/packages/5b/0a/d112ae
 version = "2.4.3-nros1"
 system = ["libssl3"]
 upstream = "v2.4.3" # = source.ref (eProsima release tag)
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/xrce-agent-2.4.3-nros1/xrce-agent-linux-x86_64.tar.zst", sha256 = "61c2e7786ffdbc3ea7f19882f12fb9dd3c28756c6dafd6ec459c9fa86de9438f" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/xrce-agent-2.4.3-nros1/xrce-agent-linux-arm64.tar.zst", sha256 = "29c6d7db3147bd9b0fac7d76ece23d90fa22907a7a556b88c3c2f9d6b8ba0344" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/xrce-agent-2.4.3-nros1/xrce-agent-macos-arm64.tar.zst", sha256 = "08133ec56db8fb5c0d80cfb5c99b5dea52e8b1af5932a5057fd153c1cb896e96" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/xrce-agent-2.4.3-nros1/xrce-agent-linux-x86_64.tar.zst", sha256 = "61c2e7786ffdbc3ea7f19882f12fb9dd3c28756c6dafd6ec459c9fa86de9438f", floor = { glibc = "2.34", glibcxx = "3.4.30" } }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/xrce-agent-2.4.3-nros1/xrce-agent-linux-arm64.tar.zst", sha256 = "29c6d7db3147bd9b0fac7d76ece23d90fa22907a7a556b88c3c2f9d6b8ba0344", floor = { glibc = "2.34", glibcxx = "3.4.30" } }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/xrce-agent-2.4.3-nros1/xrce-agent-macos-arm64.tar.zst", sha256 = "08133ec56db8fb5c0d80cfb5c99b5dea52e8b1af5932a5057fd153c1cb896e96", floor = { macos = "14.0" } }
 [tool.xrce-agent.source]
 git = "https://github.com/eProsima/Micro-XRCE-DDS-Agent"
 ref = "v2.4.3"
@@ -487,9 +499,9 @@ install = '''cmake --build build --parallel $(nproc) && mkdir -p {prefix}/bin {p
 version = "0.10.5-nros1"
 system = ["libssl3"]
 upstream = "12b4af2c5ac98657d42df84a5a45006ceede503b" # fork sha = submodule pointer
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/cyclonedds-0.10.5-nros1/cyclonedds-linux-x86_64.tar.zst", sha256 = "ed8a51eac91a884f39bfff4fe824923e5edf1f9dadb4a941c99a9f080c7217d3" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/cyclonedds-0.10.5-nros1/cyclonedds-linux-arm64.tar.zst", sha256 = "4c224398115bd45e14b37d6c8de7e94f4aed6f46da762f517654221327c51d5e" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/cyclonedds-0.10.5-nros1/cyclonedds-macos-arm64.tar.zst", sha256 = "f13c0dab71aa953c72aa5e5b4d7d8022a48de1670ccf28b103920ec06f1c3715" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/cyclonedds-0.10.5-nros1/cyclonedds-linux-x86_64.tar.zst", sha256 = "ed8a51eac91a884f39bfff4fe824923e5edf1f9dadb4a941c99a9f080c7217d3", floor = { glibc = "2.34" } }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/cyclonedds-0.10.5-nros1/cyclonedds-linux-arm64.tar.zst", sha256 = "4c224398115bd45e14b37d6c8de7e94f4aed6f46da762f517654221327c51d5e", floor = { glibc = "2.34" } }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/cyclonedds-0.10.5-nros1/cyclonedds-macos-arm64.tar.zst", sha256 = "f13c0dab71aa953c72aa5e5b4d7d8022a48de1670ccf28b103920ec06f1c3715", floor = { macos = "14.0" } }
 [tool.cyclonedds.source]
 git = "https://github.com/NEWSLabNTU/cyclonedds"
 ref = "12b4af2c5ac98657d42df84a5a45006ceede503b"
@@ -553,7 +565,7 @@ install = "cmake --build build --parallel $(nproc) --target install"
 # row gains a `dist.linux-x86_64`.
 [tool.play_launch_parser]
 version = "0.1.0-nros1"
-system = ["libexpat1", "libpython310", "libz1"]
+system = ["libexpat1", "libpython3", "libz1"]
 upstream = "838ce948551f8ba263648fbb7eeb572cec9d5950" # = source.ref (play_launch pin; no upstream tags)
 [tool.play_launch_parser.source]
 git = "https://github.com/NEWSLabNTU/play_launch"
@@ -834,9 +846,9 @@ upstream = "v1.13.2" # = the ninja-build/ninja release tag
 # prefix) cannot take these: they are zips, and they hold a BARE `ninja` with no
 # `bin/` directory. That is what an upstream asset looks like when it was not
 # built to our mirror's shape, and it is why `DistArtifact.install` exists.
-dist.linux-x86_64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux.zip", sha256 = "5749cbc4e668273514150a80e387a957f933c6ed3f5f11e03fb30955e2bbead6", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja" }
-dist.linux-arm64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux-aarch64.zip", sha256 = "fd2cacc8050a7f12a16a2e48f9e06fca5c14fc4c2bee2babb67b58be17a607fc", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja" }
-dist.macos-arm64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-mac.zip", sha256 = "c99048673aa765960a99cf10c6ddb9f1fad506099ff0a0e137ad8960a88f321b", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja" }
+dist.linux-x86_64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux.zip", sha256 = "5749cbc4e668273514150a80e387a957f933c6ed3f5f11e03fb30955e2bbead6", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja", floor = { glibc = "2.15", glibcxx = "3.4.21" } }
+dist.linux-arm64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux-aarch64.zip", sha256 = "fd2cacc8050a7f12a16a2e48f9e06fca5c14fc4c2bee2babb67b58be17a607fc", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja", floor = { glibc = "2.17", glibcxx = "3.4.21" } }
+dist.macos-arm64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-mac.zip", sha256 = "c99048673aa765960a99cf10c6ddb9f1fad506099ff0a0e137ad8960a88f321b", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja", floor = { macos = "11.0" } }
 system = ["unzip"]
 # Fallback only. Verified 2026-08-31 that it does produce a 1.13.2 binary, so a
 # host off the three asset arches is not stranded.
@@ -930,10 +942,10 @@ smoke = [
     { run = "bin/mdbook --version", expect = "mdbook v0.5.4" },
 ]
 upstream = "v0.5.4" # rust-lang/mdBook release tag (SSOT for the URLs below)
-dist.linux-x86_64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-x86_64-unknown-linux-musl.tar.gz", sha256 = "5222beabd3e37dc5be0d18ff99b79058469354db5c220153a1b92db5ba12be89", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook" }
-dist.linux-arm64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-aarch64-unknown-linux-musl.tar.gz", sha256 = "753e5c5c363ee8a56972344dcf91466f005a51db84a7aeffe427ae3ef83d6d44", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook" }
-dist.macos-arm64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-aarch64-apple-darwin.tar.gz", sha256 = "03e8a6d8b13a2971e0b3280affd03b388373c1485e26f73407c3a76b0b1838df", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook" }
-dist.macos-x86_64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-x86_64-apple-darwin.tar.gz", sha256 = "a47d7bf0d5d670cff9ee6cce95537cbeb62dc10704d9e7131ffbd13e2b59a5de", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook" }
+dist.linux-x86_64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-x86_64-unknown-linux-musl.tar.gz", sha256 = "5222beabd3e37dc5be0d18ff99b79058469354db5c220153a1b92db5ba12be89", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook", floor = { none = "statically linked (x86_64-unknown-linux-musl): no PT_INTERP, no DT_NEEDED" } }
+dist.linux-arm64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-aarch64-unknown-linux-musl.tar.gz", sha256 = "753e5c5c363ee8a56972344dcf91466f005a51db84a7aeffe427ae3ef83d6d44", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook", floor = { none = "statically linked (aarch64-unknown-linux-musl): no PT_INTERP, no DT_NEEDED" } }
+dist.macos-arm64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-aarch64-apple-darwin.tar.gz", sha256 = "03e8a6d8b13a2971e0b3280affd03b388373c1485e26f73407c3a76b0b1838df", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook", floor = { macos = "11.0" } }
+dist.macos-x86_64 = { url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-x86_64-apple-darwin.tar.gz", sha256 = "a47d7bf0d5d670cff9ee6cce95537cbeb62dc10704d9e7131ffbd13e2b59a5de", install = "mkdir -p {prefix}/bin && tar -xf {archive} -C {prefix}/bin && chmod +x {prefix}/bin/mdbook", floor = { macos = "10.12" } }
 
 # Verus — unbounded deductive verification (`just verification verus`, run by
 # `just verify-verus`).
@@ -988,9 +1000,9 @@ smoke = [
 # `[tool.ninja]`. Nothing else: the bundle's external closure is base glibc only.
 system = ["unzip"]
 upstream = "release/0.2026.06.28.1847ab3" # verus-lang/verus release tag (SSOT)
-dist.linux-x86_64 = { url = "https://github.com/verus-lang/verus/releases/download/release/0.2026.06.28.1847ab3/verus-0.2026.06.28.1847ab3-x86-linux.zip", sha256 = "b12a622a2f44c31e72a459fc8b764e8d4bd2275e54995d21c405771b316a81e7", install = "rm -rf {prefix}/bin {prefix}/.unpack && unzip -q -o {archive} -d {prefix}/.unpack && mv {prefix}/.unpack/verus-x86-linux {prefix}/bin && rmdir {prefix}/.unpack && chmod +x {prefix}/bin/verus {prefix}/bin/cargo-verus {prefix}/bin/z3 {prefix}/bin/rust_verify" }
-dist.macos-arm64 = { url = "https://github.com/verus-lang/verus/releases/download/release/0.2026.06.28.1847ab3/verus-0.2026.06.28.1847ab3-arm64-macos.zip", sha256 = "225978b94c0f75edeeee76a042bc865afe0e76e87ceb97a305ea89ab21183d98", install = "rm -rf {prefix}/bin {prefix}/.unpack && unzip -q -o {archive} -d {prefix}/.unpack && mv {prefix}/.unpack/verus-arm64-macos {prefix}/bin && rmdir {prefix}/.unpack && chmod +x {prefix}/bin/verus {prefix}/bin/cargo-verus {prefix}/bin/z3 {prefix}/bin/rust_verify" }
-dist.macos-x86_64 = { url = "https://github.com/verus-lang/verus/releases/download/release/0.2026.06.28.1847ab3/verus-0.2026.06.28.1847ab3-x86-macos.zip", sha256 = "4d6b27a6e96079b56d910ec9290485467985aa9f8d68de03c5ca19a91312be75", install = "rm -rf {prefix}/bin {prefix}/.unpack && unzip -q -o {archive} -d {prefix}/.unpack && mv {prefix}/.unpack/verus-x86-macos {prefix}/bin && rmdir {prefix}/.unpack && chmod +x {prefix}/bin/verus {prefix}/bin/cargo-verus {prefix}/bin/z3 {prefix}/bin/rust_verify" }
+dist.linux-x86_64 = { url = "https://github.com/verus-lang/verus/releases/download/release/0.2026.06.28.1847ab3/verus-0.2026.06.28.1847ab3-x86-linux.zip", sha256 = "b12a622a2f44c31e72a459fc8b764e8d4bd2275e54995d21c405771b316a81e7", install = "rm -rf {prefix}/bin {prefix}/.unpack && unzip -q -o {archive} -d {prefix}/.unpack && mv {prefix}/.unpack/verus-x86-linux {prefix}/bin && rmdir {prefix}/.unpack && chmod +x {prefix}/bin/verus {prefix}/bin/cargo-verus {prefix}/bin/z3 {prefix}/bin/rust_verify", floor = { glibc = "2.34", glibcxx = "3.4.26" } }
+dist.macos-arm64 = { url = "https://github.com/verus-lang/verus/releases/download/release/0.2026.06.28.1847ab3/verus-0.2026.06.28.1847ab3-arm64-macos.zip", sha256 = "225978b94c0f75edeeee76a042bc865afe0e76e87ceb97a305ea89ab21183d98", install = "rm -rf {prefix}/bin {prefix}/.unpack && unzip -q -o {archive} -d {prefix}/.unpack && mv {prefix}/.unpack/verus-arm64-macos {prefix}/bin && rmdir {prefix}/.unpack && chmod +x {prefix}/bin/verus {prefix}/bin/cargo-verus {prefix}/bin/z3 {prefix}/bin/rust_verify", floor = { macos = "11.0" } }
+dist.macos-x86_64 = { url = "https://github.com/verus-lang/verus/releases/download/release/0.2026.06.28.1847ab3/verus-0.2026.06.28.1847ab3-x86-macos.zip", sha256 = "4d6b27a6e96079b56d910ec9290485467985aa9f8d68de03c5ca19a91312be75", install = "rm -rf {prefix}/bin {prefix}/.unpack && unzip -q -o {archive} -d {prefix}/.unpack && mv {prefix}/.unpack/verus-x86-macos {prefix}/bin && rmdir {prefix}/.unpack && chmod +x {prefix}/bin/verus {prefix}/bin/cargo-verus {prefix}/bin/z3 {prefix}/bin/rust_verify", floor = { macos = "11.0" } }
 
 # --- source packages (built with the app for the user's target) ---
 #
@@ -1166,7 +1178,7 @@ upstream = "FM-11.31"
 # with `bin/FVP_BaseR_AEMv8R` beneath it, so the default prefix-rooted unpack
 # would bury the binary one level down and every resolver would miss it.
 # Verified by listing the archive, not assumed from the name.
-dist.linux-x86_64 = { url = "https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.31/FVP_Base_AEMv8R_11.31_28_Linux_x86.tar.gz", sha256 = "627500afdb115701b412b85520e5c0e370b7f7e3f425f7ae4b1e8b14cbd4441a", install = "tar -xzf {archive} -C {prefix} --strip-components=1" }
+dist.linux-x86_64 = { url = "https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.31/FVP_Base_AEMv8R_11.31_28_Linux_x86.tar.gz", sha256 = "627500afdb115701b412b85520e5c0e370b7f7e3f425f7ae4b1e8b14cbd4441a", install = "tar -xzf {archive} -C {prefix} --strip-components=1", floor = { glibc = "2.17", glibcxx = "3.4.26" } }
 
 # --- RMW host packages (Phase 191.6.a): the RMW axis, orthogonal to the board.
 # `nros setup <board> --rmw <name>` resolves `board.packages ∪ rmw.packages`
@@ -2195,13 +2207,17 @@ check = { cmd = "nros" }
 # dist's copy behind `RUNPATH=$ORIGIN/../lib`. That is issue 0774's class, and
 # an audit inheriting the caller's environment measures the caller.
 #
-# Two of these pin a version INSIDE the soname — `libpython3.10.so.1.0` and
-# `libssl.so.3` — so they are host-distro constraints rather than ordinary
-# prerequisites: no `apt install` satisfies them on a release that ships a
-# different minor/major. Declaring them lets setup and doctor SAY so; only
-# re-cutting the dist removes them.
+# A soname that pins a version (`libssl.so.3`) is a host-distro constraint
+# rather than an ordinary prerequisite: no `apt install` satisfies it on a
+# release that ships a different major. phase-447 D2 lets a row say so per
+# release — `apt = { default = [..], noble = [..] }`, with an explicitly EMPTY
+# list meaning "not packaged on that release" — and phase-447 D1's floor probe
+# reads exactly that to refuse a prebuilt BEFORE downloading it on such a host,
+# falling back to its source recipe. Only re-cutting the dist removes the
+# constraint itself.
 #
-# apt names verified against the archive on Ubuntu 22.04 (2026-08-30).
+# apt names verified against the archive on Ubuntu 22.04 (2026-08-30); the
+# noble overrides against 24.04 (2026-09-11).
 # dnf/pacman/brew are best-effort, per this file's existing convention.
 
 [prereq.openocd]
@@ -2248,8 +2264,35 @@ pacman = ["pcre2"]
 brew = ["pcre2"]
 check = { sharedlib = "libpcre2-8.so.0" }
 
-[prereq.libpython310]
+# phase-447 D2 — was `[prereq.libpython310]`, and the minor version in the KEY
+# was the defect, not just a stale package name. Its only consumer is the
+# play_launch_parser SOURCE build (there is no dist — RFC-0099 D4's ten), and a
+# source build links whatever CPython the HOST has: 3.10 on jammy, 3.12 on
+# noble. So the requirement is "this host's libpython3", and a key naming 3.10
+# asked every non-jammy host for a package it could not have (noble has no
+# `libpython3.10`; the old dnf/pacman rows asked for non-default side installs).
+#
+# A soname-EXACT requirement (`libpython3.10.so.1.0`) is a different thing: it
+# belongs to a binary that links one minor. That key exists — it is
+# `[prereq.libpython310]`, directly below, for the `nros-launch-resolve`
+# release binary (issue 0897, PR #896). `check-dist-runtime-deps` maps sonames
+# through `check.sharedlib`, and this prefix probe matches none exactly, so a
+# dist that links one minor is steered to that key, not this one.
+#
+# `default` is `libpython3-dev`, the one name that pulls the RELEASE's own
+# minor on every Debian/Ubuntu; jammy/noble name the runtime package directly
+# (verified in the archive 2026-09-11 — noble's is the t64 rename).
+[prereq.libpython3]
 role = "infra"
+why = "this host's CPython embedding library — the play_launch_parser SOURCE build links it (pyo3 auto-initialize)"
+apt = { default = ["libpython3-dev"], jammy = ["libpython3.10"], noble = ["libpython3.12t64"] }
+dnf = ["python3-libs"]
+pacman = ["python"]
+check = { sharedlib = "libpython3." }
+
+# The soname-EXACT sibling of `[prereq.libpython3]` above: the two keys are two
+# requirements that the old single key conflated (phase-447 D2).
+#
 # Corrected for issue 1273 / RFC-0099 D4 — `play_launch_parser` has no dist (it
 # is on the dist-or-reason ratchet, `.config/dist-or-reason-baseline.txt`), so
 # that could never have been the true reason. The real one: PR #896
@@ -2258,8 +2301,17 @@ role = "infra"
 # links `libpython3.10.so.1.0` as a hard `DT_NEEDED` (pyo3's
 # `auto-initialize`) — this prereq exists for THAT binary, not for a dist that
 # does not exist.
+#
+# For a binary linked against one minor, the minor IS the requirement, so here
+# the version in the key is right. phase-447 D2 lets it say where that minor
+# is not packaged at all: noble ships 3.12 and no `libpython3.10` (verified
+# 2026-09-11), and `noble = []` is exactly the signal D1's backward half reads
+# to refuse such a binary before downloading it. No `default`: jammy is the only
+# Ubuntu LTS that packages 3.10, and a default would claim the others do.
+[prereq.libpython310]
+role = "infra"
 why = "runtime dep of the nros-launch-resolve release binary (pyo3 auto-initialize links libpython3.10.so.1.0; phase-447 A1 / PR #896)"
-apt = ["libpython3.10"]
+apt = { jammy = ["libpython3.10"], noble = [] }
 dnf = ["python3.10-libs"]
 pacman = ["python310"]
 check = { sharedlib = "libpython3.10.so.1.0" }
@@ -2275,7 +2327,10 @@ check = { sharedlib = "libselinux.so.1" }
 [prereq.libssl3]
 role = "infra"
 why = "runtime dep of the cyclonedds, xrce-agent dist(s) (issue 0926)"
-apt = ["libssl3"]
+# phase-447 D2 — noble's 64-bit time_t transition renamed the package to
+# `libssl3t64` (the soname stays `libssl.so.3`, so the probe is unchanged).
+# Verified in the archive 2026-09-11: noble has no `libssl3`.
+apt = { default = ["libssl3"], noble = ["libssl3t64"] }
 dnf = ["openssl-libs"]
 pacman = ["openssl"]
 brew = ["openssl@3"]

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -238,9 +238,9 @@ dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/
 version = "0.16.8"
 upstream = "v0.16.8" # sdk-ng release tag (SSOT for the URLs below)
 dist.linux-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-x86_64.tar.xz", sha256 = "cb4e4012751e4526aaf1ec1e8ab9b4ded5681e2e01711b64f7a1b519ff7dbc6a", floor = { glibc = "2.27", glibcxx = "3.4.21" } }
-dist.linux-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-aarch64.tar.xz", sha256 = "83782b4cf595bb3da8a6c7c1ade01eed00ad03f8ba0c72da6680693192b3668d" }
-dist.macos-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_macos-aarch64.tar.xz", sha256 = "e06138c1e50cc5b4508646640bd08c50f05f0eb3f2949e756d84d3367f581593" }
-dist.macos-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_macos-x86_64.tar.xz", sha256 = "b96c849cc63e0f0218c196be8faba548ed473894fb7fced67311aa39fe97ac21" }
+dist.linux-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-aarch64.tar.xz", sha256 = "83782b4cf595bb3da8a6c7c1ade01eed00ad03f8ba0c72da6680693192b3668d", floor = { glibc = "2.27", glibcxx = "3.4.21" } }
+dist.macos-arm64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_macos-aarch64.tar.xz", sha256 = "e06138c1e50cc5b4508646640bd08c50f05f0eb3f2949e756d84d3367f581593", floor = { macos = "11.0" } }
+dist.macos-x86_64 = { url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_macos-x86_64.tar.xz", sha256 = "b96c849cc63e0f0218c196be8faba548ed473894fb7fced67311aa39fe97ac21", floor = { macos = "11.0" } }
 
 [tool.zephyr-sdk-1-0-1]
 # The Zephyr SDK for the 4.4 ROLLING line. A second entry rather than a version

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -324,9 +324,9 @@ upstream = "0.17.0" # = source.ref (mozilla/sccache release tag, without the `v`
 smoke = [
     { run = "bin/sccache --version", expect = "sccache 0.17.0" },
 ]
-dist.linux-x86_64 = { url = "https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz", sha256 = "67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006", install = "mkdir -p {prefix}/bin && tar -xOf {archive} sccache-v0.17.0-x86_64-unknown-linux-musl/sccache > {prefix}/bin/sccache && chmod +x {prefix}/bin/sccache" }
-dist.linux-arm64 = { url = "https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-aarch64-unknown-linux-musl.tar.gz", sha256 = "821a86343191aa1cbab74bd42f9e93c9a63bf85e4742945f40d3ae84193c1c77", install = "mkdir -p {prefix}/bin && tar -xOf {archive} sccache-v0.17.0-aarch64-unknown-linux-musl/sccache > {prefix}/bin/sccache && chmod +x {prefix}/bin/sccache" }
-dist.macos-arm64 = { url = "https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-aarch64-apple-darwin.tar.gz", sha256 = "0c560bfba31aef5bdfb4fb3d2677f6e61d71c5c00952f2a83344f47aa31f00f1", install = "mkdir -p {prefix}/bin && tar -xOf {archive} sccache-v0.17.0-aarch64-apple-darwin/sccache > {prefix}/bin/sccache && chmod +x {prefix}/bin/sccache" }
+dist.linux-x86_64 = { url = "https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz", sha256 = "67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006", install = "mkdir -p {prefix}/bin && tar -xOf {archive} sccache-v0.17.0-x86_64-unknown-linux-musl/sccache > {prefix}/bin/sccache && chmod +x {prefix}/bin/sccache", floor = { none = "statically linked (x86_64-unknown-linux-musl): no PT_INTERP, no DT_NEEDED" } }
+dist.linux-arm64 = { url = "https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-aarch64-unknown-linux-musl.tar.gz", sha256 = "821a86343191aa1cbab74bd42f9e93c9a63bf85e4742945f40d3ae84193c1c77", install = "mkdir -p {prefix}/bin && tar -xOf {archive} sccache-v0.17.0-aarch64-unknown-linux-musl/sccache > {prefix}/bin/sccache && chmod +x {prefix}/bin/sccache", floor = { none = "statically linked (aarch64-unknown-linux-musl): no PT_INTERP, no DT_NEEDED" } }
+dist.macos-arm64 = { url = "https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-aarch64-apple-darwin.tar.gz", sha256 = "0c560bfba31aef5bdfb4fb3d2677f6e61d71c5c00952f2a83344f47aa31f00f1", install = "mkdir -p {prefix}/bin && tar -xOf {archive} sccache-v0.17.0-aarch64-apple-darwin/sccache > {prefix}/bin/sccache && chmod +x {prefix}/bin/sccache", floor = { macos = "11.0" } }
 [tool.sccache.source]
 git = "https://github.com/mozilla/sccache"
 ref = "v0.17.0"
@@ -778,9 +778,9 @@ upstream = "v4.5.0" # = source.ref (esp-rs/espflash release tag)
 smoke = [
     { run = "bin/espflash --version", expect = "espflash 4.5.0" },
 ]
-dist.linux-x86_64 = { url = "https://github.com/esp-rs/espflash/releases/download/v4.5.0/espflash-x86_64-unknown-linux-musl.zip", sha256 = "542c5cc81f0cca384cbead1cacb7ccc9f35072a989b2de0fb95333d814272c22", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/espflash" }
-dist.linux-arm64 = { url = "https://github.com/esp-rs/espflash/releases/download/v4.5.0/espflash-aarch64-unknown-linux-gnu.zip", sha256 = "2d5972b9c18fc89bf253e60fe6df6a4f8db3aee5db0166b2c97b53bd21c01f09", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/espflash" }
-dist.macos-arm64 = { url = "https://github.com/esp-rs/espflash/releases/download/v4.5.0/espflash-aarch64-apple-darwin.zip", sha256 = "6614ff70e523a6bce5f4ccc6459b77275f5e7e900429004bb7eec463c95db28a", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/espflash" }
+dist.linux-x86_64 = { url = "https://github.com/esp-rs/espflash/releases/download/v4.5.0/espflash-x86_64-unknown-linux-musl.zip", sha256 = "542c5cc81f0cca384cbead1cacb7ccc9f35072a989b2de0fb95333d814272c22", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/espflash", floor = { none = "statically linked (x86_64-unknown-linux-musl): no PT_INTERP, no DT_NEEDED" } }
+dist.linux-arm64 = { url = "https://github.com/esp-rs/espflash/releases/download/v4.5.0/espflash-aarch64-unknown-linux-gnu.zip", sha256 = "2d5972b9c18fc89bf253e60fe6df6a4f8db3aee5db0166b2c97b53bd21c01f09", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/espflash", floor = { glibc = "2.34" } }
+dist.macos-arm64 = { url = "https://github.com/esp-rs/espflash/releases/download/v4.5.0/espflash-aarch64-apple-darwin.zip", sha256 = "6614ff70e523a6bce5f4ccc6459b77275f5e7e900429004bb7eec463c95db28a", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/espflash", floor = { macos = "11.0" } }
 system = ["unzip"]
 [tool.espflash.source]
 git = "https://github.com/esp-rs/espflash"

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -1641,7 +1641,13 @@ fn describe(action: &InstallAction, version: &str, host: &str) -> String {
     match action {
         InstallAction::Present => format!("present {version} (skip)"),
         InstallAction::Prebuilt { .. } => format!("prebuilt {version} (dist {host})"),
+        // phase-447 D1 — a prebuilt refused by its floor says WHY, here in the
+        // plan, so `--dry-run` shows the fallback before anything runs.
+        InstallAction::Source {
+            refused: Some(why), ..
+        } => format!("source build {version} ({why})"),
         InstallAction::Source { .. } => format!("source build {version} (no prebuilt for {host})"),
+        InstallAction::Refused { reason } => format!("REFUSED {version} ({reason}; no source)"),
         InstallAction::Unavailable => {
             format!("UNAVAILABLE {version} (no prebuilt for {host}, no source)")
         }
@@ -2887,6 +2893,39 @@ fn compose_packages(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// phase-447 D1 — the plan line says WHY a prebuilt was refused, so
+    /// `--dry-run` shows the fallback and its reason before anything runs; an
+    /// ordinary no-dist source build keeps its old wording.
+    #[test]
+    fn describe_names_a_floor_refusal() {
+        use crate::orchestration::sdk_store::SourceFetch;
+        let src = |refused: Option<&str>| InstallAction::Source {
+            fetch: SourceFetch::Git {
+                git: "g".into(),
+                git_ref: "r".into(),
+            },
+            configure: None,
+            install: None,
+            respect_toolchain: false,
+            refused: refused.map(str::to_string),
+        };
+        let line = describe(&src(Some("needs glibc >= 2.35")), "1", "linux-x86_64");
+        assert!(line.contains("needs glibc >= 2.35"), "{line}");
+        let plain = describe(&src(None), "1", "linux-x86_64");
+        assert!(plain.contains("no prebuilt for linux-x86_64"), "{plain}");
+        let refused = describe(
+            &InstallAction::Refused {
+                reason: "needs glibc >= 2.35".into(),
+            },
+            "1",
+            "linux-x86_64",
+        );
+        assert!(
+            refused.starts_with("REFUSED") && refused.contains("2.35"),
+            "{refused}"
+        );
+    }
 
     /// phase-431 W5 — a path the user TYPED is never second-guessed; only the
     /// default falls back to the copy shipped beside the binary.

--- a/packages/cli/nros-cli-core/src/orchestration/host_floor.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/host_floor.rs
@@ -1,0 +1,489 @@
+//! phase-447 D1 (RFC-0099 D5) — is THIS host at or above a dist's floor?
+//!
+//! A dist is ABI-bound, and `host_key()` is `<os>-<arch>` with no OS version and
+//! no libc in it, so the key alone offers every Linux x86_64 host every Linux
+//! x86_64 dist — including hosts that cannot run it. Widening the key was
+//! rejected (compatibility is a RANGE: a glibc 2.39 host runs a 2.35 binary), so
+//! the dist row carries a MEASURED floor and this module compares the host with
+//! it before anything is downloaded.
+//!
+//! Two halves, because the runtime has two halves:
+//!
+//! * **Forward** — the loader/libc family and the C++ runtime, which
+//!   `nano-ros-sdk`'s `bundle.sh` never bundles. A number: `floor.glibc`,
+//!   `floor.glibcxx`, `floor.macos`. An OLDER host fails it.
+//! * **Backward** — a library the dist links BY NAME that a NEWER host no longer
+//!   ships (`libpython3.10.so.1.0` on noble, which has 3.12). Not a number. It
+//!   is the tool's `system = [..]` list, and a host is refused only when the
+//!   soname is absent AND the prereq's per-release package names say the
+//!   manager does not package it on this release (phase-447 D2) — absent but
+//!   installable is `nros setup --system`'s job, as it always was.
+//!
+//! Every probe that cannot answer ABSTAINS. "Could not tell" never refuses a
+//! dist: a false refusal costs a source build nobody needed, which is worse than
+//! the loader error this exists to pre-empt.
+
+use std::{collections::BTreeSet, sync::OnceLock};
+
+use super::sdk_index::{DistArtifact, PrereqDep, host_key, host_os_release, version_cmp};
+
+/// The C library this host runs, as far as it can be told.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum Libc {
+    /// Could not be determined — abstain.
+    #[default]
+    Unknown,
+    /// glibc, at this version.
+    Glibc(String),
+    /// Some other libc (musl): a glibc-linked dist cannot start at all.
+    Other(String),
+}
+
+/// The host's libstdc++, as far as it can be told.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum Libstdcxx {
+    #[default]
+    Unknown,
+    /// The loader can find no `libstdc++.so.6`.
+    Absent,
+    /// The highest `GLIBCXX_3.4.N` it defines, written `3.4.N`.
+    Glibcxx(String),
+}
+
+/// What the floor comparison needs to know about a host. Gathered ONCE, at
+/// the edge ([`HostFacts::current`]); the comparison itself is pure.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HostFacts {
+    pub libc: Libc,
+    pub libstdcxx: Libstdcxx,
+    /// `sw_vers -productVersion`, on macOS.
+    pub macos: Option<String>,
+    /// The detected package manager (`apt`, `dnf`, …).
+    pub manager: Option<String>,
+    /// `VERSION_CODENAME` / `VERSION_ID` — the D2 release key.
+    pub release: Option<String>,
+    /// Every soname `ldconfig -p` lists. `None` = could not ask.
+    pub sonames: Option<BTreeSet<String>>,
+}
+
+impl HostFacts {
+    /// Facts that answer nothing, so every comparison abstains. What a plan for
+    /// a FOREIGN host key uses: this machine's glibc says nothing about it.
+    #[must_use]
+    pub fn unknown() -> Self {
+        Self::default()
+    }
+
+    /// This machine's facts, probed on first use and cached for the process —
+    /// a board setup plans ~20 tools and must not run `ldconfig` twenty times.
+    #[must_use]
+    pub fn current() -> &'static Self {
+        static FACTS: OnceLock<HostFacts> = OnceLock::new();
+        FACTS.get_or_init(Self::probe)
+    }
+
+    fn probe() -> Self {
+        let ldconfig = ldconfig_listing();
+        let sonames = ldconfig.as_deref().map(|l| {
+            l.lines()
+                .filter_map(|line| line.split_whitespace().next())
+                .filter(|s| s.contains(".so"))
+                .map(str::to_string)
+                .collect()
+        });
+        let libstdcxx = match ldconfig.as_deref() {
+            None => Libstdcxx::Unknown,
+            Some(l) => match libstdcxx_path(l) {
+                None => Libstdcxx::Absent,
+                Some(p) => std::fs::read(&p)
+                    .ok()
+                    .and_then(|bytes| max_glibcxx(&bytes))
+                    .map_or(Libstdcxx::Unknown, Libstdcxx::Glibcxx),
+            },
+        };
+        Self {
+            libc: probe_libc(),
+            libstdcxx,
+            macos: probe_macos(),
+            manager: crate::cmd::setup::detect_package_manager().map(str::to_string),
+            release: host_os_release(),
+            sonames,
+        }
+    }
+
+    /// Whether some library whose soname starts with `lib` is loadable — the
+    /// same PREFIX rule `check.sharedlib` uses, so a probe written for the
+    /// `--check` path means the same thing here. `None` = could not ask.
+    #[must_use]
+    pub fn has_soname(&self, lib: &str) -> Option<bool> {
+        self.sonames
+            .as_ref()
+            .map(|set| set.iter().any(|s| s.starts_with(lib)))
+    }
+}
+
+fn below(have: &str, want: &str) -> bool {
+    version_cmp(have, want) == std::cmp::Ordering::Less
+}
+
+/// Why `dist` must not be downloaded onto a host with `facts`, or `None`.
+///
+/// `system` is the tool's `system = [..]` list resolved to its prereq rows
+/// ([`super::sdk_index::ToolPackage::system_deps`]). The returned text names
+/// the failing requirement AND the remedy; the caller adds what happens next
+/// (a source build, or nothing to fall back to).
+#[must_use]
+pub fn refusal(
+    dist: &DistArtifact,
+    system: &[(String, PrereqDep)],
+    facts: &HostFacts,
+) -> Option<String> {
+    if let Some(floor) = &dist.floor {
+        if let Some(want) = &floor.glibc {
+            match &facts.libc {
+                Libc::Glibc(have) if below(have, want) => {
+                    return Some(format!(
+                        "it needs glibc >= {want} and this host has glibc {have}. Remedy: \
+                         use a host whose distribution ships glibc {want} or newer"
+                    ));
+                }
+                Libc::Other(name) => {
+                    return Some(format!(
+                        "it is linked against glibc (>= {want}) and this host's C library \
+                         is {name}. Remedy: use a glibc-based host"
+                    ));
+                }
+                _ => {}
+            }
+        }
+        if let Some(want) = &floor.glibcxx {
+            match &facts.libstdcxx {
+                Libstdcxx::Glibcxx(have) if below(have, want) => {
+                    return Some(format!(
+                        "it needs a libstdc++ defining GLIBCXX_{want} and this host's \
+                         newest is GLIBCXX_{have}. Remedy: install a newer libstdc++6 \
+                         (a newer distribution, or its toolchain backports)"
+                    ));
+                }
+                Libstdcxx::Absent => {
+                    return Some(format!(
+                        "it needs libstdc++.so.6 (GLIBCXX_{want}) and the loader finds none \
+                         on this host. Remedy: install libstdc++6"
+                    ));
+                }
+                _ => {}
+            }
+        }
+        if let (Some(want), Some(have)) = (&floor.macos, &facts.macos)
+            && below(have, want)
+        {
+            return Some(format!(
+                "it needs macOS {want} or newer and this host is {have}. Remedy: \
+                 upgrade macOS"
+            ));
+        }
+    }
+    // The backward half. Only for Linux artifacts, where `ldconfig` answers.
+    let (Some(mgr), Some(release)) = (facts.manager.as_deref(), facts.release.as_deref()) else {
+        return None;
+    };
+    for (key, dep) in system {
+        let Some(so) = dep.check.as_ref().and_then(|c| c.sharedlib.as_deref()) else {
+            continue;
+        };
+        if facts.has_soname(so) != Some(false) {
+            continue; // present, or cannot tell
+        }
+        let unpackaged = dep
+            .manager_packages(mgr)
+            .and_then(|m| m.named_for(Some(release)))
+            .is_some_and(<[String]>::is_empty);
+        if unpackaged {
+            return Some(format!(
+                "it links `{so}` ([prereq.{key}]), which this host lacks and {mgr} does not \
+                 package on {release} (the index says so: `{mgr}.{release} = []`). Remedy: \
+                 a release that ships it, or a source build against this host's own"
+            ));
+        }
+    }
+    None
+}
+
+/// The facts to plan `host` with: this machine's when `host` IS this machine,
+/// otherwise nothing (every comparison abstains).
+#[must_use]
+pub fn facts_for(host: &str) -> std::borrow::Cow<'static, HostFacts> {
+    if host == host_key() {
+        std::borrow::Cow::Borrowed(HostFacts::current())
+    } else {
+        std::borrow::Cow::Owned(HostFacts::unknown())
+    }
+}
+
+fn ldconfig_listing() -> Option<String> {
+    if std::env::consts::OS != "linux" {
+        return None;
+    }
+    for cmd in ["ldconfig", "/sbin/ldconfig", "/usr/sbin/ldconfig"] {
+        if let Ok(out) = std::process::Command::new(cmd).arg("-p").output()
+            && out.status.success()
+        {
+            return Some(String::from_utf8_lossy(&out.stdout).into_owned());
+        }
+    }
+    None
+}
+
+/// The `libstdc++.so.6` path `ldconfig -p` resolves, for this process's arch.
+fn libstdcxx_path(listing: &str) -> Option<String> {
+    let tag = match std::env::consts::ARCH {
+        "x86_64" => "x86-64",
+        "aarch64" => "AArch64",
+        _ => "",
+    };
+    listing
+        .lines()
+        .filter(|l| l.trim_start().starts_with("libstdc++.so.6 "))
+        .filter(|l| tag.is_empty() || l.contains(tag))
+        .find_map(|l| l.split("=>").nth(1).map(|p| p.trim().to_string()))
+}
+
+/// The highest `GLIBCXX_3.4.N` string in a libstdc++ image, as `3.4.N`.
+fn max_glibcxx(bytes: &[u8]) -> Option<String> {
+    let needle = b"GLIBCXX_3.4";
+    let mut best: Option<String> = None;
+    let mut i = 0;
+    while let Some(pos) = bytes[i..].windows(needle.len()).position(|w| w == needle) {
+        let start = i + pos + "GLIBCXX_".len();
+        let mut end = start;
+        while end < bytes.len() && (bytes[end].is_ascii_digit() || bytes[end] == b'.') {
+            end += 1;
+        }
+        let v = String::from_utf8_lossy(&bytes[start..end])
+            .trim_end_matches('.')
+            .to_string();
+        if best.as_deref().is_none_or(|b| below(b, &v)) {
+            best = Some(v);
+        }
+        i = end.max(i + pos + 1);
+    }
+    best
+}
+
+fn probe_libc() -> Libc {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    {
+        // SAFETY: returns a pointer to a static NUL-terminated string owned by
+        // glibc; it is never freed and never mutated.
+        let v = unsafe { std::ffi::CStr::from_ptr(libc::gnu_get_libc_version()) };
+        Libc::Glibc(v.to_string_lossy().into_owned())
+    }
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+    {
+        if std::env::consts::OS != "linux" {
+            return Libc::Unknown;
+        }
+        // A non-glibc `nros` (musl-static) may still run on a glibc host.
+        if let Ok(out) = std::process::Command::new("getconf")
+            .arg("GNU_LIBC_VERSION")
+            .output()
+            && out.status.success()
+            && let Some(v) = String::from_utf8_lossy(&out.stdout)
+                .split_whitespace()
+                .nth(1)
+        {
+            return Libc::Glibc(v.to_string());
+        }
+        if let Ok(out) = std::process::Command::new("ldd").arg("--version").output() {
+            let text = format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            if text.to_ascii_lowercase().contains("musl") {
+                return Libc::Other("musl".to_string());
+            }
+        }
+        Libc::Unknown
+    }
+}
+
+fn probe_macos() -> Option<String> {
+    if std::env::consts::OS != "macos" {
+        return None;
+    }
+    let out = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestration::sdk_index::{CheckProbe, DistFloor, ManagerPackages};
+    use std::collections::BTreeMap;
+
+    fn dist(floor: DistFloor) -> DistArtifact {
+        DistArtifact {
+            url: "u".into(),
+            sha256: "h".into(),
+            install: None,
+            floor: Some(floor),
+        }
+    }
+
+    fn glibc(v: &str) -> DistFloor {
+        DistFloor {
+            glibc: Some(v.into()),
+            ..DistFloor::default()
+        }
+    }
+
+    fn host(libc: Libc) -> HostFacts {
+        HostFacts {
+            libc,
+            ..HostFacts::default()
+        }
+    }
+
+    /// The forward half: an OLDER glibc is refused, an equal or newer one is
+    /// not — a range, not an identity (RFC-0099 D5).
+    #[test]
+    fn glibc_floor_is_a_minimum() {
+        let d = dist(glibc("2.35"));
+        let old = host(Libc::Glibc("2.31".into()));
+        let r = refusal(&d, &[], &old).expect("2.31 < 2.35 must refuse");
+        assert!(r.contains("glibc >= 2.35") && r.contains("2.31"), "{r}");
+        assert!(r.contains("Remedy"), "a refusal must name the remedy: {r}");
+        assert_eq!(refusal(&d, &[], &host(Libc::Glibc("2.35".into()))), None);
+        assert_eq!(refusal(&d, &[], &host(Libc::Glibc("2.39".into()))), None);
+        // 2.4 vs 2.35 is numeric, not lexical.
+        assert!(refusal(&dist(glibc("2.17")), &[], &host(Libc::Glibc("2.4".into()))).is_some());
+    }
+
+    /// A glibc-linked dist cannot start on musl at all; a host that cannot be
+    /// read abstains rather than refusing.
+    #[test]
+    fn non_glibc_refuses_and_unknown_abstains() {
+        let d = dist(glibc("2.17"));
+        assert!(refusal(&d, &[], &host(Libc::Other("musl".into()))).is_some());
+        assert_eq!(refusal(&d, &[], &host(Libc::Unknown)), None);
+        assert_eq!(refusal(&d, &[], &HostFacts::unknown()), None);
+    }
+
+    #[test]
+    fn glibcxx_and_macos_floors() {
+        let d = dist(DistFloor {
+            glibcxx: Some("3.4.30".into()),
+            ..DistFloor::default()
+        });
+        let with = |s: Libstdcxx| HostFacts {
+            libstdcxx: s,
+            ..HostFacts::default()
+        };
+        assert!(refusal(&d, &[], &with(Libstdcxx::Glibcxx("3.4.28".into()))).is_some());
+        assert!(refusal(&d, &[], &with(Libstdcxx::Absent)).is_some());
+        assert_eq!(
+            refusal(&d, &[], &with(Libstdcxx::Glibcxx("3.4.32".into()))),
+            None
+        );
+        assert_eq!(refusal(&d, &[], &with(Libstdcxx::Unknown)), None);
+
+        let m = dist(DistFloor {
+            macos: Some("11.0".into()),
+            ..DistFloor::default()
+        });
+        let mac = |v: &str| HostFacts {
+            macos: Some(v.into()),
+            ..HostFacts::default()
+        };
+        assert!(refusal(&m, &[], &mac("10.15")).is_some());
+        assert_eq!(refusal(&m, &[], &mac("14.2")), None);
+    }
+
+    /// `none` is a MEASURED absence of a floor and never refuses.
+    #[test]
+    fn a_none_floor_never_refuses() {
+        let d = dist(DistFloor {
+            none: Some("static musl".into()),
+            ..DistFloor::default()
+        });
+        assert_eq!(refusal(&d, &[], &host(Libc::Other("musl".into()))), None);
+    }
+
+    /// The backward half — the libpython3.10-on-noble shape. Refused only when
+    /// the soname is ABSENT and the index says the manager does not package it
+    /// on THIS release; absent-but-installable is `--system`'s job.
+    #[test]
+    fn backward_half_needs_absent_and_unpackaged_here() {
+        let dep = PrereqDep {
+            apt: ManagerPackages::ByRelease(BTreeMap::from([
+                ("jammy".to_string(), vec!["libpython3.10".to_string()]),
+                ("noble".to_string(), Vec::new()),
+            ])),
+            check: Some(CheckProbe {
+                sharedlib: Some("libpython3.10.so.1.0".into()),
+                ..CheckProbe::default()
+            }),
+            ..PrereqDep::default()
+        };
+        let system = vec![("libpython310".to_string(), dep)];
+        let d = DistArtifact {
+            floor: None,
+            ..dist(DistFloor::default())
+        };
+        let on = |release: &str, libs: &[&str]| HostFacts {
+            manager: Some("apt".into()),
+            release: Some(release.into()),
+            sonames: Some(libs.iter().map(|s| (*s).to_string()).collect()),
+            ..HostFacts::default()
+        };
+        let r = refusal(&d, &system, &on("noble", &["libc.so.6"]))
+            .expect("absent and unpackaged on noble must refuse");
+        assert!(
+            r.contains("libpython3.10.so.1.0") && r.contains("noble"),
+            "{r}"
+        );
+        // Absent on jammy, where apt DOES package it: not a refusal.
+        assert_eq!(refusal(&d, &system, &on("jammy", &["libc.so.6"])), None);
+        // Present on noble (a deadsnakes PPA): not a refusal.
+        assert_eq!(
+            refusal(&d, &system, &on("noble", &["libpython3.10.so.1.0"])),
+            None
+        );
+        // A release the table does not name: cannot say, so abstain.
+        assert_eq!(refusal(&d, &system, &on("oracular", &["libc.so.6"])), None);
+        // `ldconfig` unanswered: abstain.
+        let blind = HostFacts {
+            sonames: None,
+            ..on("noble", &[])
+        };
+        assert_eq!(refusal(&d, &system, &blind), None);
+    }
+
+    #[test]
+    fn glibcxx_scan_takes_the_highest() {
+        let img = b"..GLIBCXX_3.4\0GLIBCXX_3.4.9\0GLIBCXX_3.4.30\0GLIBCXX_3.4.29\0";
+        assert_eq!(max_glibcxx(img).as_deref(), Some("3.4.30"));
+        assert_eq!(max_glibcxx(b"nothing here"), None);
+    }
+
+    #[test]
+    fn libstdcxx_path_picks_this_arch() {
+        let listing = "\tlibstdc++.so.6 (libc6) => /usr/lib32/libstdc++.so.6\n\
+                       \tlibstdc++.so.6 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libstdc++.so.6\n";
+        if std::env::consts::ARCH == "x86_64" {
+            assert_eq!(
+                libstdcxx_path(listing).as_deref(),
+                Some("/usr/lib/x86_64-linux-gnu/libstdc++.so.6")
+            );
+        }
+        assert_eq!(
+            libstdcxx_path("\tlibc.so.6 (libc6) => /lib/libc.so.6\n"),
+            None
+        );
+    }
+}

--- a/packages/cli/nros-cli-core/src/orchestration/mod.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/mod.rs
@@ -59,6 +59,8 @@ pub mod release_manifest;
 /// `<depend>` ladder falls back to below `[prereq.*]`.
 pub mod rosdep_snapshot;
 pub use nros_orchestration_ir::rtos_realizer;
+/// phase-447 D1 (RFC-0099 D5) — is this host at or above a dist's floor?
+pub mod host_floor;
 pub mod schema;
 pub mod sdk_index;
 pub mod sdk_store;

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
@@ -255,6 +255,129 @@ pub enum PrereqRole {
     Unclassified,
 }
 
+/// One package manager's names for a `[prereq.*]` key — RFC-0099 D9 /
+/// phase-447 D2.
+///
+/// Two spellings, and the flat one is unchanged:
+///
+/// ```toml
+/// apt = ["libssl3"]                                         # every release
+/// apt = { default = ["libssl3"], noble = ["libssl3t64"] }   # one override
+/// ```
+///
+/// Why a `default` key INSIDE the table rather than `apt = [..]` beside
+/// `apt.noble = [..]`: TOML cannot hold both — `apt` is either an array or a
+/// table, never both — so the spelling RFC-0099 D9 sketched is unwritable
+/// exactly when it is needed, which is an entry with an ordinary name AND one
+/// release that renamed it (`libssl3` -> `libssl3t64` on noble).
+///
+/// Keyed by the MANAGER first and the release second — narrower than rosdep's
+/// OS-then-version nesting on purpose: the manager is what installs, and the
+/// release names are the manager's own (`VERSION_CODENAME` from
+/// `/etc/os-release`, else `VERSION_ID`; see [`host_os_release`]).
+///
+/// An explicitly EMPTY list for a release is a real answer, and a different one
+/// from "not named": it says the manager does not package this on that release
+/// (`libpython3.10` on noble). The dist floor probe (phase-447 D1) reads exactly
+/// that to refuse a prebuilt before downloading it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ManagerPackages {
+    /// The same names on every release.
+    Every(Vec<String>),
+    /// Per-release names; the [`Self::DEFAULT_KEY`] entry, if any, covers every
+    /// release the table does not name.
+    ByRelease(BTreeMap<String, Vec<String>>),
+}
+
+impl Default for ManagerPackages {
+    fn default() -> Self {
+        Self::Every(Vec::new())
+    }
+}
+
+impl From<Vec<String>> for ManagerPackages {
+    fn from(v: Vec<String>) -> Self {
+        Self::Every(v)
+    }
+}
+
+impl ManagerPackages {
+    /// The key a per-release table uses for "every other release".
+    pub const DEFAULT_KEY: &'static str = "default";
+
+    /// The names for a release this entry does not single out.
+    #[must_use]
+    pub fn every(&self) -> &[String] {
+        match self {
+            Self::Every(v) => v,
+            Self::ByRelease(m) => m.get(Self::DEFAULT_KEY).map_or(&[], Vec::as_slice),
+        }
+    }
+
+    /// The list the table names for `release` EXPLICITLY, or `None` when it
+    /// does not single that release out. `Some(&[])` is "not packaged there".
+    #[must_use]
+    pub fn named_for(&self, release: Option<&str>) -> Option<&[String]> {
+        match (self, release) {
+            (Self::ByRelease(m), Some(r)) if r != Self::DEFAULT_KEY => m.get(r).map(Vec::as_slice),
+            _ => None,
+        }
+    }
+
+    /// The names that apply on `release`: its override, else the default.
+    #[must_use]
+    pub fn for_release(&self, release: Option<&str>) -> &[String] {
+        self.named_for(release).unwrap_or_else(|| self.every())
+    }
+
+    /// No names under any release — the entry does not map this manager.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Every(v) => v.is_empty(),
+            Self::ByRelease(m) => m.values().all(Vec::is_empty),
+        }
+    }
+
+    /// Every release key a per-release table names (never `default`).
+    pub fn releases(&self) -> impl Iterator<Item = &str> {
+        let keys: Vec<&str> = match self {
+            Self::Every(_) => Vec::new(),
+            Self::ByRelease(m) => m
+                .keys()
+                .map(String::as_str)
+                .filter(|k| *k != Self::DEFAULT_KEY)
+                .collect(),
+        };
+        keys.into_iter()
+    }
+}
+
+/// This host's OS release, in the vocabulary [`ManagerPackages`] keys on:
+/// `VERSION_CODENAME` from `/etc/os-release` (`jammy`, `noble`, `bookworm`),
+/// else `VERSION_ID` (Fedora's `40`); `None` where neither exists (Arch is
+/// rolling and has no release to name).
+#[must_use]
+pub fn host_os_release() -> Option<String> {
+    let raw = std::fs::read_to_string("/etc/os-release").ok()?;
+    os_release_key(&raw)
+}
+
+/// The pure half of [`host_os_release`], so the precedence has a test.
+#[must_use]
+pub fn os_release_key(os_release: &str) -> Option<String> {
+    let field = |name: &str| {
+        os_release.lines().find_map(|l| {
+            l.strip_prefix(name)
+                .and_then(|v| v.strip_prefix('='))
+                .map(|v| v.trim().trim_matches('"').to_string())
+                .filter(|v| !v.is_empty())
+        })
+    };
+    field("VERSION_CODENAME").or_else(|| field("VERSION_ID"))
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrereqDep {
@@ -279,14 +402,16 @@ pub struct PrereqDep {
     pub providers: Vec<Provider>,
     #[serde(default)]
     pub provider: Provider,
+    /// Per-manager package names — a flat list for every OS release, or a
+    /// per-release table (RFC-0099 D9 / phase-447 D2). See [`ManagerPackages`].
     #[serde(default)]
-    pub apt: Vec<String>,
+    pub apt: ManagerPackages,
     #[serde(default)]
-    pub dnf: Vec<String>,
+    pub dnf: ManagerPackages,
     #[serde(default)]
-    pub pacman: Vec<String>,
+    pub pacman: ManagerPackages,
     #[serde(default)]
-    pub brew: Vec<String>,
+    pub brew: ManagerPackages,
     /// Every soname this entry satisfies, when it satisfies more than the one
     /// `check.sharedlib` probes — issue 0926. `libssl3` provides BOTH
     /// `libssl.so.3` and `libcrypto.so.3`; `libglib2` provides four.
@@ -338,15 +463,24 @@ impl PrereqDep {
     /// The native package list for `manager`, **as declared** — placeholders
     /// unexpanded. For anything a user acts on, use [`Self::packages_for`].
     ///
-    /// Exists for the gates, which have to read what the index SAYS.
+    /// Exists for the gates, which have to read what the index SAYS. The
+    /// every-release list; a per-release override is read through
+    /// [`Self::manager_packages`].
     #[must_use]
     pub fn packages_declared(&self, manager: &str) -> &[String] {
+        self.manager_packages(manager)
+            .map_or(&[], ManagerPackages::every)
+    }
+
+    /// The whole declaration for `manager`, release overrides included.
+    #[must_use]
+    pub fn manager_packages(&self, manager: &str) -> Option<&ManagerPackages> {
         match manager {
-            "apt" => &self.apt,
-            "dnf" => &self.dnf,
-            "pacman" => &self.pacman,
-            "brew" => &self.brew,
-            _ => &[],
+            "apt" => Some(&self.apt),
+            "dnf" => Some(&self.dnf),
+            "pacman" => Some(&self.pacman),
+            "brew" => Some(&self.brew),
+            _ => None,
         }
     }
 
@@ -366,7 +500,12 @@ impl PrereqDep {
     /// derivable prefix per row. A literal list still wins where one is given.
     #[must_use]
     pub fn packages_for(&self, manager: &str, ctx: &PrereqContext) -> Vec<String> {
-        let declared = self.packages_declared(manager);
+        // phase-447 D2 — the host's release picks an override where the entry
+        // names one; every other release reads the default, so a flat list is
+        // byte-for-byte the old behaviour.
+        let declared = self
+            .manager_packages(manager)
+            .map_or(&[][..], |m| m.for_release(ctx.os_release.as_deref()));
         if !declared.is_empty() {
             // An explicit list WINS over the derivation — the escape hatch for
             // a distro rename or a split (phase-435 W3).
@@ -389,6 +528,10 @@ impl PrereqDep {
 pub struct PrereqContext {
     /// The ROS distribution whose packages are being named.
     pub ros_distro: String,
+    /// The host's OS release (`jammy`, `noble`) — picks a per-release
+    /// override in a [`ManagerPackages`] table (phase-447 D2). `None` reads
+    /// every entry's default, which is exactly the pre-D2 behaviour.
+    pub os_release: Option<String>,
 }
 
 impl PrereqContext {
@@ -406,7 +549,10 @@ impl PrereqContext {
             .ok()
             .filter(|v| !v.trim().is_empty())
             .unwrap_or_else(|| Self::DEFAULT_ROS_DISTRO.to_string());
-        Self { ros_distro }
+        Self {
+            ros_distro,
+            os_release: host_os_release(),
+        }
     }
 
     /// The OS package name for a ROS package under `manager` — phase-435 W3.
@@ -443,10 +589,10 @@ impl From<&SystemDep> for PrereqDep {
             role: PrereqRole::Unclassified,
             providers: Vec::new(),
             provider: Provider::System,
-            apt: d.apt.clone(),
-            dnf: d.dnf.clone(),
-            pacman: d.pacman.clone(),
-            brew: d.brew.clone(),
+            apt: d.apt.clone().into(),
+            dnf: d.dnf.clone().into(),
+            pacman: d.pacman.clone().into(),
+            brew: d.brew.clone().into(),
             // Empty, and that is not a dropped field: `[system.*]` has no
             // `provides` to map. The legacy shape predates it, and phase-398
             // W4 retired `[system.*]` outright — an entry arriving here is a
@@ -561,7 +707,7 @@ pub fn extract_version(text: &str, marker: Option<&str>) -> Option<String> {
 /// Compare dotted numeric versions component-wise. Missing components are 0,
 /// so `0.12` and `0.12.0` compare equal.
 #[must_use]
-fn version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+pub(crate) fn version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
     let parts = |v: &str| -> Vec<u64> {
         v.split('.')
             .map(|p| p.parse::<u64>().unwrap_or(0))
@@ -850,6 +996,17 @@ pub struct ToolPackage {
     /// fails on (phase-431 W2) and `nros build` refuses (W1).
     #[serde(default)]
     pub front: Vec<String>,
+    /// `system` resolved to its `[prereq.*]` entries — filled by
+    /// [`SdkIndex::parse`], never authored.
+    ///
+    /// phase-447 D1: the floor probe runs where the install is PLANNED, and the
+    /// planner is handed one tool. Its soname half ("does this host lack a lib
+    /// the dist links, which its package manager does not even package on this
+    /// release?") needs the prereq rows, so they travel with the tool rather than
+    /// widening every planner call site. A `ToolPackage` deserialized outside
+    /// `parse` carries none, and that half then abstains — never refuses.
+    #[serde(skip)]
+    pub system_deps: Vec<(String, PrereqDep)>,
 }
 
 /// `[build_type.<name>]` — the host tools a builder needs present.
@@ -929,6 +1086,98 @@ pub struct DistArtifact {
     /// downloaded file, `{prefix}` the install prefix.
     #[serde(default)]
     pub install: Option<String>,
+    /// phase-447 D1 (RFC-0099 D5) — the oldest HOST this artifact runs on,
+    /// MEASURED from its own binaries by `scripts/sdk/measure-dist-floor.py`.
+    ///
+    /// `nros setup` compares the host against it BEFORE downloading, and a host
+    /// below it falls back to the source recipe with the reason printed —
+    /// instead of paying for the download, unpacking, and dying at the loader.
+    /// `check-dist-floors` requires every dist row to carry one (a ratchet).
+    #[serde(default)]
+    pub floor: Option<DistFloor>,
+}
+
+/// What a host must provide for one prebuilt artifact to RUN — phase-447 D1.
+///
+/// Compatibility is a RANGE, not an identity (RFC-0099 D5 rejected a
+/// `linux-x86_64-glibc2.35` host key for exactly that reason): a glibc 2.39
+/// host runs a 2.35 binary. So a floor is a set of MINIMUMS against the half of
+/// the runtime that `nano-ros-sdk`'s `bundle.sh` deliberately does NOT bundle —
+/// the loader/libc family and the C++ runtime — plus, for macOS, the deployment
+/// target.
+///
+/// The OTHER half — a named dep a newer host no longer ships (`libpython3.10`
+/// on noble) — is not a number and is not here: it is the tool's `system = [..]`
+/// list read against the prereq's per-release package names (phase-447 D2).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DistFloor {
+    /// Highest `GLIBC_x.y` symbol version any ELF in the dist references.
+    #[serde(default)]
+    pub glibc: Option<String>,
+    /// Highest `GLIBCXX_3.4.N` referenced against a libstdc++ the dist does
+    /// NOT bundle — i.e. the host's. Written as `3.4.N`.
+    #[serde(default)]
+    pub glibcxx: Option<String>,
+    /// Highest macOS deployment target (`LC_BUILD_VERSION.minos`).
+    #[serde(default)]
+    pub macos: Option<String>,
+    /// MEASURED to have no floor — e.g. a static musl binary (no `PT_INTERP`,
+    /// no `DT_NEEDED`). The value is the reason, so "none" is never a blank.
+    #[serde(default)]
+    pub none: Option<String>,
+}
+
+impl DistFloor {
+    /// Shape rules, per host column. A floor field that cannot apply to the
+    /// host it sits on (`macos` on a Linux artifact) is refused rather than
+    /// ignored: an ignored floor is a floor nobody is checking.
+    pub fn validate(&self, tool: &str, host: &str) -> Result<()> {
+        let is_mac = host.starts_with("macos-");
+        let numeric = |v: &str| !v.is_empty() && v.split('.').all(|p| p.parse::<u64>().is_ok());
+        let fields = [
+            ("glibc", &self.glibc),
+            ("glibcxx", &self.glibcxx),
+            ("macos", &self.macos),
+        ];
+        let set: Vec<&str> = fields
+            .iter()
+            .filter(|(_, v)| v.is_some())
+            .map(|(n, _)| *n)
+            .collect();
+        if let Some(reason) = &self.none {
+            if reason.trim().is_empty() {
+                bail!("[tool.{tool}] dist.{host}: `floor.none` must say WHY there is no floor");
+            }
+            if !set.is_empty() {
+                bail!(
+                    "[tool.{tool}] dist.{host}: `floor.none` excludes {}",
+                    set.join("/")
+                );
+            }
+            return Ok(());
+        }
+        if set.is_empty() {
+            bail!(
+                "[tool.{tool}] dist.{host}: an empty `floor = {{}}` says nothing — measure it \
+                 (scripts/sdk/measure-dist-floor.py) or write `none = \"<why>\"`"
+            );
+        }
+        for (name, v) in fields {
+            let Some(v) = v else { continue };
+            if !numeric(v) {
+                bail!("[tool.{tool}] dist.{host}: `floor.{name} = {v:?}` is not a dotted version");
+            }
+            let applies = if name == "macos" { is_mac } else { !is_mac };
+            if !applies {
+                bail!(
+                    "[tool.{tool}] dist.{host}: `floor.{name}` cannot apply to a {host} \
+                     artifact — a floor nobody can check is not a floor"
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 /// The source-build fallback recipe — installs into the same prefix as `dist`.
@@ -1277,7 +1526,19 @@ impl SdkIndex {
     /// Parse from a string (schema only — no cross-reference validation, so unit
     /// tests can parse partial fixtures). [`load`] additionally [`validate`]s.
     pub fn parse(raw: &str) -> Result<Self> {
-        toml::from_str(raw).wrap_err("invalid nros-sdk-index.toml schema")
+        let mut idx: Self = toml::from_str(raw).wrap_err("invalid nros-sdk-index.toml schema")?;
+        // phase-447 D1 — resolve each tool's `system` keys once, so the floor
+        // probe can read them with only the tool in hand. An unknown key is
+        // skipped here and refused by `validate`, which names it.
+        let prereqs = idx.prereqs();
+        for tool in idx.tool.values_mut() {
+            tool.system_deps = tool
+                .system
+                .iter()
+                .filter_map(|k| prereqs.get(k).map(|d| (k.clone(), d.clone())))
+                .collect();
+        }
+        Ok(idx)
     }
 
     /// Phase 191.4 — every `[board.*].packages` name must be a defined
@@ -1359,7 +1620,36 @@ impl SdkIndex {
         // satisfied by either spelling while both exist, or the W4 rename of
         // `[system.*]` → `[prereq.*]` would break every such reference at once.
         let prereq_keys = self.prereqs();
+        // phase-447 D2 — a per-release table names releases, and a key that is
+        // not a plausible release name (a typo'd manager nested one level too
+        // deep, an uppercase codename) would silently never match a host.
+        for (key, dep) in &prereq_keys {
+            for mgr in ["apt", "dnf", "pacman", "brew"] {
+                let Some(pk) = dep.manager_packages(mgr) else {
+                    continue;
+                };
+                for rel in pk.releases() {
+                    let ok = rel
+                        .chars()
+                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || ".-_".contains(c));
+                    if rel.is_empty() || !ok {
+                        bail!(
+                            "[prereq.{key}] {mgr}.{rel:?} is not a release name — use the \
+                             host's VERSION_CODENAME (`noble`) or VERSION_ID (`40`), or \
+                             `default` for every other release"
+                        );
+                    }
+                }
+            }
+        }
         for (name, tool) in &self.tool {
+            // phase-447 D1 — a floor's SHAPE; its presence is the ratchet's job
+            // (`check-dist-floors`), so an index mid-migration still loads.
+            for (host, d) in &tool.dist {
+                if let Some(f) = &d.floor {
+                    f.validate(name, host)?;
+                }
+            }
             for key in &tool.system {
                 if !prereq_keys.contains_key(key) {
                     bail!(
@@ -1872,6 +2162,7 @@ check = { cmd = "west" }
         };
         let jazzy = PrereqContext {
             ros_distro: "jazzy".to_string(),
+            os_release: None,
         };
         assert_eq!(dep.packages_for("apt", &jazzy), ["ros-jazzy-rmw-zenoh-cpp"]);
 
@@ -1890,7 +2181,7 @@ check = { cmd = "west" }
         // An explicit list WINS — the escape hatch for a rename or a split.
         let pinned = PrereqDep {
             ros_package: Some("rmw_zenoh_cpp".to_string()),
-            apt: vec!["ros-humble-rmw-zenoh-cpp-legacy".to_string()],
+            apt: vec!["ros-humble-rmw-zenoh-cpp-legacy".to_string()].into(),
             ..PrereqDep::default()
         };
         assert_eq!(
@@ -1900,7 +2191,7 @@ check = { cmd = "west" }
 
         // A key with neither derives nothing, rather than an empty name.
         let plain = PrereqDep {
-            apt: vec!["doxygen".to_string()],
+            apt: vec!["doxygen".to_string()].into(),
             ..PrereqDep::default()
         };
         assert_eq!(plain.packages_for("apt", &jazzy), ["doxygen"]);
@@ -1912,6 +2203,7 @@ check = { cmd = "west" }
         assert_eq!(PrereqContext::DEFAULT_ROS_DISTRO, "humble");
         let ctx = PrereqContext {
             ros_distro: PrereqContext::DEFAULT_ROS_DISTRO.to_string(),
+            os_release: None,
         };
         assert_eq!(
             ctx.ros_os_package("apt", "rmw_zenoh_cpp").as_deref(),
@@ -1943,8 +2235,118 @@ check = { cmd = "west" }
         );
         let iron = PrereqContext {
             ros_distro: "iron".to_string(),
+            os_release: None,
         };
         assert_eq!(dep.packages_for("apt", &iron), ["ros-iron-rmw-zenoh-cpp"]);
+    }
+
+    /// phase-447 D2 — the flat spelling is unchanged, and a per-release table
+    /// overrides exactly the release it names.
+    #[test]
+    fn manager_packages_take_a_per_release_override() {
+        let idx = SdkIndex::parse(
+            "[prereq.flat]\napt = [\"libx1\"]\n\
+             [prereq.libssl3]\napt = { default = [\"libssl3\"], noble = [\"libssl3t64\"] }\n\
+             [prereq.gone]\napt = { jammy = [\"libpython3.10\"], noble = [] }\n",
+        )
+        .unwrap();
+        let ctx = |r: Option<&str>| PrereqContext {
+            ros_distro: "humble".into(),
+            os_release: r.map(str::to_string),
+        };
+        let ssl = &idx.prereq["libssl3"];
+        assert_eq!(ssl.packages_for("apt", &ctx(Some("jammy"))), ["libssl3"]);
+        assert_eq!(ssl.packages_for("apt", &ctx(Some("noble"))), ["libssl3t64"]);
+        assert_eq!(ssl.packages_for("apt", &ctx(None)), ["libssl3"]);
+        assert_eq!(
+            ssl.packages_declared("apt"),
+            ["libssl3"],
+            "the every-release list"
+        );
+
+        let flat = &idx.prereq["flat"];
+        for r in [None, Some("jammy"), Some("noble")] {
+            assert_eq!(
+                flat.packages_for("apt", &ctx(r)),
+                ["libx1"],
+                "flat = every release"
+            );
+        }
+
+        // An explicit empty list is "not packaged there" — and is distinct from
+        // a release the table does not name at all.
+        let gone = idx.prereq["gone"].manager_packages("apt").unwrap();
+        assert_eq!(gone.named_for(Some("noble")), Some(&[][..]));
+        assert_eq!(gone.named_for(Some("oracular")), None);
+        assert_eq!(gone.named_for(Some("default")), None);
+        assert!(
+            idx.prereq["gone"]
+                .packages_for("apt", &ctx(Some("noble")))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn os_release_key_prefers_the_codename() {
+        assert_eq!(
+            os_release_key("ID=ubuntu\nVERSION_ID=\"24.04\"\nVERSION_CODENAME=noble\n").as_deref(),
+            Some("noble")
+        );
+        assert_eq!(
+            os_release_key("ID=fedora\nVERSION_ID=40\nVERSION_CODENAME=\"\"\n").as_deref(),
+            Some("40")
+        );
+        assert_eq!(os_release_key("ID=arch\nBUILD_ID=rolling\n"), None);
+    }
+
+    #[test]
+    fn a_release_key_must_look_like_one() {
+        let bad = SdkIndex::parse("[prereq.x]\napt = { Noble = [\"x\"] }\n").unwrap();
+        let err = format!("{:#}", bad.validate().unwrap_err());
+        assert!(err.contains("not a release name"), "{err}");
+        let ok = SdkIndex::parse("[prereq.x]\napt = { default = [\"x\"], \"24.04\" = [\"y\"] }\n");
+        ok.unwrap().validate().unwrap();
+    }
+
+    /// phase-447 D1 — a floor's SHAPE is refused at load when it cannot mean
+    /// anything; its PRESENCE is `check-dist-floors`' job.
+    #[test]
+    fn dist_floor_shape_is_validated_per_host() {
+        let with = |host: &str, floor: &str| {
+            SdkIndex::parse(&format!(
+                "[tool.t]\nversion=\"1\"\ndist.{host}={{url=\"u\",sha256=\"h\",floor={floor}}}\n"
+            ))
+            .unwrap()
+            .validate()
+        };
+        with("linux-x86_64", "{glibc=\"2.35\",glibcxx=\"3.4.30\"}").unwrap();
+        with("macos-arm64", "{macos=\"11.0\"}").unwrap();
+        with("linux-x86_64", "{none=\"static musl\"}").unwrap();
+        for (host, floor, why) in [
+            ("linux-x86_64", "{macos=\"11.0\"}", "cannot apply"),
+            ("macos-arm64", "{glibc=\"2.35\"}", "cannot apply"),
+            ("linux-x86_64", "{}", "says nothing"),
+            ("linux-x86_64", "{none=\" \"}", "WHY"),
+            ("linux-x86_64", "{none=\"x\",glibc=\"2.17\"}", "excludes"),
+            ("linux-x86_64", "{glibc=\"2.35-ubuntu\"}", "dotted version"),
+        ] {
+            let err = format!("{:#}", with(host, floor).unwrap_err());
+            assert!(err.contains(why), "{host} {floor}: {err}");
+        }
+    }
+
+    /// The parse step resolves `system` so the planner, handed one tool, can
+    /// read the prereq rows the floor's soname half needs.
+    #[test]
+    fn parse_resolves_tool_system_deps() {
+        let idx = SdkIndex::parse(
+            "[prereq.libz1]\napt=[\"zlib1g\"]\n[tool.t]\nversion=\"1\"\nsystem=[\"libz1\"]\n",
+        )
+        .unwrap();
+        let deps = &idx.tool["t"].system_deps;
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].0, "libz1");
+        assert_eq!(deps[0].1.packages_declared("apt"), ["zlib1g"]);
     }
 
     #[test]

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -433,22 +433,57 @@ pub enum InstallAction {
         /// Issue 0374 d4 — build with the checkout's own `rust-toolchain.toml`
         /// rather than the workspace channel.
         respect_toolchain: bool,
+        /// phase-447 D1 — set when a prebuilt EXISTS for this host and was
+        /// refused by its floor before any download; the text is why. `None` is
+        /// the ordinary "no dist row for this host" source build.
+        refused: Option<String>,
     },
+    /// A prebuilt exists, this host is below its floor, and there is no source
+    /// recipe to fall back to (phase-447 D1). Nothing was downloaded.
+    Refused { reason: String },
     /// No prebuilt for this host and no source recipe.
     Unavailable,
 }
 
 /// Decide how to install `tool` on `host`, given the prefix's current state.
-/// Pure — does no I/O beyond reading the provenance marker.
+///
+/// Reads the provenance marker and, when `host` is THIS machine, the cached
+/// host facts the dist floor is compared against (phase-447 D1) — so a dist
+/// this host cannot run is refused HERE, before `execute` would download it.
+/// For a foreign `host` the facts are unknown and the floor abstains.
 pub fn plan_install(tool: &ToolPackage, host: &str, prefix: &Path) -> InstallAction {
+    plan_install_on(tool, host, prefix, &super::host_floor::facts_for(host))
+}
+
+/// [`plan_install`] against explicit host facts — the pure core, and the seam
+/// the floor's tests drive.
+pub fn plan_install_on(
+    tool: &ToolPackage,
+    host: &str,
+    prefix: &Path,
+    facts: &super::host_floor::HostFacts,
+) -> InstallAction {
     if Provenance::read(prefix).is_some() {
         return InstallAction::Present;
     }
+    let mut refused = None;
     if let Some(d) = tool.dist_for(host) {
-        return InstallAction::Prebuilt {
-            url: d.url.clone(),
-            sha256: d.sha256.clone(),
-            install: d.install.clone(),
+        // The floor is decided in the PLAN, which runs before any fetch: a
+        // refusal here means `execute` is never handed the URL at all.
+        match super::host_floor::refusal(d, &tool.system_deps, facts) {
+            None => {
+                return InstallAction::Prebuilt {
+                    url: d.url.clone(),
+                    sha256: d.sha256.clone(),
+                    install: d.install.clone(),
+                };
+            }
+            Some(reason) => refused = Some(format!("the {host} prebuilt was refused: {reason}")),
+        }
+    }
+    if refused.is_some() && tool.source.is_none() {
+        return InstallAction::Refused {
+            reason: refused.unwrap_or_default(),
         };
     }
     if let Some(s) = &tool.source {
@@ -471,6 +506,7 @@ pub fn plan_install(tool: &ToolPackage, host: &str, prefix: &Path) -> InstallAct
             configure: s.configure.clone(),
             install: s.install.clone(),
             respect_toolchain: s.respect_toolchain,
+            refused,
         };
     }
     InstallAction::Unavailable
@@ -587,7 +623,14 @@ fn execute_install(
             configure,
             install,
             respect_toolchain,
+            refused,
         } => {
+            if let Some(why) = refused {
+                eprintln!(
+                    "nros setup: {tool} {version}: {why}\n    \
+                     Nothing was downloaded; falling back to the source recipe."
+                );
+            }
             // Issue 0374 d4 — build with the workspace's pinned channel unless
             // the recipe opts out. `None` (unreadable pin, or opted out) keeps
             // the old behaviour: rustup resolves from the checkout, which may
@@ -701,6 +744,12 @@ fn execute_install(
             };
             p.write(prefix)?;
             Ok(p)
+        }
+        InstallAction::Refused { reason } => {
+            bail!(
+                "{tool} {version}: {reason}\n  Nothing was downloaded, and the index has no \
+                 source recipe for {tool} to fall back to."
+            )
         }
         InstallAction::Unavailable => {
             bail!("{tool} {version}: no prebuilt for this host and no source recipe in the index")
@@ -1739,6 +1788,96 @@ mod tests {
             InstallAction::Present
         );
         std::fs::remove_dir_all(&present).ok();
+    }
+
+    /// phase-447 D1 — a host below a dist's floor is refused IN THE PLAN, so
+    /// the URL never reaches `execute`. The primary mutation this pins is "the
+    /// floor probe runs after the download": that plan would still hand back
+    /// `Prebuilt`, and every assertion below goes red.
+    #[test]
+    fn floor_refusal_happens_before_download_and_falls_back_to_source() {
+        use super::super::host_floor::{HostFacts, Libc};
+        let idx = SdkIndex::parse(
+            "[tool.q]\nversion=\"1\"\n\
+             dist.linux-x86_64={url=\"file:///nonexistent/q.tar.zst\",sha256=\"h\",floor={glibc=\"2.35\"}}\n\
+             [tool.q.source]\ngit=\"g\"\nref=\"r\"\n\
+             [tool.nosrc]\nversion=\"1\"\n\
+             dist.linux-x86_64={url=\"file:///nonexistent/n.tar.zst\",sha256=\"h\",floor={glibc=\"2.35\"}}\n",
+        )
+        .unwrap();
+        let old = HostFacts {
+            libc: Libc::Glibc("2.31".into()),
+            ..HostFacts::default()
+        };
+        let new = HostFacts {
+            libc: Libc::Glibc("2.39".into()),
+            ..HostFacts::default()
+        };
+        let fresh = tmp("floor-fresh");
+        let _ = std::fs::remove_dir_all(&fresh);
+
+        // At/above the floor: the prebuilt, unchanged.
+        assert!(matches!(
+            plan_install_on(&idx.tool["q"], "linux-x86_64", &fresh, &new),
+            InstallAction::Prebuilt { .. }
+        ));
+        // Below it, with a source recipe: a source build carrying the reason.
+        match plan_install_on(&idx.tool["q"], "linux-x86_64", &fresh, &old) {
+            InstallAction::Source {
+                refused: Some(why), ..
+            } => assert!(
+                why.contains("glibc >= 2.35") && why.contains("Remedy"),
+                "{why}"
+            ),
+            other => panic!("below the floor must fall back to source, got {other:?}"),
+        }
+        // Below it, with no source: refused, and executing that downloads
+        // nothing — the archive path `execute` would write never appears.
+        let action = plan_install_on(&idx.tool["nosrc"], "linux-x86_64", &fresh, &old);
+        let InstallAction::Refused { reason } = &action else {
+            panic!("no source to fall back to must be Refused, got {action:?}");
+        };
+        assert!(reason.contains("2.31"), "{reason}");
+        let err = execute_install(&action, "nosrc", "1", &fresh).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("Nothing was downloaded"),
+            "{err:#}"
+        );
+        assert!(!fresh.with_extension("download").exists());
+        assert!(
+            !fresh.exists(),
+            "a refused install must not create its prefix"
+        );
+
+        // A host that cannot be read abstains: the prebuilt is still offered.
+        assert!(matches!(
+            plan_install_on(
+                &idx.tool["nosrc"],
+                "linux-x86_64",
+                &fresh,
+                &HostFacts::unknown()
+            ),
+            InstallAction::Prebuilt { .. }
+        ));
+    }
+
+    /// phase-447 D1 — the ordinary "no dist row for this host" source build is
+    /// NOT a refusal, so it must not print one.
+    #[test]
+    fn a_missing_dist_row_is_not_a_refusal() {
+        let idx =
+            SdkIndex::parse("[tool.q]\nversion=\"1\"\n[tool.q.source]\ngit=\"g\"\nref=\"r\"\n")
+                .unwrap();
+        let fresh = tmp("floor-norow");
+        match plan_install_on(
+            &idx.tool["q"],
+            "linux-x86_64",
+            &fresh,
+            &super::super::host_floor::HostFacts::unknown(),
+        ) {
+            InstallAction::Source { refused: None, .. } => {}
+            other => panic!("expected an unrefused Source, got {other:?}"),
+        }
     }
 
     /// Issue 0833 follow-on — the refspec predicate behind

--- a/scripts/check-dist-floors.py
+++ b/scripts/check-dist-floors.py
@@ -43,7 +43,7 @@ BASELINE = os.path.join(ROOT, ".config", "dist-floor-baseline.txt")
 
 # The number of rows `.config/dist-floor-baseline.txt` may hold. It may only go
 # DOWN: lower it in the same change that removes a row.
-BASELINE_CEILING = 3
+BASELINE_CEILING = 0
 
 LINUX_FIELDS = ("glibc", "glibcxx")
 MAC_FIELDS = ("macos",)

--- a/scripts/check-dist-floors.py
+++ b/scripts/check-dist-floors.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Every `[tool.*].dist.<host>` row declares a FLOOR, or is recorded debt.
+
+WHY THIS EXISTS
+
+`host_key()` is `<os>-<arch>` — no OS version, no libc — so the key offers every
+Linux x86_64 host every Linux x86_64 dist, including hosts that cannot run it.
+RFC-0099 D5 rejected widening the key (compatibility is a RANGE, not an
+identity) and phase-447 D1 put a MEASURED floor on the dist row instead, which
+`nros setup` compares the host against BEFORE downloading.
+
+A floor only protects the rows that carry one. `smoke`'s own doc says "absent
+means no opinion, not a pass", and the same is true here: a row with no floor is
+offered to every host, silently. So this is a RATCHET, not an allowlist:
+
+  * a dist row must carry `floor = { .. }` — measured with
+    `scripts/sdk/measure-dist-floor.py`, or `none = "<why>"` when the
+    measurement says there is none (a static binary);
+  * the only escape is a line in `.config/dist-floor-baseline.txt`, and that
+    file may only SHRINK: `BASELINE_CEILING` below is its size, so growing it
+    is an edit to this script a reviewer sees, and a row that gains a floor
+    must leave the baseline.
+
+Another agent adding dist rows (phase-447 C2) is exactly who this catches.
+
+WHAT IT DOES NOT CHECK
+
+The floor's SHAPE (a `macos` field on a Linux artifact, a non-numeric version)
+is refused by `SdkIndex::validate` when `nros` loads the index; this gate
+repeats only the part that decides whether a row counts as covered.
+Whether the NUMBER is right is the measuring script's job: re-run it when an
+artifact is re-cut.
+
+Usage:  check-dist-floors.py
+"""
+
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INDEX = os.path.join(ROOT, "nros-sdk-index.toml")
+BASELINE = os.path.join(ROOT, ".config", "dist-floor-baseline.txt")
+
+# The number of rows `.config/dist-floor-baseline.txt` may hold. It may only go
+# DOWN: lower it in the same change that removes a row.
+BASELINE_CEILING = 3
+
+LINUX_FIELDS = ("glibc", "glibcxx")
+MAC_FIELDS = ("macos",)
+
+
+def load_index(path=INDEX):
+    try:
+        import tomllib as toml
+    except ModuleNotFoundError:
+        import tomli as toml
+    with open(path, "rb") as fh:
+        return toml.load(fh)
+
+
+def load_baseline(path=BASELINE):
+    rows = []
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.split("#", 1)[0].strip()
+                if line:
+                    rows.append(tuple(line.split()[:2]))
+    except FileNotFoundError:
+        pass
+    return rows
+
+
+def covered(host, floor):
+    """Does `floor` say something checkable about a `host` artifact?"""
+    if not isinstance(floor, dict):
+        return False
+    if str(floor.get("none", "")).strip():
+        return True
+    fields = MAC_FIELDS if host.startswith("macos-") else LINUX_FIELDS
+    return any(floor.get(f) for f in fields)
+
+
+def audit(index, baseline, ceiling):
+    """Problems, as printable lines. Empty means the gate holds."""
+    rows = {}
+    for name, tool in sorted((index.get("tool") or {}).items()):
+        for host, dist in sorted((tool.get("dist") or {}).items()):
+            rows[(name, host)] = covered(host, dist.get("floor"))
+    problems = []
+    listed = set(baseline)
+    for (name, host), ok in rows.items():
+        if not ok and (name, host) not in listed:
+            problems.append(
+                f"[tool.{name}] dist.{host} has no floor. Measure it:\n"
+                f"      python3 scripts/sdk/measure-dist-floor.py {name} --host {host}\n"
+                f"    and write the `floor = {{ .. }}` it prints into the dist row "
+                f"(`none = \"<why>\"` if it measures none)."
+            )
+    for row in baseline:
+        if row not in rows:
+            problems.append(
+                f"baseline row {' '.join(row)} names no dist row — delete it "
+                f"(and lower BASELINE_CEILING)."
+            )
+        elif rows[row]:
+            problems.append(
+                f"baseline row {' '.join(row)} now HAS a floor — delete it from "
+                f"the baseline and lower BASELINE_CEILING. The debt only shrinks."
+            )
+    if len(baseline) > ceiling:
+        problems.append(
+            f"the baseline holds {len(baseline)} row(s) against a ceiling of "
+            f"{ceiling}. It may only SHRINK: a new dist declares its floor instead."
+        )
+    if len(set(baseline)) != len(baseline):
+        problems.append("the baseline lists a row twice.")
+    return problems, len(rows)
+
+
+def self_test():
+    """The gate must be able to go red — synthetic BAD input, every run."""
+    good = {"glibc": "2.35"}
+    idx = {
+        "tool": {
+            "a": {"dist": {"linux-x86_64": {"floor": good}, "macos-arm64": {"floor": {"macos": "11.0"}}}},
+            "s": {"dist": {"linux-x86_64": {"floor": {"none": "static musl"}}}},
+        }
+    }
+    assert audit(idx, [], 0)[0] == [], audit(idx, [], 0)
+    # A row with no floor, not in the baseline: red.
+    bad = {"tool": {"b": {"dist": {"linux-x86_64": {}}}}}
+    assert any("no floor" in p for p in audit(bad, [], 0)[0])
+    # ...unless it is recorded debt under the ceiling.
+    assert audit(bad, [("b", "linux-x86_64")], 1)[0] == []
+    # A floor that cannot apply to its host does not count as covered.
+    wrong = {"tool": {"c": {"dist": {"linux-x86_64": {"floor": {"macos": "11.0"}}}}}}
+    assert any("no floor" in p for p in audit(wrong, [], 0)[0])
+    # An empty `none` is not a reason.
+    blank = {"tool": {"c": {"dist": {"linux-x86_64": {"floor": {"none": "  "}}}}}}
+    assert any("no floor" in p for p in audit(blank, [], 0)[0])
+    # The baseline may only shrink: over the ceiling is red.
+    assert any("ceiling" in p for p in audit(bad, [("b", "linux-x86_64")], 0)[0])
+    # A baseline row whose dist gained a floor must leave.
+    assert any("now HAS a floor" in p for p in audit(idx, [("a", "linux-x86_64")], 1)[0])
+    # A baseline row naming nothing is stale.
+    assert any("names no dist row" in p for p in audit(idx, [("zz", "linux-x86_64")], 1)[0])
+
+
+def main():
+    self_test()
+    problems, n = audit(load_index(), load_baseline(), BASELINE_CEILING)
+    if problems:
+        print("check-dist-floors: %d problem(s):\n" % len(problems), file=sys.stderr)
+        for p in problems:
+            print("  " + p, file=sys.stderr)
+        print(
+            "\n  A dist with no floor is offered to every host with the same "
+            "<os>-<arch>,\n  including one that cannot run it (RFC-0099 D5, "
+            "phase-447 D1).",
+            file=sys.stderr,
+        )
+        return 1
+    debt = len(load_baseline())
+    print(
+        f"check-dist-floors OK — {n} dist row(s); every one declares a floor "
+        f"({debt} recorded as debt, ceiling {BASELINE_CEILING})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-workflow-indexed-apt.py
+++ b/scripts/check-workflow-indexed-apt.py
@@ -45,6 +45,9 @@ import re
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
+import index_packages  # noqa: E402 — phase-447 D2: the one manager-field reader
+
 WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
 INDEX = os.path.join(ROOT, "nros-sdk-index.toml")
 
@@ -61,7 +64,10 @@ def indexed_apt_packages(path=INDEX):
         index = toml.load(fh)
     out = {}
     for key, entry in (index.get("prereq") or {}).items():
-        for pkg in entry.get("apt") or []:
+        # Every release's names: a workflow installing noble's `libssl3t64` is
+        # installing an indexed package. `entry.get("apt")` on a per-release
+        # table would iterate the RELEASE NAMES instead (phase-447 D2).
+        for pkg in index_packages.all_names(entry.get("apt")):
             out.setdefault(pkg, key)
     return out
 

--- a/scripts/lib/index_packages.py
+++ b/scripts/lib/index_packages.py
@@ -1,0 +1,66 @@
+"""Read a `[prereq.*]` manager field — the ONE Python spelling (phase-447 D2).
+
+A manager field (`apt`, `dnf`, `pacman`, `brew`) has two shapes since D2:
+
+    apt = ["libssl3"]                                         # every release
+    apt = { default = ["libssl3"], noble = ["libssl3t64"] }   # per release
+
+`PrereqDep::manager_packages` / `ManagerPackages` is the Rust half. Every
+script that reads the index goes through here rather than `entry.get("apt")`,
+because on the table shape that expression returns a DICT and iterating it
+yields release names — `noble` read as an apt package, silently.
+"""
+
+DEFAULT_KEY = "default"
+
+
+def for_release(value, release=None):
+    """The names that apply on `release`: its override, else the default."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    if release is not None and release != DEFAULT_KEY and release in value:
+        return list(value[release])
+    return list(value.get(DEFAULT_KEY, []))
+
+
+def all_names(value):
+    """Every name the field mentions, under any release — for a gate asking
+    "is this package indexed at all?"."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    out = []
+    for names in value.values():
+        out.extend(names)
+    return out
+
+
+def host_release(path="/etc/os-release"):
+    """`VERSION_CODENAME`, else `VERSION_ID` — mirrors `host_os_release`."""
+    try:
+        with open(path) as fh:
+            text = fh.read()
+    except OSError:
+        return None
+    fields = {}
+    for line in text.splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            fields[k.strip()] = v.strip().strip('"')
+    return fields.get("VERSION_CODENAME") or fields.get("VERSION_ID") or None
+
+
+def self_test():
+    ssl = {"default": ["libssl3"], "noble": ["libssl3t64"]}
+    assert for_release(["x"], "noble") == ["x"]
+    assert for_release(ssl, "noble") == ["libssl3t64"]
+    assert for_release(ssl, "jammy") == ["libssl3"]
+    assert for_release(ssl, None) == ["libssl3"]
+    assert for_release({"noble": []}, "noble") == []
+    assert for_release({"jammy": ["a"]}, "noble") == []
+    assert sorted(all_names(ssl)) == ["libssl3", "libssl3t64"]
+    assert "noble" not in all_names(ssl), "a release name is not a package"
+    assert for_release(None) == [] and all_names(None) == []

--- a/scripts/sdk/measure-dist-floor.py
+++ b/scripts/sdk/measure-dist-floor.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Measure a `[tool.*].dist.<host>` artifact's host FLOOR from its own binaries.
+
+RFC-0099 D5 / phase-447 D1. A dist's `floor = { .. }` is what `nros setup`
+compares the HOST against before it downloads anything, so the number has to be
+read off the artifact, never guessed from the runner it was built on. A dist
+built on `ubuntu-22.04` does not need glibc 2.35 just because the runner had it:
+it needs the highest `GLIBC_x.y` symbol version any of its ELF files actually
+references, and that is frequently lower.
+
+WHAT IS MEASURED
+
+Every file in the RELEASED archive (downloaded by URL, sha256-verified) whose
+header says ELF for the artifact's own machine, or Mach-O:
+
+* ELF — `readelf -W -d -l -V`:
+  - `PT_INTERP` (the loader it asks for)       -> reported, not a floor field
+  - `DT_NEEDED`                                 -> the external closure, minus
+    what the dist ships itself (same rule as `check-dist-runtime-deps`)
+  - version NEEDS (`.gnu.version_r`) against the loader/libc family
+    (`libc.so.6`, `libm.so.6`, `libpthread`, `libdl`, `librt`, `ld-linux*`)
+    -> `glibc` = the highest `GLIBC_x.y` referenced
+  - version needs against `libstdc++.so.6` when the dist does NOT bundle it
+    -> `glibcxx` = the highest `GLIBCXX_3.4.N`
+* Mach-O (thin or fat) — `LC_BUILD_VERSION.minos` / `LC_VERSION_MIN_MACOSX`
+  -> `macos` = the highest deployment target of any binary.
+
+A Linux artifact with no dynamically-linked ELF at all (no `PT_INTERP`, no
+`DT_NEEDED`) has no libc floor, and the script says so: that is what
+`floor = { none = "<reason>" }` is for.
+
+The archive is STREAMED (`tarfile` `r|*` over `zstd -dc`/`xz`/gzip, or
+`zipfile`), so a 1.3 GB Zephyr SDK is inspected without being unpacked.
+
+Usage:
+  measure-dist-floor.py                      # every dist row in the index
+  measure-dist-floor.py qemu ninja           # only these tools
+  measure-dist-floor.py --host linux-arm64   # only this host column
+  measure-dist-floor.py --cache DIR          # keep downloads (default tmp/dist-floor-cache)
+  measure-dist-floor.py --json               # machine-readable
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import struct
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+INDEX = os.path.join(ROOT, "nros-sdk-index.toml")
+DEFAULT_CACHE = os.path.join(ROOT, "tmp", "dist-floor-cache")
+
+# ELF e_machine per host-key arch.
+EM = {"x86_64": 62, "arm64": 183}
+# The loader/libc family — the half of glibc `bundle.sh` never bundles, and
+# therefore the half whose version is the host's to supply.
+LIBC_FAMILY = re.compile(r"^(libc|libm|libpthread|libdl|librt|libutil|libresolv|ld-linux.*)\.so")
+BASE = re.compile(
+    r"^(libc|libm|libdl|libpthread|librt|libstdc\+\+|libgcc_s|libutil|libresolv"
+    r"|ld-linux.*|linux-vdso)\.so"
+)
+
+
+def load_index():
+    try:
+        import tomllib as toml
+    except ModuleNotFoundError:
+        import tomli as toml
+    with open(INDEX, "rb") as fh:
+        return toml.load(fh)
+
+
+def vkey(v):
+    return tuple(int(p) if p.isdigit() else 0 for p in v.split("."))
+
+
+def vmax(a, b):
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if vkey(a) >= vkey(b) else b
+
+
+# --------------------------------------------------------------------- ELF
+
+
+def readelf(path):
+    out = subprocess.run(
+        ["readelf", "-W", "-d", "-l", "-V", path], capture_output=True, text=True, timeout=120
+    ).stdout
+    interp, needed, verneed = None, set(), {}
+    current = None
+    for line in out.splitlines():
+        m = re.search(r"Requesting program interpreter: ([^\]]+)\]", line)
+        if m:
+            interp = m.group(1)
+        m = re.search(r"\(NEEDED\)\s+Shared library: \[([^\]]+)\]", line)
+        if m:
+            needed.add(m.group(1))
+        m = re.search(r"Version: \d+\s+File: (\S+)\s+Cnt:", line)
+        if m:
+            current = m.group(1)
+            verneed.setdefault(current, set())
+            continue
+        m = re.search(r"Name: (\S+)\s+Flags:", line)
+        if m and current:
+            verneed[current].add(m.group(1))
+    return interp, needed, verneed
+
+
+def elf_machine(head):
+    if head[:4] != b"\x7fELF" or len(head) < 20:
+        return None
+    endian = "<" if head[5] == 1 else ">"
+    return struct.unpack(endian + "H", head[18:20])[0]
+
+
+# ------------------------------------------------------------------ Mach-O
+
+LC_VERSION_MIN_MACOSX = 0x24
+LC_BUILD_VERSION = 0x32
+MH = {b"\xcf\xfa\xed\xfe": ("<", 32), b"\xce\xfa\xed\xfe": ("<", 28)}
+FAT = {b"\xca\xfe\xba\xbe", b"\xca\xfe\xba\xbf"}
+
+
+def _ver(x):
+    return f"{x >> 16}.{(x >> 8) & 0xFF}"
+
+
+def macho_minos(data):
+    """Highest deployment target in a thin or fat Mach-O, or None."""
+    magic = data[:4]
+    if magic in FAT:
+        (n,) = struct.unpack(">I", data[4:8])
+        best = None
+        wide = magic == b"\xca\xfe\xba\xbf"
+        step = 32 if wide else 20
+        for i in range(n):
+            off = 8 + i * step
+            if wide:
+                _, _, o, s = struct.unpack(">iiQQ", data[off : off + 24])
+            else:
+                _, _, o, s, _ = struct.unpack(">iiIII", data[off : off + 20])
+            best = vmax(best, macho_minos(data[o : o + s]))
+        return best
+    if magic not in MH:
+        return None
+    endian, hdr = MH[magic]
+    ncmds = struct.unpack(endian + "I", data[16:20])[0]
+    off, best = hdr, None
+    for _ in range(ncmds):
+        if off + 8 > len(data):
+            break
+        cmd, size = struct.unpack(endian + "II", data[off : off + 8])
+        if cmd == LC_BUILD_VERSION:
+            _, minos = struct.unpack(endian + "II", data[off + 8 : off + 16])
+            best = vmax(best, _ver(minos))
+        elif cmd == LC_VERSION_MIN_MACOSX:
+            (v,) = struct.unpack(endian + "I", data[off + 8 : off + 12])
+            best = vmax(best, _ver(v))
+        off += max(size, 8)
+    return best
+
+
+# ---------------------------------------------------------------- archives
+
+
+def members(archive):
+    """Yield (name, bytes-reader) for every regular file in the archive."""
+    name = archive.lower()
+    if name.endswith((".zip", ".whl")):
+        with zipfile.ZipFile(archive) as z:
+            for info in z.infolist():
+                if not info.is_dir():
+                    yield info.filename, (lambda i=info: z.read(i))
+        return
+    if name.endswith((".zst", ".tzst")):
+        proc = subprocess.Popen(["zstd", "-dc", archive], stdout=subprocess.PIPE)
+        stream = proc.stdout
+    else:
+        proc, stream = None, open(archive, "rb")
+    try:
+        with tarfile.open(fileobj=stream, mode="r|*") as t:
+            for m in t:
+                if m.isfile():
+                    f = t.extractfile(m)
+                    yield m.name, (lambda f=f: f.read())
+    finally:
+        stream.close()
+        if proc:
+            proc.wait()
+
+
+def dir_members(root):
+    """Yield (name, reader) for every regular file under an unpacked dist."""
+    # walk-ok: the subject is an unpacked SDK OUTSIDE the repository (e.g. an
+    # installed Zephyr SDK); nothing in it is tracked.
+    for dirpath, _, names in os.walk(root):
+        for n in names:
+            p = os.path.join(dirpath, n)
+            if os.path.isfile(p) and not os.path.islink(p):
+                yield os.path.relpath(p, root), (lambda p=p: open(p, "rb").read())
+
+
+def measure_dir(root, host):
+    return measure(root, host, source=dir_members(root))
+
+
+def measure(archive, host, source=None):
+    os_name, arch = host.split("-", 1)
+    own, files, libc_paths = set(), [], []
+    glibc = glibcxx = macos = None
+    interps, needed_all, dynamic = set(), set(), 0
+    elf_seen = 0
+    with tempfile.TemporaryDirectory() as td:
+        for name, read in source if source is not None else members(archive):
+            base = os.path.basename(name)
+            if ".so" in base or base.endswith(".dylib"):
+                own.add(base)
+            # A dist that ships its OWN loader + libc (the Zephyr SDK's
+            # `sysroots/x86_64-pokysdk-linux`) runs those binaries against the
+            # bundled copy, not the host's — so their GLIBC needs are not a
+            # host floor. Remember where each bundled libc lives.
+            if base.startswith("libc.so.6") or base.startswith("ld-linux"):
+                libc_paths.append(name)
+            data = read()
+            head = data[:64]
+            if os_name == "macos":
+                v = macho_minos(data)
+                if v:
+                    macos = vmax(macos, v)
+                continue
+            if elf_machine(head) != EM.get(arch):
+                continue
+            elf_seen += 1
+            p = os.path.join(td, "elf")
+            with open(p, "wb") as fh:
+                fh.write(data)
+            interp, needed, verneed = readelf(p)
+            if interp or needed:
+                dynamic += 1
+            if interp:
+                interps.add(interp)
+            needed_all |= needed
+            files.append((name, verneed, interp))
+    # The sysroot a bundled libc belongs to: `<root>/lib/libc.so.6` -> `<root>`.
+    roots = {os.path.dirname(os.path.dirname(p)) for p in libc_paths}
+    roots.discard("")
+    system_loader = ("/lib/", "/lib64/", "/usr/lib/", "/usr/lib64/")
+
+    def self_hosted(name, interp):
+        if interp and not interp.startswith(system_loader):
+            return True  # asks for the dist's own loader
+        return any(name == r or name.startswith(r + "/") for r in roots)
+
+    excluded = 0
+    for name, verneed, interp in files:
+        if self_hosted(name, interp):
+            excluded += 1
+            continue
+        for lib, names in verneed.items():
+            if LIBC_FAMILY.match(lib):
+                for n in names:
+                    if n.startswith("GLIBC_") and n[6:7].isdigit():
+                        glibc = vmax(glibc, n[6:])
+            elif lib == "libstdc++.so.6" and lib not in own:
+                for n in names:
+                    if n.startswith("GLIBCXX_"):
+                        glibcxx = vmax(glibcxx, n[8:])
+    external = sorted(s for s in needed_all if s not in own and not BASE.match(s))
+    return {
+        "glibc": glibc,
+        "glibcxx": glibcxx,
+        "macos": macos,
+        "interp": sorted(interps),
+        "external_needed": external,
+        "elf_files": elf_seen,
+        "dynamic_elf_files": dynamic,
+        # ELF files run against a libc the dist bundles itself, and therefore
+        # left out of the floor (reported, so the exclusion is never silent).
+        "self_hosted_excluded": excluded,
+        "bundles_libstdcxx": "libstdc++.so.6" in own,
+    }
+
+
+def fetch(url, sha256, dest):
+    if not os.path.exists(dest):
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        subprocess.run(
+            # Resumable: a 1.3 GB Zephyr SDK over a slow link dies mid-stream
+            # (measured: curl 92, HTTP/2 stream reset at 221 MB), and a restart
+            # from zero would never finish.
+            [
+                "curl", "-L", "--fail", "--silent", "--show-error",
+                "--retry", "8", "--retry-all-errors", "-C", "-",
+                "-o", dest + ".part", url,
+            ],
+            check=True,
+        )
+        os.replace(dest + ".part", dest)
+    h = hashlib.sha256()
+    with open(dest, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    if h.hexdigest() != sha256:
+        raise SystemExit(f"sha256 mismatch for {url}: {h.hexdigest()} != {sha256}")
+    return dest
+
+
+def floor_of(host, m):
+    """The `floor = { .. }` a measurement supports, as a TOML inline table."""
+    if host.startswith("macos"):
+        return f'{{ macos = "{m["macos"]}" }}' if m["macos"] else None
+    if not m["dynamic_elf_files"]:
+        return '{ none = "no dynamically-linked ELF: no PT_INTERP, no DT_NEEDED" }'
+    if m.get("self_hosted_excluded", 0) >= m["dynamic_elf_files"]:
+        return (
+            '{ none = "every dynamic ELF runs on the dist\'s OWN bundled loader + '
+            'glibc (a self-contained sysroot); nothing links the host libc" }'
+        )
+    parts = []
+    if m["glibc"]:
+        parts.append(f'glibc = "{m["glibc"]}"')
+    if m["glibcxx"]:
+        parts.append(f'glibcxx = "{m["glibcxx"]}"')
+    return "{ " + ", ".join(parts) + " }" if parts else None
+
+
+def self_test():
+    """The parsers must be able to say something — and to say NOTHING."""
+    # A thin arm64 Mach-O header with one LC_BUILD_VERSION, minos 11.0.
+    lc = struct.pack("<IIIIII", LC_BUILD_VERSION, 24, 1, (11 << 16), (13 << 16), 0)
+    hdr = b"\xcf\xfa\xed\xfe" + struct.pack("<iiIIIII", 0x0100000C, 0, 2, 1, len(lc), 0, 0)
+    assert macho_minos(hdr + lc) == "11.0", macho_minos(hdr + lc)
+    assert macho_minos(b"\x7fELF" + b"\0" * 60) is None
+    elf = b"\x7fELF\x02\x01" + b"\0" * 12 + struct.pack("<H", 62)
+    assert elf_machine(elf) == 62
+    assert elf_machine(b"PK\x03\x04" + b"\0" * 20) is None
+    assert vmax("2.17", "2.34") == "2.34" and vmax("2.4", "2.34") == "2.34"
+    assert floor_of("linux-x86_64", {"dynamic_elf_files": 0}).startswith("{ none")
+    # Every dynamic ELF on a bundled loader (a Yocto sysroot): no host floor,
+    # and it must say so rather than print nothing.
+    assert "OWN bundled loader" in floor_of(
+        "linux-x86_64",
+        {"dynamic_elf_files": 108, "self_hosted_excluded": 109, "glibc": None, "glibcxx": None},
+    )
+    # ...but ONE host-linked binary among them restores a real floor.
+    assert floor_of(
+        "linux-x86_64",
+        {"dynamic_elf_files": 108, "self_hosted_excluded": 107, "glibc": "2.17", "glibcxx": None},
+    ) == '{ glibc = "2.17" }'
+    assert floor_of("linux-x86_64", {"dynamic_elf_files": 3, "glibc": "2.34", "glibcxx": None}) == (
+        '{ glibc = "2.34" }'
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("tools", nargs="*")
+    ap.add_argument("--host")
+    ap.add_argument("--cache", default=DEFAULT_CACHE)
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("-j", "--jobs", type=int, default=1, help="artifacts fetched in parallel")
+    ap.add_argument(
+        "--dir",
+        help="measure an ALREADY-UNPACKED dist here instead of downloading "
+        "(needs exactly one tool and --host; say where it came from)",
+    )
+    a = ap.parse_args()
+    index = load_index()
+    work = []
+    for name, tool in sorted(index.get("tool", {}).items()):
+        if a.tools and name not in a.tools:
+            continue
+        for host, dist in sorted(tool.get("dist", {}).items()):
+            if a.host and host != a.host:
+                continue
+            work.append((name, host, dist))
+
+    def one(item):
+        name, host, dist = item
+        if a.dir:
+            m = measure_dir(a.dir, host)
+        else:
+            url = dist["url"]
+            dest = os.path.join(a.cache, name, host, os.path.basename(url))
+            m = measure(fetch(url, dist["sha256"], dest), host)
+        m.update(tool=name, host=host, floor=floor_of(host, m))
+        return m
+
+    if a.dir and len(work) != 1:
+        raise SystemExit("--dir measures ONE artifact: name one tool and pass --host")
+    from concurrent.futures import ThreadPoolExecutor
+
+    results = []
+    with ThreadPoolExecutor(max_workers=max(1, a.jobs)) as pool:
+        for m in pool.map(one, work):
+            results.append(m)
+            if not a.json:
+                print(f"[tool.{m['tool']}] dist.{m['host']}: floor = {m['floor']}")
+                print(
+                    f"    elf={m['elf_files']} dynamic={m['dynamic_elf_files']} "
+                    f"interp={m['interp']} bundles_libstdc++={m['bundles_libstdcxx']}"
+                )
+                if m["external_needed"]:
+                    print(f"    external DT_NEEDED: {', '.join(m['external_needed'])}")
+                sys.stdout.flush()
+    if a.json:
+        json.dump(results, sys.stdout, indent=2)
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    self_test()
+    sys.exit(main())

--- a/scripts/sdk/prereq-packages.py
+++ b/scripts/sdk/prereq-packages.py
@@ -28,6 +28,9 @@ import os
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
+import index_packages  # noqa: E402 — phase-447 D2: the one manager-field reader
+
 INDEX = os.path.join(ROOT, "nros-sdk-index.toml")
 MANAGERS = ("apt", "dnf", "pacman", "brew")
 
@@ -53,11 +56,19 @@ def load(path=INDEX):
 DEFAULT_ROS_DISTRO = "humble"
 
 
-def prereq_context(env=None):
-    """The values a derivation needs, read once from the environment."""
-    env = os.environ if env is None else env
+def prereq_context(env=None, release=None):
+    """The values a derivation needs, read once from the environment.
+
+    `release` is the host's OS release (phase-447 D2), which picks a
+    per-release override; `None` reads `/etc/os-release` when `env` is the real
+    environment, and nothing (every entry's default) when a test passes a dict.
+    """
+    real = env is None
+    env = os.environ if real else env
     distro = (env.get("ROS_DISTRO") or "").strip()
-    return {"ros_distro": distro or DEFAULT_ROS_DISTRO}
+    if release is None and real:
+        release = index_packages.host_release()
+    return {"ros_distro": distro or DEFAULT_ROS_DISTRO, "release": release}
 
 
 def ros_os_package(manager, ros_package, ctx):
@@ -87,7 +98,7 @@ def packages_for(index, manager, keys, ctx=None):
         if entry is None:
             missing.append(k)
             continue
-        pkgs = entry.get(manager) or []
+        pkgs = index_packages.for_release(entry.get(manager), ctx.get("release"))
         if not pkgs and entry.get("ros_package"):
             derived = ros_os_package(manager, entry["ros_package"], ctx)
             pkgs = [derived] if derived else []
@@ -163,6 +174,17 @@ def self_test():
     if packages_for(index, "apt", ["doxygen"], jazzy) != ["doxygen"]:
         print("  FAIL: a literal name was rewritten")
         failures += 1
+
+    # phase-447 D2 — a per-release table: the host's release picks its
+    # override, every other release its default.
+    index["prereq"]["ssl"] = {"apt": {"default": ["libssl3"], "noble": ["libssl3t64"]}}
+    for release, want in (("noble", ["libssl3t64"]), ("jammy", ["libssl3"]), (None, ["libssl3"])):
+        got = packages_for(index, "apt", ["ssl"], prereq_context({}, release=release))
+        if got != want:
+            print(f"  FAIL: per-release {release}: {got} != {want}")
+            failures += 1
+
+    index_packages.self_test()
 
     for keys, why in ((["nope"], "unknown key"), (["graphviz"], "unmapped manager")):
         manager = "apt" if why == "unknown key" else "dnf"


### PR DESCRIPTION
Implements **phase-447 D1 + D2** (RFC-0099 D5 + D9). One PR because both own `orchestration/sdk_index.rs`.

> **F1 is no longer carried.** This branch was built on `main` + F1's commit (PR #906), cherry-picked because F1 also edits `sdk_index.rs` and `nros-sdk-index.toml`. F1 then landed on `main` (`cca69d3fa`) before this push, and the rebase dropped the carried copy by patch-id; the commit count was checked after it (2 → 3 of this PR's own, 0 carried).
>
> Three commits:
> 1. **D1+D2.**
> 2. **The last three zephyr-sdk 0.16.8 archives measured.** This takes the ratchet from 3 to 0.
> 3. **Floors for C2's six new dist rows.** C2 (#1273) landed on `main` first, and the ratchet named exactly those six rows on the rebase.

## D1 — a dist declares a measured floor, and the host is compared BEFORE the download

`host_key()` is `<os>-<arch>`, with no OS version and no libc, so the key offered every Linux x86_64 host every Linux x86_64 dist. RFC-0099 D5 rejected widening the key: compatibility is a RANGE, not an identity. So each `dist.<host>` row now carries `floor = { glibc, glibcxx, macos }` or `none = "<why>"`.

**Where the check runs.** `plan_install` decides it in the PLAN, so a refused prebuilt's URL never reaches `execute`:

- **Below the floor, with a source recipe** → `Source { refused: Some(why) }`. This is printed on the plan line (so `--dry-run` shows it) and again at install time: *"…was refused: it needs glibc >= 2.34 and this host has glibc 2.31. Remedy: … Nothing was downloaded; falling back to the source recipe."*
- **Below the floor, with no source recipe** → new `InstallAction::Refused`, which bails naming the remedy and downloads nothing.

**Both halves of the runtime** (`orchestration/host_floor.rs`):

- **Forward half.** The loader/libc family and libstdc++, which `bundle.sh` never bundles. These are numbers: `floor.glibc`, `floor.glibcxx`, `floor.macos`.
- **Backward half.** A library a NEWER host dropped (`libpython3.10.so.1.0` on noble). This is the tool's `system = [..]` list read against D2's per-release names. A host is refused **only** when the soname is absent AND the index says the manager does not package it on this release. Absent-but-installable is still `--system`'s job.

A probe that cannot answer ABSTAINS and never refuses. Host facts are gathered once per process (`gnu_get_libc_version`, `ldconfig -p`, the host libstdc++'s `GLIBCXX_*`, `/etc/os-release`). A plan for a foreign host key abstains.

**Ratchet — `check-dist-floors`** (fast line, runs its selftest on the normal path with synthetic BAD input, not in the selftest baseline):

- Every dist row must declare a floor, or be listed in `.config/dist-floor-baseline.txt`.
- That baseline may only shrink (`BASELINE_CEILING`).
- A row that gains a floor must leave the baseline.

Phase-447 C2's new dist rows are exactly what this catches.

### Floors — measured, not guessed

I measured with the new `scripts/sdk/measure-dist-floor.py`. It downloads each RELEASED archive, verifies its sha256, streams it without unpacking, and reads:

- ELF version-needs, taking the highest `GLIBC_x.y` and `GLIBCXX_3.4.N` against a libstdc++ the dist does not bundle;
- `DT_NEEDED` and `PT_INTERP`;
- Mach-O `LC_BUILD_VERSION.minos`.

I cross-checked the parser against `objdump -T` on xrce-agent: both say 2.34 / 3.4.30.

| tool | linux-x86_64 | linux-arm64 | macOS |
| --- | --- | --- | --- |
| arm-fvp | glibc 2.17, glibcxx 3.4.26 | — | — |
| arm-none-eabi-gcc | 2.34, 3.4.19 | 2.34, 3.4.22 | arm64 11.0 |
| cargo-llvm-cov | 2.34 | 2.34 | — |
| cargo-nextest | 2.27 | 2.27 | — |
| clang-format | 2.16, 3.4.19 | 2.17, 3.4.19 | arm64 11.0 |
| cyclonedds | 2.34 | 2.34 | arm64 14.0 |
| espflash (C2) | none (static musl) | 2.34 (a `-gnu` build) | arm64 11.0 |
| mdbook | none (static musl) | none (static musl) | arm64 11.0, x86_64 10.12 |
| ninja | 2.15, 3.4.21 | 2.17, 3.4.21 | arm64 11.0 |
| openocd | 2.34 | 2.34 | arm64 14.0 |
| qemu | 2.34 | 2.34 | arm64 14.0 |
| riscv-none-elf-gcc | 2.27, 3.4.30 | 2.27, 3.4.30 | arm64 11.0 |
| sccache (C2) | none (static musl) | none (static musl) | arm64 11.0 |
| verus | 2.34, 3.4.26 | — | arm64 11.0, x86_64 11.0 |
| xrce-agent | 2.34, 3.4.30 | 2.34, 3.4.30 | arm64 14.0 |
| zephyr-sdk 0.16.8 | 2.27, 3.4.21 † | 2.27, 3.4.21 | arm64 11.0, x86_64 11.0 |
| zephyr-sdk-1-0-1 | none (self-hosted sysroot) ‡ | none (self-hosted sysroot) ‡ | arm64 14.0 |

**What the measurement corrected:**

- **No dist needs glibc 2.35.** The runner HAS 2.35; every nano-ros-sdk dist USES at most `GLIBC_2.34`.
- **The C++ runtime is a real floor.** riscv-none-elf-gcc and xrce-agent need `GLIBCXX_3.4.30` (GCC 12).
- **† zephyr-sdk 0.16.8 linux-x86_64 was measured from a local install of the same release** (`sdk_version` 0.16.8). 55 of its 1334 dynamic ELF run on the SDK's own pokysdk `ld.so` + glibc. Counting those against the host would have been wrong, so the script now excludes self-hosted ELF, and reports how many.
- **‡ zephyr-sdk-1-0-1's `_minimal` Linux archive holds no ELF at all.** A first measurement read that as floor-less. In fact the host tools ride inside a 70 MB Yocto self-extractor. I measured its payload, extracted after `MARKER:` and never executed: 109/108 ELF, every one on the sysroot's own loader. So `none` is right, for a reason the first pass could not see.

**All 49 dist rows across 17 tools are measured: the original 15 tools, plus the 2 that C2 added. The baseline is EMPTY and `BASELINE_CEILING = 0`.** C2's `espflash` is the instructive case. Its x86_64 asset is a static musl build with no floor, and its arm64 asset is `-gnu` at glibc 2.34. So two columns of ONE tool need different answers, which a per-tool floor could not have said. The three zephyr-sdk 0.16.8 archives (linux-arm64 / macos-arm64 / macos-x86_64, 1.0–1.3 GB upstream) landed first as recorded debt with a ceiling of 3. The second commit measured them and took the ceiling to 0, which is the ratchet shrinking as designed. linux-arm64 measured from the archive gives 2.27 / 3.4.21, identical to linux-x86_64 measured from an install: two methods agreeing. Every one of the three needed a resumed download (curl 92, HTTP/2 stream reset), so the measuring script's fetch now resumes.

## D2 — the manager fields gain an OS-release dimension

**Schema.** `apt` / `dnf` / `pacman` / `brew` become `ManagerPackages`. The flat list is **unchanged**, and a table overrides one release:

```toml
apt = ["libssl3"]                                         # every release (as before)
apt = { default = ["libssl3"], noble = ["libssl3t64"] }   # one release renamed it
```

**Why a `default` key inside the table, and not `apt.noble = [..]` beside `apt = [..]`.** TOML cannot hold a key as both an array and a table. So the RFC's sketch is unwritable exactly when it is needed: an entry with an ordinary name AND one release that renamed it.

**What an empty list means.** Release keys are `VERSION_CODENAME`, else `VERSION_ID`, and `validate` refuses one that cannot be a release name. `noble = []` means "not packaged there". That is a different answer from "not named", and D1's backward half reads exactly it.

**One Python reader.** Python reads the fields only through `scripts/lib/index_packages.py`, and both readers moved onto it. The reason: on the table shape, `entry.get("apt")` iterates RELEASE NAMES, so `check-workflow-indexed-apt` would have indexed `noble` as an apt package.

- **`libssl3`** gains `noble = ["libssl3t64"]` (the t64 rename; the soname is unchanged).
- **`[prereq.libpython310]` was misnamed, not merely stale.** Its only consumer is the `play_launch_parser` **source** build, and a source build links the HOST's own CPython. The requirement is therefore "this host's libpython3", and a key naming 3.10 asked every non-jammy host for something it cannot have. It is now `[prereq.libpython3]`:
  - `jammy = libpython3.10`, `noble = libpython3.12t64`, `default = libpython3-dev`;
  - the probe is `sharedlib = "libpython3."`, which is minor-independent;
  - dnf / pacman ask for the distro's default Python instead of a 3.10 side-install.

  A soname-EXACT requirement belongs to a prebuilt that links one minor. It gets its own key the day such a dist row exists, and `check-dist-runtime-deps` will demand it. I checked every noble name against the archive: both `libssl3` and `libpython3.12` turned out to be t64 renames there.

## Mutation pass

Controls first: the unmutated tests are green (62 passed), and so are the gate and helper. Each mutant ran against the targeted tests or self-tests.

| # | mutation | killed by |
| --- | --- | --- |
| R1 | **PRIMARY — floor not decided in the plan, so any check runs after the download** | `floor_refusal_happens_before_download_and_falls_back_to_source` |
| R2 | version comparison inverted | `glibcxx_and_macos_floors` |
| R3 | non-glibc (musl) host not refused | `non_glibc_refuses_and_unknown_abstains` |
| R4 | glibcxx floor ignored | `glibcxx_and_macos_floors` |
| R5 | backward half refuses absent-but-packaged too | `backward_half_needs_absent_and_unpackaged_here` |
| R6 | backward half ignores presence | `backward_half_needs_absent_and_unpackaged_here` |
| R7 | refused dist WITH source goes to `Refused` | `floor_refusal_happens_before_download_…` |
| R8 | D2 override ignored | `manager_packages_take_a_per_release_override` |
| R9 | `named_for` answers for unnamed releases | `backward_half_needs_absent_and_unpackaged_here` |
| R10 | `parse` stops resolving `system_deps` | `parse_resolves_tool_system_deps` |
| R11 | floor host/field pairing not validated | `dist_floor_shape_is_validated_per_host` |
| R12 | release-key validation dropped | `a_release_key_must_look_like_one` |
| R13 | `--dry-run` line drops the refusal reason | `describe_names_a_floor_refusal` |
| P1 | gate: every floor counts as covered | selftest |
| P2 | gate: host/field pairing ignored | selftest |
| P3 | gate: blank `none` accepted | selftest |
| P4 | gate: ceiling not enforced | selftest |
| P5 | gate: a baseline row that gained a floor is kept | selftest |
| P6 | gate: a missing row is not reported | selftest |
| P7 | helper: override ignored | `prereq-packages --self-test` |
| P8 | helper: `all_names` yields release keys | `prereq-packages --self-test` |
| P9 | reader: `prereq-packages` ignores the release | `prereq-packages --self-test` |

**22/22 killed.** R1 is the brief's "the floor probe runs after the download": that plan still returns `Prebuilt`, and the test asserts the refusal, no `.download` file, and no prefix. To rule out equivalent mutants, the gate mutants ran against an index copy where the unmutated gate is GREEN. A mutant that dies because the control was already red would prove nothing.

## Not covered, deliberately

- **`nros-launch-resolve`: declared now, enforced later.** It links `libpython3.10.so.1.0` (issue 0897), but it ships INSIDE the release asset via `install.sh`, not as an index dist, so `plan_install` never sees it. The rebase met C2's correction of `[prereq.libpython310]`: C2 had worked out that this very binary is that key's real consumer. So the merge keeps BOTH keys. `libpython310` is the soname-exact requirement of that binary, where the minor in the name is correct, now with `apt = { jammy = [..], noble = [] }`. `libpython3` is the host's CPython for the source build. Enforcement arrives when `[tool.nros]` gains `dist.<host>` rows (phase-431 W5). The ratchet then demands a floor, and `system = ["libpython310"]` makes the backward half refuse it on noble before the download.
- **Side finding, not fixed.** The `arm-none-eabi-gcc` linux-arm64 dist bundles focal's CPython 3.8, whose `lib-dynload/_ssl` needs `libssl.so.1.1`, which jammy does not ship. So `import ssl` fails inside that gdb's Python, while gdb itself is fine. That is a `nano-ros-sdk` re-cut question.

## Verification

- **Lanes:** `just ci gate` (compile + unit + the 300 fast gates), `cargo clippy -p nros-cli-core --all-targets -D warnings`, and `cargo +nightly fmt`.
- **Setup:** the gates needed zenoh-pico and the xrce pair, which I initialised shallow and non-recursive.
- **Tier:** this is the compile + unit tier. No fixture tier ran; the change touches the provisioner and the index, not a fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
