### PR TITLE
fix(check): two gates walked 20 G of build output for 152 tracked files — 37 min to 1 s

### DIFF
--- a/.config/gate-selftest-baseline.txt
+++ b/.config/gate-selftest-baseline.txt
@@ -57,7 +57,6 @@ scripts/check-no-allow-multiple-def.sh
 scripts/check-no-board-init.sh
 scripts/check-no-direct-kernel-alloc.sh
 scripts/check-no-silent-sample-drop.py
-scripts/check-no-tracked-file-find.sh
 scripts/check-no-tracked-models.sh
 scripts/check-nuttx-integration-makefile.sh
 scripts/check-nuttx-libc-struct-sizes.py

--- a/scripts/check-config-header-single-writer.py
+++ b/scripts/check-config-header-single-writer.py
@@ -33,6 +33,8 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+from tracked import tracked  # noqa: E402 — issue 0721: index lookup, not a walk
 HEADER = "config_generated"
 WRITER = "mirror-generated-header.sh"
 
@@ -120,12 +122,17 @@ def self_test() -> None:
 def main() -> int:
     self_test()
 
+    # The INDEX, not a filesystem glob. The rule is about AUTHORED cmake, which
+    # is tracked by definition; `REPO.glob("packages/**/...")` walked every cargo
+    # `target/` and build dir under `packages/` (20 G on disk against 5.6 MB
+    # tracked). Measured on the walk it replaced: 714 files returned, 461 of
+    # them (65%) generated build output this gate had no business reading, and
+    # 37 minutes inside a loaded `check fast` — the tail of every push — for a
+    # scan the index answers instantly. `check-no-tracked-file-find` missed it
+    # because its regex required the `**` to lead the pattern.
     files = sorted(
-        list(REPO.glob("cmake/**/*.cmake"))
-        + list(REPO.glob("packages/**/CMakeLists.txt"))
-        + list(REPO.glob("packages/**/*.cmake"))
-        + list(REPO.glob("zephyr/**/*.cmake"))
-        + list(REPO.glob("integrations/**/*.cmake"))
+        set(tracked("cmake", "packages", "zephyr", "integrations", suffix=".cmake"))
+        | set(tracked("packages", name="CMakeLists.txt"))
     )
     # RELATIVE to the repo. Against the ABSOLUTE path this skipped every file
     # whenever the checkout itself lived under a directory called

--- a/scripts/check-just-recipe-refs.py
+++ b/scripts/check-just-recipe-refs.py
@@ -46,6 +46,8 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+from tracked import tracked  # noqa: E402 — issue 0721: index lookup, not a walk
 
 # `just` at a command position: line start, after `&&`/`||`/`;`/`(`, or after a
 # leading `@`/`-` recipe prefix. Captures the first argument.
@@ -145,7 +147,12 @@ TEST_FLAG = re.compile(r"--test\s+([A-Za-z0-9_-]+)")
 def package_dirs():
     """{package name: directory} for in-repo crates, from their manifests."""
     out = {}
-    for man in REPO.glob("packages/**/Cargo.toml"):
+    # The index, not `REPO.glob("packages/**/Cargo.toml")`: that walked every
+    # cargo `target/` under `packages/` and discarded them AFTER descending, the
+    # same post-hoc filter that made `check-example-leaf-target-dirs` the
+    # 27-minute tail of `check fast`. The filter below stays for `generated/`,
+    # which a committed interface package can legitimately track.
+    for man in tracked("packages", name="Cargo.toml"):
         if any(part in ("target", "third-party", "generated") for part in man.parts):
             continue
         m = re.search(r'^\s*name\s*=\s*"([^"]+)"', man.read_text(errors="replace"), re.M)

--- a/scripts/check-no-tracked-file-find.sh
+++ b/scripts/check-no-tracked-file-find.sh
@@ -148,17 +148,24 @@ for f in FILES:
 # `check-site-config` had the same shape. Matching `recursive=True` catches the
 # spelling regardless of where the pattern or the root came from — which is the
 # property the other three alternatives lack.
-PY_WALK = re.compile(r"\.rglob\(|\.glob\(\s*[\"']\*\*|\bos\.walk\(|recursive\s*=\s*True")
+# The literal alternative still required the `**` to LEAD the pattern:
+# `\.glob\(\s*["']\*\*` sees `glob("**/x")` and not `glob("packages/**/x")`,
+# which recurses exactly as hard. Two gates wrote the second form over
+# `packages/` — `check-config-header-single-writer` (714 files returned, 65% of
+# them build output, 37 MINUTES inside a loaded `check fast`) and
+# `check-just-recipe-refs`. The alternative now takes a `**` anywhere in the
+# literal. This gate had no selftest, which is how a regex that could not see
+# the common spelling stayed green; it has one now.
+PY_WALK = re.compile(r"\.rglob\(|\.glob\(\s*[\"'][^\"']*\*\*|\bos\.walk\(|recursive\s*=\s*True")
 PY_ALLOW = re.compile(r"walk-ok:")
 
-PY_FILES = [f for f in FILES if f.endswith(".py")]
-for f in PY_FILES:
-    if f.endswith("check-no-tracked-file-find.py"):
-        continue
-    try:
-        lines = open(f).read().split("\n")
-    except OSError:
-        continue
+def _py_walk_hits(lines):
+    """Line numbers of UNMARKED recursive walks in one file's lines.
+
+    Factored out of the scan so the selftest drives the same predicate the
+    gate runs — a check whose test exercises a copy is a check nobody tested.
+    """
+    hits = []
     # Triple-quoted blocks are PROSE, not code. `scripts/lib/tracked.py` — the
     # helper this rule exists to send people to — documents the antipattern by
     # showing it, so the gate flagged its own remedy and `just check` went red
@@ -198,8 +205,57 @@ for f in PY_FILES:
                 break
             j -= 1
         if not allowed:
-            bad.append(f"  {f}:{n}: recursive walk — use `git ls-files`, "
-                       f"or mark it `# walk-ok: <reason>`")
+            hits.append(n)
+    return hits
+
+
+def self_test():
+    """Both directions, on the normal path, over synthetic lines.
+
+    This gate had none, and that is how `\.glob\(\s*["']\*\*` — blind to a
+    `**` anywhere but the start of the pattern — stayed green while two gates
+    walked 20 G of build output under `packages/`.
+    """
+    must_flag = [
+        ('files = list(REPO.glob("packages/**/CMakeLists.txt"))', "dir/** glob"),
+        ('files = list(REPO.glob("**/Cargo.toml"))', "leading ** glob"),
+        ("for c in root.rglob('*.c'):", "rglob"),
+        ("glob.glob(os.path.join(ROOT, pat), recursive=True)", "recursive=True"),
+        ("for dirpath, _, names in os.walk(root):", "os.walk"),
+    ]
+    must_pass = [
+        ('files = list(REPO.glob("cmake/*.cmake"))', "non-recursive glob"),
+        ("for c in root.rglob('*.c'):  # walk-ok: build dir", "trailing marker"),
+        ("# for c in root.rglob('*.c'):", "a comment is not code"),
+    ]
+    bad_cases = []
+    for line, label in must_flag:
+        if _py_walk_hits([line]) != [1]:
+            bad_cases.append(f"self-test: expected a violation for {label!r}")
+    for line, label in must_pass:
+        if _py_walk_hits([line]):
+            bad_cases.append(f"self-test: unexpected violation for {label!r}")
+    marked = ["# walk-ok: build output, untracked by definition", "for d in os.walk(b):"]
+    if _py_walk_hits(marked):
+        bad_cases.append("self-test: a walk-ok in the comment block above must exempt it")
+    if bad_cases:
+        print("\n".join(bad_cases), file=sys.stderr)
+        sys.exit(2)
+
+
+self_test()
+
+PY_FILES = [f for f in FILES if f.endswith(".py")]
+for f in PY_FILES:
+    if f.endswith("check-no-tracked-file-find.py"):
+        continue
+    try:
+        lines = open(f).read().split("\n")
+    except OSError:
+        continue
+    for n in _py_walk_hits(lines):
+        bad.append(f"  {f}:{n}: recursive walk — use `git ls-files`, "
+                   f"or mark it `# walk-ok: <reason>`")
 
 if bad:
     print("FAIL: filesystem walk used to locate git-tracked files:")


### PR DESCRIPTION
With `check-example-leaf-target-dirs` fixed (#911), the next tail of every `check fast` was **`check-config-header-single-writer` at 37 minutes** — measured as the slowest gate on #930's push (2,243,968 ms). It now takes **0.95 s**.

## Cause

```python
list(REPO.glob("packages/**/CMakeLists.txt"))
+ list(REPO.glob("packages/**/*.cmake"))
```

`Path.glob("packages/**/…")` walks the **filesystem**, and `packages/` is 20 G on disk against 5.6 MB tracked. Measured on the walk it replaced: **714 files returned, 461 of them (65 %) generated build output**, where `git ls-files` for the same five patterns gives **152**. The gate's rule is about *authored* cmake, which is tracked by definition — so two thirds of what it read was a false-positive risk as well as a cost. It finished in 37 s run alone and 37 min in a loaded hook: `check-no-tracked-file-find.sh`'s own header explains the gap (*"it was never compute-bound, it was starved on I/O walking build trees"*).

After the fix it reports **152 cmake file(s)** — exactly the index count, so it is equivalent on the set it should scan, not merely faster.

`check-just-recipe-refs.py` had the same shape (`REPO.glob("packages/**/Cargo.toml")`, filtering `target/` only after descending). Both now go through the shared `scripts/lib/tracked.py` helper rather than a second spelling of the index lookup.

## Why the gate for this class missed it

`check-no-tracked-file-find.sh` has had a Python arm since issue 0721:

```python
PY_WALK = re.compile(r"\.rglob\(|\.glob\(\s*[\"']\*\*|\bos\.walk\(|recursive\s*=\s*True")
```

`\.glob\(\s*["']\*\*` sees `glob("**/x")` and **not** `glob("packages/**/x")`, which recurses exactly as hard. The rule it states — every recursive walk — was broader than what it enforced (issue 0196's shape). It now matches a `**` anywhere in the literal. Widening it and running the gate was the sweep: it named exactly these two sites and nothing else.

## The gate had no selftest

It sat in `.config/gate-selftest-baseline.txt`, which is how a regex blind to the common spelling stayed green. The per-line predicate is now a function the scan and a new `self_test()` both drive, on the normal path: `dir/**`, leading `**`, `rglob`, `recursive=True` and `os.walk` must flag; a non-recursive glob, a trailing `walk-ok`, a comment, and a `walk-ok` in the comment block above must not. The baseline line is removed, as the ratchet requires (197/303 gates now self-test).

**Mutation:** narrowing the regex back to a leading `**` → exit 2, `self-test: expected a violation for 'dir/** glob'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
