### PR TITLE
feat(phase-447 E3): the session plan executes as a pipeline, bounded by the host

### DIFF
--- a/docs/design/0099-provisioning-is-planned-once-and-prefers-prebuilts.md
+++ b/docs/design/0099-provisioning-is-planned-once-and-prefers-prebuilts.md
@@ -265,6 +265,23 @@ long before the cores do, and two concurrent source builds mostly move contentio
 around. The win is overlapping a BUILD with another package's DOWNLOAD — which is
 also why D4 comes first.
 
+**How it executes** (phase-447 E3). A worker pool over the resolved plan, as many
+workers as the host has CPUs, overridable with `nros setup -j/--jobs N` or
+`NROS_SETUP_JOBS` (the lazy `ensure_tools` path reaches only the variable). The
+pool owns the order of nothing: each ordered thing above is somebody else's — the
+lock and `bin_dirs` are `SessionRun::finish`'s single plan-order fold, output is
+the plan-order log's, and one-install-per-tool is the plan's. What the pool does
+own is that no step is dropped or run twice and that a failure (or a panic) is
+that step's outcome, never a reason to stop its siblings. Two LANES serialise
+what must not overlap even under a free CPU: `[tool.*]` source builds (each
+already uses the whole machine) and `[source.*]` steps (they share the
+workspace's `index.lock` and `.git/config`); the scheduler hands out the earliest
+step whose lane is free, so a waiting build never idles a worker a download
+could use. Output a step produces BELOW the session — `sdk_store`'s notes and
+its children's stdio — reaches the same log through a per-step sink
+(`orchestration/step_log.rs`), and a long download reports its progress there
+(issue 1266).
+
 `--tool` becomes repeatable. `--source` already is, and that asymmetry is the
 whole reason `ninja` and `make` are two processes in `workspace.just`.
 

--- a/docs/issues/archived/1266-setup-fetch-blocks-extract.md
+++ b/docs/issues/archived/1266-setup-fetch-blocks-extract.md
@@ -3,12 +3,13 @@ id: 1266
 title: "`nros setup` downloads, verifies and unpacks one package strictly in
   series, and the download is silent — a 1.4 GB fetch is 15 minutes of a log
   that looks hung"
-status: open
+status: resolved
 type: tech-debt
 area: cli, build
 severity: medium
 found: 2026-09-10
-related: [issue-1267, issue-1273, issue-1274, issue-1275, issue-0374, issue-0385, rfc-0014]
+resolved: 2026-09-11
+related: [issue-1267, issue-1273, issue-1274, issue-1275, issue-0374, issue-0385, rfc-0014, rfc-0099, phase-447]
 ---
 
 ## What this is
@@ -83,3 +84,25 @@ A contained self-hosted runner bootstrap on this workstation: 24 `nros setup`
 invocations across 11 distinct tools, plus the Zephyr SDK, plus source builds
 for `play_launch_parser` and `espflash`. The pre-Zephyr steps ran mostly warm
 (the store already held them) and the Zephyr SDK fetch was cold.
+
+## Resolution (2026-09-11, phase-447 E3 / RFC-0099 D7)
+
+Both halves, as the fix section asked, with the overlap taken further than the
+one-deep pipeline proposed: the session plan (phase-447 E2) is executed by a
+bounded worker pool, so fetch, verify and unpack of DIFFERENT packages overlap —
+package *n+1* downloads while package *n* verifies and unpacks. Within one
+package they stay serial, which they must: the sha256 needs the whole archive.
+
+**Progress.** The two `curl` copies in `sdk_store.rs` (prebuilt dist, source
+tarball) are one helper, `download`. curl stays `--silent --show-error` — its
+own bar is a carriage-return repaint, one very long line in a CI log — and
+`orchestration/step_log.rs::watch_download` watches the archive's size instead:
+nothing for the first 10 s (so a short fetch prints nothing at all), then one
+plain line every 30 s, `… downloading <file>: 412.3 MB in 8m35s (0.80 MB/s)`,
+and a closing `fetched` line if it ever spoke. `cmd/setup.rs::fetch_index`
+stays silent on purpose: it fetches a small TOML with fail-fast timeouts.
+
+The policy is a pure function of (elapsed, last line), tested at synthetic
+instants; the watcher is tested by handshake, never by sleeping.
+
+The "What NOT to do" held: no second downloader, `aria2` untouched.

--- a/docs/issues/archived/1267-setup-installs-packages-one-at-a-time.md
+++ b/docs/issues/archived/1267-setup-installs-packages-one-at-a-time.md
@@ -2,12 +2,13 @@
 id: 1267
 title: "`nros setup` installs its packages one at a time — the loop is
   sequential in the CLI, so no caller can parallelise it"
-status: open
+status: resolved
 type: tech-debt
 area: cli, build
 severity: medium
 found: 2026-09-10
-related: [issue-1266, issue-1273, issue-1274, issue-0374, issue-0500, rfc-0014]
+resolved: 2026-09-11
+related: [issue-1266, issue-1273, issue-1274, issue-0374, issue-0500, rfc-0014, rfc-0099, phase-447]
 ---
 
 ## What this is
@@ -110,3 +111,41 @@ A contained self-hosted runner bootstrap on this workstation, 2026-09-10: 24
 `nros setup` invocations across 11 distinct tools, plus the Zephyr SDK and two
 source builds. The same loop is every contributor's first hour, not only a
 runner's.
+
+## Resolution (2026-09-11, phase-447 E3 / RFC-0099 D7)
+
+`cmd/setup/session.rs::run_pipelined` replaced E2's sequential loop and nothing
+else. A bounded worker pool executes the resolved plan. **The bound is the host's
+CPU count, not the 4 proposed above** — a user decision recorded in RFC-0099 D7 —
+overridable with `nros setup -j/--jobs N` or `NROS_SETUP_JOBS` (the lazy
+`ensure_tools` path and the `just` recipes pass no flag). Zero or a non-number is
+refused by name.
+
+The four shared things, decided as the issue asked:
+
+1. **The lock** — join-then-record: no step touches it; `SessionRun::finish` is
+   its one writer and walks PLAN order.
+2. **`front_newest`** — a plan holds one step per package, and the scheduler
+   hands each step out exactly once, so the same tool is never installed (and
+   fronted) twice concurrently.
+3. **`bin_dirs`** — folded by `finish` from plan order into
+   `SessionReport::bin_dirs`, which is what the CMakePreset `PATH` and
+   `ensure_tools` now read.
+4. **Output** — every line of a step goes through the plan-order `OrderedLog`,
+   including what `sdk_store` prints and what its children (`curl`, `tar`,
+   `git`, `configure`, `make`) write: `orchestration/step_log.rs` installs a
+   per-step sink on the worker thread and routes child stdio through it. The
+   earliest unfinished step streams live; the ones ahead of it buffer.
+
+The "two further limits" became two LANES rather than a smaller pool: `[tool.*]`
+source builds run one at a time (each already uses the whole machine), and
+`[source.*]` steps run one at a time (the submodule arm takes the
+superproject's `index.lock` and rewrites `.git/config`). The scheduler hands out
+the earliest step whose lane is free, so a queue of source builds never holds a
+worker idle while a download behind it could be moving. Expect less than the
+package count — the link saturates first; the overlap that pays is one build or
+unpack beside other downloads.
+
+Every ordered property is tested UNDER concurrency, with completion forced out of
+plan order by handshake and a failing and a panicking step among the siblings;
+see phase-447 E3 for the tests and the mutation table.

--- a/docs/roadmap/phase-447-provisioning-revision.md
+++ b/docs/roadmap/phase-447-provisioning-revision.md
@@ -481,13 +481,13 @@ where it matters.
 | PR | item | note |
 | --- | --- | --- |
 | #927 | E1+E2 session plan | closes 1274. Re-armed by the poller once #918 landed; rebased onto main, 2 -> 1 commit |
-| #933 | E3 pipelined executor | closes 1266 and 1267. Rebased 4 -> 2 (C1 and its fix dropped by patch-id); still carries E1+E2 until #927 lands. Armed |
+| #933 | E3 pipelined executor | closes 1266 and 1267. Rebased 4 -> 1: C1 and its fix, then E1+E2 itself, all dropped by patch-id once they landed on main. Armed |
 
 ### In flight at this checkpoint
 
 | work | branch | state |
 | --- | --- | --- |
-| #1304 (A4) | `work/1304-installed-setup-provisions-without-a-checkout` | the agent stopped at the API session limit mid-change. Its tree is pushed as-is: A3's probe commit `b7ec5e55a`, two `wip(#1304)` commits (unreviewed, untested), and a fix to `cargo-target-spelling`'s no-triple arm — the WIP's rustup fallback defeated that PATH-only negative control, which is what first refused the push. No PR yet |
+| #1304 (A4) | `work/1304-installed-setup-provisions-without-a-checkout` | the agent stopped at the API session limit mid-change. Its tree is pushed as-is: A3's probe commit, two `wip(#1304)` commits (unreviewed, untested), and a fix to `cargo-target-spelling`'s no-triple arm — the WIP's rustup fallback defeated that PATH-only negative control, which is what first refused the push. No PR yet |
 
 ### What is left
 

--- a/docs/roadmap/phase-447-provisioning-revision.md
+++ b/docs/roadmap/phase-447-provisioning-revision.md
@@ -1,6 +1,7 @@
 # Phase 447 — provisioning revision
 
-**Status (2026-09-11). E1 and E2 landed (below); other items as marked.** Implements
+**Status (2026-09-11). E1, E2 and E3 landed (below) — E3 was the last E item;
+other items as marked.** Implements
 [RFC-0099](../design/0099-provisioning-is-planned-once-and-prefers-prebuilts.md).
 Makes the installed path reach a build, makes a repeated `nros setup` cheap, and
 makes "prefer a prebuilt" a rule instead of an intention.
@@ -321,6 +322,70 @@ is visible for a long download.
 (issue 0500's newest-first rule, where a stale entry shadowing a fresh one prints
 success on BOTH paths), `bin_dirs` PATH order, and per-package output flushed in
 plan order.
+
+**Landed** — `run_pipelined` replaced `run_sequential`, and nothing around it
+changed. A worker pool over the resolved plan, as many workers as the host has
+CPUs, overridable with `nros setup -j/--jobs N` or `NROS_SETUP_JOBS`; zero or a
+non-number is refused by name. The pool owns the order of nothing — the four
+ordered things stay where E2 put them — and owns two properties of its own: no
+step is dropped or run twice, and a step that fails or PANICS is its own outcome.
+`SessionReport::bin_dirs`, folded by `finish` beside the lock, is what the
+CMakePreset `PATH` and `ensure_tools` now read.
+
+* **The gap E2 named is closed.** `orchestration/step_log.rs` installs a
+  per-step sink on the worker thread: `sdk_store`'s three `eprintln!`s go
+  through `step_log::say`, and every child it spawns (`curl`, `tar`, `git`,
+  `configure`, `make`) has its stdout/stderr routed line by line into the same
+  plan-order log. With no sink both behave exactly as before, so `sdk_store`
+  kept its signatures.
+* **Two lanes, not a smaller pool.** `[tool.*]` source builds run one at a time
+  (each already uses the whole machine), and so do `[source.*]` steps (the
+  submodule arm takes the superproject's `index.lock` and rewrites
+  `.git/config` — a hazard the plan's one-step-per-package does not cover). The
+  scheduler hands out the EARLIEST step whose lane is free, so a waiting build
+  never idles a worker a download could use.
+* **Progress for a long download** (1266): the two `curl` copies are one
+  `download` helper; curl stays silent (its bar is a carriage-return repaint,
+  one long line in a CI log) and `step_log::watch_download` prints a plain
+  byte-count line after 10 s and every 30 s after, then a closing line. A short
+  fetch prints nothing. `cmd/setup.rs::fetch_index` stays silent on purpose.
+
+*Tested under concurrency*, completion forced out of plan order by handshake
+(`StepCtx::wait_closed`) and asserted on order and outcome, never on time; each
+test also asserts the completion order it forced, so "in plan order" is a claim:
+
+| property | test |
+| --- | --- |
+| output (incl. child stdio and `step_log::say`), lock never written by a step, `bin_dirs`, error + smoke fold | `under_concurrency_every_ordered_thing_leaves_in_plan_order` (completion `[3,2,1,0]`) |
+| one broken package stops nothing; each step runs exactly once | `a_failing_or_panicking_step_stops_none_of_its_siblings` |
+| lanes never overlap; the rest flow around a waiting build | `steps_that_share_a_lane_never_overlap_and_the_rest_flow_around_them` (completion `[2,0,1,3,4]`) |
+| real path at concurrency 3: each package's lines whole, in plan order | `the_real_install_path_prints_each_package_whole_and_in_plan_order` |
+| C1/E2's board-path test, now at concurrency 3 | `a_board_install_smokes_every_package_and_a_broken_one_stops_nothing` |
+
+*Mutation pass* (each applied, the session + step_log tests run, source restored):
+
+| mutant | result |
+| --- | --- |
+| fold (lock, smoke, errors) in completion order | RED |
+| record ONLY the lock in completion order | survives — **equivalent**: `SdkLock` is a map keyed by tool name and a plan holds one step per name, so recording order is unobservable in the file |
+| derive `bin_dirs` from completion order | RED |
+| `OrderedLog` releases a step's lines as it finishes | RED |
+| `OrderedLog` streams every step live | RED |
+| a failing step aborts its siblings | RED |
+| no lanes | RED |
+| scheduler blocks on a held lane in plan order | RED (the deadlock guard) |
+| child output bypasses the step sink (E2's gap reopened) | RED |
+| a long download never reports progress | RED |
+| install without the smoke probe (C1's) | RED |
+
+The pass also caught two defects in the first draft, which surfaced as one hang
+(read from the stuck test binary's thread names): a download test raced its
+watcher's first tick, and a `fetch` that panicked then DEADLOCKED the watcher,
+because the stop sender outlived the scope that joins it. Both are fixed and
+tested. Looking for the same class found a third: a child that leaves a
+background process holding its pipes (a build server) would have hung the step
+on EOF, where inherited stdio never did — so the drain after a child exits is
+bounded, and says when it gave up.
 
 ### F1 — the Zephyr module set moves under the index — **LANDED 2026-09-11**
 

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -15,7 +15,9 @@ use eyre::{Result, WrapErr, bail};
 
 mod session;
 
-use self::session::{Mode, PlanInputs, PrereqState, SessionLedger, SessionPlan, run_sequential};
+use self::session::{
+    Jobs, Mode, PlanInputs, PrereqState, SessionLedger, SessionPlan, run_pipelined,
+};
 use crate::{
     cmd::board::find_workspace_root,
     orchestration::{
@@ -158,6 +160,18 @@ pub struct Args {
     /// the message can say which of the two flags is missing.
     #[arg(long, conflicts_with = "check")]
     pub sudo: bool,
+
+    /// How many packages to install at once (phase-447 E3 / RFC-0099 D7).
+    /// Default: this host's CPU count; `NROS_SETUP_JOBS` overrides the default,
+    /// and this overrides both.
+    ///
+    /// Expect less than N times faster: the link saturates long before the
+    /// cores do, and a tool built from source already uses the whole machine,
+    /// so source builds run one at a time and the overlap that pays is one
+    /// package's build or unpack beside another's download. Output stays per
+    /// package and in plan order whatever the value.
+    #[arg(long, short = 'j', value_name = "N")]
+    pub jobs: Option<usize>,
 }
 
 /// `nros setup <subcommand>` (Phase 215.J.2).
@@ -338,6 +352,7 @@ pub fn run(args: Args) -> Result<()> {
             args.prefix.as_deref(),
             args.dry_run,
             args.sudo,
+            Jobs::from_env(args.jobs)?,
         );
     }
 
@@ -383,7 +398,7 @@ pub fn run(args: Args) -> Result<()> {
     // phase-447 E2 / RFC-0099 D7 — the WHOLE set is resolved before anything is
     // fetched: every `plan_install`, and one system-package ask for the union of
     // what its tools declare. The loop that used to interleave deciding with
-    // downloading is `run_sequential` now, over this plan.
+    // downloading is `run_pipelined` now, over this plan (E3).
     let plan = SessionPlan::resolve(
         &index,
         &packages,
@@ -423,8 +438,18 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     let lock = (!args.dry_run).then_some(lock_path.as_path());
-    let report =
-        run_sequential(&plan, &workspace, shallow_override(&args), args.dry_run).finish(lock)?;
+    let jobs = Jobs::from_env(args.jobs)?;
+    let mut report = run_pipelined(
+        &plan,
+        &workspace,
+        shallow_override(&args),
+        args.dry_run,
+        jobs,
+    )
+    .finish(lock)?;
+    // Folded by `finish` in PLAN order, with the lock — never in the order the
+    // installs happened to complete (RFC-0099 D7).
+    let bin_dirs = std::mem::take(&mut report.bin_dirs);
 
     if args.dry_run {
         eprintln!("(--dry-run: nothing installed)");
@@ -449,7 +474,7 @@ pub fn run(args: Args) -> Result<()> {
     // toolchain. Best-effort: a failure here never fails provisioning. The store
     // bin dirs fold onto its PATH in PLAN order (RFC-0099 D7).
     if !args.dry_run
-        && let Err(e) = emit_board_cmake_preset(board, &workspace, &plan.bin_dirs())
+        && let Err(e) = emit_board_cmake_preset(board, &workspace, &bin_dirs)
     {
         eprintln!("nros setup: CMakePreset not written: {e:#}");
     }
@@ -703,7 +728,9 @@ fn run_board(args: BoardSetupArgs) -> Result<()> {
             // just cannot run it here. Failing would deny them the build too.
             // The plan collects per tool, so one that cannot install does not
             // stop the others, and the error names each.
-            if let Err(e) = install_tools(&index, &names, None, false, false) {
+            if let Err(e) = Jobs::from_env(None)
+                .and_then(|jobs| install_tools(&index, &names, None, false, false, jobs))
+            {
                 eprintln!("      WARNING: board tool(s) not installed: {e:#}");
                 eprintln!("      The board's other provisioning steps continue.");
             }
@@ -836,6 +863,7 @@ fn install_tools(
     prefix_override: Option<&Path>,
     dry_run: bool,
     run_sudo: bool,
+    jobs: Jobs,
 ) -> Result<()> {
     let host = host_key();
     let root = store_root();
@@ -890,8 +918,8 @@ fn install_tools(
          system = [..]; re-run with --sudo to install them first):",
     );
 
-    let report =
-        run_sequential(&plan, Path::new("."), None, dry_run).finish(Some(Path::new(LOCK_FILE)))?;
+    let report = run_pipelined(&plan, Path::new("."), None, dry_run, jobs)
+        .finish(Some(Path::new(LOCK_FILE)))?;
     if dry_run {
         eprintln!("(--dry-run: nothing installed)");
         return Ok(());
@@ -1116,10 +1144,11 @@ pub fn ensure_tools(board: &str, workspace: Option<&Path>) -> Result<Vec<PathBuf
         &mut |_| PrereqState::Present,
         &Default::default(),
     )?;
-    run_sequential(&plan, &ws, None, false)
-        .finish(Some(Path::new(LOCK_FILE)))?
-        .conclude(&index)?;
-    Ok(plan.bin_dirs().into_iter().filter(|b| b.is_dir()).collect())
+    let mut report = run_pipelined(&plan, &ws, None, false, Jobs::from_env(None)?)
+        .finish(Some(Path::new(LOCK_FILE)))?;
+    let bin_dirs = std::mem::take(&mut report.bin_dirs);
+    report.conclude(&index)?;
+    Ok(bin_dirs.into_iter().filter(|b| b.is_dir()).collect())
 }
 
 /// Method A — prepend the store `bin/` dirs (from [`ensure_tools`]) to this
@@ -4112,6 +4141,7 @@ mod tests {
             Some(&good_prefix),
             false,
             false,
+            Jobs::resolve(Some(2), None, None).unwrap(),
         )
         .expect("a dist that runs must install cleanly");
         assert!(good_prefix.join("bin/widget").is_file());
@@ -4125,6 +4155,7 @@ mod tests {
             Some(&bad_prefix),
             false,
             false,
+            Jobs::resolve(Some(2), None, None).unwrap(),
         )
         .expect_err("a dist that cannot run must NOT install successfully");
         assert!(

--- a/packages/cli/nros-cli-core/src/cmd/setup/session.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup/session.rs
@@ -8,8 +8,9 @@
 //!
 //! Resolution is pure: a probe is injected, so the plan is a function of the
 //! index, the host and what the probes answer (the property issue 0374 gave
-//! `plan_install`). Execution is sequential in E2. E3 replaces
-//! [`run_sequential`] with a pipeline bounded by the CPU count, and the four
+//! `plan_install`). Execution is a pipeline bounded by the host's CPU count
+//! ([`run_pipelined`], phase-447 E3, which replaced E2's sequential loop and
+//! nothing else), and the four
 //! things that must stay ORDERED under that concurrency are properties of the
 //! types here rather than of the loop, so a pipeline cannot break them by
 //! accident:
@@ -28,8 +29,10 @@
 //!    accumulated by whoever finishes first.
 //! 4. **Per-package output in plan order.** Every per-step line goes through an
 //!    [`OrderedLog`], which emits a step's lines only once every earlier step
-//!    has closed. Sequentially that is live output; under a pipeline it is
-//!    buffering, with the same text in the same order.
+//!    has closed. The earliest unfinished step streams live; the steps ahead
+//!    of it buffer, and release the same text in the same order. What
+//!    `sdk_store` prints and what its children write reach the same log
+//!    through the step's sink (`orchestration/step_log.rs`).
 //!
 //! # One ask per SESSION, across processes
 //!
@@ -48,6 +51,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
+    sync::{Arc, Condvar, Mutex, MutexGuard},
 };
 
 use eyre::{Result, bail};
@@ -59,6 +63,7 @@ use crate::orchestration::{
         InstallAction, Provenance, SdkLock, SourceDisposition, plan_install, provision_source,
         tool_prefix,
     },
+    step_log::{self, StepSink},
 };
 
 /// The environment variable naming this session's ledger file.
@@ -654,6 +659,61 @@ impl OrderedLog {
 // Execution.
 // ---------------------------------------------------------------------------
 
+/// Where released lines go — stderr in a real run, a buffer in a test.
+pub(super) type Emit = Box<dyn FnMut(&str) + Send>;
+
+/// The plan-order log and its emitter, behind one lock so a release of lines is
+/// atomic with respect to every other step's: the lines of step `n` can never
+/// be split by step `n+1`'s.
+///
+/// Shared (`Arc`) because a step's lines come from several threads — the
+/// worker, a spawned child's reader threads, a download's progress watcher —
+/// and every one of them reaches it through the step's [`StepSink`].
+pub(super) struct PlanOutput {
+    state: Mutex<(OrderedLog, Emit)>,
+}
+
+impl PlanOutput {
+    fn new(emit: Emit) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new((OrderedLog::default(), emit)),
+        })
+    }
+
+    fn say(&self, step: usize, line: String) {
+        let mut g = lock(&self.state);
+        let (log, emit) = &mut *g;
+        for l in log.push(step, line) {
+            emit(&l);
+        }
+    }
+
+    fn close(&self, step: usize) {
+        let mut g = lock(&self.state);
+        let (log, emit) = &mut *g;
+        for l in log.close(step) {
+            emit(&l);
+        }
+    }
+
+    /// A line that belongs to no step — printed before any step runs.
+    fn note(&self, line: &str) {
+        (lock(&self.state).1)(line);
+    }
+
+    /// Step `step`'s sink: what `sdk_store` and its children write into.
+    fn sink(self: &Arc<Self>, step: usize) -> StepSink {
+        let me = Arc::clone(self);
+        Arc::new(move |line| me.say(step, line))
+    }
+}
+
+/// A poisoned lock is a step that panicked while holding it; the data is still
+/// the log and the schedule, and the run must still finish and report.
+fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// What one step produced. Nothing here touches the lock.
 #[derive(Default)]
 pub(super) struct Outcome {
@@ -667,8 +727,13 @@ pub(super) struct Outcome {
 /// order, and [`SessionRun::finish`] is the one writer of the lock.
 pub(super) struct SessionRun<'p, 'i> {
     plan: &'p SessionPlan<'i>,
-    log: OrderedLog,
+    out: Arc<PlanOutput>,
     outcomes: Vec<Option<Outcome>>,
+    /// The order steps actually finished in. Nothing may be derived from it —
+    /// it exists so a test can prove a run finished OUT of plan order, which is
+    /// what makes "the result is in plan order" a claim rather than a tautology.
+    #[cfg_attr(not(test), allow(dead_code))]
+    completed: Vec<usize>,
 }
 
 /// What a finished run amounts to.
@@ -679,38 +744,47 @@ pub(super) struct SessionReport {
     pub(super) smoke: SmokeFailures,
     /// `(package, error)`, in plan order.
     pub(super) errors: Vec<(String, String)>,
+    /// Store `bin/` dirs in PLAN order — what the emitted CMakePreset's `PATH`
+    /// and `ensure_tools`'s PATH prepend are folded from (RFC-0099 D7).
+    pub(super) bin_dirs: Vec<PathBuf>,
 }
 
 impl<'p, 'i> SessionRun<'p, 'i> {
     pub(super) fn new(plan: &'p SessionPlan<'i>) -> Self {
-        Self {
-            plan,
-            log: OrderedLog::default(),
-            outcomes: plan.steps.iter().map(|_| None).collect(),
-        }
+        Self::with_emitter(plan, Box::new(|l: &str| eprintln!("{l}")))
     }
 
-    /// A per-step line, routed through the plan-order log.
-    pub(super) fn say(&mut self, step: usize, line: String) {
-        for l in self.log.push(step, line) {
-            eprintln!("{l}");
+    pub(super) fn with_emitter(plan: &'p SessionPlan<'i>, emit: Emit) -> Self {
+        Self {
+            plan,
+            out: PlanOutput::new(emit),
+            outcomes: plan.steps.iter().map(|_| None).collect(),
+            completed: Vec::new(),
         }
     }
 
     pub(super) fn complete(&mut self, step: usize, outcome: Outcome) {
         self.outcomes[step] = Some(outcome);
-        for l in self.log.close(step) {
-            eprintln!("{l}");
-        }
+        self.completed.push(step);
+        self.out.close(step);
     }
 
-    /// The single writer: walk the steps in PLAN order, record every locked
-    /// provenance, save the lock ONCE, and fold smoke verdicts and failures in
-    /// the same order. Recorded before any verdict on purpose — the files are
-    /// on disk whatever the probes say, and a lock that omitted them would make
-    /// the next run re-download the same broken dist to reach the same answer.
+    #[cfg(test)]
+    pub(super) fn completion_order(&self) -> &[usize] {
+        &self.completed
+    }
+
+    /// The single writer, and the ONE plan-order fold: walk the steps in PLAN
+    /// order, record every locked provenance, save the lock ONCE, and fold
+    /// smoke verdicts, failures and `bin_dirs` in the same order. Recorded
+    /// before any verdict on purpose — the files are on disk whatever the
+    /// probes say, and a lock that omitted them would make the next run
+    /// re-download the same broken dist to reach the same answer.
     pub(super) fn finish(self, lock_path: Option<&Path>) -> Result<SessionReport> {
-        let mut report = SessionReport::default();
+        let mut report = SessionReport {
+            bin_dirs: self.plan.bin_dirs(),
+            ..SessionReport::default()
+        };
         let mut lock: Option<SdkLock> = None;
         for (step, outcome) in self.plan.steps.iter().zip(self.outcomes) {
             let Some(outcome) = outcome else {
@@ -769,128 +843,424 @@ impl SessionReport {
     }
 }
 
-/// Execute `plan` one step at a time, in plan order. E3 replaces this loop and
-/// nothing else.
+// ---------------------------------------------------------------------------
+// How many at once.
+// ---------------------------------------------------------------------------
+
+/// The environment variable that overrides the concurrency — the only spelling
+/// the lazy `ensure_tools` path (under `nros build`) and the `just` recipes can
+/// reach, since neither passes `--jobs`.
+pub(super) const JOBS_ENV: &str = "NROS_SETUP_JOBS";
+
+/// How many steps may be in flight, and where that number came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct Jobs {
+    pub(super) n: usize,
+    pub(super) from: &'static str,
+}
+
+impl Jobs {
+    /// `--jobs`, else `$NROS_SETUP_JOBS`, else the host's CPU count (RFC-0099
+    /// D7: bounded by the host). Pure — the caller supplies all three.
+    ///
+    /// Zero is refused rather than read as "default": `-j0` means "unlimited"
+    /// to make and "default" to cargo, and a flag that silently means one of
+    /// the two is worse than one that says it means neither.
+    pub(super) fn resolve(
+        flag: Option<usize>,
+        env: Option<&str>,
+        host: Option<usize>,
+    ) -> Result<Self> {
+        if let Some(n) = flag {
+            if n == 0 {
+                bail!("nros setup: --jobs must be at least 1");
+            }
+            return Ok(Self { n, from: "--jobs" });
+        }
+        if let Some(raw) = env.map(str::trim).filter(|v| !v.is_empty()) {
+            return match raw.parse::<usize>() {
+                Ok(n) if n > 0 => Ok(Self { n, from: JOBS_ENV }),
+                _ => bail!("nros setup: {JOBS_ENV}={raw:?} is not a positive integer"),
+            };
+        }
+        Ok(match host {
+            Some(n) if n > 0 => Self {
+                n,
+                from: "this host's CPU count",
+            },
+            _ => Self {
+                n: 1,
+                from: "the host's CPU count is unknown",
+            },
+        })
+    }
+
+    /// [`Jobs::resolve`] against this process's environment and host.
+    pub(super) fn from_env(flag: Option<usize>) -> Result<Self> {
+        let env = std::env::var(JOBS_ENV).ok();
+        let host = std::thread::available_parallelism().ok().map(usize::from);
+        Self::resolve(flag, env.as_deref(), host)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The pipeline.
+// ---------------------------------------------------------------------------
+
+/// Steps that must not run beside each other, whatever the concurrency.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Lane {
+    /// A `[source.*]` step writes the WORKSPACE's git state: the submodule arm
+    /// runs `git -C <workspace> submodule update` (which takes the
+    /// superproject's `index.lock`) and rewrites `.git/config` refspecs. Two at
+    /// once would fail on the lock, or lose a config write.
+    Workspace,
+    /// A `[tool.*]` built from source already uses the whole machine through
+    /// its own cargo/make/ninja. Two at once mostly moves CPU contention around
+    /// (issue 1267); one build beside other packages' DOWNLOADS is the overlap
+    /// that pays.
+    Build,
+}
+
+pub(super) fn lane_of(step: &Step<'_>) -> Option<Lane> {
+    match &step.kind {
+        StepKind::Source(_) => Some(Lane::Workspace),
+        StepKind::Tool {
+            action: InstallAction::Source { .. },
+            blocked_on,
+            ..
+        } if blocked_on.is_empty() => Some(Lane::Build),
+        _ => None,
+    }
+}
+
+/// Which steps have been handed out, which lanes are held, which steps closed.
+struct Schedule {
+    lanes: Vec<Option<Lane>>,
+    dispatched: Vec<bool>,
+    closed: Vec<bool>,
+    busy: Vec<Lane>,
+}
+
+impl Schedule {
+    /// The EARLIEST undispatched step whose lane is free. Earliest, so the
+    /// step the log is streaming is always among those running; "whose lane is
+    /// free", so a queue of source builds never holds a worker idle while a
+    /// download behind them could be moving.
+    fn pick(&mut self) -> Option<usize> {
+        let i = (0..self.lanes.len()).find(|&i| {
+            !self.dispatched[i] && self.lanes[i].is_none_or(|l| !self.busy.contains(&l))
+        })?;
+        self.dispatched[i] = true;
+        if let Some(l) = self.lanes[i] {
+            self.busy.push(l);
+        }
+        Some(i)
+    }
+
+    fn all_dispatched(&self) -> bool {
+        self.dispatched.iter().all(|&d| d)
+    }
+}
+
+struct Pool {
+    sched: Mutex<Schedule>,
+    changed: Condvar,
+}
+
+/// What a step's work sees: its place in the plan, and its output.
+pub(super) struct StepCtx<'s, 'p, 'i> {
+    pub(super) index: usize,
+    pub(super) step: &'p Step<'i>,
+    out: &'s PlanOutput,
+    #[cfg_attr(not(test), allow(dead_code))]
+    pool: &'s Pool,
+}
+
+impl StepCtx<'_, '_, '_> {
+    pub(super) fn say(&self, line: String) {
+        self.out.say(self.index, line);
+    }
+
+    /// Block until step `other` has CLOSED — the tests' way to force an
+    /// out-of-order finish by handshake instead of by sleeping. A test that
+    /// asserted on wall-clock time would measure the machine.
+    ///
+    /// The deadline is a deadlock guard, not a measurement: a scheduler that
+    /// cannot run `other` while this step waits (the naive "block on the lane
+    /// in plan order" shape) fails the test instead of hanging it.
+    #[cfg(test)]
+    pub(super) fn wait_closed(&self, other: usize) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        let mut s = lock(&self.pool.sched);
+        while !s.closed[other] {
+            let left = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !left.is_zero(),
+                "step {} waited for step {other}, which never closed — the executor \
+                 cannot run it while this one is in flight",
+                self.index
+            );
+            s = self
+                .pool
+                .changed
+                .wait_timeout(s, left)
+                .unwrap_or_else(|e| e.into_inner())
+                .0;
+        }
+    }
+}
+
+/// Execute `run`'s plan with up to `jobs` steps in flight. `work` does one step
+/// and returns its outcome; it may run on any worker, in any order.
+///
+/// What this owns is the ORDER of nothing: every ordered property is somebody
+/// else's — the lock and `bin_dirs` are [`SessionRun::finish`]'s plan-order
+/// fold, output is the [`OrderedLog`]'s, and one-install-per-tool (and so one
+/// `front_newest` per tool) is [`SessionPlan::resolve`]'s. So this is free to
+/// finish steps in whatever order they finish. The two things it does own:
+///
+/// * **no step is dropped or run twice** — [`Schedule::pick`] hands each index
+///   out exactly once, and a step that PANICS is an error outcome, not a lost
+///   one (`finish` refuses a step that never completed);
+/// * **a failure stops nothing** — a step's error is its own outcome; no
+///   worker stops taking steps because another failed.
+pub(super) fn execute_plan<'p, 'i, W>(
+    run: SessionRun<'p, 'i>,
+    jobs: usize,
+    work: W,
+) -> SessionRun<'p, 'i>
+where
+    W: Fn(&StepCtx<'_, 'p, 'i>) -> Outcome + Sync,
+{
+    let plan = run.plan;
+    let n = plan.steps.len();
+    let out = Arc::clone(&run.out);
+    let run = Mutex::new(run);
+    let pool = Pool {
+        sched: Mutex::new(Schedule {
+            lanes: plan.steps.iter().map(lane_of).collect(),
+            dispatched: vec![false; n],
+            closed: vec![false; n],
+            busy: Vec::new(),
+        }),
+        changed: Condvar::new(),
+    };
+    let workers = jobs.clamp(1, n.max(1));
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let next = {
+                        let mut s = lock(&pool.sched);
+                        loop {
+                            if let Some(i) = s.pick() {
+                                break Some(i);
+                            }
+                            if s.all_dispatched() {
+                                break None;
+                            }
+                            // Everything left waits on a held lane.
+                            s = pool.changed.wait(s).unwrap_or_else(|e| e.into_inner());
+                        }
+                    };
+                    let Some(i) = next else { break };
+                    let ctx = StepCtx {
+                        index: i,
+                        step: &plan.steps[i],
+                        out: &out,
+                        pool: &pool,
+                    };
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        step_log::with_step_sink(out.sink(i), || work(&ctx))
+                    }))
+                    .unwrap_or_else(|p| Outcome {
+                        error: Some(format!("the installer panicked: {}", panic_text(&*p))),
+                        ..Outcome::default()
+                    });
+                    lock(&run).complete(i, outcome);
+                    let mut s = lock(&pool.sched);
+                    s.closed[i] = true;
+                    if let Some(l) = s.lanes[i] {
+                        s.busy.retain(|&b| b != l);
+                    }
+                    drop(s);
+                    pool.changed.notify_all();
+                }
+            });
+        }
+    });
+    run.into_inner().unwrap_or_else(|e| e.into_inner())
+}
+
+fn panic_text(p: &(dyn std::any::Any + Send)) -> String {
+    p.downcast_ref::<&str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| p.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "(no message)".to_string())
+}
+
+/// Execute `plan` as a pipeline of up to `jobs` steps — RFC-0099 D7 /
+/// phase-447 E3. Replaces E2's `run_sequential`, and nothing else changed
+/// around it: resolution, the ask and [`SessionRun::finish`] are as E2 left
+/// them.
+///
+/// Fetch, verify and unpack stay serial WITHIN a package (verify needs the
+/// whole archive) and overlap ACROSS packages: while one unpacks, the next
+/// downloads (issue 1266), and a source build runs beside other packages'
+/// downloads (issue 1267).
+pub(super) fn run_pipelined<'p, 'i>(
+    plan: &'p SessionPlan<'i>,
+    workspace: &Path,
+    shallow: Option<bool>,
+    dry_run: bool,
+    jobs: Jobs,
+) -> SessionRun<'p, 'i> {
+    run_pipelined_into(SessionRun::new(plan), workspace, shallow, dry_run, jobs)
+}
+
+/// [`run_pipelined`] into a given run — a test passes one whose emitter
+/// captures, and gets the real install path with its output readable.
+pub(super) fn run_pipelined_into<'p, 'i>(
+    run: SessionRun<'p, 'i>,
+    workspace: &Path,
+    shallow: Option<bool>,
+    dry_run: bool,
+    jobs: Jobs,
+) -> SessionRun<'p, 'i> {
+    let plan = run.plan;
+    let host = crate::orchestration::sdk_index::host_key();
+    let installs = plan
+        .steps
+        .iter()
+        .filter(|s| {
+            matches!(&s.kind, StepKind::Tool { action, blocked_on, .. }
+                if will_install(action) && blocked_on.is_empty())
+        })
+        .count();
+    let workers = jobs.n.min(plan.steps.len());
+    if plan.mode != Mode::Lazy && !dry_run && installs > 1 && workers > 1 {
+        run.out.note(&format!(
+            "nros setup: {installs} package(s) to install, up to {workers} at a time ({}; \
+             override with --jobs or {JOBS_ENV}). Each package's output is shown whole, in plan \
+             order.",
+            jobs.from
+        ));
+    }
+    execute_plan(run, jobs.n, |ctx| {
+        run_step(plan.mode, ctx, &host, workspace, shallow, dry_run)
+    })
+}
+
+/// One step of the real install path.
 ///
 /// Every `[tool.*]` install goes through [`SmokeFailures::execute_and_probe`] —
 /// the ONE place installing and asking "does it run?" are paired. Reaching
 /// `sdk_store::execute` from here without it is the regression
 /// `a_board_install_smokes_every_package_and_a_broken_one_stops_nothing`
 /// exists to catch.
-pub(super) fn run_sequential<'p, 'i>(
-    plan: &'p SessionPlan<'i>,
+fn run_step(
+    mode: Mode,
+    ctx: &StepCtx<'_, '_, '_>,
+    host: &str,
     workspace: &Path,
     shallow: Option<bool>,
     dry_run: bool,
-) -> SessionRun<'p, 'i> {
-    let host = crate::orchestration::sdk_index::host_key();
-    let mut run = SessionRun::new(plan);
-    for (i, step) in plan.steps.iter().enumerate() {
-        let mut out = Outcome::default();
-        match &step.kind {
-            StepKind::Tool {
-                tool,
-                prefix,
-                action,
-                blocked_on,
-                ..
-            } => {
-                // The lazy path runs under `nros build`: it speaks only when it
-                // does something, never to list what is already there.
-                if plan.mode != Mode::Lazy {
-                    let what = super::describe(action, &tool.version, &host);
-                    run.say(i, tool_line(plan.mode, step.name, &what, prefix));
+) -> Outcome {
+    let step = ctx.step;
+    let mut out = Outcome::default();
+    match &step.kind {
+        StepKind::Tool {
+            tool,
+            prefix,
+            action,
+            blocked_on,
+            ..
+        } => {
+            // The lazy path runs under `nros build`: it speaks only when it
+            // does something, never to list what is already there.
+            if mode != Mode::Lazy {
+                let what = super::describe(action, &tool.version, host);
+                ctx.say(tool_line(mode, step.name, &what, prefix));
+            }
+            if dry_run {
+                return out;
+            }
+            match action {
+                InstallAction::Present => {}
+                InstallAction::Unavailable if mode == Mode::Lazy => {
+                    ctx.say(format!(
+                        "nros: {} {} unavailable for {host} (no prebuilt, no source) — \
+                         install it yourself if the build needs it",
+                        step.name, tool.version
+                    ));
                 }
-                if dry_run {
-                    run.complete(i, out);
-                    continue;
+                InstallAction::Unavailable => {
+                    out.error = Some(format!(
+                        "{} has no prebuilt for {host} and no source recipe",
+                        tool.version
+                    ));
                 }
-                match action {
-                    InstallAction::Present => {}
-                    InstallAction::Unavailable if plan.mode == Mode::Lazy => {
-                        run.say(
-                            i,
-                            format!(
-                                "nros: {} {} unavailable for {host} (no prebuilt, no source) — \
-                                 install it yourself if the build needs it",
-                                step.name, tool.version
-                            ),
-                        );
-                    }
-                    InstallAction::Unavailable => {
-                        out.error = Some(format!(
-                            "{} has no prebuilt for {host} and no source recipe",
-                            tool.version
+                _ if !blocked_on.is_empty() => {
+                    out.error = Some(format!(
+                        "not installed — needs system package(s) this host is missing: {} \
+                         (the one ask for them is printed above; declared as \
+                         [tool.{}] system = [..])",
+                        blocked_on.join(", "),
+                        step.name
+                    ));
+                }
+                other => {
+                    if mode == Mode::Lazy {
+                        ctx.say(format!(
+                            "nros: auto-installing {} {} (set NROS_NO_AUTO_SETUP to skip)",
+                            step.name, tool.version
                         ));
                     }
-                    _ if !blocked_on.is_empty() => {
-                        out.error = Some(format!(
-                            "not installed — needs system package(s) this host is missing: {} \
-                             (the one ask for them is printed above; declared as \
-                             [tool.{}] system = [..])",
-                            blocked_on.join(", "),
-                            step.name
-                        ));
-                    }
-                    other => {
-                        if plan.mode == Mode::Lazy {
-                            run.say(
-                                i,
-                                format!(
-                                    "nros: auto-installing {} {} (set NROS_NO_AUTO_SETUP to skip)",
-                                    step.name, tool.version
-                                ),
-                            );
+                    match out.smoke.execute_and_probe(other, step.name, tool, prefix) {
+                        Ok(prov) => {
+                            out.provenance = Some(prov);
+                            out.installed = true;
+                            ctx.say(format!("    → {}", prefix.display()));
                         }
-                        match out.smoke.execute_and_probe(other, step.name, tool, prefix) {
-                            Ok(prov) => {
-                                out.provenance = Some(prov);
-                                out.installed = true;
-                                run.say(i, format!("    → {}", prefix.display()));
-                            }
-                            Err(e) => {
-                                out.error = Some(format!("install {}: {e:#}", tool.version));
-                            }
+                        Err(e) => {
+                            out.error = Some(format!("install {}: {e:#}", tool.version));
                         }
                     }
-                }
-            }
-            StepKind::Source(src) => {
-                match provision_source(step.name, src, workspace, dry_run, shallow) {
-                    Ok(disp) => {
-                        out.installed = matches!(disp, SourceDisposition::Provisioned);
-                        if plan.mode != Mode::Lazy || out.installed {
-                            let text = super::describe_source(step.name, src, workspace, &disp);
-                            run.say(i, source_line(plan.mode, step.name, &text));
-                        }
-                    }
-                    Err(e) => {
-                        let msg = format!("provision source: {e:#}");
-                        if plan.mode == Mode::Lazy {
-                            // Best-effort, as before: the build names the miss.
-                            run.say(
-                                i,
-                                format!(
-                                    "nros: source {} provisioning failed ({msg}) — provide it \
-                                     yourself if the build needs it",
-                                    step.name
-                                ),
-                            );
-                        } else {
-                            out.error = Some(msg);
-                        }
-                    }
-                }
-            }
-            StepKind::Other(disposition) => {
-                if plan.mode != Mode::Lazy {
-                    run.say(i, format!("  {:<22} {disposition}", step.name));
                 }
             }
         }
-        run.complete(i, out);
+        StepKind::Source(src) => {
+            match provision_source(step.name, src, workspace, dry_run, shallow) {
+                Ok(disp) => {
+                    out.installed = matches!(disp, SourceDisposition::Provisioned);
+                    if mode != Mode::Lazy || out.installed {
+                        let text = super::describe_source(step.name, src, workspace, &disp);
+                        ctx.say(source_line(mode, step.name, &text));
+                    }
+                }
+                Err(e) => {
+                    let msg = format!("provision source: {e:#}");
+                    if mode == Mode::Lazy {
+                        // Best-effort, as before: the build names the miss.
+                        ctx.say(format!(
+                            "nros: source {} provisioning failed ({msg}) — provide it \
+                             yourself if the build needs it",
+                            step.name
+                        ));
+                    } else {
+                        out.error = Some(msg);
+                    }
+                }
+            }
+        }
+        StepKind::Other(disposition) => {
+            if mode != Mode::Lazy {
+                ctx.say(format!("  {:<22} {disposition}", step.name));
+            }
+        }
     }
-    run
+    out
 }
 
 fn tool_line(mode: Mode, name: &str, what: &str, prefix: &Path) -> String {
@@ -1250,7 +1620,7 @@ mod tests {
         )
         .unwrap();
 
-        let report = run_sequential(&plan, &dir, None, false)
+        let report = run_pipelined(&plan, &dir, None, false, three_at_once())
             .finish(Some(&lock))
             .unwrap();
 
@@ -1305,7 +1675,7 @@ mod tests {
         .unwrap();
         assert_eq!(plan.system.os["libfoo"], ["needy"]);
 
-        let report = run_sequential(&plan, &dir, None, false)
+        let report = run_pipelined(&plan, &dir, None, false, three_at_once())
             .finish(Some(&dir.join("lock")))
             .unwrap();
         assert!(
@@ -1388,5 +1758,361 @@ mod tests {
             panic!("an uncompleted step must be refused");
         };
         assert!(format!("{err}").contains("never completed"), "{err}");
+    }
+
+    // ---- E3: the pipeline --------------------------------------------------
+    //
+    // Every test below forces its completion order by HANDSHAKE
+    // (`StepCtx::wait_closed`) and asserts on order and outcomes, never on
+    // elapsed time — a timing assertion measures the machine. Each also asserts
+    // that the order really was out of plan order, so "the result is in plan
+    // order" is a claim and not a tautology of a run that happened to be
+    // sequential.
+
+    fn three_at_once() -> Jobs {
+        Jobs::resolve(Some(3), None, None).unwrap()
+    }
+
+    /// A `[tool.*]` with a dist for this host: `Prebuilt`, no lane. The URL is
+    /// never fetched where the work is injected.
+    fn prebuilt_entry(name: &str) -> String {
+        format!(
+            "[tool.{name}]\nversion = \"1\"\n\
+             dist.{host} = {{ url = \"file:///nowhere/{name}\", sha256 = \"00\" }}\n",
+            host = host_key()
+        )
+    }
+
+    /// A `[tool.*]` built from source: the Build lane.
+    fn source_build_entry(name: &str) -> String {
+        format!("[tool.{name}]\nversion = \"1\"\n[tool.{name}.source]\ngit = \"x\"\nref = \"y\"\n")
+    }
+
+    /// A `[source.*]`: the Workspace lane.
+    fn workspace_source_entry(name: &str) -> String {
+        format!("[source.{name}]\nversion = \"1\"\ngit = \"x\"\nref = \"y\"\ndest = \"d/{name}\"\n")
+    }
+
+    type Seen = Arc<Mutex<Vec<String>>>;
+
+    fn capturing<'p, 'i>(plan: &'p SessionPlan<'i>) -> (SessionRun<'p, 'i>, Seen) {
+        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+        let s = Arc::clone(&seen);
+        let run = SessionRun::with_emitter(
+            plan,
+            Box::new(move |l: &str| s.lock().unwrap().push(l.to_string())),
+        );
+        (run, seen)
+    }
+
+    fn source_prov(v: &str) -> Provenance {
+        Provenance {
+            kind: crate::orchestration::sdk_store::ProvenanceKind::Source,
+            version: v.into(),
+            sha256: None,
+        }
+    }
+
+    /// The four ordered properties, under a run that finishes in EXACTLY
+    /// reverse plan order:
+    ///
+    /// * output — every line of a step, including what a spawned CHILD printed
+    ///   and what `sdk_store` said through `step_log::say` (the gap E2 named),
+    ///   leaves in plan order, each step's block whole;
+    /// * the lock — no step writes it, even after every later step has
+    ///   completed; `finish` writes it once;
+    /// * `bin_dirs` — in plan order;
+    /// * the fold — failures and smoke verdicts in plan order.
+    #[cfg(unix)]
+    #[test]
+    fn under_concurrency_every_ordered_thing_leaves_in_plan_order() {
+        let names = ["a", "b", "c", "d"];
+        let idx = index(&names.iter().map(|n| prebuilt_entry(n)).collect::<String>());
+        let dir = crate::test_support::scratch_dir("e3_plan_order");
+        let host = host_key();
+        let plan = SessionPlan::resolve(
+            &idx,
+            &names,
+            &inputs(&dir, &host, Mode::Board),
+            &mut |_| PrereqState::Present,
+            &no_asks(),
+        )
+        .unwrap();
+        let lock = dir.join("lock");
+        let (run, seen) = capturing(&plan);
+        let run = execute_plan(run, names.len(), |ctx| {
+            let (i, name) = (ctx.index, ctx.step.name);
+            ctx.say(format!("{name}-start"));
+            // Finish in REVERSE plan order: each step waits for the one after.
+            if i + 1 < names.len() {
+                ctx.wait_closed(i + 1);
+            }
+            // Output from BELOW the session: a child's stdout, and a note the
+            // way `sdk_store` prints one.
+            let st = step_log::status(
+                std::process::Command::new("sh").args(["-c", &format!("echo {name}-child")]),
+            )
+            .unwrap();
+            assert!(st.success());
+            step_log::say(format!("{name}-store"));
+            // Every later step has completed by now, and none wrote the lock.
+            assert!(!lock.exists(), "a step wrote the lock");
+            ctx.say(format!("{name}-end"));
+            let mut out = Outcome {
+                installed: true,
+                ..Outcome::default()
+            };
+            if i % 2 == 0 {
+                out.provenance = Some(source_prov(&format!("v{i}")));
+                out.smoke.passed.push(name.to_string());
+            } else {
+                out.error = Some(format!("{name} broke"));
+            }
+            out
+        });
+        assert_eq!(
+            run.completion_order(),
+            [3, 2, 1, 0],
+            "the run must really have finished out of plan order"
+        );
+        let report = run.finish(Some(&lock)).unwrap();
+
+        let expected: Vec<String> = names
+            .iter()
+            .flat_map(|n| ["start", "child", "store", "end"].map(|w| format!("{n}-{w}")))
+            .collect();
+        assert_eq!(*seen.lock().unwrap(), expected, "output in plan order");
+
+        assert!(report.lock_written);
+        let l = SdkLock::load(&lock).unwrap();
+        assert_eq!(l.tool["a"].version, "v0");
+        assert_eq!(l.tool["c"].version, "v2");
+        assert_eq!(l.tool.len(), 2, "only the steps that produced a provenance");
+
+        assert_eq!(
+            report.bin_dirs,
+            names.map(|n| dir.join(n).join("1").join("bin")),
+            "bin_dirs in plan order"
+        );
+        assert_eq!(
+            report
+                .errors
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect::<Vec<_>>(),
+            ["b", "d"],
+            "failures folded in plan order"
+        );
+        assert_eq!(
+            report.smoke.passed,
+            ["a", "c"],
+            "smoke folded in plan order"
+        );
+    }
+
+    /// One broken package does not abort the rest, under concurrency — neither
+    /// a step that FAILS nor one that PANICS. Every step runs exactly once
+    /// (none skipped, none run twice: two runs of one tool would be two
+    /// `front_newest` passes racing for its link, which is what a plan holding
+    /// one step per package exists to prevent), the run finishes, and each
+    /// failure is reported against its own package.
+    #[test]
+    fn a_failing_or_panicking_step_stops_none_of_its_siblings() {
+        let names = ["a", "b", "c", "d", "e"];
+        let idx = index(&names.iter().map(|n| prebuilt_entry(n)).collect::<String>());
+        let dir = crate::test_support::scratch_dir("e3_failure_isolation");
+        let host = host_key();
+        let plan = SessionPlan::resolve(
+            &idx,
+            &names,
+            &inputs(&dir, &host, Mode::Board),
+            &mut |_| PrereqState::Present,
+            &no_asks(),
+        )
+        .unwrap();
+        let runs: Vec<std::sync::atomic::AtomicUsize> =
+            names.iter().map(|_| Default::default()).collect();
+        let (run, _seen) = capturing(&plan);
+        let run = execute_plan(run, 2, |ctx| {
+            runs[ctx.index].fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match ctx.index {
+                0 => Outcome {
+                    error: Some("boom".into()),
+                    ..Outcome::default()
+                },
+                1 => panic!("kaput"),
+                i => {
+                    // The later steps start only after the failures closed —
+                    // so they were dispatched AFTER a sibling failed.
+                    ctx.wait_closed(0);
+                    ctx.wait_closed(1);
+                    Outcome {
+                        provenance: Some(source_prov(&format!("v{i}"))),
+                        installed: true,
+                        ..Outcome::default()
+                    }
+                }
+            }
+        });
+        let lock = dir.join("lock");
+        let report = run
+            .finish(Some(&lock))
+            .expect("every step completed — none was dropped after a failure");
+        for (i, r) in runs.iter().enumerate() {
+            assert_eq!(
+                r.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "step {i} ran exactly once"
+            );
+        }
+        assert_eq!(report.errors.len(), 2, "{:?}", report.errors);
+        assert_eq!(report.errors[0], ("a".to_string(), "boom".to_string()));
+        assert_eq!(report.errors[1].0, "b");
+        assert!(
+            report.errors[1].1.contains("panicked: kaput"),
+            "{:?}",
+            report.errors
+        );
+        let l = SdkLock::load(&lock).unwrap();
+        assert_eq!(
+            l.tool.keys().map(String::as_str).collect::<Vec<_>>(),
+            ["c", "d", "e"]
+        );
+    }
+
+    /// Two source BUILDS never overlap, two `[source.*]` steps (which write the
+    /// workspace's git state) never overlap — and neither lane holds a worker
+    /// idle: the download queued BEHIND a waiting build still runs.
+    ///
+    /// Each lane's second step waits on something that closes only after the
+    /// first, so without the lanes both would be in flight at once (the
+    /// counters would read 2), and a scheduler that blocked on the lane in
+    /// plan order would deadlock here (the wait's guard fails it instead).
+    #[test]
+    fn steps_that_share_a_lane_never_overlap_and_the_rest_flow_around_them() {
+        let idx = index(&format!(
+            "{}{}{}{}{}",
+            source_build_entry("s0"),
+            source_build_entry("s1"),
+            prebuilt_entry("p2"),
+            workspace_source_entry("w3"),
+            workspace_source_entry("w4"),
+        ));
+        let dir = crate::test_support::scratch_dir("e3_lanes");
+        let host = host_key();
+        let names = ["s0", "s1", "p2", "w3", "w4"];
+        let plan = SessionPlan::resolve(
+            &idx,
+            &names,
+            &inputs(&dir, &host, Mode::Board),
+            &mut |_| PrereqState::Present,
+            &no_asks(),
+        )
+        .unwrap();
+        assert_eq!(
+            plan.steps.iter().map(lane_of).collect::<Vec<_>>(),
+            [
+                Some(Lane::Build),
+                Some(Lane::Build),
+                None,
+                Some(Lane::Workspace),
+                Some(Lane::Workspace)
+            ]
+        );
+        use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+        let (build, build_max) = (AtomicUsize::new(0), AtomicUsize::new(0));
+        let (ws, ws_max) = (AtomicUsize::new(0), AtomicUsize::new(0));
+        let (run, _seen) = capturing(&plan);
+        let run = execute_plan(run, names.len(), |ctx| {
+            let (now, max, waits_on) = match ctx.index {
+                0 | 1 => (&build, &build_max, Some(2)),
+                3 | 4 => (&ws, &ws_max, Some(1)),
+                _ => return Outcome::default(),
+            };
+            max.fetch_max(now.fetch_add(1, SeqCst) + 1, SeqCst);
+            if let Some(j) = waits_on {
+                ctx.wait_closed(j);
+            }
+            now.fetch_sub(1, SeqCst);
+            Outcome::default()
+        });
+        assert_eq!(build_max.load(SeqCst), 1, "two source builds overlapped");
+        assert_eq!(ws_max.load(SeqCst), 1, "two [source.*] steps overlapped");
+        assert_eq!(
+            run.completion_order(),
+            [2, 0, 1, 3, 4],
+            "the download behind the waiting build ran first"
+        );
+        run.finish(None).unwrap();
+    }
+
+    /// Concurrency defaults from the host and is overridable, flag over env over
+    /// host; a zero or a non-number is refused by name rather than guessed at.
+    #[test]
+    fn concurrency_defaults_to_the_host_cpu_count_and_can_be_overridden() {
+        let j = Jobs::resolve(None, None, Some(12)).unwrap();
+        assert_eq!((j.n, j.from), (12, "this host's CPU count"));
+        let j = Jobs::resolve(None, Some("3"), Some(12)).unwrap();
+        assert_eq!((j.n, j.from), (3, JOBS_ENV));
+        let j = Jobs::resolve(Some(2), Some("3"), Some(12)).unwrap();
+        assert_eq!((j.n, j.from), (2, "--jobs"));
+        assert_eq!(Jobs::resolve(None, Some("  "), Some(4)).unwrap().n, 4);
+        assert_eq!(Jobs::resolve(None, None, None).unwrap().n, 1);
+        for (flag, env) in [(Some(0), None), (None, Some("0")), (None, Some("many"))] {
+            let Err(e) = Jobs::resolve(flag, env, Some(4)) else {
+                panic!("{flag:?}/{env:?} must be refused");
+            };
+            let msg = format!("{e}");
+            assert!(
+                msg.contains("--jobs") || msg.contains(JOBS_ENV),
+                "names its source: {msg}"
+            );
+        }
+    }
+
+    /// The real install path at concurrency 3 — download, sha256, `tar -xf`,
+    /// smoke — prints each package's lines whole and in plan order, whatever
+    /// order the three installs finished in.
+    #[cfg(unix)]
+    #[test]
+    fn the_real_install_path_prints_each_package_whole_and_in_plan_order() {
+        let dir = crate::test_support::scratch_dir("e3_real_output");
+        let (url, sha) = pack(&dir, "good", "widget 1.0");
+        let names = ["w-one", "w-two", "w-three"];
+        let idx = index(
+            &names
+                .iter()
+                .map(|n| widget_entry(n, &url, &sha))
+                .collect::<String>(),
+        );
+        let root = dir.join("store");
+        let host = host_key();
+        let plan = SessionPlan::resolve(
+            &idx,
+            &names,
+            &inputs(&root, &host, Mode::Board),
+            &mut |_| PrereqState::Present,
+            &no_asks(),
+        )
+        .unwrap();
+        let (run, seen) = capturing(&plan);
+        let report = run_pipelined_into(run, &dir, None, false, three_at_once())
+            .finish(Some(&dir.join("lock")))
+            .unwrap();
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.smoke.passed, names);
+
+        let lines = seen.lock().unwrap().clone();
+        assert!(
+            lines[0].contains("3 package(s) to install, up to 3 at a time"),
+            "{lines:?}"
+        );
+        let owner = |l: &str| {
+            names
+                .iter()
+                .position(|n| l.contains(&format!("{n}/")) || l.contains(&format!("{n} ")))
+        };
+        let owners: Vec<usize> = lines[1..].iter().filter_map(|l| owner(l)).collect();
+        assert_eq!(owners, [0, 0, 1, 1, 2, 2], "{lines:#?}");
     }
 }

--- a/packages/cli/nros-cli-core/src/orchestration/mod.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/mod.rs
@@ -67,6 +67,7 @@ pub mod sdk_store;
 /// phase-351 W1 — the SITE half of a deploy target (RFC-0072 §5).
 pub mod site_config;
 pub mod source_metadata;
+pub mod step_log;
 /// phase-440 W6 — the store's inventory, pin predicate and gc plan (RFC-0095
 /// D2 + D11). `sdk_store` is where a version GOES; this is what is there.
 pub mod store;

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -530,7 +530,7 @@ pub fn execute(
 ) -> Result<Provenance> {
     let provenance = execute_install(action, tool, version, prefix)?;
     for link in front_newest(&store_root(), tool, front)? {
-        eprintln!("    → {} (newest installed)", link.display());
+        super::step_log::say(format!("    → {} (newest installed)", link.display()));
     }
     Ok(provenance)
 }
@@ -568,20 +568,7 @@ fn execute_install(
             std::fs::create_dir_all(prefix)
                 .wrap_err_with(|| format!("create {}", prefix.display()))?;
             let archive = prefix.with_extension("download");
-            sh(
-                &[
-                    "curl",
-                    "-L",
-                    "--fail",
-                    "--silent",
-                    "--show-error",
-                    "-o",
-                    &archive.to_string_lossy(),
-                    url,
-                ],
-                None,
-            )
-            .wrap_err_with(|| format!("download {url}"))?;
+            download(url, &archive).wrap_err_with(|| format!("download {url}"))?;
             verify_sha256(&archive, sha256)?;
             // Default: the mirror shape (a prefix-rooted tar). An UPSTREAM
             // asset often is not that — ninja publishes a zip holding a bare
@@ -683,20 +670,7 @@ fn execute_install(
                     std::fs::create_dir_all(&src)
                         .wrap_err_with(|| format!("create {src_str} ({tool})"))?;
                     let archive = prefix.with_extension("src.download");
-                    sh(
-                        &[
-                            "curl",
-                            "-L",
-                            "--fail",
-                            "--silent",
-                            "--show-error",
-                            "-o",
-                            &archive.to_string_lossy(),
-                            url,
-                        ],
-                        None,
-                    )
-                    .wrap_err_with(|| format!("download {url} ({tool})"))?;
+                    download(url, &archive).wrap_err_with(|| format!("download {url} ({tool})"))?;
                     verify_sha256(&archive, sha256)?;
                     sh(
                         &[
@@ -724,11 +698,11 @@ fn execute_install(
             }
             if let Some(inst) = install {
                 if let Some(tc) = toolchain {
-                    eprintln!(
+                    super::step_log::say(format!(
                         "nros setup: building {tool} with the workspace Rust channel \
                          ({tc}) rather than the checkout's own pin — set \
                          `respect_toolchain = true` on this recipe if it needs its own."
-                    );
+                    ));
                 }
                 sh_with_toolchain(
                     &["sh", "-c", &inst.replace("{prefix}", &prefix_abs)],
@@ -926,9 +900,9 @@ fn ensure_submodule_branch_refspec(workspace: &Path, path: &str, shallow: bool) 
         // Non-fatal: an offline host still gets the durable config, and the
         // next fetch materialises the ref. Failing provisioning over this
         // would be worse than the state we are repairing.
-        eprintln!(
+        super::step_log::say(format!(
             "nros setup: {path}: added fetch refspec for `{branch}`, but fetching it failed ({e}). It will resolve on the next `git fetch`."
-        );
+        ));
     }
     Ok(())
 }
@@ -1295,11 +1269,53 @@ fn sh_with_toolchain(args: &[&str], cwd: Option<&Path>, toolchain: Option<&str>)
     if let Some(tc) = toolchain {
         c.env("RUSTUP_TOOLCHAIN", tc);
     }
-    let status = c.status().wrap_err_with(|| format!("spawn {cmd}"))?;
+    // Routed through the step's sink when a session is executing this step
+    // (phase-447 E3), so a concurrent install's `tar`/`git`/`make` output
+    // lands in plan order instead of interleaving; inherited stdio otherwise.
+    let status = super::step_log::status(&mut c).wrap_err_with(|| format!("spawn {cmd}"))?;
     if !status.success() {
         bail!("`{}` failed ({status})", args.join(" "));
     }
     Ok(())
+}
+
+/// Download `url` to `dest` — the ONE spelling of a store fetch (a prebuilt
+/// dist and a source tarball used to carry a copy each).
+///
+/// `curl --silent --show-error` is right for a short fetch and wrong for a long
+/// one: a 1.4 GB Zephyr SDK was fifteen minutes of a log that looked hung
+/// (issue 1266). So curl stays silent — its own progress bar is a
+/// carriage-return repaint, one very long line in a CI log — and
+/// [`super::step_log::watch_download`] prints a byte-count line once the fetch
+/// has run long enough to need one. `cmd/setup.rs::fetch_index` is not this: it
+/// fetches a small TOML with fail-fast timeouts, and stays silent on purpose.
+fn download(url: &str, dest: &Path) -> Result<()> {
+    let what = url
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(url);
+    super::step_log::watch_download(
+        dest,
+        what,
+        super::step_log::ProgressPolicy::DEFAULT,
+        std::time::Duration::from_secs(1),
+        || {
+            sh(
+                &[
+                    "curl",
+                    "-L",
+                    "--fail",
+                    "--silent",
+                    "--show-error",
+                    "-o",
+                    &dest.to_string_lossy(),
+                    url,
+                ],
+                None,
+            )
+        },
+    )
 }
 
 /// The workspace's pinned Rust channel, read from `rust-toolchain.toml`.

--- a/packages/cli/nros-cli-core/src/orchestration/step_log.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/step_log.rs
@@ -1,0 +1,448 @@
+//! Where a provisioning step's OUTPUT goes — phase-447 E3 / RFC-0099 D7.
+//!
+//! `nros setup` installs a plan's packages concurrently, and per-package output
+//! must still read in PLAN order (the fourth of the ordered things in
+//! `cmd/setup/session.rs`). The session's `OrderedLog` does that for every line
+//! the session itself writes; this module is how the lines written BELOW it —
+//! `sdk_store`'s own notes, and the stdout/stderr of every `curl`, `tar`, `git`,
+//! `configure` and `make` a step spawns — reach the same log instead of the
+//! terminal.
+//!
+//! The mechanism is a thread-local SINK the executor installs on a worker thread
+//! for the duration of one step ([`with_step_sink`]). Code that prints asks
+//! [`say`]; code that spawns asks [`status`]. With no sink installed — every
+//! caller that is not the session executor — both behave exactly as they did:
+//! `eprintln!` and an inherited-stdio `Command::status`. So `sdk_store` keeps its
+//! signatures, and the three call sites that reach it outside a session do not
+//! change behaviour.
+//!
+//! It also owns the one piece of output a step produces by itself: progress for
+//! a LONG download (issue 1266). `curl --silent` made a 1.4 GB fetch look hung
+//! for fifteen minutes; [`watch_download`] prints a byte-count line only once a
+//! fetch has run for a while, and then periodically — plain lines, because the
+//! normal reader is a CI log, where a carriage-return progress bar renders as
+//! one very long line.
+
+use std::{
+    cell::RefCell,
+    io::{BufRead as _, BufReader, Read},
+    path::Path,
+    process::{Command, ExitStatus, Stdio},
+    sync::{Arc, mpsc},
+    time::{Duration, Instant},
+};
+
+/// Where one step's lines go. `Arc` because a step's output is produced on more
+/// than one thread: the worker, the reader threads of a spawned child, and a
+/// download's progress watcher.
+pub type StepSink = Arc<dyn Fn(String) + Send + Sync>;
+
+thread_local! {
+    static STEP_SINK: RefCell<Option<StepSink>> = const { RefCell::new(None) };
+}
+
+/// Restores the previous sink when dropped — including on unwind, so a step
+/// that panics cannot leave its sink installed for the next step the same
+/// worker takes.
+struct SinkGuard(Option<StepSink>);
+
+impl Drop for SinkGuard {
+    fn drop(&mut self) {
+        let prev = self.0.take();
+        STEP_SINK.with(|s| *s.borrow_mut() = prev);
+    }
+}
+
+/// Run `f` with every line it produces routed to `sink`.
+pub fn with_step_sink<R>(sink: StepSink, f: impl FnOnce() -> R) -> R {
+    let prev = STEP_SINK.with(|s| s.borrow_mut().replace(sink));
+    let _guard = SinkGuard(prev);
+    f()
+}
+
+/// The sink installed on THIS thread, if any.
+pub fn current_sink() -> Option<StepSink> {
+    STEP_SINK.with(|s| s.borrow().clone())
+}
+
+fn say_via(sink: Option<&StepSink>, line: String) {
+    match sink {
+        Some(s) => s(line),
+        None => eprintln!("{line}"),
+    }
+}
+
+/// Print one line of a step's output: to the step's sink when a session is
+/// executing it, else to stderr exactly as before.
+pub fn say(line: String) {
+    say_via(current_sink().as_ref(), line);
+}
+
+/// `Command::status`, with the child's stdout and stderr routed to the step's
+/// sink line by line when there is one. Without a sink the child inherits
+/// stdio, unchanged.
+///
+/// Routed output is still LIVE for the step the log is currently streaming —
+/// the `OrderedLog` holds only the lines of steps that are ahead of the
+/// earliest unfinished one — so a long source build in plan position 0 shows
+/// its compiler output as it happens, as it always did.
+pub fn status(cmd: &mut Command) -> std::io::Result<ExitStatus> {
+    let Some(sink) = current_sink() else {
+        return cmd.status();
+    };
+    let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    let streams: Vec<Box<dyn Read + Send>> = [
+        child
+            .stdout
+            .take()
+            .map(|s| Box::new(s) as Box<dyn Read + Send>),
+        child
+            .stderr
+            .take()
+            .map(|s| Box::new(s) as Box<dyn Read + Send>),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    let (done, drained) = mpsc::channel::<()>();
+    let readers = streams.len();
+    for stream in streams {
+        let (sink, done) = (sink.clone(), done.clone());
+        // Detached, not scoped: see the drain below.
+        std::thread::spawn(move || {
+            forward_lines(stream, &sink);
+            let _ = done.send(());
+        });
+    }
+    drop(done);
+    let status = child.wait()?;
+    // A child's output is complete when its pipes close — normally the moment
+    // it exits. A BACKGROUND process it started (a build server, a daemon)
+    // inherits the pipes and can hold them open for as long as it lives; with
+    // inherited stdio that was harmless, and waiting for EOF here would hang
+    // the install on it. So the drain is bounded, and says when it gave up.
+    let deadline = Instant::now() + DRAIN_GRACE;
+    for _ in 0..readers {
+        let left = deadline.saturating_duration_since(Instant::now());
+        if drained.recv_timeout(left).is_err() {
+            sink(
+                "    (a background process this step started still holds its output open; \
+                 not waiting for it)"
+                    .to_string(),
+            );
+            break;
+        }
+    }
+    Ok(status)
+}
+
+/// How long [`status`] keeps reading a child's pipes after it exited. Not a
+/// measurement of anything: an ordinary child has closed them by then, and the
+/// bound exists only so a process the child left behind cannot hang the step.
+const DRAIN_GRACE: Duration = Duration::from_secs(5);
+
+/// Forward a child's stream as lines. A carriage return is a terminal repaint,
+/// not a line: keep what the last repaint said, so a tool that draws its own
+/// progress bar contributes its final state rather than one enormous line.
+fn forward_lines(stream: impl Read, sink: &StepSink) {
+    let mut reader = BufReader::new(stream);
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {
+                let text = String::from_utf8_lossy(&buf);
+                let text = text.trim_end_matches(['\n', '\r']);
+                let text = text.rsplit('\r').find(|t| !t.is_empty()).unwrap_or("");
+                sink(text.to_string());
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Progress for a long download (issue 1266).
+// ---------------------------------------------------------------------------
+
+/// When a download earns a progress line. Pure, so the policy is tested without
+/// a clock: a test that asserted on elapsed time would measure the machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProgressPolicy {
+    /// Silent for this long. A fetch that finishes first — the index, a small
+    /// tool, a warm mirror — prints nothing at all.
+    pub quiet_for: Duration,
+    /// Then one line per this interval.
+    pub every: Duration,
+}
+
+impl ProgressPolicy {
+    /// The shipped policy: nothing for 10 s, then a line every 30 s. At the
+    /// ~0.8 MB/s issue 1267 measured, a 1.4 GB fetch prints ~60 lines over its
+    /// 30 minutes, and anything under ~8 MB prints none.
+    pub const DEFAULT: Self = Self {
+        quiet_for: Duration::from_secs(10),
+        every: Duration::from_secs(30),
+    };
+
+    /// Is a line due at `elapsed`, given when the last one was printed?
+    pub fn due(&self, elapsed: Duration, last: Option<Duration>) -> bool {
+        match last {
+            None => elapsed >= self.quiet_for,
+            Some(at) => elapsed.saturating_sub(at) >= self.every,
+        }
+    }
+}
+
+/// One progress line: what, how much so far, for how long, and the rate.
+///
+/// No total and no percentage: a dist row declares a URL and a hash, not a size,
+/// and the question an operator is asking is "is it moving", which bytes and a
+/// rate answer.
+pub fn progress_line(what: &str, bytes: u64, elapsed: Duration, finished: bool) -> String {
+    let mb = bytes as f64 / 1_000_000.0;
+    let secs = elapsed.as_secs_f64().max(0.001);
+    let rate = mb / secs;
+    let t = elapsed.as_secs();
+    let clock = if t >= 60 {
+        format!("{}m{:02}s", t / 60, t % 60)
+    } else {
+        format!("{t}s")
+    };
+    let verb = if finished { "fetched" } else { "downloading" };
+    format!("    … {verb} {what}: {mb:.1} MB in {clock} ({rate:.2} MB/s)")
+}
+
+/// Run `fetch` — which writes `dest` — and print progress for it under
+/// `policy`, checking every `tick`. A download that ever printed a progress
+/// line also prints a closing one, so the log says where it ended.
+///
+/// The watcher runs on its own thread and carries the CALLER's sink across, so
+/// its lines land in the step's plan-order output like any other.
+pub fn watch_download<R>(
+    dest: &Path,
+    what: &str,
+    policy: ProgressPolicy,
+    tick: Duration,
+    fetch: impl FnOnce() -> R,
+) -> R {
+    let sink = current_sink();
+    let (stop, stopped) = mpsc::channel::<()>();
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            let start = Instant::now();
+            let mut last: Option<Duration> = None;
+            let size = || std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
+            loop {
+                match stopped.recv_timeout(tick) {
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        let elapsed = start.elapsed();
+                        if policy.due(elapsed, last) {
+                            say_via(sink.as_ref(), progress_line(what, size(), elapsed, false));
+                            last = Some(elapsed);
+                        }
+                    }
+                    // Stopped (or the sender is gone): the fetch returned.
+                    _ => {
+                        if last.is_some() {
+                            say_via(
+                                sink.as_ref(),
+                                progress_line(what, size(), start.elapsed(), true),
+                            );
+                        }
+                        break;
+                    }
+                }
+            }
+        });
+        // Owned INSIDE the scope, so a `fetch` that panics drops it while
+        // unwinding — before the scope joins the watcher, which would otherwise
+        // wait on this channel forever and hang the panic instead of reporting it.
+        let stop = stop;
+        let result = fetch();
+        drop(stop);
+        result
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    fn capture() -> (StepSink, Arc<Mutex<Vec<String>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let s = seen.clone();
+        (Arc::new(move |l: String| s.lock().unwrap().push(l)), seen)
+    }
+
+    /// The policy, at synthetic instants: silent until `quiet_for`, then one
+    /// line per `every` — never two inside one interval.
+    #[test]
+    fn a_short_fetch_is_silent_and_a_long_one_speaks_periodically() {
+        let p = ProgressPolicy {
+            quiet_for: Duration::from_secs(10),
+            every: Duration::from_secs(30),
+        };
+        let s = Duration::from_secs;
+        assert!(!p.due(s(0), None));
+        assert!(!p.due(s(9), None), "a fetch under quiet_for prints nothing");
+        assert!(p.due(s(10), None));
+        assert!(!p.due(s(39), Some(s(10))), "not twice inside one interval");
+        assert!(p.due(s(40), Some(s(10))));
+        assert_eq!(ProgressPolicy::DEFAULT, p, "the shipped policy is this one");
+    }
+
+    #[test]
+    fn a_progress_line_names_bytes_time_and_rate() {
+        let l = progress_line(
+            "zephyr-sdk.tar.xz",
+            48_000_000,
+            Duration::from_secs(60),
+            false,
+        );
+        assert_eq!(
+            l,
+            "    … downloading zephyr-sdk.tar.xz: 48.0 MB in 1m00s (0.80 MB/s)"
+        );
+        assert!(progress_line("x", 1, Duration::from_secs(5), true).contains("fetched x"));
+    }
+
+    /// The watcher speaks for a fetch that is still running, into the CALLER's
+    /// sink, and closes with a final line. Ordered by handshake, not by time:
+    /// the "fetch" does not return until the watcher has spoken.
+    #[test]
+    fn a_long_download_reports_progress_into_the_steps_sink() {
+        let dir = crate::test_support::scratch_dir("step_log_progress");
+        let dest = dir.join("big.download");
+        let (sink, seen) = capture();
+        let policy = ProgressPolicy {
+            quiet_for: Duration::ZERO,
+            every: Duration::from_secs(3600),
+        };
+        // The bytes are on disk BEFORE the watcher's first tick can look, so
+        // every line it prints reads 2.0 MB — a write inside `fetch` would race
+        // the first tick, and a first line of 0.0 MB would then hold the next
+        // one back for `every`.
+        std::fs::write(&dest, vec![0u8; 2_000_000]).unwrap();
+        with_step_sink(sink, || {
+            watch_download(&dest, "big", policy, Duration::from_millis(1), || {
+                // Deadlock guard only; the assertion is on ORDER, not on time.
+                let deadline = Instant::now() + Duration::from_secs(60);
+                while !seen.lock().unwrap().iter().any(|l| l.contains("2.0 MB")) {
+                    assert!(Instant::now() < deadline, "the watcher never spoke");
+                    std::thread::yield_now();
+                }
+            });
+        });
+        let lines = seen.lock().unwrap().clone();
+        assert!(lines[0].contains("downloading big: 2.0 MB"), "{lines:?}");
+        assert!(
+            lines.last().unwrap().contains("fetched big: 2.0 MB"),
+            "{lines:?}"
+        );
+    }
+
+    /// A fetch that returns inside `quiet_for` leaves no trace — not even the
+    /// closing line, which only a download that spoke owes.
+    #[test]
+    fn a_fetch_that_finishes_inside_quiet_for_prints_nothing() {
+        let dir = crate::test_support::scratch_dir("step_log_quiet");
+        let (sink, seen) = capture();
+        let policy = ProgressPolicy {
+            quiet_for: Duration::from_secs(3600),
+            every: Duration::from_secs(3600),
+        };
+        with_step_sink(sink, || {
+            watch_download(&dir.join("x"), "x", policy, Duration::from_millis(1), || {})
+        });
+        assert!(seen.lock().unwrap().is_empty());
+    }
+
+    /// A spawned child's stdout AND stderr reach the sink, as lines, with a
+    /// carriage-return repaint collapsed to its final state; without a sink
+    /// nothing is captured (the child inherits stdio, as before).
+    #[cfg(unix)]
+    #[test]
+    fn a_childs_output_is_routed_to_the_sink_when_one_is_installed() {
+        let (sink, seen) = capture();
+        let st = with_step_sink(sink, || {
+            status(Command::new("sh").args([
+                "-c",
+                "echo out-line; echo err-line >&2; printf '10%%\\r50%%\\r100%%\\n'",
+            ]))
+        })
+        .unwrap();
+        assert!(st.success());
+        let mut lines = seen.lock().unwrap().clone();
+        lines.sort();
+        assert_eq!(lines, ["100%", "err-line", "out-line"]);
+        assert!(
+            current_sink().is_none(),
+            "the sink is uninstalled after the step"
+        );
+    }
+
+    /// A child that leaves a BACKGROUND process holding its pipes (a build
+    /// server) does not hang the step: the child's own output arrives, and the
+    /// drain says it stopped waiting. Asserted on outcome — the note is printed
+    /// only on the give-up path, which a 600 s holder always reaches.
+    #[cfg(unix)]
+    #[test]
+    fn a_background_process_holding_the_pipes_does_not_hang_the_step() {
+        let dir = crate::test_support::scratch_dir("step_log_daemon");
+        let pidfile = dir.join("holder.pid");
+        let (sink, seen) = capture();
+        let st = with_step_sink(sink, || {
+            status(Command::new("sh").args([
+                "-c",
+                &format!("echo before; sleep 600 & echo $! > {}", pidfile.display()),
+            ]))
+        })
+        .unwrap();
+        if let Ok(pid) = std::fs::read_to_string(&pidfile) {
+            let _ = Command::new("kill").arg(pid.trim()).status();
+        }
+        assert!(st.success());
+        let lines = seen.lock().unwrap().clone();
+        assert!(lines.contains(&"before".to_string()), "{lines:?}");
+        assert!(
+            lines.iter().any(|l| l.contains("not waiting for it")),
+            "{lines:?}"
+        );
+    }
+
+    /// A `fetch` that panics is REPORTED, not hung: the watcher is released
+    /// while the panic unwinds, so the scope can join it.
+    #[test]
+    fn a_panicking_fetch_does_not_hang_its_progress_watcher() {
+        let dir = crate::test_support::scratch_dir("step_log_panic_fetch");
+        let policy = ProgressPolicy {
+            quiet_for: Duration::from_secs(3600),
+            every: Duration::from_secs(3600),
+        };
+        let r = std::panic::catch_unwind(|| {
+            watch_download(
+                &dir.join("x"),
+                "x",
+                policy,
+                Duration::from_millis(1),
+                || panic!("the fetch fell over"),
+            )
+        });
+        assert!(r.is_err(), "the panic propagates");
+    }
+
+    /// A step that panics does not leave its sink behind for the next step on
+    /// the same worker.
+    #[test]
+    fn a_panicking_step_restores_the_previous_sink() {
+        let (sink, _seen) = capture();
+        let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_step_sink(sink, || panic!("boom"))
+        }));
+        assert!(r.is_err());
+        assert!(current_sink().is_none());
+    }
+}


### PR DESCRIPTION
Implements phase-447 **E3** (RFC-0099 D7), the last phase-447 E item. Closes issues **1266** and **1267**.

## Carries

- `f5f37bb05` — C1 (#918, `work/phase-447-c1-smoke-on-install`).
- `3b41bc81d` — E1+E2 (#927, `work/phase-447-e1-e2-session-plan`), whose plan structure this executes.
- `fc4be3845` — C1's ratchet fix (`99ed600e9` on #918's branch): C2 (#914) gave `espflash` and `sccache` real `smoke` probes, so their `.config/smoke-or-reason-baseline.txt` lines must go. Carried so this branch's pre-push is green before #918 lands.

The queue drops each copy by patch-id as its PR lands. Four commits over `main`.

## The executor

`run_pipelined` replaces `run_sequential`. Nothing around it changed: resolution, the ask and `SessionRun::finish` are as E2 left them.

- **Shape:** a worker pool over the resolved plan (`execute_plan` in `cmd/setup/session.rs`). It uses `std::thread::scope`, with no new dependency. Workers take steps from a small scheduler, which hands out the **earliest undispatched step whose lane is free**. A step that fails or panics is its own outcome (`catch_unwind`), so it never stops its siblings.
- **Concurrency:** defaults to the host's CPU count (`available_parallelism`). Override it with `nros setup -j/--jobs N` or `NROS_SETUP_JOBS`; the lazy `ensure_tools` path reaches only the variable. A zero or a non-number is refused by name. `Jobs::resolve` is pure and tested.
- **Two lanes** serialise what must not overlap, even when a CPU is free:
  - `[tool.*]` source builds run one at a time. Each already uses the whole machine; this is issue 1267's measured limit.
  - `[source.*]` steps run one at a time. The submodule arm takes the superproject's `index.lock` and rewrites `.git/config`, a hazard the plan's one-step-per-package does not cover.

  A waiting build never idles a worker that a download could use.
- **Overlap:** fetch, verify and unpack stay serial within a package, since the sha256 needs the whole archive. Across packages they overlap, and one source build runs beside other packages' downloads.

## The four ordered things, still ordered

| property | where it lives | tested under concurrency by |
| --- | --- | --- |
| lock, single writer | `finish` walks PLAN order and saves once; no step can touch it | `under_concurrency_every_ordered_thing_leaves_in_plan_order` — every step asserts the lock does not exist after every later step has completed |
| `front_newest` (0500) | one step per package (plan) + each step dispatched exactly once (scheduler) | `a_failing_or_panicking_step_stops_none_of_its_siblings` counts runs per step (all exactly 1); E2's dedup test |
| `bin_dirs` | folded by `finish` in plan order into `SessionReport::bin_dirs`, which the CMakePreset `PATH` and `ensure_tools` now read | same test, completion forced to `[3,2,1,0]` |
| output | plan-order `OrderedLog`, now reached by everything a step prints | same test, plus `the_real_install_path_prints_each_package_whole_and_in_plan_order` (real dists at concurrency 3) |

**The gap E2 named is closed.** `orchestration/step_log.rs` installs a per-step sink on the worker thread:

- `sdk_store`'s three `eprintln!`s go through `step_log::say`.
- `sh_with_toolchain` routes child stdout/stderr (`curl`, `tar`, `git`, `configure`, `make`) through `step_log::status`, line by line, into the same log.
- With no sink, both behave exactly as before, so `sdk_store` kept its signatures. That keeps the diff small in a file D1+D2 and #1304 are also editing.

All E3 tests force completion order by handshake (`StepCtx::wait_closed`) and assert on order and outcome, never on elapsed time. Each also asserts the completion order it forced, so "in plan order" is a real claim rather than the result of a run that happened to be sequential. C1/E2's `a_board_install_smokes_every_package_and_a_broken_one_stops_nothing` now runs at concurrency 3 and stays green.

## Progress for a long download (1266)

- The two `curl` copies are now one `download` helper.
- curl stays `--silent`. Its own progress bar is a carriage-return repaint, which renders as one long line in a CI log.
- `step_log::watch_download` prints a plain byte-count line (`… downloading <file>: 412.3 MB in 8m35s (0.80 MB/s)`) after 10 s and every 30 s after, then a closing line. A short fetch prints nothing.
- `cmd/setup.rs::fetch_index` stays silent on purpose.

## Mutation pass

Each mutant was applied, the session and step_log tests were run, and the source was restored.

| mutant | result |
| --- | --- |
| fold (lock, smoke, errors) in completion order | RED |
| record ONLY the lock in completion order | survives — **equivalent**: `SdkLock` is a map keyed by tool name and a plan holds one step per name, so recording order cannot show in the file |
| derive `bin_dirs` from completion order | RED |
| `OrderedLog` releases a step's lines as it finishes | RED |
| `OrderedLog` streams every step live | RED |
| a failing step aborts its siblings | RED |
| no lanes | RED |
| scheduler blocks on a held lane in plan order | RED (deadlock guard) |
| child output bypasses the step sink | RED |
| a long download never reports progress | RED |
| install without the smoke probe (C1's) | RED |

The pass also caught two defects in the first draft, which surfaced as one hang:

- A download test raced its watcher's first tick.
- A `fetch` that panicked then deadlocked its watcher, because the stop sender outlived the scope that joins it.

Both are fixed and tested. The same class turned up a third: a child that leaves a background process holding its pipes (a build server) would have hung the step on EOF, where inherited stdio never did. The drain after a child exits is now bounded, and it prints a note when it gives up waiting.

## Verified

- `cargo test -p nros-cli-core --no-fail-fast`: lib 1157 passed, and every integration target is green. Two targets first failed on preconditions of a fresh worktree (debug `nros` and `nros-launch-resolve` not yet built); both pass once built.
- The session and step_log tests ran 5 times in a row, all green.
- `cargo clippy -p nros-cli-core --all-targets -D warnings` and `cargo +nightly fmt` are clean.
- `just check fast` (`NROS_GATE_JOBS=6`) is green. The first run had 2 of 304 red: `capability-conditionals` and `xrce-vendored-versions`, both on submodules this worktree had not checked out (zenoh-pico, micro-cdr, micro-xrce-dds-client). After a shallow, non-recursive init of exactly those three, both report OK.
- `just check cli-tests` is green.

## Not verified

- `just ci gate` in full, and no fixture tier.
- A real cold bootstrap measuring the wall-clock win. The expected win is below the package count: the link saturates first, at the ~0.8 MB/s issue 1267 measured.
- `--sudo` executing an install (no sudo here, by rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
