### PR TITLE
test(#1286): a pure-C ThreadX workspace entry on rv-virt-threadx, built and run

### DIFF
--- a/docs/issues/archived/1286-threadx-c-entry-needs-cpp-runtime.md
+++ b/docs/issues/archived/1286-threadx-c-entry-needs-cpp-runtime.md
@@ -167,3 +167,58 @@ built for this run.
 The 15 skips are cells whose fixtures this worktree did not build: Zephyr,
 FreeRTOS, NuttX, and the threadx-linux C++ and mixed cells. rv-virt has no C
 workspace cell, so its runtime is untested.
+
+## Follow-up (2026-09-11): the rv-virt C workspace entry
+
+The gap above is closed. A C workspace row now exists for rv-virt-threadx, and it
+has been built and run.
+
+**Declared.**
+- `examples/workspaces/c` `system.toml`: `[image.riscv_threadx]` with
+  `board = "rv-virt-threadx"` (the `riscv_nuttx` spelling), plus its
+  `board_config`.
+- `examples/fixtures.toml`: `workspace-c-threadx-riscv64`, a migrated image row.
+  Its locator is `tcp/10.0.2.2:9530`, which is
+  `alloc::port_of(ThreadxRiscv64, C, EntryPubsub)`. Its `build_subdir` is
+  `build/threadx-riscv64-zenoh-rv-virt-threadx/cmake`, the name `nros build`'s
+  `cmake_coordinate` gives this image.
+- `matrix::CELLS`: `cell(ThreadxRiscv64, C, Zenoh, EntryPubsub, Workspace, Runtime)`,
+  claimed by `entry_e2e` in `w1_consumer_of`. `entry_e2e` gained
+  `Boot::ThreadxRiscv64`: `QemuProcess::start_riscv64_virt(entry, 0)`, user-mode
+  slirp, router bound on 0.0.0.0.
+- `just threadx_riscv64 build-fixture-extras` builds the row.
+
+**Built** with the repo's builder, xPack `riscv-none-elf-gcc` 14.2.0, newlib:
+`NROS_FIXTURE_ID=workspace-c-threadx-riscv64 scripts/build/workspace-fixtures-build.sh threadx-riscv64 c`
+- `nros codegen entry-pack --lang c --board rv-virt-threadx` answers `pack=c`,
+  `routed=0`. The build log has no "C++ pack" line.
+- The entry TU is `riscv_threadx_entry_nros_main_generated.c`. The build dir
+  holds 0 C++ objects, and the link line names no `stdc++`, `supc++` or `g++`.
+- `riscv_threadx_entry` linked, a static RV64 ELF.
+  `riscv-none-elf-nm` shows `app_main`, `nros_app_main` and
+  `nros_board_rtos_run_components` all as `T`. There are 0 matches for
+  `__cxa_|_ZSt|_ZN9__gnu_cxx|__gxx_personality`, and no undefined symbols.
+- The runner (`CMakeFiles/riscv_threadx_entry.dir/…/nros_rtos_run_components.c.obj`)
+  compiled in the app target, as `THREADX_STARTUP_SOURCE` intends. Its depfile
+  names `…/cmake/nano_ros/packages/api/nros-cpp/include/nros/nros_cpp_config_generated.h`,
+  where `NROS_CPP_EXECUTOR_STORAGE_SIZE` is 90424, not the 81920 fallback. In
+  `flags.make` that mirror's `-I` comes before the in-tree stub's
+  `packages/api/nros-cpp/include`, so a missing header is the stub's `#error`.
+
+**Runtime.** PASSED, solo:
+`cargo test -p nros-tests --test entry_e2e entry_matrix` printed
+`entry_matrix: 1 ran, 16 skipped, 0 failed (of 17 cells)`. The cell that ran is
+`threadx-riscv64/c/entry_pubsub`. The pure-C entry boots in QEMU riscv64 virt
+(NetX Duo over virtio-net, 10.0.2.40) and publishes `/chatter` through the slirp
+gateway. The native C listener (`native_robot2_entry`, built for this run) logged
+`INT32_LISTENER_LOG_PREFIX` at least 3 times within 90 s. The 16 skips are
+fixtures this worktree did not build: Zephyr, FreeRTOS, NuttX, and threadx-linux.
+
+All of this was measured twice. The first pass ran on the original base with
+this fix cherry-picked. The second ran after rebasing onto the `main` that merged
+it, which had also moved the CLI, `nros-entry-lower` and the rmw cffi bindings.
+For the second pass the CLI was rebuilt first, then both fixtures, and the image
+was built at 16:03:33, after the rebased HEAD (15:48:44). Every fact above
+reproduced unchanged: the same symbols at the same addresses, 90424, and the
+same include order. The cell passed again: 1 ran, 16 skipped, 0 failed, in
+12.7 s (80 s on the first, cold run).

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -611,6 +611,24 @@ image = "threadx"
 build_subdir = "build/threadx-linux-zenoh/cmake"
 cmake_defs = { NANO_ROS_PLATFORM = "threadx", NANO_ROS_BOARD = "threadx-linux", NROS_ENTRY_LOCATOR = "tcp/127.0.0.1:9130" }
 
+# issue 1286 follow-up — the rv-virt (riscv64 QEMU virt, NetX Duo over
+# virtio-net) sibling of the row above: the same pure-C `demo_bringup` entry,
+# cross-built with the board's riscv64 toolchain. The guest runs QEMU user-mode
+# (slirp) networking, so it dials the router through the gateway 10.0.2.2.
+# Port 9530 = `alloc::port_of(ThreadxRiscv64, C, EntryPubsub)`. Built by
+# `just threadx_riscv64 build-fixtures` (build-fixture-extras). Consumed by
+# tests/entry_e2e.rs (threadx-riscv64/c/entry_pubsub cell).
+[[workspace_fixture]]
+id = "workspace-c-threadx-riscv64"
+platform = "threadx-riscv64"
+lang = "c"
+rmw = "zenoh"
+dir = "examples/workspaces/c"
+bringup = "src/demo_bringup"
+image = "riscv_threadx"
+build_subdir = "build/threadx-riscv64-zenoh-rv-virt-threadx/cmake"
+cmake_defs = { NANO_ROS_PLATFORM = "threadx", NANO_ROS_BOARD = "rv-virt-threadx", NROS_ENTRY_LOCATOR = "tcp/10.0.2.2:9530" }
+
 # phase-263 C2b (issue 0097) — the FIRST QEMU-cross embedded C workspace entry:
 # `nano_ros_entry(BOARD mps2-an385-freertos LAUNCH …)`, the FreeRTOS sibling to the C2a
 # threadx-linux host sim. The workspace root maps the board to its arm-none-eabi

--- a/examples/workspaces/c/src/demo_bringup/system.toml
+++ b/examples/workspaces/c/src/demo_bringup/system.toml
@@ -140,6 +140,13 @@ launch = "service_server.launch.xml"
 [image.nuttx]
 board = "qemu-armv7a-nuttx"
 
+# issue 1286 follow-up — the rv-virt (riscv64, bare-metal QEMU virt) sibling of
+# `threadx`. Same default topology; `riscv_` prefix as `realtime-cpp`'s
+# `riscv_nuttx`. A `--lang c` ThreadX entry is pure C since #1286, and this is
+# the image that measures it off the host sim.
+[image.riscv_threadx]
+board = "rv-virt-threadx"
+
 [image.threadx]
 board = "threadx-linux"
 
@@ -164,5 +171,12 @@ sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
 # SDK roots it builds against. Keyed by BOARD, not by a deploy or image
 # name, because that is what the fact is about (issue 0951).
 [board_config."threadx-linux"]
+netstack = "netxduo"
+sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."rv-virt-threadx"]
 netstack = "netxduo"
 sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }

--- a/just/threadx-riscv64.just
+++ b/just/threadx-riscv64.just
@@ -355,6 +355,11 @@ build-fixture-extras:
     export NROS_CMAKE_EXTRA_DEFS="$base_defs"
     bash scripts/build/fixtures-build.sh threadx-riscv64 c zenoh
     bash scripts/build/fixtures-build.sh threadx-riscv64 cpp zenoh
+    # issue 1286 follow-up — the pure-C WORKSPACE entry (`workspace-c-threadx-riscv64`,
+    # image `riscv_threadx`), consumed by tests/entry_e2e.rs. A migrated row:
+    # `nros build` generates the root and resolves the board's own toolchain file,
+    # so none of the -D set above reaches it (NROS_CMAKE_EXTRA_DEFS is not read).
+    bash scripts/build/workspace-fixtures-build.sh threadx-riscv64 c
 
     cyclonedds_prefix="$root/build/cyclonedds-threadx-rv64-install"
     # Phase 203 decision — build the ThreadX-RV64 Cyclone fixtures BY DEFAULT so a

--- a/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
@@ -320,6 +320,9 @@ static FREERTOS_POSIX_WORKSPACE_CPP_ENTRY_BINARY: OnceCell<PathBuf> = OnceCell::
 /// phase-263 C2a — cached path to the threadx-linux C workspace EMBEDDED entry
 /// (`nano_ros_entry(BOARD threadx-linux …)`, the first embedded LAUNCH entry).
 static THREADX_LINUX_WORKSPACE_C_ENTRY_BINARY: OnceCell<PathBuf> = OnceCell::new();
+/// issue 1286 follow-up — the rv-virt (riscv64 QEMU virt) sibling of the entry
+/// above: the same pure-C `demo_bringup` entry, cross-built for the board.
+static THREADX_RISCV64_WORKSPACE_C_ENTRY_BINARY: OnceCell<PathBuf> = OnceCell::new();
 
 /// phase-263 C2b — cached path to the FreeRTOS (QEMU MPS2-AN385) C workspace embedded
 /// entry (`nano_ros_entry(BOARD mps2-an385-freertos …)`, the first QEMU-cross entry).
@@ -2828,6 +2831,23 @@ pub fn build_threadx_linux_workspace_c_entry() -> TestResult<&'static Path> {
                 // along: a missing binary and an absent toolchain look identical
                 // from here.
                 "threadx_entry",
+            )
+        })
+        .map(|p| p.as_path())
+}
+
+/// issue 1286 follow-up — the rv-virt (riscv64 QEMU virt) C workspace EMBEDDED
+/// entry (cached). A migrated row: `nros build` generates the root, so the
+/// entry lands at the top of the row's `build_subdir`, with a compile-time-baked
+/// `tcp/10.0.2.2:<port>` locator the slirp guest dials.
+pub fn build_threadx_riscv64_workspace_c_entry() -> TestResult<&'static Path> {
+    THREADX_RISCV64_WORKSPACE_C_ENTRY_BINARY
+        .get_or_try_init(|| {
+            build_workspace_cmake_entry_in(
+                "workspace-c-threadx-riscv64",
+                "c",
+                "build/threadx-riscv64-zenoh-rv-virt-threadx/cmake",
+                "riscv_threadx_entry",
             )
         })
         .map(|p| p.as_path())

--- a/packages/testing/nros-tests/src/matrix.rs
+++ b/packages/testing/nros-tests/src/matrix.rs
@@ -871,6 +871,9 @@ pub const CELLS: &[Cell] = &[
     cell(ThreadxLinux, C,     Zenoh, EntryPubsub, Workspace, Runtime),
     cell(ThreadxLinux, Cpp,   Zenoh, EntryPubsub, Workspace, Runtime),
     cell(ThreadxLinux, Mixed, Zenoh, EntryPubsub, Workspace, Runtime),
+    // issue 1286 follow-up — the pure-C ThreadX entry off the host sim:
+    // rv-virt (riscv64 QEMU virt, slirp), `workspace-c-threadx-riscv64`.
+    cell(ThreadxRiscv64, C, Zenoh, EntryPubsub, Workspace, Runtime),
     cell(FreertosMps2, Mixed, Zenoh, EntryPubsub, Workspace, Runtime),
     cell(NuttxArm,     Rust,  Zenoh, EntryPubsub, Workspace, Runtime),
     // See the nuttx-riscv correction above — the rust riscv workspace row
@@ -1046,6 +1049,8 @@ pub fn w1_consumer_of(cell: &Cell) -> Option<W1Consumer> {
         (PlatformId::ThreadxLinux, Lang::C | Lang::Cpp | Lang::Mixed, Workload::EntryPubsub, _) => {
             Some(Entry)
         }
+        // issue 1286 follow-up — the rv-virt pure-C workspace entry (QEMU virt).
+        (PlatformId::ThreadxRiscv64, Lang::C, Workload::EntryPubsub, _) => Some(Entry),
         (PlatformId::FreertosMps2, Lang::C | Lang::Cpp | Lang::Mixed, Workload::EntryPubsub, _) => {
             Some(Entry)
         }

--- a/packages/testing/nros-tests/tests/entry_e2e.rs
+++ b/packages/testing/nros-tests/tests/entry_e2e.rs
@@ -58,12 +58,14 @@ use nros_tests::{
         build_freertos_workspace_mixed_entry, build_int32_sink, build_native_listener,
         build_native_workspace_c_entry_robot2, build_nuttx_workspace_c_entry,
         build_threadx_linux_workspace_c_entry, build_threadx_linux_workspace_cpp_entry,
-        build_threadx_linux_workspace_mixed_entry, build_zephyr_workspace_c_entry,
-        build_zephyr_workspace_cpp_entry, build_zephyr_workspace_mixed_entry,
-        build_zephyr_workspace_rust_lifecycle_entry, build_zephyr_workspace_rust_params_entry,
-        build_zephyr_workspace_rust_qos_entry, build_zephyr_workspace_rust_safety_entry, freertos,
-        is_qemu_available, nuttx, require_zenohd,
+        build_threadx_linux_workspace_mixed_entry, build_threadx_riscv64_workspace_c_entry,
+        build_zephyr_workspace_c_entry, build_zephyr_workspace_cpp_entry,
+        build_zephyr_workspace_mixed_entry, build_zephyr_workspace_rust_lifecycle_entry,
+        build_zephyr_workspace_rust_params_entry, build_zephyr_workspace_rust_qos_entry,
+        build_zephyr_workspace_rust_safety_entry, freertos, is_qemu_available,
+        is_qemu_riscv64_available, nuttx, require_zenohd,
         threadx_linux::{is_nsos_netx_available, is_threadx_available},
+        threadx_riscv64,
     },
     matrix::{
         Cell as MCell, Lang as ML, PlatformId as MP, Tier as MT, W1Consumer, Workload as MW,
@@ -96,6 +98,9 @@ enum Boot {
     ZephyrNativeSim,
     /// NuttX QEMU arm-virt guest (slirp gateway 10.0.2.2 → host router).
     NuttxArm,
+    /// ThreadX QEMU riscv64 virt guest (NetX Duo over virtio-net, static
+    /// 10.0.2.40 on user-mode slirp; gateway 10.0.2.2 → host router).
+    ThreadxRiscv64,
 }
 
 /// The per-cell workload contract, preserved 1:1 from the
@@ -148,6 +153,7 @@ fn plat_str(p: MP) -> &'static str {
         MP::FreertosMps2 => "freertos",
         MP::ZephyrNativeSim => "zephyr",
         MP::NuttxArm => "nuttx-arm",
+        MP::ThreadxRiscv64 => "threadx-riscv64",
         _ => "?",
     }
 }
@@ -256,6 +262,15 @@ fn exec_for(platform: MP, lang: ML, workload: MW) -> Exec {
                    nros_platform_link_app (ferried into the cc-rs entry-TU compile at CONFIGURE \
                    time) — the old 'console issue' was this missing bake",
         },
+        (MP::ThreadxRiscv64, ML::C, MW::EntryPubsub) => Exec {
+            resolver: threadx_riscv64_c_entry,
+            port: port_of(MP::ThreadxRiscv64, ML::C, MW::EntryPubsub),
+            boot: Boot::ThreadxRiscv64,
+            proof: chatter_c(60000, 90),
+            note: "issue 1286: a `--lang c` ThreadX entry is PURE C — the shared \
+                   nros_board_rtos_run_components runner compiled in the app target \
+                   (THREADX_STARTUP_SOURCE) against the per-build nros_cpp_config_generated.h",
+        },
         (MP::NuttxArm, ML::Rust, MW::EntryPubsub) => Exec {
             // #130: the nuttx rust entry historically bakes the classic Pubsub
             // port band, not the EntryPubsub band — preserved verbatim.
@@ -328,6 +343,9 @@ fn threadx_cpp_entry() -> TestResult<PathBuf> {
 }
 fn threadx_mixed_entry() -> TestResult<PathBuf> {
     build_threadx_linux_workspace_mixed_entry().map(|p| p.to_path_buf())
+}
+fn threadx_riscv64_c_entry() -> TestResult<PathBuf> {
+    build_threadx_riscv64_workspace_c_entry().map(|p| p.to_path_buf())
 }
 fn freertos_c_entry() -> TestResult<PathBuf> {
     build_freertos_workspace_c_entry().map(|p| p.to_path_buf())
@@ -420,6 +438,17 @@ fn require_cell_env(cell: &Exec) {
         Boot::NuttxArm => {
             if !is_qemu_available() {
                 nros_tests::skip!("qemu-system-arm not found");
+            }
+        }
+        Boot::ThreadxRiscv64 => {
+            if !threadx_riscv64::is_threadx_available() {
+                nros_tests::skip!("THREADX_DIR not set or invalid");
+            }
+            if !threadx_riscv64::is_netx_available() {
+                nros_tests::skip!("NETX_DIR not set or invalid");
+            }
+            if !is_qemu_riscv64_available() {
+                nros_tests::skip!("qemu-system-riscv64 not found");
             }
         }
         Boot::ZephyrNativeSim => {}
@@ -520,6 +549,12 @@ fn boot_guest(cell: &Exec, entry: &PathBuf) -> Guest {
         Boot::NuttxArm => Guest::Qemu(
             QemuProcess::start_nuttx_virt(entry, true)
                 .unwrap_or_else(|e| panic!("boot NuttX QEMU: {e}")),
+        ),
+        // Peer index 0 = the board's default identity (10.0.2.40, MAC :56),
+        // the one the board's generated `NROS_APP_CONFIG` bakes.
+        Boot::ThreadxRiscv64 => Guest::Qemu(
+            QemuProcess::start_riscv64_virt(entry, 0)
+                .unwrap_or_else(|e| panic!("boot ThreadX riscv64 QEMU: {e}")),
         ),
     }
 }
@@ -735,7 +770,7 @@ fn run_cell(pcell: &MCell) {
     // observer always dials the host loopback.
     let bind_host = match cell.boot {
         Boot::ThreadxLinux | Boot::ZephyrNativeSim => "127.0.0.1",
-        Boot::FreertosMps2 | Boot::NuttxArm => "0.0.0.0",
+        Boot::FreertosMps2 | Boot::NuttxArm | Boot::ThreadxRiscv64 => "0.0.0.0",
     };
     // Bound to `_router` (NOT `let _ = router` — that pattern drops the
     // guard, and Drop kills zenohd) so the router lives for the whole cell.


### PR DESCRIPTION
This is a follow-up to issue 1286 and #919. It adds test coverage for a pure-C ThreadX workspace entry on **rv-virt-threadx** (QEMU riscv64). #919 measured the C entry on threadx-linux only; on rv-virt only the plain C talker was built, because no C workspace fixture existed for that board.

## What it adds

- **`examples/workspaces/c/src/demo_bringup/system.toml`:** a `[image.riscv_threadx]` image (`board = "rv-virt-threadx"`) plus its `board_config`.
- **`examples/fixtures.toml`:** a `workspace-c-threadx-riscv64` row, modelled on `workspace-c-threadx-linux`. The locator is `tcp/10.0.2.2:9530`, which is `port_of(ThreadxRiscv64, C, EntryPubsub)`.
- **`matrix.rs`:** a `(ThreadxRiscv64, C, Zenoh, EntryPubsub, Workspace, Runtime)` cell, consumed by `entry_e2e`.
- **`entry_e2e.rs`:**
  - a `Boot::ThreadxRiscv64` variant, which boots through `QemuProcess::start_riscv64_virt`;
  - the router binds on 0.0.0.0, because the guest reaches the host through QEMU user networking;
  - the cell's environment checks.
- **`fixtures/binaries/mod.rs`:** a resolver for the new artifact.
- **`just/threadx-riscv64.just`:** `build-fixture-extras` builds the row.
- **The 1286 issue doc:** a dated follow-up section with the evidence below.

## Evidence (rebased tree)

- **Build:** `NROS_FIXTURE_ID=workspace-c-threadx-riscv64 scripts/build/workspace-fixtures-build.sh threadx-riscv64 c` (xPack `riscv-none-elf-gcc` 14.2.0).
  - `entry-pack` reports `pack=c`, `routed=0`.
  - The entry is `riscv_threadx_entry_nros_main_generated.c`; there are 0 C++ objects, and the link line names no `stdc++` or `supc++`.
- **Symbols:** `app_main`, `nros_app_main` and `nros_board_rtos_run_components` are defined. There are 0 `__cxa_*`/`_ZSt*`/`_ZN9__gnu_cxx*`/`__gxx_personality` symbols, and 0 undefined ones.
- **Storage size:** the runner's depfile names the per-build `nros_cpp_config_generated.h`, whose storage size is 90424, not the runner's 81920 fallback. In `flags.make` the per-build include directory (position 11) comes before the in-tree stub (position 12).
- **Runtime:** `entry_matrix` solo reported `1 ran, 16 skipped, 0 failed`. The cell that ran is `threadx-riscv64/c/entry_pubsub`: the QEMU guest publishes, and a native C listener logs at least 3 samples within 90 s (12.7 s after rebase). The 16 skips are fixtures the worktree did not build.

## Gates

- **`matrix_fixture_coverage`:** 10/10. This covers `fixture_rows_all_modeled_by_matrix`, `every_runtime_cell_has_a_fixture_row`, and interop G1–G5.
- **`just check fast`:** 301/301.
- **`nros-tests --lib`:** 212/213 after the rebase. The one failure, `gated_absence_is_a_hard_failure`, passes when run alone. It is an environment race under plain `cargo test`: a sibling test clears the same variable in the same process, and the test itself notes that it needs nextest's process-per-test. The race was already there.
- **`lane_build_covers_run`:** 10/11. `a_native_build_satisfies_the_tier1_run` fails because `run_scope` hard-codes `Tier1` to coordinate scoping, while the lane script refuses to run with `NROS_TEST_COORDS` unset. Neither reads `CELLS`, so this was also already failing and is unrelated to this PR.
- **`just ci gate`: incomplete.** Its `check fast` step passed (299 run, 2 skipped: `ivc-fsp` and `leaf-lockfiles`), then the host's low-memory killer stopped the job, so `test-unit` never completed. The queue is its first complete run.

The runtime cell needs QEMU riscv64, `rmw_zenohd` and the native observer fixture; where any of them is missing, it skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zw1nseWJBSTRqVQzRAZcg
