### PR TITLE
docs(phase-453, issues): hand off the codegen campaign follow-ups

### DIFF
--- a/docs/issues/1311-cyclonedds-sumseq-generated-c-fails-to-compile.md
+++ b/docs/issues/1311-cyclonedds-sumseq-generated-c-fails-to-compile.md
@@ -1,0 +1,72 @@
+---
+id: 1311
+title: "`check::build`'s `rmw-cyclonedds` lane: idlc-generated `SumSeq.c` fails to
+  compile and `service_roundtrip` cannot link — seen twice, NOT yet reproduced on
+  a main checkout"
+status: open
+type: bug
+area: rmw, cyclonedds, build
+severity: medium
+related: [issue-0319]
+---
+
+## Read this first
+
+This was seen in two FRESHLY PROVISIONED agent worktrees on 2026-09-11. It was
+never reproduced in a long-lived checkout of `main`. CLAUDE.md's rule on
+filing from a failing fixture (issues 0859–0862, all retracted) applies:
+**reproduce it on a clean `main` checkout before fixing anything.** If it does
+not reproduce, the defect is in how a worktree provisions cyclonedds. That is
+still worth fixing, but it is a different issue, and this one should be
+retitled.
+
+## What was seen
+
+`just ci gate` → `check::build` → the `rmw-cyclonedds` gate (the Cyclone C/C++
+test suite, `packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/`). It failed the
+same way twice, each time on a branch whose diff touched nothing under
+`packages/rmw`, `third-party`, msg-to-idl or rosidl:
+
+- **Branch `fix/1284-backing-meets-default`:**
+  `nros_rmw_cyclonedds_service_roundtrip` (tests `CMakeLists.txt`, line ~328)
+  failed to link:
+  `undefined reference to 'nros_test_srv_dds__SumSeq_Request__desc'` and the
+  same for `_Response__desc`.
+- **Branch `fix/1285-followup-rtos-substring`:** one step earlier. Cyclone's
+  `idlc`-generated
+  `…/build/tests/cyclonedds-from-msg/nros_test/gen/SumSeq.c` includes its own
+  header, yet `uint32_t`, `NULL` and the `DDS_OP_*` opcodes come out
+  undeclared.
+
+The two are consistent with one cause. If `SumSeq.c` does not compile, its
+`*_desc` symbols never exist, and the roundtrip test cannot link.
+
+In both worktrees `third-party/dds/cyclonedds` had just been initialised with
+`git submodule update --init` (non-recursive, at its recorded pin), because
+agent worktrees start without it.
+
+## Hypotheses, most likely first
+
+1. **Worktree provisioning.** The `idlc` that ran is not the one built from
+   this checkout's cyclonedds, or the generated header directory is not on the
+   include path the first time round. Check:
+   `ninja -C <build> -t query <SumSeq.c.o>` and the `idlc` path in `build.ninja`.
+2. **An include the generated TU relies on transitively** (`<stdint.h>`,
+   `<stddef.h>`, `dds/ddsi/ddsi_serdata.h`), which a recent header change
+   stopped providing. That would reproduce on main.
+3. **The msg-to-IDL step emitting a `SumSeq.idl`** whose generated C sits in a
+   directory shadowed by another `SumSeq.h`.
+
+## Where it runs
+
+`rmw-cyclonedds` is a `check::build` gate, so it runs in `just ci gate` locally.
+Per CLAUDE.md the Cyclone suite belongs in a `check-*` lane (issue 0319); check
+which CI events reach it before judging how long it could have been red
+unnoticed.
+
+## Acceptance
+
+Reproduced on a clean `main` checkout or ruled out, with the evidence in this
+issue. If it reproduces, the fix lands with the gate green. If it doesn't, the
+provisioning defect is filed separately and this issue is closed as not a
+defect on main.

--- a/docs/issues/1312-zephyr-system-generate-passes-no-image-id.md
+++ b/docs/issues/1312-zephyr-system-generate-passes-no-image-id.md
@@ -1,0 +1,50 @@
+---
+id: 1312
+title: "`nros_system_generate.cmake` passes `--target zephyr-<rmw>`, which names no
+  deploy block, so the tier resolver answers for the host, not Zephyr"
+status: open
+type: bug
+area: zephyr, cli, codegen
+severity: low
+related: [issue-1285]
+---
+
+## What happens
+
+`zephyr/cmake/nros_system_generate.cmake` calls `nros codegen-system` with
+`--target "zephyr-${_rmw}"` (line 182; the comment at line 145 says it maps the
+Kconfig RMW "to a --target string the CLI understands"). The tier resolver
+(`tier_resolver::derive_target_rtos`) uses `--target` to pick a `[deploy.*]`
+block and then reads that block's board id. `zephyr-zenoh` and its siblings
+name no block, so no board id is resolved and the resolver falls back to the
+HOST default. A Zephyr image baked through this module therefore gets
+host-flavoured tier values rather than `[tiers.*.zephyr]` ones.
+
+## Why it is latent
+
+The two bringups the module bakes today declare no tiers, so no image output
+changes. It becomes wrong the first time a tiered bringup is baked through this
+path.
+
+## History
+
+Before the issue-1285 follow-up (PR #938), the resolver matched the RTOS by
+substring. That PR made the resolver read board ids from the board catalog, and
+it recorded this case as out of scope rather than reading "zephyr" out of the
+`--target` string, which would reintroduce the substring guess.
+
+## Fix
+
+Have the module pass the IMAGE's identity. That is either the image/deploy-block
+name the bringup's `system.toml` declares for this Zephyr image, or the board id
+directly, if `codegen-system` grows a flag for it. Then the resolver answers
+from the catalog: `native_sim/native/64` → zephyr, the mps2/an385 Zephyr boards →
+zephyr. Check how the non-Zephyr callers (`nros build` → `codegen-system`) pass
+it, and use the same spelling.
+
+## Acceptance
+
+A test bakes a bringup with a `[tiers]` table through the Zephyr module path,
+or through its CLI invocation verbatim, and the generated tier code carries the
+`[tiers.*.zephyr]` values. The test must fail with today's `--target
+zephyr-<rmw>`.

--- a/docs/issues/1313-nros-tests-gated-absence-env-race.md
+++ b/docs/issues/1313-nros-tests-gated-absence-env-race.md
@@ -1,0 +1,44 @@
+---
+id: 1313
+title: "`gated_absence_is_a_hard_failure` races a sibling test on process env under
+  plain `cargo test`"
+status: open
+type: bug
+area: testing
+severity: low
+related: []
+---
+
+## What happens
+
+`packages/testing/nros-tests/src/fixtures/binaries/mod.rs`,
+`fn gated_absence_is_a_hard_failure` (line ~5849), reads an environment
+variable that a sibling test in the same module clears. Under nextest each test
+is its own process, so it passes. Under plain `cargo test -p nros-tests --lib`
+the tests share one process and run on threads, and it fails intermittently:
+observed 212/213 on 2026-09-11 (branch `test/rv-virt-threadx-c-workspace`,
+PR #936). It passes when run alone. The test's own comment says it relies on
+nextest's process-per-test.
+
+## Why it matters
+
+A red that goes away on retry teaches people to retry. And
+`std::env::set_var` / `remove_var` are `unsafe` in edition 2024 precisely
+because concurrent access is undefined behaviour, so this is a latent UB site,
+not only a flake.
+
+## Fix
+
+Pick one:
+- **Stop reading process env in the code under test for this path.** Inject the
+  value, which is the better fix.
+- **Serialise every test in the module that touches that variable** behind one
+  `static` mutex, and document it.
+
+Grep for siblings with the same shape: `rg -n 'set_var|remove_var'
+packages/testing/nros-tests/src`.
+
+## Acceptance
+
+`cargo test -p nros-tests --lib` passes 20 times in a row with the default
+thread count.

--- a/docs/issues/1314-tier1-lane-contract-test-refuses-unscoped-run.md
+++ b/docs/issues/1314-tier1-lane-contract-test-refuses-unscoped-run.md
@@ -1,0 +1,54 @@
+---
+id: 1314
+title: "`lane_build_covers_run::a_native_build_satisfies_the_tier1_run` failed when
+  run directly — a defect, or an unmet precondition of how it was invoked?"
+status: open
+type: bug
+area: testing, ci
+severity: low
+related: [issue-0828]
+---
+
+## What was seen
+
+On 2026-09-11, in the worktree for branch `test/rv-virt-threadx-c-workspace`
+(PR #936), `packages/testing/nros-tests/tests/lane_build_covers_run.rs` ran
+10/11. `fn a_native_build_satisfies_the_tier1_run` (line ~330) failed. The
+agent's diagnosis:
+- `CiLane::run_scope` hard-codes `Tier1` to COORDINATE scoping;
+- the lane script refuses to run when `NROS_TEST_COORDS` is unset;
+- so a test asserting "a native build satisfies the tier-1 run" cannot pass in
+  an environment that does not set it.
+
+Neither reads `matrix::CELLS`, so the PR's cell additions did not cause it.
+
+## The contradiction to resolve first
+
+In two OTHER worktrees the same day, `just test-lane-contracts` passed 17/17
+(branches `fix/1284-backing-meets-default` and `fix/1285-followup-rtos-
+substring`). So either:
+- this test is not in that recipe's set, in which case it is in no lane, which
+  is itself the issue-1226 shape; or
+- it is, and passes when invoked through the recipe, in which case the direct
+  run lacked a precondition the recipe supplies, and the only defect is that it
+  fails with a confusing message instead of a `skip!` naming what is missing.
+
+Establish which before changing any code.
+
+## Fix, by outcome
+
+- **In no lane:** put it in one, or delete it. `check-default-gates-run-somewhere`
+  should have caught that; if it did not, its scope is narrower than its rule.
+- **Precondition:** make the test state its precondition with
+  `nros_tests::skip!` or a hard failure that names `NROS_TEST_COORDS`, per
+  "tests must fail on unmet preconditions".
+- **Real contradiction:** CLAUDE.md says tier 1 narrows its run by NAME
+  (`NROS_TEST_SCOPE`) and tiers 2 and nightly by COORDINATE. If `run_scope` now
+  says `Tier1` is coordinate-scoped, then either the doc or the code is stale.
+  Fix the stale one, and cite issue 0828.
+
+## Acceptance
+
+Record the outcome in this issue, with the test green or explicitly skipped
+under every supported invocation (`just test-lane-contracts`, bare `cargo test
+--test lane_build_covers_run`, nextest).

--- a/docs/roadmap/phase-453-codegen-followups-handoff.md
+++ b/docs/roadmap/phase-453-codegen-followups-handoff.md
@@ -1,0 +1,88 @@
+# Phase 453 — codegen campaign follow-ups: landing and handoff
+
+**Status (2026-09-11). Handoff.** Phase 432 (RFC-0091, "one codegen producer,
+many language packs") is finished. Its archive lands with PR #937. This doc
+exists so the next session, human or agent, can pick up from `main` without
+reading a chat log. Every item below is on origin. Nothing lives only on one
+machine.
+
+**Relates to:** [RFC-0091](../design/0091-one-entry-codegen-producer-many-language-packs.md),
+[RFC-0068](../design/0068-language-neutral-codegen-ir.md).
+
+## W1 — land the four open PRs
+
+Each is rebased onto `main` as of 2026-09-11 and authored with a local test run.
+`just ci gate` never finished cleanly in any of their worktrees, but in every
+case the cause was the environment: unprovisioned CycloneDDS or XRCE sources,
+or the host's low-memory killer. So the merge queue is the first COMPLETE gate
+for each. Read an ejection before re-queueing.
+
+| PR | branch | what it does |
+| --- | --- | --- |
+| #934 | `fix/entry-sched-bind-rc` | Both entry packs fail closed when `nros_cpp_bind_*_sched` refuses a binding. The C entry banner names the runner the entry actually calls. |
+| #936 | `test/rv-virt-threadx-c-workspace` | A pure-C ThreadX workspace entry on rv-virt-threadx: fixture row, matrix cell, and an `entry_e2e` boot variant. The runtime cell passed solo on QEMU riscv64. |
+| #937 | `docs/phase-432-closeout` | The silent `_ => emit_cpp` dispatch fallback becomes an explicit refusal. RFC-0091 §8/§9 and the book now admit that adding a language takes Rust. RFC-0068 gains Amendment 1 (`TargetProfile` retired). Phase 432 is archived. |
+| #938 | `fix/1285-followup-rtos-substring` | No RTOS is ever read from a key's spelling. It CHANGES some answers deliberately, for example `native_sim/native/64` → zephyr and unknown ids become errors; the full table is in the PR body. |
+
+**Done when:** all four are merged, or closed with a reason recorded here.
+
+## W2 — the open issues this campaign produced
+
+- [1306](../issues/1306-cli-build-rs-misses-worktree-git-index.md): in a
+  linked worktree, the CLI source stamp never re-runs on a commit. Every
+  agent hit this. The workaround is `touch packages/cli/nros-cli-core/build.rs`.
+  The fix is `git rev-parse --git-path index`.
+- [1307](../issues/1307-sizes-build-nested-cargo-rewrites-root-lock.md): every
+  NuttX build rewrites the root `Cargo.lock`. `--locked` alone would break the
+  build, and the issue lists the options.
+- [1311](../issues/1311-cyclonedds-sumseq-generated-c-fails-to-compile.md): the
+  `rmw-cyclonedds` `SumSeq` compile and link failure. **Reproduce on a clean
+  main checkout first.** It may be a worktree-provisioning artifact.
+- [1312](../issues/1312-zephyr-system-generate-passes-no-image-id.md): the Zephyr
+  system-generate module passes no image id, so the tier resolver answers for
+  the host.
+- [1313](../issues/1313-nros-tests-gated-absence-env-race.md): an env race
+  under plain `cargo test`.
+- [1314](../issues/1314-tier1-lane-contract-test-refuses-unscoped-run.md): a
+  tier-1 lane-contract test failed when run directly. Establish whether it is a
+  defect or a precondition before touching it.
+
+## W3 — triage the backed-up local branches
+
+Ten local branches carried commits with no patch-equivalent on `main`. Before
+anything was deleted, they were pushed to origin under
+`backup/local-2026-09-11/<original-name>`. Some may have landed in edited form;
+`git cherry origin/main <ref>` marks only the patches that did not land
+unchanged. For each ref: land it, file what it knew, or delete it with a
+one-line reason here.
+
+| ref (under `backup/local-2026-09-11/`) | not on main | subject area |
+| --- | --- | --- |
+| `fix/0998-sertype-freestanding` | 10 | #0998 sertype TU, #0968/#1003 Zephyr XRCE docs, phase-414 |
+| `backup/pre-recovery` | 5 | #0998, #0999 preflight, #0968/#1003 docs |
+| `fix/1172-tier-group-node-qualified` | 4 | a squashed variant of #741; main carries the other session's version |
+| `backup/741-pre-rebase` | 2 | #741 before its rebase |
+| `verify/0979-0985` | 2 | #0979 build-script cwd, #0985 sizes-heal |
+| `feature/phase-172` | 1 | 192.10 infra/debug endpoints |
+| `fix/0972-domain-range` | 1 | #0972/#0974 ROS domain cap |
+| `fix/0979-build-script-platform-root` | 1 | #0979 |
+| `fix/cxx-compat-libstdcpp-passthrough` | 1 | Zephyr cxx-compat shims |
+| `wip/zenoh-linux-test` | 1 | #1039 NuttX true/false |
+
+**Done when:** every row has an outcome and the `backup/local-2026-09-11/*`
+refs are deleted.
+
+## Resume
+
+```
+gh pr list --state open --search "934 936 937 938"
+just issues --id 1311    # and 1306, 1307, 1312, 1313, 1314
+git ls-remote origin 'refs/heads/backup/local-2026-09-11/*'
+```
+
+Tooling notes for whoever runs this from an agent worktree:
+- Agent worktrees start without most submodules. Initialise the ones a gate
+  needs non-recursively, at their pins: cyclonedds, zenoh-pico, micro-cdr,
+  micro-xrce-dds-client, play_launch (then `just setup-launch-resolve`).
+- Run `just ci gate` on its own. Two parallel gate runs were killed by the
+  low-memory killer on 2026-09-11.


### PR DESCRIPTION
This hands off the codegen campaign, so the next session can resume from `main`. It is docs only.

## Phase 453 (`docs/roadmap/phase-453-codegen-followups-handoff.md`)

The phase doc gathers what is still in flight after phase 432 closed:
- **W1:** the four open PRs (#934, #936, #937 and #938), what each does, and why the merge queue is the first complete gate for each.
- **W2:** the open issues this campaign produced.
- **W3:** triage of 10 unmerged local branches, which were backed up to origin under `backup/local-2026-09-11/*` before any deletion.
- **Resume:** commands to pick the work back up, plus notes on running it from an agent worktree.

## Four issues, each seen during the campaign and none filed until now

- **1311:** the `rmw-cyclonedds` gate's idlc-generated `SumSeq.c` fails to compile, and `service_roundtrip` then fails to link. It was seen in two fresh agent worktrees and has **not** been reproduced on a main checkout; the issue says to reproduce it first.
- **1312:** `nros_system_generate.cmake` passes `--target zephyr-<rmw>`, which names no deploy block, so the tier resolver answers for the host. This is latent: no baked bringup declares tiers today.
- **1313:** under plain `cargo test`, `gated_absence_is_a_hard_failure` races a sibling test that modifies the process environment. That is also latent undefined behaviour under edition 2024.
- **1314:** `a_native_build_satisfies_the_tier1_run` failed when run directly, yet `test-lane-contracts` passed 17/17 elsewhere. The issue asks to find out which of the two outcomes is real before changing any code.

## Gates

- `prose-issue-refs`: OK.
- `check-markdown-links`: OK, 820 live documents.
- `check-roadmap-status`: OK, 83 active phases.
- `just issues --id` parses all four new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zw1nseWJBSTRqVQzRAZcg
