### PR TITLE
fix(#1317): component.hpp includes <new> on Zephyr instead of waiting for a consumer to

### DIFF
--- a/changelog.d/1317.fix.md
+++ b/changelog.d/1317.fix.md
@@ -1,0 +1,1 @@
+A Zephyr C++ component compiles whatever its translation unit included first. `component.hpp` now includes `<new>` itself on Zephyr, so its placement-new shim is always in force; before, the shim was skipped when nothing had already pulled Zephyr's stub `<new>` in, and `NROS_COMPONENT` failed with "no matching function for call to `operator new(sizetype, void*&)`".

--- a/docs/issues/archived/1317-zephyr-cpp-component-placement-new-shim-lost.md
+++ b/docs/issues/archived/1317-zephyr-cpp-component-placement-new-shim-lost.md
@@ -1,0 +1,51 @@
+---
+id: 1317
+title: "A Zephyr C++ component fails to compile when its translation unit
+  reaches component.hpp before anything includes <new>"
+status: resolved
+type: bug
+area: api, cpp, zephyr
+severity: high
+resolved_in: "fix(#1317): component.hpp includes <new> on Zephyr instead of waiting for a consumer to"
+related: [issue-0730]
+---
+
+## What happens
+
+A Zephyr C++ image carrying a component stops at
+
+```
+packages/api/nros-cpp/include/nros/component.hpp:655:67: error: no matching
+function for call to 'operator new(sizetype, void*&)'
+```
+
+which is `NROS_COMPONENT`'s `new (storage) Class(...)`.
+
+## Why
+
+Zephyr's minimal libcpp ships a stub `<new>` that declares `nothrow_t` but not
+placement new, so `component.hpp` carries the standard non-allocating forms
+itself. They sit behind `#ifdef ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_`, which is
+Zephyr's OWN include guard for that header: it is defined only after something
+has already included `<new>`.
+
+So whether the shim exists depends on the consumer's include order. A
+translation unit that includes a node header which includes `component.hpp`
+before anything drags `<new>` in compiles the shim away, and the factory macro
+below it has no placement new.
+
+Measured on Autoware Safety Island, four C++ component sources built for
+native_sim: three of them reached `<new>` transitively and compiled;
+`stop_mode_operator.cpp` did not and failed. Nothing in the failing file is
+unusual, and nothing in this header can see the difference.
+
+## Fix
+
+`component.hpp` includes `<new>` itself under `__ZEPHYR__`, immediately before
+the guarded block. The guard is then always defined on Zephyr, the shim always
+compiles, and the factory always has placement new whatever the consumer
+included first. Zephyr's stub has no placement new of its own, so there is
+nothing to collide with.
+
+Verified: the island's four-component native_sim image failed to compile
+before this change and links after it.

--- a/packages/api/nros-cpp/include/nros/component.hpp
+++ b/packages/api/nros-cpp/include/nros/component.hpp
@@ -475,6 +475,17 @@ constexpr ::nros::QoS qos_from_declared_depth(int declared) {
 // "no matching operator new(sizetype, void*&)" (first hit porting real
 // Autoware components to a Zephyr image; ASI's FVP build used a full-libcpp
 // toolchain and never saw it). Provide the standard non-allocating forms.
+//
+// Issue 1317 — `<new>` is INCLUDED here rather than waited for. The guard
+// below is Zephyr's own include guard, so it is defined only once something
+// else has already pulled `<new>` in, and a translation unit that reaches
+// this header first got the shim compiled away and the factory failing. That
+// is a property of the CONSUMER's include order, which this header cannot
+// see: measured on a downstream where three of four component sources
+// happened to include `<new>` transitively and the fourth did not.
+#ifdef __ZEPHYR__
+#include <new>
+#endif
 #ifdef ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_
 inline void* operator new(::std::size_t, void* ptr) noexcept {
     return ptr;


### PR DESCRIPTION
A Zephyr C++ image carrying a component failed to compile, depending on what its translation unit happened to include first:

```
packages/api/nros-cpp/include/nros/component.hpp:655:67: error: no matching function
for call to 'operator new(sizetype, void*&)'
```

## Cause

Zephyr's minimal libcpp ships a stub `<new>` that declares `nothrow_t` but not placement new, so `component.hpp` carries the non-allocating forms itself. They sit behind `#ifdef ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_`, which is Zephyr's OWN include guard for `<new>`: it is defined only after something has already included that header.

So the shim existed or not according to the CONSUMER's include order, which this header cannot see. A translation unit reaching `component.hpp` before anything pulled `<new>` in compiled the shim away, and `NROS_COMPONENT`'s `new (storage) Class(...)` right below it had no placement new.

## Fix

Include `<new>` here under `__ZEPHYR__`, immediately before the guarded block. The guard is then always defined on Zephyr, the shim is always in force, and the factory always has placement new. Zephyr's stub declares no placement new of its own, so nothing collides.

## Measured

Autoware Safety Island, four C++ component sources built for native_sim: three reached `<new>` transitively and compiled; `stop_mode_operator.cpp` did not and failed. Nothing distinguishes the failing file. With this change the image links.

Issue 1317 is filed in `archived/` with this PR, plus a changelog fragment.

`just check fast`: all 306 gates pass through the pre-push hook, with the zenoh-pico submodule and the vendored XRCE trees provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPYy9LfvLmiFG6AnZ9nExE