### PR TITLE
fix(#1268): the parameter services register their types, say which node failed, and stop retrying what cannot change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,8 @@ version = "0.5.0"
 dependencies = [
  "critical-section",
  "heapless 0.8.0",
+ "nros-lifecycle-msgs",
+ "nros-rcl-interfaces",
  "nros-rmw",
  "nros-serdes",
  "spin",

--- a/docs/issues/1268-cyclone-param-services-unsupported-silently-dropped.md
+++ b/docs/issues/1268-cyclone-param-services-unsupported-silently-dropped.md
@@ -72,3 +72,62 @@ limits (32 slots of 8,920 B), for services no ROS 2 tool can reach.
 - `ros2 param list`, `get` and `set` reach every node of a multi-node Cyclone
   image (this also needs issue 1269's node naming).
 - A registration failure is logged exactly once, naming the node and service.
+
+## Status — 2026-09-11 (phase-444 W6): fixed in the tree, UNVERIFIED LIVE
+
+All three items of the Fix shape landed. The first acceptance above is NOT
+checked off: it needs a ROS 2 peer, this host has none, and the agent that made
+the change did not run the distrobox. The issue stays OPEN for that reason
+alone. What a live run has to confirm is `ros2 param list/get/set` against a
+multi-node Cyclone image; the cell that would do it in the live-peer lane is
+named at the bottom of this section.
+
+- **Registered.** `create_param_srv` (`nros-node/src/executor/spin.rs`) calls
+  `register_type::<Svc::Request>()` / `::<Svc::Reply>()` before
+  `create_service`, exactly as a typed user service does
+  (`register_service_sized`). Chosen over baking the descriptors into the
+  backend the way `ParticipantEntitiesInfo` is: the generic seam already
+  existed, it is what every other service uses, and it keeps zenoh and xrce
+  no-ops (which is why zenoh served this image all along).
+- **The types do build.** `nros-rmw-cyclonedds/tests/infra_service_descriptors.rs`
+  builds a descriptor for each of the twelve. That was the open question —
+  `Parameter` / `ParameterValue` / `ParameterDescriptor` carry sequences of
+  nested structs, sequences of strings and a bounded sequence, the class that
+  was rejected outright before phase-212 K.7.4.c.
+- **Reported once, naming both.** The log line now names the node FQN and the
+  service suffix (`/mrm_handler` at `get_parameters`), from a
+  `ParamServiceReconcileFailure` recorded where the failure happens — the only
+  place that knows both.
+- **Stopped retrying.** A `Transport(Unsupported)` is marked permanent and
+  `parameter_services_pending()` returns false, so the spin no longer runs six
+  `create_service` calls per spin forever. An explicit
+  `register_parameter_services()` still tries, because that is a caller asking
+  rather than the spin guessing. Test:
+  `a_permanent_parameter_service_failure_is_asked_once_and_names_what_failed`
+  (nros-node). Negative control: with the stop-retrying clause reverted it
+  fails — `five spins made 5 create_service call(s)`.
+- **Sized.** `NROS_CYCLONEDDS_MAX_TYPES` is derived from the SystemModel, which
+  names only what an entry WIRES, so the twelve were invisible to it;
+  `cyclonedds_type_sizing::infra_types` counts them from the same
+  `InfraServices::from_model` predicate the queryable counts use. Before the
+  registration landed they cost no slots, because nothing registered them.
+- **0745 comment corrected** in `nros-cli-core/src/codegen/entry/emit_c.rs`: the
+  cause was never "an RMW without service-server support".
+
+**The class, swept.** Of the entities the executor creates on its own:
+`/clock` goes through the subscription path, which already registers its type;
+action protocol types are registered by `A::register_protocol_types`;
+`/parameter_events`, `/rosout` and the type_description services are not created
+by nros-node at all. The one remaining gap is the **lifecycle** services, and
+they are NOT fixed here: three of their request types are empty and the
+descriptor builder refuses an empty schema. That is **issue 1293**, filed with
+the serializer half it also needs;
+`infra_service_descriptors::empty_request_types_have_no_descriptor_yet` pins the
+boundary so it fails when 1293 lands.
+
+**What would verify it live:** a Cyclone parameter cell in `interop::CELLS`
+alongside the existing `native-params-rust-zenoh` /
+`native-params-per-node-rust-zenoh` (`packages/testing/nros-tests/src/interop.rs`),
+with its verdict row in `.config/interop-verdicts.toml` and the lane in
+`.github/workflows/live-peer.yml`. No Cyclone params cell exists today, on any
+RMW but zenoh.

--- a/docs/issues/1293-cyclone-rust-empty-struct-types-have-no-descriptor.md
+++ b/docs/issues/1293-cyclone-rust-empty-struct-types-have-no-descriptor.md
@@ -1,0 +1,65 @@
+---
+id: 1293
+title: "On the Rust Cyclone path an EMPTY message has no descriptor, so lifecycle
+  services (and any empty-request service) cannot be created"
+status: open
+type: bug
+area: rmw
+severity: medium
+related: [issue-1268]
+---
+
+## Symptom
+
+Found while fixing issue 1268 and sweeping its class: the services the executor
+creates on its own. The six parameter services now register their types and
+come up on Cyclone. The five lifecycle services do not. Three of their request
+types are EMPTY:
+
+| type | `FIELDS` |
+| --- | --- |
+| `lifecycle_msgs/srv/GetState_Request` | `&[]` |
+| `lifecycle_msgs/srv/GetAvailableStates_Request` | `&[]` |
+| `lifecycle_msgs/srv/GetAvailableTransitions_Request` | `&[]` |
+
+The Rust descriptor builder refuses an empty schema outright
+(`nros-rmw-cyclonedds/src/dynamic_type.rs`, `BuildError::EmptySchema`), and so
+does the C++ bridge behind it (`BridgeError::EmptySchema`). So
+`register_type::<GetStateRequest>()` fails, and so does every service whose
+request or response is empty. That includes user services: `std_srvs/Trigger`
+and `std_srvs/Empty` on a Rust Cyclone image.
+
+## Cause
+
+ROS pads an empty struct. `rosidl_generator_dds_idl` emits
+`uint8 structure_needs_at_least_one_member` for it, so on the wire an empty
+request is one byte, not zero. The IDL path here does the same:
+`scripts/cyclonedds/msg_to_cyclone_idl.py` and `nros-msg-to-idl`'s emitter both
+add the member, which is why the C/C++ CMake route (`nros_generate_interfaces`)
+has no such gap. The Rust path does not pad in either place:
+
+- the generated schema has `FIELDS = &[]`, and the builder rejects that;
+- the generated `Serialize` writes zero payload bytes (`begin_dheader` /
+  `end_dheader`, which is no bytes under humble's FINAL extensibility).
+
+So fixing only the descriptor, by synthesizing the one `uint8` member when
+`FIELDS` is empty, would give a Cyclone topic whose type says one byte while
+our writer sends none. Stock peers would then fail to deserialize. Both halves
+have to move together, and the codegen change affects every generated crate.
+That is why this was split out of 1268 rather than landing half of it there.
+
+## Fix shape
+
+- `DescriptorBuilder`: an empty schema becomes a single
+  `structure_needs_at_least_one_member: uint8` member (the name rosidl uses),
+  not an error.
+- Codegen: an empty message serializes and deserializes that one byte, on
+  every RMW. Check the zenoh and XRCE wire against stock before changing it,
+  since those peers use the same rosidl typesupport.
+- Then `create_lc_srv` (`nros-node/src/executor/spin.rs`) calls
+  `register_type` for both halves, as `create_param_srv` does since 1268.
+
+## Acceptance
+
+- `ros2 lifecycle get /<node>` answers from a Cyclone image.
+- A `std_srvs/Trigger` server on a Rust Cyclone image answers `ros2 service call`.

--- a/packages/cli/nros-cli-core/src/codegen/entry/emit_c.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/emit_c.rs
@@ -529,8 +529,14 @@ mod tests {
 
     #[test]
     fn typed_emit_param_services_registration_is_non_fatal_both_paths() {
-        // Issue 0745 — registration builds six service servers and fails outright on
-        // an RMW without service-server support (cyclonedds today). Launch params are
+        // Issue 0745 — registration builds six service servers, and a backend can
+        // refuse the whole set. The stated cause here was WRONG and issue 1268
+        // corrected it: cyclonedds has service-server support and serves an image's
+        // own services. What it refused was the rcl_interfaces TYPES, which nothing
+        // registered a descriptor for; it now registers them with the rest. The
+        // non-fatal shape below is unchanged and still right — a backend that cannot
+        // serve the six must cost the runtime get/set RPC and nothing else. Launch
+        // params are
         // seeded pre-construction by `emit_declare_params`, so a failed registration
         // must cost the runtime get/set RPC and nothing else. The C++ emitter moved to
         // the non-fatal shape with 0745; BOTH C paths kept the pre-0745 block, which

--- a/packages/cli/nros-cli-core/src/orchestration/model_ingest.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/model_ingest.rs
@@ -568,7 +568,12 @@ pub fn resolve_cyclonedds_max_types_with(
 ) -> Result<Option<usize>> {
     use nros_orchestration_ir::cyclonedds_type_sizing as ty;
 
-    let counted = ty::count_dds_types(model, |_| true);
+    // Issue 1268 — the model names what an ENTRY wires; the six parameter
+    // services are the EXECUTOR's, so they are counted from the same feature
+    // predicate `entity_facts` and the queryable counts use, not from a second
+    // reading of `execution.features`.
+    let infra = crate::entity_inventory::InfraServices::from_model(model);
+    let counted = ty::count_dds_types(model, |_| true) + ty::infra_types(infra.param_services);
     if counted == 0 {
         return Ok(None);
     }

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -8356,9 +8356,18 @@ impl<'s> Executor<'s> {
     /// it without carrying the reconcile's frame (see below).
     #[inline]
     pub(crate) fn parameter_services_pending(&self) -> bool {
-        self.params
-            .as_ref()
-            .is_some_and(|p| p.requested && p.services.len() < self.nodes.len().max(1))
+        self.params.as_ref().is_some_and(|p| {
+            p.requested
+                && p.services.len() < self.nodes.len().max(1)
+                // Issue 1268 — a failure that cannot change is not pending
+                // work. This used to retry six `create_service` calls on EVERY
+                // spin, for the life of an image that would never serve them,
+                // and the result was discarded; 1271 made it say so once, which
+                // left the retrying. An explicit
+                // `register_parameter_services()` still tries, because that is
+                // a caller asking rather than the spin guessing.
+                && p.reconcile_failure.as_ref().is_none_or(|f| !f.permanent)
+        })
     }
 
     /// Issue 1271 -- say, once, that the parameter services could not be
@@ -8378,14 +8387,27 @@ impl<'s> Executor<'s> {
             return;
         }
         params.reconcile_failure_reported = true;
+        // Issue 1268 — name the node and the service. "could not be created
+        // ({:?})" named neither, so a reader could not tell a name too long for
+        // one node from a backend that will serve none of the six.
+        let (node_fqn, service, permanent) = match params.reconcile_failure.as_ref() {
+            Some(f) => (f.node_fqn.as_str(), f.service, f.permanent),
+            None => ("<unknown node>", "<unknown service>", false),
+        };
         nros_log::log_error!(
             nros_log::get_logger("nros"),
-            "parameter services could not be created ({:?}): `ros2 param` cannot reach \
-             {} of this image's {} node(s). Retrying on every spin; logged once (issue 1271, \
-             and issue 1268 for the Cyclone case).",
+            "parameter services could not be created for node {} at service {}: {:?}. \
+             `ros2 param` cannot reach {} of this image's {} node(s). {} (issues 1271, 1268).",
+            node_fqn,
+            service,
             e,
             self.nodes.len().max(1) - params.services.len(),
-            self.nodes.len().max(1)
+            self.nodes.len().max(1),
+            if permanent {
+                "Not retrying: this failure cannot change without a rebuild."
+            } else {
+                "Retrying on every spin; logged once."
+            }
         );
     }
 
@@ -8471,11 +8493,35 @@ impl<'s> Executor<'s> {
             );
         }
         for (index, name, namespace) in todo {
-            let servers = self.build_parameter_service_set(
+            let servers = match self.build_parameter_service_set(
                 nros_params::NodeKey::new(index),
                 &name,
                 &namespace,
-            )?;
+            ) {
+                Ok(servers) => servers,
+                Err((e, service)) => {
+                    // Issue 1268 — keep WHAT failed and WHERE, for the one log
+                    // line, and decide once whether retrying could ever help.
+                    // `Unsupported` from the transport is a property of the
+                    // build (the backend has no descriptor for the
+                    // `rcl_interfaces` types), so a later spin asks the same
+                    // question and gets the same answer.
+                    let permanent = matches!(e, NodeError::Transport(TransportError::Unsupported));
+                    if let Some(params) = self.params.as_mut() {
+                        let mut node_fqn = heapless::String::<256>::new();
+                        if let Ok(fqn) = crate::names::fully_qualified_name(&name, &namespace) {
+                            let _ = node_fqn.push_str(fqn.as_str());
+                        }
+                        params.reconcile_failure =
+                            Some(crate::parameter_services::ParamServiceReconcileFailure {
+                                node_fqn,
+                                service,
+                                permanent,
+                            });
+                    }
+                    return Err(e);
+                }
+            };
             let services_box: alloc::boxed::Box<
                 dyn crate::parameter_services::ParamServiceProcessor,
             > = alloc::boxed::Box::new(servers);
@@ -8515,6 +8561,9 @@ impl<'s> Executor<'s> {
         // registered after this one) is news again and earns its own line.
         if let Some(params) = self.params.as_mut() {
             params.reconcile_failure_reported = false;
+            // Issue 1268 -- and drop the record with it, so a later failure is
+            // reported against the node it actually happened on.
+            params.reconcile_failure = None;
         }
         Ok(())
     }
@@ -8532,7 +8581,7 @@ impl<'s> Executor<'s> {
         node: nros_params::NodeKey,
         node_name: &str,
         namespace: &str,
-    ) -> Result<crate::parameter_services::ParameterServiceServers, NodeError> {
+    ) -> Result<crate::parameter_services::ParameterServiceServers, (NodeError, &'static str)> {
         use crate::parameter_services::{
             DescribeParameters, GetParameterTypes, GetParameters, ListParameters,
             ParamServiceHandle as PSrv, ParameterServiceServers, SetParameters,
@@ -8547,25 +8596,52 @@ impl<'s> Executor<'s> {
         // did not. A join with three spellings has no answer to "what does the
         // tree do with `my_ns`".
         let node_fqn = crate::names::fully_qualified_name(node_name, namespace)
-            .map_err(|()| NodeError::NameTooLong)?;
+            .map_err(|()| (NodeError::NameTooLong, "get_parameters"))?;
         // The service names below still take the two halves separately.
         let ns: &str = namespace;
         let nn: &str = node_name;
 
         /// Build a service name like `{node_fqn}/{suffix}` and create the server handle.
-        fn create_param_srv<Svc: RosService>(
+        ///
+        /// Issue 1268 — the error carries the SUFFIX, so a failure can name the
+        /// service a tool would have called instead of "one of six".
+        fn create_param_srv<Svc>(
             session: &mut session::ConcreteSession,
             domain_id: u32,
             node_fqn: &str,
             namespace: &str,
             node_name: &str,
-            suffix: &str,
-        ) -> Result<session::RmwServiceServer, NodeError> {
+            suffix: &'static str,
+        ) -> Result<session::RmwServiceServer, (NodeError, &'static str)>
+        where
+            Svc: RosService,
+            Svc::Request: crate::rmw_type_registry::MessageForRmw,
+            Svc::Reply: crate::rmw_type_registry::MessageForRmw,
+        {
+            // Issue 1268 — REGISTER THE TYPES FIRST, exactly as a typed user
+            // service does (`register_service_sized`). A backend that keys
+            // topics on a registered type descriptor — Cyclone does — fails
+            // `create_service` with `Unsupported` for a type it has never been
+            // told about, and nothing else in the image registers the
+            // `rcl_interfaces` service types: the generated typesupport of a
+            // downstream covers ITS OWN message packages, and the backend bakes
+            // in only `ParticipantEntitiesInfo` for the graph. So the six
+            // parameter services failed on every spin while the image's own
+            // services worked, which is what made the cause look like "no
+            // service support" for two phases (the issue-0745 comment).
+            //
+            // A no-op on backends that need no descriptors (zenoh, xrce), which
+            // is why zenoh served this same image all along.
+            let register = |e: NodeError| (e, suffix);
+            crate::rmw_type_registry::register_type::<Svc::Request>().map_err(register)?;
+            crate::rmw_type_registry::register_type::<Svc::Reply>().map_err(register)?;
             let mut name = heapless::String::<256>::new();
             name.push_str(node_fqn)
-                .map_err(|_| NodeError::NameTooLong)?;
-            name.push_str("/").map_err(|_| NodeError::NameTooLong)?;
-            name.push_str(suffix).map_err(|_| NodeError::NameTooLong)?;
+                .map_err(|_| (NodeError::NameTooLong, suffix))?;
+            name.push_str("/")
+                .map_err(|_| (NodeError::NameTooLong, suffix))?;
+            name.push_str(suffix)
+                .map_err(|_| (NodeError::NameTooLong, suffix))?;
             let mut info = ServiceInfo::new(&name, Svc::SERVICE_NAME, Svc::SERVICE_HASH)
                 // issue 0824 follow-up — `domain_id` is a PARAMETER, not `self.domain_id`:
                 // this is a nested `fn`, not a method, so `self` is not in scope and
@@ -8586,7 +8662,7 @@ impl<'s> Executor<'s> {
             // the deep queue is for.
             session
                 .create_service(&info, QoSProfile::parameters_default())
-                .map_err(NodeError::Transport)
+                .map_err(|e| (NodeError::Transport(e), suffix))
         }
 
         let get_handle = create_param_srv::<GetParameters>(
@@ -9076,6 +9152,7 @@ impl<'s> Executor<'s> {
             // Issue 1270 -- allocated with the first set of services, not here.
             buffers: None,
             reconcile_failure_reported: false,
+            reconcile_failure: None,
             // phase-430 W2 — no node has been auto-declared yet; the caller
             // (`ensure_parameter_store`) seeds PRIMARY immediately after.
             #[cfg(feature = "sim-time")]

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -3396,6 +3396,74 @@ fn use_sim_time_is_declared_on_a_node_that_never_named_it() {
     );
 }
 
+/// Issue 1268 — a backend that will NEVER serve the parameter services is
+/// asked once, not once per spin, and the report names the node and the
+/// service.
+///
+/// The real one is Cyclone: it keys a topic on a registered type descriptor,
+/// nothing registered the `rcl_interfaces` ones, and `create_service` answered
+/// `Unsupported` forever while the image's own services worked. The executor
+/// retried all six on every spin and (before 1271) discarded the result, so an
+/// image with no `ros2 param` access said nothing at all about it.
+///
+/// `Unsupported` is the case that cannot change without a rebuild. A transport
+/// that is merely late still gets retried — that is what `permanent` decides,
+/// and why this test asserts the ATTEMPT COUNT rather than just the log.
+#[cfg(feature = "param-services")]
+#[test]
+fn a_permanent_parameter_service_failure_is_asked_once_and_names_what_failed() {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    static ATTEMPTS: AtomicUsize = AtomicUsize::new(0);
+    ATTEMPTS.store(0, Ordering::SeqCst);
+
+    let session = MockSession::with_failing_service_create(TransportError::Unsupported, &ATTEMPTS);
+    let cfg = ExecutorConfig::default();
+    let mut executor: Executor = Executor::from_session_with(session, &cfg);
+    executor.set_node_identity("bare", "/");
+    executor
+        .register_parameter_services()
+        .expect("the request is recorded even with no node yet");
+
+    for _ in 0..5 {
+        let _ = executor.spin_once(core::time::Duration::from_millis(0));
+    }
+
+    let attempts = ATTEMPTS.load(Ordering::SeqCst);
+    assert_eq!(
+        attempts, 1,
+        "a failure that cannot change must be asked ONCE: five spins made \
+         {attempts} create_service call(s). Before issue 1268 this was six per spin, \
+         for the life of the image."
+    );
+
+    let params = executor.params.as_ref().expect("the store exists");
+    assert!(
+        params.services.is_empty(),
+        "no set of six can be serving when every create_service failed"
+    );
+    let failure = params
+        .reconcile_failure
+        .as_ref()
+        .expect("the failure must be recorded, or the log can name neither node nor service");
+    assert_eq!(
+        failure.node_fqn.as_str(),
+        "/bare",
+        "the report must name the node `ros2 param` could not reach"
+    );
+    assert_eq!(
+        failure.service, "get_parameters",
+        "the report must name the service a tool would have called"
+    );
+    assert!(
+        failure.permanent,
+        "Unsupported is a property of the build; a retry asks the same question"
+    );
+    assert!(
+        !executor.parameter_services_pending(),
+        "a permanent failure is not pending work — that predicate is what stops the retry"
+    );
+}
+
 /// phase-430 W2 — the same, for a node that declares NOTHING WHATEVER and only
 /// registers the six parameter services.
 ///

--- a/packages/core/nros-node/src/mock.rs
+++ b/packages/core/nros-node/src/mock.rs
@@ -229,12 +229,36 @@ pub struct MockSession {
     /// test functions on parallel threads, and one shared counter would make
     /// every close in the suite look like this test's.
     close_observer: Option<&'static core::sync::atomic::AtomicUsize>,
+    /// Issue 1268 — make `create_service` fail, so a test can watch what the
+    /// executor does with a backend that will not serve the parameter services.
+    /// The real one that does this is Cyclone with no registered descriptor for
+    /// the `rcl_interfaces` types, which answers `Unsupported`.
+    service_create_error: Option<TransportError>,
+    /// Issue 1268 — counts `create_service` calls, which is how a test tells
+    /// "asked once and gave up" from "asks again on every spin". A `&'static`
+    /// the TEST owns, for the reason `close_observer` documents above.
+    service_create_attempts: Option<&'static core::sync::atomic::AtomicUsize>,
 }
 
 impl MockSession {
     pub fn new() -> Self {
         Self {
             close_observer: None,
+            service_create_error: None,
+            service_create_attempts: None,
+        }
+    }
+
+    /// Issue 1268 — a session whose `create_service` always fails with `error`,
+    /// counting each attempt into `attempts`.
+    pub fn with_failing_service_create(
+        error: TransportError,
+        attempts: &'static core::sync::atomic::AtomicUsize,
+    ) -> Self {
+        Self {
+            close_observer: None,
+            service_create_error: Some(error),
+            service_create_attempts: Some(attempts),
         }
     }
 
@@ -242,6 +266,8 @@ impl MockSession {
     pub fn with_close_observer(observer: &'static core::sync::atomic::AtomicUsize) -> Self {
         Self {
             close_observer: Some(observer),
+            service_create_error: None,
+            service_create_attempts: None,
         }
     }
 }
@@ -281,6 +307,12 @@ impl Session for MockSession {
         _service: &ServiceInfo,
         _qos: QoSProfile,
     ) -> Result<MockServiceServer, TransportError> {
+        if let Some(attempts) = self.service_create_attempts {
+            attempts.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+        }
+        if let Some(e) = self.service_create_error.as_ref() {
+            return Err(e.clone());
+        }
         Ok(MockServiceServer::new())
     }
 

--- a/packages/core/nros-node/src/parameter_services.rs
+++ b/packages/core/nros-node/src/parameter_services.rs
@@ -1901,6 +1901,23 @@ impl ParamServiceProcessor for ParameterServiceServers {
     }
 }
 
+/// Issue 1268 -- why a node has no parameter services.
+///
+/// Recorded where the failure happens, because that is the only place that
+/// knows both the node and which of the six was being created. `permanent`
+/// asks one question: can a retry change this? A transport that refuses the
+/// TYPE (`Unsupported`) answers no — the descriptor set is a property of the
+/// build, not of when you ask — so the spin stops retrying rather than running
+/// six `create_service` calls per spin for the life of the image.
+pub(crate) struct ParamServiceReconcileFailure {
+    /// The node the six would have been published under.
+    pub(crate) node_fqn: heapless::String<256>,
+    /// Which of the six, as its service-name suffix (`"list_parameters"`).
+    pub(crate) service: &'static str,
+    /// Whether a later spin could succeed where this one failed.
+    pub(crate) permanent: bool,
+}
+
 /// Holds parameter server state for the executor.
 ///
 /// Stored outside the arena so it doesn't consume `MAX_CBS` slots.
@@ -1945,6 +1962,15 @@ pub(crate) struct ParamState<'s> {
     /// image said so. One line per run of failures; cleared once every node
     /// is served, so a later failure is news again.
     pub(crate) reconcile_failure_reported: bool,
+    /// Issue 1268 -- WHICH node and WHICH service the last reconcile failed on,
+    /// and whether that failure can change.
+    ///
+    /// The 1271 log said only "could not be created ({:?})", which names
+    /// neither, so the reader could not tell a name too long for one node from
+    /// a backend that will never serve any of the six. Both halves of the
+    /// answer are known at the `create_service` call and nowhere above it, so
+    /// they are recorded here as the call fails.
+    pub(crate) reconcile_failure: Option<ParamServiceReconcileFailure>,
     /// phase-430 W2 — for each node key, whether that node's `use_sim_time`
     /// entry is the AUTO-DECLARED `false` the executor seeded (as rclcpp does
     /// in every node constructor) rather than a value the application named.

--- a/packages/core/nros-orchestration-ir/src/cyclonedds_type_sizing.rs
+++ b/packages/core/nros-orchestration-ir/src/cyclonedds_type_sizing.rs
@@ -64,6 +64,41 @@ const TYPES_PER_ACTION: usize = 8;
 /// action (`CancelGoal_{Request,Response}`, `GoalStatusArray`).
 const ACTION_MSGS_SHARED: usize = 3;
 
+/// Issue 1268 — distinct DDS type names the SIX parameter services register.
+///
+/// They are the executor's own, not the model's: `param_services` puts a set of
+/// six on every node, and each service registers `_Request` + `_Response`, so
+/// twelve names — `rcl_interfaces::srv::dds_::{Get,Set,SetAtomically,List,
+/// Describe,GetTypes}Parameters_{Request,Response}_`. Shared across every node
+/// of the image (one descriptor per TYPE, not per node), so the count does not
+/// scale with node count.
+///
+/// Counted here because the model names only what an entry WIRES, and these are
+/// wired by the runtime. Before 1268 they registered nothing at all — the six
+/// `create_service` calls went straight to the backend, which refused each — so
+/// they cost no registry slots and the omission could not be observed.
+pub const PARAM_SERVICE_TYPES: usize = 6 * TYPES_PER_SRV;
+
+/// The lifecycle services' types are NOT counted, and that is issue 1293: three
+/// of their request types are EMPTY, the descriptor builder refuses an empty
+/// schema, and `create_lc_srv` therefore still registers nothing. When 1293
+/// gives an empty message its `structure_needs_at_least_one_member` byte in
+/// BOTH the descriptor and the serializer, this becomes `5 * TYPES_PER_SRV`
+/// minus the shared `GetAvailableTransitions` pair — i.e. 8 — and joins
+/// [`infra_types`].
+pub const LIFECYCLE_SERVICE_TYPES_WHEN_1293_LANDS: usize = 8;
+
+/// Distinct DDS type names the executor's OWN services add, given what the
+/// bringup declares. `param_services` is the caller's answer to
+/// `InfraServices::from_model`, so the feature predicate has one spelling.
+pub fn infra_types(param_services: bool) -> usize {
+    if param_services {
+        PARAM_SERVICE_TYPES
+    } else {
+        0
+    }
+}
+
 /// Node FQN owning an endpoint ref (`"/ns/node/endpoint"` → `"/ns/node"`).
 fn endpoint_node(ep: &str) -> &str {
     ep.rsplit_once('/').map(|(node, _)| node).unwrap_or(ep)
@@ -272,5 +307,19 @@ mod tests {
         assert_eq!(derive_max_types(33), 64);
         assert_eq!(derive_max_types(65), 128);
         assert!(derive_max_types(200).is_power_of_two());
+    }
+
+    /// Issue 1268 — the six parameter services register twelve types, and the
+    /// sizing has to see them: they are the executor's, so no model wiring
+    /// names them, and an image whose own types already fill the table would
+    /// meet `RegistryFull` at runtime rather than a sized knob at bake time.
+    #[test]
+    fn infra_types_counts_the_parameter_services_only_when_declared() {
+        assert_eq!(infra_types(false), 0, "an image without them pays nothing");
+        assert_eq!(
+            infra_types(true),
+            12,
+            "six services x (_Request + _Response); the lifecycle five are issue 1293"
+        );
     }
 }

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/Cargo.toml
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/Cargo.toml
@@ -85,5 +85,15 @@ critical-section = { version = "1.2", default-features = false }
 [target.'cfg(not(target_os = "none"))'.dependencies]
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 
+# Issue 1268 — the executor's OWN services (the six `rcl_interfaces` parameter
+# ones) must have a Cyclone descriptor, or `create_service` fails `Unsupported`
+# and `ros2 param` reaches no node of the image. `infra_service_descriptors`
+# builds each of their types here, where a rejection is a test failure rather
+# than a runtime one. Both crates are pre-generated and committed
+# (`packages/interfaces/*`), so this needs no codegen and no ROS.
+[dev-dependencies]
+nros-rcl-interfaces = { version = "0.5.0", path = "../../../interfaces/rcl-interfaces/generated/humble/nros-rcl-interfaces", default-features = false }
+nros-lifecycle-msgs = { version = "0.5.0", path = "../../../interfaces/lifecycle-msgs/generated/humble/nros-lifecycle-msgs", default-features = false }
+
 [lints]
 workspace = true

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/infra_service_descriptors.rs
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/infra_service_descriptors.rs
@@ -1,0 +1,131 @@
+//! Issue 1268 — the services the executor creates ON ITS OWN must have a
+//! Cyclone type descriptor.
+//!
+//! Cyclone creates a topic only for a type it has a registered descriptor for;
+//! `create_service` on any other type fails `UNSUPPORTED`. The backend bakes in
+//! exactly one descriptor of its own (`ParticipantEntitiesInfo`, for the
+//! graph), and a downstream's generated typesupport covers ITS OWN message
+//! packages — so nothing covered the six `rcl_interfaces` parameter services,
+//! and `ros2 service list` showed none of them for any node of a Cyclone image
+//! while the image's own services worked.
+//!
+//! The executor now registers those types before creating the servers
+//! (`create_param_srv`, `nros-node/src/executor/spin.rs`), which is only
+//! useful if the builder ACCEPTS them: `Parameter`, `ParameterValue` and
+//! `ParameterDescriptor` carry sequences of nested structs, sequences of
+//! strings and a bounded sequence, which is the shape class that was rejected
+//! outright before phase-212 K.7.4.c. This test builds all twelve.
+//!
+//! It uses the no-op bridge stub below when `bridge-stub` is off (same shape as
+//! `registry_seq_nested.rs`), so it runs in the plain workspace test lane with
+//! no feature flags and no `libddsc`. That means it checks the RUST half — the
+//! schema walk, nesting depth and field kinds — and not the C++ op emitter.
+
+#[cfg(not(feature = "bridge-stub"))]
+use core::ffi::{c_char, c_int, c_void};
+
+use nros_rmw_cyclonedds::dynamic_type::{BuildError, DescriptorBuilder};
+use nros_serdes::schema::Message;
+
+#[cfg(not(feature = "bridge-stub"))]
+static STUB_BACKING: u8 = 0;
+
+#[cfg(not(feature = "bridge-stub"))]
+#[unsafe(no_mangle)]
+extern "C" fn nros_cyclonedds_build_descriptor_from_schema(
+    _type_name: *const c_char,
+    _fields: *const u8,
+    _field_count: u32,
+    _kinds: *const u8,
+    _kind_count: u32,
+    _out_err: *mut c_int,
+) -> *const c_void {
+    &STUB_BACKING as *const u8 as *const c_void
+}
+
+#[cfg(not(feature = "bridge-stub"))]
+#[unsafe(no_mangle)]
+extern "C" fn nros_rmw_cyclonedds_register_descriptor(
+    _type_name: *const c_char,
+    _descriptor: *const c_void,
+) {
+}
+
+fn builds<M: Message>() {
+    match DescriptorBuilder::build::<M>() {
+        Ok(ptr) => assert!(
+            !ptr.is_null(),
+            "{}: descriptor built but null — Cyclone would refuse the topic",
+            M::TYPE_NAME
+        ),
+        Err(e) => panic!(
+            "{}: no descriptor ({e:?}) — `create_service` for a parameter service \
+             would fail Unsupported and `ros2 param` would reach no node (issue 1268)",
+            M::TYPE_NAME
+        ),
+    }
+}
+
+/// The twelve types the six parameter services put on the wire.
+#[test]
+fn every_parameter_service_type_builds_a_descriptor() {
+    use nros_rcl_interfaces::srv::{
+        DescribeParametersRequest, DescribeParametersResponse, GetParameterTypesRequest,
+        GetParameterTypesResponse, GetParametersRequest, GetParametersResponse,
+        ListParametersRequest, ListParametersResponse, SetParametersAtomicallyRequest,
+        SetParametersAtomicallyResponse, SetParametersRequest, SetParametersResponse,
+    };
+
+    builds::<GetParametersRequest>();
+    builds::<GetParametersResponse>();
+    builds::<SetParametersRequest>();
+    builds::<SetParametersResponse>();
+    builds::<SetParametersAtomicallyRequest>();
+    builds::<SetParametersAtomicallyResponse>();
+    builds::<ListParametersRequest>();
+    builds::<ListParametersResponse>();
+    builds::<DescribeParametersRequest>();
+    builds::<DescribeParametersResponse>();
+    builds::<GetParameterTypesRequest>();
+    builds::<GetParameterTypesResponse>();
+}
+
+/// Issue 1293 — why the LIFECYCLE services are not fixed by the same change.
+///
+/// Three of their request types are empty (`FIELDS = &[]`), and the builder
+/// refuses an empty schema. ROS pads an empty struct with
+/// `uint8 structure_needs_at_least_one_member`, so on the wire it is one byte;
+/// our IDL path does that too, and the Rust schema path does not — in EITHER
+/// the descriptor or the serializer. Fixing only the descriptor would describe
+/// a byte the writer never sends.
+///
+/// This test states the boundary rather than leaving it to be rediscovered: if
+/// someone makes empty schemas build, this fails and points at 1293, which is
+/// where the serializer half is written down.
+#[test]
+fn empty_request_types_have_no_descriptor_yet() {
+    use nros_lifecycle_msgs::srv::{
+        GetAvailableStatesRequest, GetAvailableTransitionsRequest, GetStateRequest,
+    };
+
+    for (name, result) in [
+        (
+            GetStateRequest::TYPE_NAME,
+            DescriptorBuilder::build::<GetStateRequest>(),
+        ),
+        (
+            GetAvailableStatesRequest::TYPE_NAME,
+            DescriptorBuilder::build::<GetAvailableStatesRequest>(),
+        ),
+        (
+            GetAvailableTransitionsRequest::TYPE_NAME,
+            DescriptorBuilder::build::<GetAvailableTransitionsRequest>(),
+        ),
+    ] {
+        assert!(
+            matches!(result, Err(BuildError::EmptySchema)),
+            "{name} is empty, so the builder must still refuse it with EmptySchema \
+             (issue 1293 carries the descriptor + serializer pair that makes it work); got {result:?}"
+        );
+    }
+}


### PR DESCRIPTION
Issue 1268 (phase-444 W6). Based on `main`; it carries no other PR's commits.

## What was wrong

A downstream 4-node C++ image with `param_services` declared all 21 of its parameters and booted, and `ros2 service list` showed none of the six rcl_interfaces services for any node — while the image's OWN two services worked. Registration failed `Transport(Unsupported)` and the executor retried it on every spin.

Cyclone creates a topic only for a type it has a **registered descriptor** for. The backend bakes in exactly one of its own (`ParticipantEntitiesInfo`, for the graph), and a downstream's generated typesupport covers its own message packages — so nothing registered the `rcl_interfaces` service types and `create_service` refused all six.

## What changed

- **Register the types.** `create_param_srv` calls `register_type::<Svc::Request>()` / `::<Svc::Reply>()` before `create_service`, exactly as a typed user service does (`register_service_sized`). Chosen over baking descriptors into the backend the way `ParticipantEntitiesInfo` is: the generic seam already exists, it is what every other service uses, and it stays a **no-op on zenoh and xrce** — which is why zenoh served this same image all along.
- **Say which node and which service.** The issue-1271 line read `could not be created ({:?})`, naming neither, so "a name too long for one node" and "a backend that will serve none of the six" read alike. A `ParamServiceReconcileFailure` is recorded where the failure happens — the only place that knows both — and the log names the node FQN and the service suffix.
- **Stop retrying what cannot change.** `Unsupported` is a property of the build, so `parameter_services_pending()` is false once it is seen, instead of six `create_service` calls per spin for the life of the image. An explicit `register_parameter_services()` still tries: that is a caller asking rather than the spin guessing.
- **Size the registry.** `NROS_CYCLONEDDS_MAX_TYPES` is derived from the SystemModel, which names only what an entry WIRES, so the twelve new types were invisible to it. `cyclonedds_type_sizing::infra_types` counts them, from the same `InfraServices::from_model` predicate the queryable counts use rather than a second reading of `execution.features`. They cost nothing before, because nothing registered them.
- **Correct the 0745 comment** in `emit_c.rs`: the cause was never "an RMW without service-server support (cyclonedds today)".

## Tests

| test | what it pins |
| --- | --- |
| `a_permanent_parameter_service_failure_is_asked_once_and_names_what_failed` (nros-node) | five spins, **one** `create_service` attempt; the record names `/bare` at `get_parameters`; `permanent` is set |
| `infra_service_descriptors::every_parameter_service_type_builds_a_descriptor` (nros-rmw-cyclonedds) | each of the twelve types builds a descriptor — the open question, since `Parameter` / `ParameterValue` / `ParameterDescriptor` carry sequences of nested structs, sequences of strings and a bounded sequence |
| `infra_service_descriptors::empty_request_types_have_no_descriptor_yet` | the lifecycle boundary: it fails when issue 1293 lands |

**Negative control** (the fix reverted against the otherwise-fixed tree): remove the stop-retrying clause from `parameter_services_pending` and the unit test fails —

```
assertion `left == right` failed: a failure that cannot change must be asked ONCE:
five spins made 5 create_service call(s). Before issue 1268 this was six per spin,
for the life of the image.
```

The descriptor test is a **precondition check, not a regression of this fix** — it would pass before the change too, and its value is proving the registration can succeed.

## Class sweep

`grep -n 'create_service\|register_type::' packages/core/nros-node/src/executor/spin.rs` — every entity the executor creates on its own. `/clock` goes through the subscription path, which registers its type; action protocol types come from `A::register_protocol_types`; `/parameter_events`, `/rosout` and type_description are not created by nros-node.

The **lifecycle** services are the one remaining gap and are **not** fixed here: three of their request types are empty (`FIELDS = &[]`), the descriptor builder refuses an empty schema, and a descriptor-only fix would describe a `structure_needs_at_least_one_member` byte the serializer never writes. Filed as **issue 1293** with the serializer half it also needs.

## Local checks

- `just ci gate` — **`CI gate passed (compile + unit; no fixtures were built or needed)`**, exit 0. `test-unit`: `1299 tests run: 1296 passed, 3 failed, 3 skipped` → exit 0; the three "failures" are `[SKIPPED]` unmet preconditions (`zenohd not found` on this host) that the lane's junit rewrite turns into skips. `test-lane-contracts`: `17 tests run: 17 passed`. The run count rose from 1296 to 1299: the three tests above.
- Not run: `just check rmw-cyclonedds` (the Cyclone C++ ctest suite). This change touches that crate only through a new Rust test file and two dev-dependencies; no C++ source is modified.

## NOT verified live, and what would verify it

Issue 1268's first acceptance — `ros2 param list/get/set` reaching every node of a multi-node Cyclone image — **is not checked off**. It needs a ROS 2 peer; this host has none (ROS Humble exists only in a distrobox, and building there means cloning nano-ros inside it). **Issue 1268 therefore stays OPEN**, with a status section recording exactly what landed and what remains.

The cell that would verify it: a Cyclone parameter cell in `interop::CELLS` (`packages/testing/nros-tests/src/interop.rs`) beside the existing `native-params-rust-zenoh` and `native-params-per-node-rust-zenoh`, with its verdict row in `.config/interop-verdicts.toml` and the lane in `.github/workflows/live-peer.yml`. No Cyclone params cell exists today — those two zenoh cells are the only parameter cells on any RMW.

Issues: **1268** updated, still open (live acceptance outstanding). **1293** filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7tie7AFCdqoRkxphQcqRx
