### PR TITLE
feat(phase-444 W3): Cyclone could be seen in the ROS graph and could not read it — ten more slots now

### DIFF
--- a/book/src/reference/rmw-feature-matrix.md
+++ b/book/src/reference/rmw-feature-matrix.md
@@ -40,7 +40,7 @@ backends land implementations.
 | Actual-QoS read-back | — | — | wired |
 | Wait-for-acked | — | — | — |
 | Take-with-info | wired | — | — |
-| Graph introspection (names/types/counts) | wired | — | — |
+| Graph introspection (names/types/counts) | wired | — | wired |
 
 ## Node-layer features
 

--- a/docs/design/0036-ros2-api-divergences.md
+++ b/docs/design/0036-ros2-api-divergences.md
@@ -121,6 +121,14 @@ Each divergence: **what ROS 2 does → what nano-ros does → why → owner**.
   what issue 0791 filed and phase-381 closed: twelve `rmw` graph slots, filled
   on zenoh and (for node names) on Cyclone, reachable from all three languages.
 
+  **Cyclone answers the same eleven as of phase-444 W3** — the DDS builtin
+  topics (`DCPSPublication` / `DCPSSubscription`) say which endpoints exist, on
+  what topic, with what type and granted QoS, and `ros_discovery_info` says
+  which NODE owns each, which is the edge DDS itself does not have. The twelfth,
+  `node_get_graph_guard_condition`, is filled by NO backend and is classified
+  `inert`: it would have to fire from Cyclone's own receive thread, which is the
+  context the status-event slots decline for the same reason.
+
   Three properties a caller must know, because they are what makes this
   honest rather than a claim of parity:
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds-sys/build.rs
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds-sys/build.rs
@@ -122,6 +122,9 @@ fn vendored_build() {
         "service.cpp",
         "descriptors.cpp",
         "graph.cpp",
+        // phase-444 W3 — the graph READ slots. Added to BOTH lists in one
+        // change, which is what issue 0984 is about.
+        "graph_query.cpp",
         "qos.cpp",
         // issue 0984 — added by #0970 to the CMake list and NOT to this one, so
         // the cmake path linked and the cargo path did not. `check-cyclone-backend-sources`

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
@@ -133,6 +133,8 @@ add_library(nros_rmw_cyclonedds STATIC
     src/service.cpp
     src/descriptors.cpp
     src/graph.cpp
+    # phase-444 W3 — the graph READ slots (builtin topics + ros_discovery_info).
+    src/graph_query.cpp
     src/qos.cpp
     src/nros_sertype.cpp
     # Phase 212.K.7.4 — C++ bridge for the Rust DescriptorBuilder.

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.cpp
@@ -172,8 +172,11 @@ void graph_fini(GraphState* g) {
     g->writer = 0;
     g->topic = 0;
     // phase-381 W5 — the graph reader cascades from the participant like the
-    // writer does; only the handle is reset here.
+    // writer does; only the handle is reset here. phase-444 W3's builtin-topic
+    // readers are the participant's children too, and go the same way.
     g->graph_reader = 0;
+    g->builtin_pub_reader = 0;
+    g->builtin_sub_reader = 0;
     g->active = false;
     g->n_readers = 0;
     g->n_writers = 0;
@@ -318,11 +321,17 @@ void graph_publish(GraphState* g) {
     ddsrt_free(infos);
 }
 
-/// phase-381 W5 — the READER half. Contract in graph.hpp.
-bool graph_visit_nodes(GraphState* g, void* ctx,
-                       bool (*visit)(void* ctx, const char* node_name,
-                                     const char* node_namespace)) {
-    if (g == nullptr || visit == nullptr || !g->active || g->topic <= 0) {
+namespace {
+
+/// phase-381 W5 — the READER half, and phase-444 W3's node ATTRIBUTION, over
+/// ONE read of `ros_discovery_info`.
+///
+/// `on_node(const NodeEntitiesInfo_&)` per discovered node record, returning
+/// `false` to stop. Both public visitors below go through here: the sample
+/// read, the loan return and the newest-wins dedup are one path, not two
+/// transcriptions of one protocol.
+template <typename F> bool visit_graph_records(GraphState* g, F&& on_node) {
+    if (g == nullptr || !g->active || g->topic <= 0) {
         return false;
     }
 
@@ -442,7 +451,7 @@ bool graph_visit_nodes(GraphState* g, void* ctx,
             continue;
         }
         for (uint32_t j = 0; j < count; ++j) {
-            if (!visit(ctx, nodes[j].node_name, nodes[j].node_namespace)) {
+            if (!on_node(nodes[j])) {
                 (void)dds_return_loan(g->graph_reader, raw, n);
                 return true;
             }
@@ -452,6 +461,46 @@ bool graph_visit_nodes(GraphState* g, void* ctx,
     // The samples are LOANED from the reader; returning them is not optional.
     (void)dds_return_loan(g->graph_reader, raw, n);
     return true;
+}
+
+} // namespace
+
+/// phase-381 W5 — the READER half. Contract in graph.hpp.
+bool graph_visit_nodes(GraphState* g, void* ctx,
+                       bool (*visit)(void* ctx, const char* node_name,
+                                     const char* node_namespace)) {
+    if (visit == nullptr) {
+        return false;
+    }
+    return visit_graph_records(g, [&](const rmw_dds_common_msg_dds__NodeEntitiesInfo_& n) {
+        return visit(ctx, n.node_name, n.node_namespace);
+    });
+}
+
+/// phase-444 W3 — every ENDPOINT the graph attributes to a node. Contract in
+/// graph.hpp.
+bool graph_visit_endpoints(GraphState* g, void* ctx,
+                           bool (*visit)(void* ctx, const char* node_name,
+                                         const char* node_namespace, const uint8_t gid[24],
+                                         bool is_writer)) {
+    if (visit == nullptr) {
+        return false;
+    }
+    return visit_graph_records(g, [&](const rmw_dds_common_msg_dds__NodeEntitiesInfo_& n) {
+        for (uint32_t i = 0; i < n.reader_gid_seq._length; ++i) {
+            if (!visit(ctx, n.node_name, n.node_namespace, n.reader_gid_seq._buffer[i].data,
+                       false)) {
+                return false;
+            }
+        }
+        for (uint32_t i = 0; i < n.writer_gid_seq._length; ++i) {
+            if (!visit(ctx, n.node_name, n.node_namespace, n.writer_gid_seq._buffer[i].data,
+                       true)) {
+                return false;
+            }
+        }
+        return true;
+    });
 }
 
 } // namespace nros_rmw_cyclonedds

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.hpp
@@ -62,6 +62,12 @@ struct GraphState {
     /// Created lazily on the first graph query: a node that never asks pays
     /// nothing, which matters because most embedded images never ask.
     dds_entity_t graph_reader{0};
+    /// phase-444 W3 — the DDS BUILTIN-topic readers the graph QUERIES read
+    /// (`DCPSPublication` / `DCPSSubscription`). Lazily created on the first
+    /// query for the same reason `graph_reader` is: an image that never asks
+    /// pays no reader and no history.
+    dds_entity_t builtin_pub_reader{0};
+    dds_entity_t builtin_sub_reader{0};
     uint8_t participant_gid[24]{};
 
     /// Slots are STABLE: a released record is marked unused and never moved,
@@ -142,6 +148,23 @@ void graph_publish(GraphState* g);
 /// the caller reports as `UNSUPPORTED` — distinct from an empty graph.
 bool graph_visit_nodes(GraphState* g, void* ctx,
                        bool (*visit)(void* ctx, const char* node_name, const char* node_namespace));
+
+/// phase-444 W3 — every ENDPOINT the graph attributes to a node, across every
+/// participant that has published `ros_discovery_info`.
+///
+/// `visit(ctx, node_name, node_namespace, gid, is_writer)` per listed GID;
+/// return `false` to stop. Strings and `gid` are BORROWED for the call.
+///
+/// This is the ATTRIBUTION half of the graph queries: the DDS builtin topics
+/// say which endpoints exist, on what topic, with what type and QoS, and say
+/// nothing about nodes — ROS's node layer exists only in this message. Same
+/// read, same dedup and the same "reports what has been DISCOVERED" contract as
+/// `graph_visit_nodes`; `false` means the graph is inactive, which the caller
+/// reports as UNSUPPORTED.
+bool graph_visit_endpoints(GraphState* g, void* ctx,
+                           bool (*visit)(void* ctx, const char* node_name,
+                                         const char* node_namespace, const uint8_t gid[24],
+                                         bool is_writer));
 
 } // namespace nros_rmw_cyclonedds
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph_query.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph_query.cpp
@@ -1,0 +1,583 @@
+// phase-444 W3 — the graph READ side: the eleven slots beyond `get_node_names`.
+//
+// Cyclone was VISIBLE in the ROS graph and could not read it: `graph.cpp`
+// published `ros_discovery_info` and (since phase-381 W5) read back node names,
+// and every other graph slot was NULL — so `count_publishers`, "what types are
+// on this topic" and "what does node X publish" answered UNSUPPORTED on the one
+// backend that meets real ROS 2 peers.
+//
+// TWO SOURCES, and neither alone is enough:
+//
+//   * **The DDS builtin topics** (`DCPSPublication` / `DCPSSubscription`) know
+//     every discovered endpoint — its topic, its type, its QoS and its GUID —
+//     and know nothing about ROS nodes, because DDS has none.
+//   * **`ros_discovery_info`** is where the node layer lives: one
+//     `ParticipantEntitiesInfo` per participant, each listing its nodes and the
+//     endpoint GIDs belonging to each. That is the ONLY place the
+//     endpoint -> node edge exists, which is why the `*_by_node` slots and the
+//     `node_name` on an endpoint info are attributed through it.
+//
+// The contract (RFC-0036 "Static CONNECTION, dynamic GRAPH"): these report what
+// has been DISCOVERED and never block; empty means "nobody seen yet", never
+// "nobody exists"; and a slot that cannot answer says UNSUPPORTED, which stays
+// distinct from empty. A graph with no `ros_discovery_info` writer (the
+// descriptor missing) is inactive, and inactive is UNSUPPORTED.
+//
+// **No allocator is assumed.** Every string handed to a visitor is borrowed for
+// that call: names point into the loaned builtin sample or into a small stack
+// buffer. The one heap use is the transient sample batch, from
+// `ddsrt_malloc` — never libc, because the RTOS heap is separate
+// (cyclonedds-known-limitations.md).
+
+#include "internal.hpp"
+
+#include <cstddef>
+#include <cstring>
+
+#include <dds/dds.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
+#include "graph.hpp"
+#include "qos.hpp"
+#include "topic_prefix.hpp"
+
+namespace nros_rmw_cyclonedds {
+
+namespace {
+
+/// How many endpoints one query examines.
+///
+/// A bound rather than a loop, because Cyclone's reader API has no cursor: a
+/// second `dds_read` returns the same first N instances, so pagination is not
+/// available and the alternative to a bound is an unbounded stack/heap batch on
+/// a target that may have neither. 32 endpoints is well past what an embedded
+/// image's own graph holds, and a host-side query that hits the ceiling reports
+/// the first 32 — which is what "reports what has been discovered" already
+/// admits. Raising it costs `kScanMax * (sizeof(void*) + sizeof(sample_info))`
+/// of transient heap per query.
+constexpr int kScanMax = 32;
+
+/// One demangled name or type. `string<256>` is the `NodeEntitiesInfo` bound
+/// and comfortably past a ROS name.
+constexpr std::size_t kNameCap = 256;
+
+/// Distinct types reported for ONE name. ROS allows several (the same topic
+/// published with two types is a real, diagnosable state) and in practice it is
+/// one; a name with more than this reports the first few rather than dropping
+/// the name.
+constexpr int kMaxTypesPerName = 4;
+
+/// A batch of builtin-topic samples, held for the life of one query so the slot
+/// bodies can index it twice — once to pick the next undreported name, once to
+/// collect that name's types. `dds_read` (not take) leaves the history intact,
+/// so a later query sees the same graph rather than draining it.
+class EndpointBatch {
+  public:
+    EndpointBatch() = default;
+    ~EndpointBatch() { release(); }
+    EndpointBatch(const EndpointBatch&) = delete;
+    EndpointBatch& operator=(const EndpointBatch&) = delete;
+
+    /// Create (once per session) and read the builtin reader for writers or
+    /// readers. False only when the reader cannot be created — an EMPTY graph
+    /// is a successful read of nothing.
+    bool read(GraphState* g, dds_entity_t participant, bool writers) {
+        release();
+        if (g == nullptr || participant <= 0) return false;
+        dds_entity_t* slot = writers ? &g->builtin_pub_reader : &g->builtin_sub_reader;
+        if (*slot <= 0) {
+            // Created on FIRST USE, like the `ros_discovery_info` reader: an
+            // image that never asks pays no reader. The builtin subscriber
+            // supplies its own QoS; passing NULL takes it.
+            const dds_entity_t topic =
+                writers ? DDS_BUILTIN_TOPIC_DCPSPUBLICATION : DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION;
+            dds_entity_t r = dds_create_reader(participant, topic, nullptr, nullptr);
+            if (r < 0) return false;
+            *slot = r;
+        }
+        reader_ = *slot;
+        raw_ = static_cast<void**>(ddsrt_malloc(sizeof(void*) * kScanMax));
+        info_ = static_cast<dds_sample_info_t*>(ddsrt_malloc(sizeof(dds_sample_info_t) * kScanMax));
+        if (raw_ == nullptr || info_ == nullptr) {
+            release();
+            return false;
+        }
+        std::memset(raw_, 0, sizeof(void*) * kScanMax);
+        n_ = dds_read(reader_, raw_, info_, kScanMax, kScanMax);
+        if (n_ < 0) n_ = 0;
+        return true;
+    }
+
+    int count() const { return static_cast<int>(n_); }
+
+    /// The sample at `i`, or nullptr where the sample carries no data (a
+    /// disposed endpoint leaves an instance behind with `valid_data == false` —
+    /// reporting it would list endpoints that have gone away).
+    const dds_builtintopic_endpoint_t* at(int i) const {
+        if (i < 0 || i >= count() || !info_[i].valid_data) return nullptr;
+        return static_cast<const dds_builtintopic_endpoint_t*>(raw_[i]);
+    }
+
+    void release() {
+        if (reader_ > 0 && n_ > 0 && raw_ != nullptr) {
+            (void)dds_return_loan(reader_, raw_, n_);
+        }
+        if (raw_ != nullptr) ddsrt_free(raw_);
+        if (info_ != nullptr) ddsrt_free(info_);
+        raw_ = nullptr;
+        info_ = nullptr;
+        n_ = 0;
+        reader_ = 0;
+    }
+
+  private:
+    dds_entity_t reader_{0};
+    void** raw_{nullptr};
+    dds_sample_info_t* info_{nullptr};
+    int32_t n_{0};
+};
+
+/* ---- ROS 2 name mangling, the read direction ------------------------------
+ *
+ * `topic_prefix.hpp` owns the WRITE direction (`rt/` + name). These are its
+ * inverse, and they must agree with stock `rmw_cyclonedds_cpp` rather than only
+ * with us: what comes back is whatever a real ROS 2 peer put on the wire.
+ */
+
+/// `"rt/chatter"` -> `"/chatter"`, borrowed from the sample. nullptr when the
+/// DDS topic is not a ROS TOPIC — a service's `rq/`/`rr/` topic, or an
+/// unprefixed one like `ros_discovery_info` itself, which stock `ros2 topic
+/// list` does not show either.
+const char* demangle_topic(const char* dds_name) {
+    if (dds_name == nullptr) return nullptr;
+    if (dds_name[0] == 'r' && dds_name[1] == 't' && dds_name[2] == '/') return dds_name + 2;
+    return nullptr;
+}
+
+/// `"rq/add_two_intsRequest"` / `"rr/add_two_intsReply"` -> `"/add_two_ints"`.
+/// False when the name is not a service topic of the requested half.
+bool demangle_service(const char* dds_name, bool request_half, char* out, std::size_t cap) {
+    if (dds_name == nullptr || out == nullptr) return false;
+    const char want = request_half ? 'q' : 'r';
+    if (dds_name[0] != 'r' || dds_name[1] != want || dds_name[2] != '/') return false;
+    const char* body = dds_name + 2; // keep the '/' as the ROS leading slash
+    const std::size_t len = std::strlen(body);
+    // Stock spells the reply half `Reply`; `Response` is accepted because the
+    // .srv member is named that and a hand-built peer may use it.
+    static const char* const kSuffixes[] = {"Request", "Response", "Reply"};
+    for (const char* suffix : kSuffixes) {
+        const std::size_t slen = std::strlen(suffix);
+        if (len > slen && std::strcmp(body + len - slen, suffix) == 0) {
+            if (len - slen + 1 > cap) return false;
+            std::memcpy(out, body, len - slen);
+            out[len - slen] = '\0';
+            return true;
+        }
+    }
+    if (len + 1 > cap) return false;
+    std::memcpy(out, body, len + 1);
+    return true;
+}
+
+/// `"std_msgs::msg::dds_::String_"` -> `"std_msgs/msg/String"`, and a service
+/// type's `_Request` / `_Response` tail dropped so both halves of a service
+/// report the type ROS names.
+bool demangle_type(const char* dds_type, char* out, std::size_t cap) {
+    if (dds_type == nullptr || out == nullptr || cap == 0) return false;
+    std::size_t w = 0;
+    const char* p = dds_type;
+    bool first = true;
+    while (*p != '\0') {
+        const char* sep = std::strstr(p, "::");
+        const std::size_t seg_len =
+            (sep != nullptr) ? static_cast<std::size_t>(sep - p) : std::strlen(p);
+        // The `dds_` segment is the mangling's own marker, not part of the type.
+        const bool is_dds_marker = (seg_len == 4 && std::strncmp(p, "dds_", 4) == 0);
+        if (seg_len > 0 && !is_dds_marker) {
+            if (!first) {
+                if (w + 1 >= cap) return false;
+                out[w++] = '/';
+            }
+            if (w + seg_len >= cap) return false;
+            std::memcpy(out + w, p, seg_len);
+            w += seg_len;
+            first = false;
+        }
+        if (sep == nullptr) break;
+        p = sep + 2;
+    }
+    out[w] = '\0';
+    // The trailing `_` idlc appends to every struct name.
+    if (w > 0 && out[w - 1] == '_') {
+        out[--w] = '\0';
+    }
+    static const char* const kHalves[] = {"_Request", "_Response", "_Reply"};
+    for (const char* half : kHalves) {
+        const std::size_t hlen = std::strlen(half);
+        if (w > hlen && std::strcmp(out + w - hlen, half) == 0) {
+            w -= hlen;
+            out[w] = '\0';
+            break;
+        }
+    }
+    return w > 0;
+}
+
+/// What a query is asking for. The DDS topic prefix plus the endpoint side is
+/// what separates a service SERVER from its CLIENT: both use `rq/` and `rr/`,
+/// and a server SUBSCRIBES to requests while a client PUBLISHES them.
+enum class Want {
+    Topic,         ///< `rt/`, either side (which side is the batch's business)
+    ServiceServer, ///< reader on `rq/`
+    ServiceClient, ///< writer on `rq/`
+};
+
+/// The name this endpoint reports under, or nullptr when it is not what `want`
+/// asked for. `scratch` backs a service name; a topic name borrows the sample.
+const char* wanted_name(const dds_builtintopic_endpoint_t* ep, Want want, bool no_demangle,
+                        char* scratch, std::size_t cap) {
+    if (ep == nullptr || ep->topic_name == nullptr) return nullptr;
+    if (want == Want::Topic) {
+        // `no_demangle` is upstream's "give me the DDS names": every topic, raw.
+        if (no_demangle) return ep->topic_name;
+        return demangle_topic(ep->topic_name);
+    }
+    return demangle_service(ep->topic_name, /*request_half=*/true, scratch, cap) ? scratch
+                                                                                 : nullptr;
+}
+
+/// Node attribution for one endpoint GUID, through `ros_discovery_info`.
+struct OwnerQuery {
+    const uint8_t* want_gid; ///< 16 GUID bytes
+    bool want_writer;
+    char name[kNameCap];
+    char ns[kNameCap];
+    bool found;
+};
+
+bool owner_visit(void* ctx, const char* node_name, const char* node_ns, const uint8_t gid[24],
+                 bool is_writer) {
+    auto* q = static_cast<OwnerQuery*>(ctx);
+    if (is_writer != q->want_writer || std::memcmp(gid, q->want_gid, 16) != 0) {
+        return true;
+    }
+    ddsrt_strlcpy(q->name, node_name != nullptr ? node_name : "", sizeof(q->name));
+    ddsrt_strlcpy(q->ns, node_ns != nullptr ? node_ns : "/", sizeof(q->ns));
+    q->found = true;
+    return false; // stop: an endpoint belongs to one node
+}
+
+/// Fill `name`/`ns` with the node that owns `ep`, or empty strings when the
+/// graph does not say. Empty is honest: the endpoint was discovered through
+/// DDS, and no participant has claimed it in `ros_discovery_info` — a raw-DDS
+/// peer, or a ROS node whose graph sample has not arrived yet.
+void owner_of(GraphState* g, const dds_builtintopic_endpoint_t* ep, bool writer, char* name,
+              char* ns, std::size_t cap) {
+    name[0] = '\0';
+    ns[0] = '\0';
+    if (g == nullptr || ep == nullptr) return;
+    OwnerQuery q;
+    q.want_gid = ep->key.v;
+    q.want_writer = writer;
+    q.name[0] = '\0';
+    q.ns[0] = '\0';
+    q.found = false;
+    (void)graph_visit_endpoints(g, &q, owner_visit);
+    if (q.found) {
+        ddsrt_strlcpy(name, q.name, cap);
+        ddsrt_strlcpy(ns, q.ns, cap);
+    }
+}
+
+bool same_node(const char* a_name, const char* a_ns, const char* b_name, const char* b_ns) {
+    if (a_name == nullptr || b_name == nullptr) return false;
+    const char* an = (a_ns != nullptr && a_ns[0] != '\0') ? a_ns : "/";
+    const char* bn = (b_ns != nullptr && b_ns[0] != '\0') ? b_ns : "/";
+    return std::strcmp(a_name, b_name) == 0 && std::strcmp(an, bn) == 0;
+}
+
+/// One side of the graph, as the name-and-types slots see it.
+struct Side {
+    EndpointBatch batch;
+    bool writers;
+};
+
+/// The shared body of all six names-and-types slots.
+///
+/// `node_name == nullptr` means "every node" (the session-wide forms);
+/// otherwise only endpoints the graph attributes to that node are reported.
+/// Dedup is positional — a name is reported by its FIRST endpoint, and a later
+/// endpoint carrying the same name only contributes its type — which needs no
+/// table and therefore no allocator.
+rmw_ret_t names_and_types(const rmw_session_t* session, Want want, bool writers, bool no_demangle,
+                          const char* node_name, const char* node_namespace,
+                          rmw_names_and_types_visitor_t visitor) {
+    if (session == nullptr || visitor.visit == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    GraphState* g = session_graph(const_cast<rmw_session_t*>(session));
+    const dds_entity_t pp = session_participant(session);
+    if (g == nullptr || !g->active || pp <= 0) {
+        // No graph publisher means no node layer, and every answer here is
+        // about nodes even when the question is not. UNSUPPORTED, not empty.
+        return NROS_RMW_RET_UNSUPPORTED;
+    }
+
+    EndpointBatch batch;
+    if (!batch.read(g, pp, writers)) {
+        return NROS_RMW_RET_ERROR;
+    }
+
+    char name_buf[kNameCap];
+    char other_buf[kNameCap];
+    char owner_name[kNameCap];
+    char owner_ns[kNameCap];
+    char types[kMaxTypesPerName][kNameCap];
+
+    for (int i = 0; i < batch.count(); ++i) {
+        const dds_builtintopic_endpoint_t* ep = batch.at(i);
+        const char* name = wanted_name(ep, want, no_demangle, name_buf, sizeof(name_buf));
+        if (name == nullptr) continue;
+        if (node_name != nullptr) {
+            owner_of(g, ep, writers, owner_name, owner_ns, kNameCap);
+            if (!same_node(owner_name, owner_ns, node_name, node_namespace)) continue;
+        }
+
+        // Already reported by an earlier endpoint?
+        bool seen = false;
+        for (int j = 0; j < i && !seen; ++j) {
+            const dds_builtintopic_endpoint_t* pe = batch.at(j);
+            const char* pn = wanted_name(pe, want, no_demangle, other_buf, sizeof(other_buf));
+            if (pn == nullptr || std::strcmp(pn, name) != 0) continue;
+            if (node_name != nullptr) {
+                char pon[kNameCap];
+                char pons[kNameCap];
+                owner_of(g, pe, writers, pon, pons, kNameCap);
+                if (!same_node(pon, pons, node_name, node_namespace)) continue;
+            }
+            seen = true;
+        }
+        if (seen) continue;
+
+        // Collect this name's distinct types.
+        int n_types = 0;
+        for (int j = 0; j < batch.count() && n_types < kMaxTypesPerName; ++j) {
+            const dds_builtintopic_endpoint_t* te = batch.at(j);
+            const char* tn = wanted_name(te, want, no_demangle, other_buf, sizeof(other_buf));
+            if (tn == nullptr || std::strcmp(tn, name) != 0) continue;
+            if (node_name != nullptr) {
+                char ton[kNameCap];
+                char tons[kNameCap];
+                owner_of(g, te, writers, ton, tons, kNameCap);
+                if (!same_node(ton, tons, node_name, node_namespace)) continue;
+            }
+            char one[kNameCap];
+            const char* type = nullptr;
+            if (no_demangle) {
+                type = te->type_name;
+            } else if (demangle_type(te->type_name, one, sizeof(one))) {
+                type = one;
+            }
+            if (type == nullptr) continue;
+            bool dup = false;
+            for (int k = 0; k < n_types; ++k) {
+                if (std::strcmp(types[k], type) == 0) dup = true;
+            }
+            if (!dup) {
+                ddsrt_strlcpy(types[n_types], type, kNameCap);
+                ++n_types;
+            }
+        }
+
+        const char* type_ptrs[kMaxTypesPerName];
+        for (int k = 0; k < n_types; ++k)
+            type_ptrs[k] = types[k];
+        if (!visitor.visit(visitor.ctx, name, type_ptrs, static_cast<std::size_t>(n_types))) {
+            return NROS_RMW_RET_OK; // the caller stopped; that is not an error
+        }
+    }
+    return NROS_RMW_RET_OK;
+}
+
+/// Shared body of `count_publishers` / `count_subscribers`.
+rmw_ret_t count_on_topic(const rmw_session_t* session, const char* topic_name, bool writers,
+                         std::size_t* count) {
+    if (session == nullptr || topic_name == nullptr || count == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    GraphState* g = session_graph(const_cast<rmw_session_t*>(session));
+    const dds_entity_t pp = session_participant(session);
+    if (g == nullptr || !g->active || pp <= 0) {
+        return NROS_RMW_RET_UNSUPPORTED;
+    }
+    // Mangle the ASKED name once and compare raw, rather than demangling every
+    // endpoint — the same direction `publisher_create` writes, so a topic this
+    // session could publish is a topic this count can find.
+    char mangled[kNameCap];
+    if (!topic_prefix::apply(topic_name, "rt", mangled, sizeof(mangled))) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    EndpointBatch batch;
+    if (!batch.read(g, pp, writers)) {
+        return NROS_RMW_RET_ERROR;
+    }
+    std::size_t n = 0;
+    for (int i = 0; i < batch.count(); ++i) {
+        const dds_builtintopic_endpoint_t* ep = batch.at(i);
+        if (ep != nullptr && ep->topic_name != nullptr &&
+            std::strcmp(ep->topic_name, mangled) == 0) {
+            ++n;
+        }
+    }
+    *count = n;
+    return NROS_RMW_RET_OK;
+}
+
+/// Shared body of `get_publishers_info_by_topic` / `get_subscriptions_info_by_topic`.
+rmw_ret_t endpoint_info_by_topic(const rmw_session_t* session, const char* topic_name,
+                                 bool no_mangle, bool writers,
+                                 rmw_topic_endpoint_info_visitor_t visitor) {
+    if (session == nullptr || topic_name == nullptr || visitor.visit == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    GraphState* g = session_graph(const_cast<rmw_session_t*>(session));
+    const dds_entity_t pp = session_participant(session);
+    if (g == nullptr || !g->active || pp <= 0) {
+        return NROS_RMW_RET_UNSUPPORTED;
+    }
+    char mangled[kNameCap];
+    if (no_mangle) {
+        ddsrt_strlcpy(mangled, topic_name, sizeof(mangled));
+    } else if (!topic_prefix::apply(topic_name, "rt", mangled, sizeof(mangled))) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+
+    EndpointBatch batch;
+    if (!batch.read(g, pp, writers)) {
+        return NROS_RMW_RET_ERROR;
+    }
+    char owner_name[kNameCap];
+    char owner_ns[kNameCap];
+    char type_buf[kNameCap];
+    for (int i = 0; i < batch.count(); ++i) {
+        const dds_builtintopic_endpoint_t* ep = batch.at(i);
+        if (ep == nullptr || ep->topic_name == nullptr) continue;
+        if (std::strcmp(ep->topic_name, mangled) != 0) continue;
+
+        owner_of(g, ep, writers, owner_name, owner_ns, kNameCap);
+        rmw_topic_endpoint_info_t info;
+        std::memset(&info, 0, sizeof(info));
+        info.node_name = owner_name;
+        info.node_namespace = owner_ns[0] != '\0' ? owner_ns : "";
+        if (no_mangle || !demangle_type(ep->type_name, type_buf, sizeof(type_buf))) {
+            info.topic_type = ep->type_name != nullptr ? ep->type_name : "";
+        } else {
+            info.topic_type = type_buf;
+        }
+        info.endpoint_type = writers ? RMW_ENDPOINT_PUBLISHER : RMW_ENDPOINT_SUBSCRIPTION;
+        // Cyclone's GUID is 16 bytes; `rmw_gid_t::data` is 24, zero-padded —
+        // the same derivation `graph.cpp` uses, so a GID from here compares
+        // equal to the one `ros_discovery_info` lists for the same endpoint.
+        std::memcpy(info.endpoint_gid.data, ep->key.v, sizeof(ep->key.v));
+        info.endpoint_gid.implementation_identifier = "cyclonedds";
+        // The GRANTED profile, read off the remote's own discovery sample —
+        // not the local entity's request. One mapping, shared with
+        // `read_entity_qos` (`qos.hpp`).
+        qos_from_dds(ep->qos, &info.qos_profile);
+        if (!visitor.visit(visitor.ctx, &info)) {
+            return NROS_RMW_RET_OK;
+        }
+    }
+    return NROS_RMW_RET_OK;
+}
+
+} // namespace
+
+/* ---- the slots ---------------------------------------------------------- */
+
+rmw_ret_t graph_get_topic_names_and_types(const rmw_session_t* session, bool no_demangle,
+                                          rmw_names_and_types_visitor_t visitor) {
+    // Both sides: a topic with only a subscriber is still a topic, and
+    // upstream's `rmw_get_topic_names_and_types` reports it.
+    rmw_ret_t r = names_and_types(session, Want::Topic, /*writers=*/true, no_demangle, nullptr,
+                                  nullptr, visitor);
+    if (r != NROS_RMW_RET_OK) return r;
+    // The reader pass re-reports a name the writer pass already visited: the
+    // two batches cannot see each other, and a visitor that must dedup is the
+    // contract upstream has too (`rmw_names_and_types_t` is a set the CALLER
+    // merges). Reporting a name twice is recoverable; dropping a
+    // subscriber-only topic is not.
+    return names_and_types(session, Want::Topic, /*writers=*/false, no_demangle, nullptr, nullptr,
+                           visitor);
+}
+
+rmw_ret_t graph_get_service_names_and_types(const rmw_session_t* session,
+                                            rmw_names_and_types_visitor_t visitor) {
+    // A service exists where a SERVER does, and a server is the side that
+    // subscribes to `rq/`. Counting clients here would report a service that
+    // nobody offers.
+    return names_and_types(session, Want::ServiceServer, /*writers=*/false, /*no_demangle=*/false,
+                           nullptr, nullptr, visitor);
+}
+
+rmw_ret_t graph_get_publisher_names_and_types_by_node(const rmw_session_t* session,
+                                                      const char* node_name,
+                                                      const char* node_namespace, bool no_demangle,
+                                                      rmw_names_and_types_visitor_t visitor) {
+    if (node_name == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
+    return names_and_types(session, Want::Topic, /*writers=*/true, no_demangle, node_name,
+                           node_namespace, visitor);
+}
+
+rmw_ret_t graph_get_subscriber_names_and_types_by_node(const rmw_session_t* session,
+                                                       const char* node_name,
+                                                       const char* node_namespace, bool no_demangle,
+                                                       rmw_names_and_types_visitor_t visitor) {
+    if (node_name == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
+    return names_and_types(session, Want::Topic, /*writers=*/false, no_demangle, node_name,
+                           node_namespace, visitor);
+}
+
+rmw_ret_t graph_get_service_names_and_types_by_node(const rmw_session_t* session,
+                                                    const char* node_name,
+                                                    const char* node_namespace,
+                                                    rmw_names_and_types_visitor_t visitor) {
+    if (node_name == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
+    return names_and_types(session, Want::ServiceServer, /*writers=*/false,
+                           /*no_demangle=*/false, node_name, node_namespace, visitor);
+}
+
+rmw_ret_t graph_get_client_names_and_types_by_node(const rmw_session_t* session,
+                                                   const char* node_name,
+                                                   const char* node_namespace,
+                                                   rmw_names_and_types_visitor_t visitor) {
+    if (node_name == nullptr) return NROS_RMW_RET_INVALID_ARGUMENT;
+    // The client is the side that WRITES `rq/` — the mirror of the server rule.
+    return names_and_types(session, Want::ServiceClient, /*writers=*/true, /*no_demangle=*/false,
+                           node_name, node_namespace, visitor);
+}
+
+rmw_ret_t graph_get_publishers_info_by_topic(const rmw_session_t* session, const char* topic_name,
+                                             bool no_mangle,
+                                             rmw_topic_endpoint_info_visitor_t visitor) {
+    return endpoint_info_by_topic(session, topic_name, no_mangle, /*writers=*/true, visitor);
+}
+
+rmw_ret_t graph_get_subscriptions_info_by_topic(const rmw_session_t* session,
+                                                const char* topic_name, bool no_mangle,
+                                                rmw_topic_endpoint_info_visitor_t visitor) {
+    return endpoint_info_by_topic(session, topic_name, no_mangle, /*writers=*/false, visitor);
+}
+
+rmw_ret_t graph_count_publishers(const rmw_session_t* session, const char* topic_name,
+                                 std::size_t* count) {
+    return count_on_topic(session, topic_name, /*writers=*/true, count);
+}
+
+rmw_ret_t graph_count_subscribers(const rmw_session_t* session, const char* topic_name,
+                                  std::size_t* count) {
+    return count_on_topic(session, topic_name, /*writers=*/false, count);
+}
+
+} // namespace nros_rmw_cyclonedds

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
@@ -12,6 +12,9 @@
 #include "nros/rmw_entity.h"
 #include "nros/rmw_event.h"
 #include "nros/rmw_ret.h"
+// phase-444 W3 — the graph slots' visitor types (`rmw_names_and_types_visitor_t`
+// and friends) are declared with the vtable, not with the entities.
+#include "nros/rmw_vtable.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -133,6 +136,45 @@ int graph_node_of(const rmw_node_t *node);
 rmw_ret_t node_create(rmw_session_t *session, const char *name, const char *namespace_,
                       rmw_node_t *out);
 rmw_ret_t node_destroy(rmw_node_t *node);
+
+/* ---- graph_query.cpp — phase-444 W3, the graph READ slots ----------------
+ *
+ * The DDS builtin topics (`DCPSPublication` / `DCPSSubscription`) supply topic,
+ * type, QoS and endpoint GUID; `ros_discovery_info` supplies the node the
+ * endpoint belongs to. Each reports what has been DISCOVERED and never blocks;
+ * an inactive graph answers UNSUPPORTED, which stays distinct from empty. */
+rmw_ret_t graph_get_topic_names_and_types(const rmw_session_t *session, bool no_demangle,
+                                          rmw_names_and_types_visitor_t visitor);
+rmw_ret_t graph_get_service_names_and_types(const rmw_session_t *session,
+                                            rmw_names_and_types_visitor_t visitor);
+rmw_ret_t graph_get_publisher_names_and_types_by_node(const rmw_session_t *session,
+                                                      const char *node_name,
+                                                      const char *node_namespace,
+                                                      bool no_demangle,
+                                                      rmw_names_and_types_visitor_t visitor);
+rmw_ret_t graph_get_subscriber_names_and_types_by_node(const rmw_session_t *session,
+                                                       const char *node_name,
+                                                       const char *node_namespace,
+                                                       bool no_demangle,
+                                                       rmw_names_and_types_visitor_t visitor);
+rmw_ret_t graph_get_service_names_and_types_by_node(const rmw_session_t *session,
+                                                    const char *node_name,
+                                                    const char *node_namespace,
+                                                    rmw_names_and_types_visitor_t visitor);
+rmw_ret_t graph_get_client_names_and_types_by_node(const rmw_session_t *session,
+                                                   const char *node_name,
+                                                   const char *node_namespace,
+                                                   rmw_names_and_types_visitor_t visitor);
+rmw_ret_t graph_get_publishers_info_by_topic(const rmw_session_t *session, const char *topic_name,
+                                             bool no_mangle,
+                                             rmw_topic_endpoint_info_visitor_t visitor);
+rmw_ret_t graph_get_subscriptions_info_by_topic(const rmw_session_t *session,
+                                                const char *topic_name, bool no_mangle,
+                                                rmw_topic_endpoint_info_visitor_t visitor);
+rmw_ret_t graph_count_publishers(const rmw_session_t *session, const char *topic_name,
+                                 std::size_t *count);
+rmw_ret_t graph_count_subscribers(const rmw_session_t *session, const char *topic_name,
+                                  std::size_t *count);
 
 /* ---- publisher.cpp / subscriber.cpp helpers ---- */
 /** Return the Cyclone writer handle for a publisher created by

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/qos.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/qos.cpp
@@ -137,17 +137,9 @@ dds_qos_t *make_dds_qos(const rmw_qos_profile_t *src) {
  * the caller passed in, so an unreported field reads as "unchanged" rather than
  * as zero — a zeroed `depth` would look like a legitimate answer.
  */
-rmw_ret_t read_entity_qos(dds_entity_t entity, rmw_qos_profile_t *out) {
-    if (entity <= 0 || out == nullptr) {
-        return NROS_RMW_RET_INVALID_ARGUMENT;
-    }
-    dds_qos_t *q = dds_create_qos();
-    if (q == nullptr) {
-        return NROS_RMW_RET_BAD_ALLOC;
-    }
-    if (dds_get_qos(entity, q) != DDS_RETCODE_OK) {
-        dds_delete_qos(q);
-        return NROS_RMW_RET_ERROR;
+void qos_from_dds(const dds_qos_t *q, rmw_qos_profile_t *out) {
+    if (q == nullptr || out == nullptr) {
+        return;
     }
 
     dds_reliability_kind_t rel;
@@ -202,7 +194,21 @@ rmw_ret_t read_entity_qos(dds_entity_t entity, rmw_qos_profile_t *out) {
                                        ? NROS_RMW_DURATION_INFINITE_MS
                                        : (uint32_t)(lease / DDS_NSECS_IN_MSEC);
     }
+}
 
+rmw_ret_t read_entity_qos(dds_entity_t entity, rmw_qos_profile_t *out) {
+    if (entity <= 0 || out == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    dds_qos_t *q = dds_create_qos();
+    if (q == nullptr) {
+        return NROS_RMW_RET_BAD_ALLOC;
+    }
+    if (dds_get_qos(entity, q) != DDS_RETCODE_OK) {
+        dds_delete_qos(q);
+        return NROS_RMW_RET_ERROR;
+    }
+    qos_from_dds(q, out);
     dds_delete_qos(q);
     return NROS_RMW_RET_OK;
 }

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/qos.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/qos.hpp
@@ -14,6 +14,21 @@ namespace nros_rmw_cyclonedds {
  */
 dds_qos_t *make_dds_qos(const rmw_qos_profile_t *src);
 
+/**
+ * Fold a Cyclone `dds_qos_t` into an `rmw_qos_profile_t` — the inverse of
+ * `make_dds_qos`, and the ONE place that mapping lives.
+ *
+ * `out` must arrive carrying the profile the caller already believes: a policy
+ * this `dds_qos_t` does not carry is left untouched, so an unreported field
+ * reads as "unchanged" instead of as a zero that looks like an answer.
+ *
+ * Two callers, deliberately one function: `read_entity_qos` asks a LOCAL
+ * entity (`dds_get_qos`), and the graph queries read a REMOTE endpoint's qos
+ * straight off its `DCPSPublication` / `DCPSSubscription` sample. A second
+ * transcription of this table is the hand-mirror class CLAUDE.md names.
+ */
+void qos_from_dds(const dds_qos_t *q, rmw_qos_profile_t *out);
+
 } // namespace nros_rmw_cyclonedds
 
 #endif // NROS_RMW_CYCLONEDDS_QOS_HPP

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
@@ -405,16 +405,22 @@ const nros_rmw_vtable_t kVtable = {
     /*take_with_info*/ nullptr,
     /*take_loaned_message_with_info*/ nullptr,
     /*get_node_names*/ cyclone_get_node_names,
-    /*get_topic_names_and_types*/ nullptr,
-    /*get_service_names_and_types*/ nullptr,
-    /*get_publisher_names_and_types_by_node*/ nullptr,
-    /*get_subscriber_names_and_types_by_node*/ nullptr,
-    /*get_service_names_and_types_by_node*/ nullptr,
-    /*get_client_names_and_types_by_node*/ nullptr,
-    /*get_publishers_info_by_topic*/ nullptr,
-    /*get_subscriptions_info_by_topic*/ nullptr,
-    /*count_publishers*/ nullptr,
-    /*count_subscribers*/ nullptr,
+    /* phase-444 W3 — the other eleven-twelfths of the graph family, from the
+     * DDS builtin topics (what endpoints exist, on what topic, with what type
+     * and QoS) crossed with `ros_discovery_info` (which node owns each). These
+     * were NULL since phase-376 W4, so Cyclone — the backend that meets real
+     * ROS 2 peers — answered UNSUPPORTED to every graph question but
+     * `get_node_names`. Bodies in `graph_query.cpp`. */
+    /*get_topic_names_and_types*/ graph_get_topic_names_and_types,
+    /*get_service_names_and_types*/ graph_get_service_names_and_types,
+    /*get_publisher_names_and_types_by_node*/ graph_get_publisher_names_and_types_by_node,
+    /*get_subscriber_names_and_types_by_node*/ graph_get_subscriber_names_and_types_by_node,
+    /*get_service_names_and_types_by_node*/ graph_get_service_names_and_types_by_node,
+    /*get_client_names_and_types_by_node*/ graph_get_client_names_and_types_by_node,
+    /*get_publishers_info_by_topic*/ graph_get_publishers_info_by_topic,
+    /*get_subscriptions_info_by_topic*/ graph_get_subscriptions_info_by_topic,
+    /*count_publishers*/ graph_count_publishers,
+    /*count_subscribers*/ graph_count_subscribers,
     /*node_get_graph_guard_condition*/ nullptr,
     /* Issue 1269 — one `ros_discovery_info` NodeEntitiesInfo per node. NULL
      * here made every endpoint in the image belong to the session's one

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
@@ -172,6 +172,28 @@ add_test(
     COMMAND nros_rmw_cyclonedds_graph_node_set
 )
 
+# phase-444 W3 — the graph READ slots, asked from a SECOND participant so the
+# answers cross the wire. The service half needs the generated AddTwoInts
+# sources (`rosidl_adapter`); where they exist it drives the real
+# `create_service` / `create_client` path, and where they do not the topic half
+# still runs rather than the whole test disappearing.
+add_executable(nros_rmw_cyclonedds_graph_query
+    graph_query.cpp
+    ${_test_string_sources}
+)
+target_link_libraries(nros_rmw_cyclonedds_graph_query PRIVATE nros_rmw_cyclonedds)
+target_include_directories(nros_rmw_cyclonedds_graph_query
+    PRIVATE
+        ${NROS_RMW_CFFI_DIR}
+        "${CMAKE_CURRENT_BINARY_DIR}/types"
+)
+add_test(
+    NAME nros_rmw_cyclonedds_graph_query
+    COMMAND nros_rmw_cyclonedds_graph_query
+)
+set_tests_properties(nros_rmw_cyclonedds_graph_query PROPERTIES
+    ENVIRONMENT "${_nros_rmw_test_env}")
+
 # Issue 0823 — the QoS read-back. Pre-loads the out-struct with values the
 # entity cannot have, so an echoing or zeroing implementation is visible.
 add_executable(nros_rmw_cyclonedds_actual_qos
@@ -289,6 +311,13 @@ if(_addtwoints_sources)
         NAME nros_rmw_cyclonedds_service_smoke
         COMMAND nros_rmw_cyclonedds_service_smoke
     )
+
+    # phase-444 W3 — the graph query test's SERVICE half, wired here because
+    # this is where the generated AddTwoInts sources become available. With
+    # them it drives the real `create_service` / `create_client`; without them
+    # the target above still builds and its topic assertions still run.
+    target_sources(nros_rmw_cyclonedds_graph_query PRIVATE ${_addtwoints_sources})
+    target_compile_definitions(nros_rmw_cyclonedds_graph_query PRIVATE NROS_TEST_HAS_SERVICE=1)
 
     # Phase 117.7 service request/reply data round-trip — Phase
     # 117.X.3 reshapes wire to include cdds_request_header_t.

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/graph_query.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/graph_query.cpp
@@ -1,0 +1,434 @@
+// phase-444 W3 — the graph READ slots, asked ACROSS a participant boundary.
+//
+// A second session runs every query, so what it answers came off the wire —
+// the DDS builtin topics for "what endpoints exist, on what topic, with what
+// type and QoS", and the producer's `ros_discovery_info` for "which node owns
+// this endpoint". A test that queried the producing session would pass on a
+// backend that only reported its own local entities, which is the failure this
+// shape exists to exclude.
+//
+// What each assertion is really about:
+//
+//   * the name and type are DEMANGLED (`rt/x` -> `/x`,
+//     `pkg::msg::dds_::T_` -> `pkg/msg/T`), and `no_demangle` gives the raw DDS
+//     spelling instead;
+//   * counts MOVE with the graph, and a topic nobody publishes counts 0 rather
+//     than erroring — empty is a legitimate answer;
+//   * an endpoint carries its OWNING NODE, which only `ros_discovery_info`
+//     knows, plus the GRANTED QoS read off the remote's own discovery sample
+//     (asserted on a value that differs from the profile default, so an
+//     implementation returning zeros or echoing a request fails);
+//   * the `*_by_node` forms filter by node identity INCLUDING namespace, and a
+//     node that does not exist yields an empty OK, never UNSUPPORTED.
+//
+// The service half is compiled only where the generated AddTwoInts sources
+// exist (they need `rosidl_adapter`), so it drives the REAL `service_create` /
+// `client_create` path rather than hand-built DDS endpoints shaped like one.
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <dds/dds.h>
+
+#include "nros/rmw_entity.h"
+#include "nros/rmw_ret.h"
+#include "nros/rmw_vtable.h"
+#include "nros_rmw_cyclonedds.h"
+#include "nros_test_domain.h"
+
+namespace {
+const nros_rmw_vtable_t* g_vt = nullptr;
+int g_bad = 0;
+
+void expect(bool ok, const char* what) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        g_bad = 1;
+    }
+}
+
+/// One `(name, types)` the graph reported.
+struct NameTypes {
+    std::string name;
+    std::vector<std::string> types;
+};
+
+bool collect_names(void* ctx, const char* name, const char* const* types, size_t types_count) {
+    auto* out = static_cast<std::vector<NameTypes>*>(ctx);
+    NameTypes nt;
+    nt.name = name != nullptr ? name : "";
+    for (size_t i = 0; i < types_count; ++i) {
+        nt.types.push_back(types[i] != nullptr ? types[i] : "");
+    }
+    out->push_back(nt);
+    return true;
+}
+
+/// A flattened endpoint info. Copied, because every string is borrowed for the
+/// duration of the visit.
+struct Endpoint {
+    std::string node_name;
+    std::string node_namespace;
+    std::string topic_type;
+    rmw_endpoint_type_t kind;
+    std::string gid;
+    std::string identifier;
+    rmw_qos_profile_t qos;
+};
+
+bool collect_endpoints(void* ctx, const rmw_topic_endpoint_info_t* info) {
+    auto* out = static_cast<std::vector<Endpoint>*>(ctx);
+    Endpoint e;
+    e.node_name = info->node_name != nullptr ? info->node_name : "";
+    e.node_namespace = info->node_namespace != nullptr ? info->node_namespace : "";
+    e.topic_type = info->topic_type != nullptr ? info->topic_type : "";
+    e.kind = info->endpoint_type;
+    e.gid.assign(reinterpret_cast<const char*>(info->endpoint_gid.data), RMW_GID_STORAGE_SIZE);
+    e.identifier = info->endpoint_gid.implementation_identifier != nullptr
+                       ? info->endpoint_gid.implementation_identifier
+                       : "";
+    e.qos = info->qos_profile;
+    out->push_back(e);
+    return true;
+}
+
+const NameTypes* find_name(const std::vector<NameTypes>& v, const char* name) {
+    for (const auto& e : v) {
+        if (e.name == name) return &e;
+    }
+    return nullptr;
+}
+
+bool has_type(const NameTypes* nt, const char* type) {
+    if (nt == nullptr) return false;
+    for (const auto& t : nt->types) {
+        if (t == type) return true;
+    }
+    return false;
+}
+
+std::vector<NameTypes> topic_names(const rmw_session_t* s, bool no_demangle) {
+    std::vector<NameTypes> out;
+    rmw_names_and_types_visitor_t v{collect_names, &out};
+    (void)g_vt->get_topic_names_and_types(s, no_demangle, v);
+    return out;
+}
+
+std::vector<NameTypes> by_node(rmw_ret_t (*slot)(const rmw_session_t*, const char*, const char*,
+                                                 bool, rmw_names_and_types_visitor_t),
+                               const rmw_session_t* s, const char* node, const char* ns,
+                               rmw_ret_t* rc_out) {
+    std::vector<NameTypes> out;
+    rmw_names_and_types_visitor_t v{collect_names, &out};
+    const rmw_ret_t rc = slot(s, node, ns, false, v);
+    if (rc_out != nullptr) *rc_out = rc;
+    return out;
+}
+
+std::vector<NameTypes> by_node_srv(rmw_ret_t (*slot)(const rmw_session_t*, const char*, const char*,
+                                                     rmw_names_and_types_visitor_t),
+                                   const rmw_session_t* s, const char* node, const char* ns,
+                                   rmw_ret_t* rc_out) {
+    std::vector<NameTypes> out;
+    rmw_names_and_types_visitor_t v{collect_names, &out};
+    const rmw_ret_t rc = slot(s, node, ns, v);
+    if (rc_out != nullptr) *rc_out = rc;
+    return out;
+}
+
+std::vector<Endpoint> endpoints(rmw_ret_t (*slot)(const rmw_session_t*, const char*, bool,
+                                                  rmw_topic_endpoint_info_visitor_t),
+                                const rmw_session_t* s, const char* topic) {
+    std::vector<Endpoint> out;
+    rmw_topic_endpoint_info_visitor_t v{collect_endpoints, &out};
+    (void)slot(s, topic, false, v);
+    return out;
+}
+
+bool gid_nonzero(const std::string& gid) {
+    for (char c : gid) {
+        if (c != '\0') return true;
+    }
+    return false;
+}
+
+constexpr const char* kTopic = "gq_chatter";
+constexpr const char* kMsgType = "nros_test::msg::TestString";
+constexpr const char* kRosMsgType = "nros_test/msg/TestString";
+#ifdef NROS_TEST_HAS_SERVICE
+constexpr const char* kService = "gq_add";
+constexpr const char* kSrvType = "nros_test::srv::dds_::AddTwoInts";
+constexpr const char* kRosSrvType = "nros_test/srv/AddTwoInts";
+#endif
+
+/// Has the producer's graph reached the observer yet? Discovery is
+/// asynchronous, so the whole battery is retried rather than sampled once.
+bool converged(const rmw_session_t* obs) {
+    const std::vector<NameTypes> topics = topic_names(obs, false);
+    const NameTypes* t = find_name(topics, "/gq_chatter");
+    if (!has_type(t, kRosMsgType)) return false;
+    size_t pubs = 0;
+    size_t subs = 0;
+    if (g_vt->count_publishers(obs, kTopic, &pubs) != NROS_RMW_RET_OK || pubs != 1) return false;
+    if (g_vt->count_subscribers(obs, kTopic, &subs) != NROS_RMW_RET_OK || subs != 1) return false;
+    const std::vector<Endpoint> pe = endpoints(g_vt->get_publishers_info_by_topic, obs, kTopic);
+    const std::vector<Endpoint> se = endpoints(g_vt->get_subscriptions_info_by_topic, obs, kTopic);
+    if (pe.size() != 1 || se.size() != 1) return false;
+    // Attribution arrives with the producer's ros_discovery_info sample, which
+    // may land after its endpoints do.
+    if (pe[0].node_name != "talker" || se[0].node_name != "listener") return false;
+#ifdef NROS_TEST_HAS_SERVICE
+    std::vector<NameTypes> svc;
+    rmw_names_and_types_visitor_t v{collect_names, &svc};
+    if (g_vt->get_service_names_and_types(obs, v) != NROS_RMW_RET_OK) return false;
+    if (find_name(svc, "/gq_add") == nullptr) return false;
+#endif
+    return true;
+}
+} // namespace
+
+extern "C" rmw_ret_t nros_rmw_cffi_register_named(const char* /*name*/,
+                                                  const nros_rmw_vtable_t* vt) {
+    g_vt = vt;
+    return NROS_RMW_RET_OK;
+}
+
+int main() {
+    if (nros_rmw_cyclonedds_register() != NROS_RMW_RET_OK || g_vt == nullptr) {
+        return 1;
+    }
+    // Precondition, not a skip: an unfilled slot here means the test would be
+    // asserting against UNSUPPORTED, which is the state this work item ends.
+    if (g_vt->get_topic_names_and_types == nullptr ||
+        g_vt->get_service_names_and_types == nullptr ||
+        g_vt->get_publisher_names_and_types_by_node == nullptr ||
+        g_vt->get_subscriber_names_and_types_by_node == nullptr ||
+        g_vt->get_service_names_and_types_by_node == nullptr ||
+        g_vt->get_client_names_and_types_by_node == nullptr ||
+        g_vt->get_publishers_info_by_topic == nullptr ||
+        g_vt->get_subscriptions_info_by_topic == nullptr || g_vt->count_publishers == nullptr ||
+        g_vt->count_subscribers == nullptr || g_vt->create_node == nullptr) {
+        std::fprintf(stderr, "FAIL: a graph slot under test is NULL\n");
+        return 2;
+    }
+
+    const uint32_t domain = nros_test_domain(95);
+
+    rmw_session_t producer{};
+    producer.node_name = "graph_query_producer";
+    producer.namespace_ = "/";
+    if (g_vt->create_session(nullptr, 0, domain, producer.node_name, nullptr, &producer) !=
+        NROS_RMW_RET_OK) {
+        return 3;
+    }
+    rmw_session_t observer{};
+    observer.node_name = "graph_query_observer";
+    observer.namespace_ = "/";
+    if (g_vt->create_session(nullptr, 0, domain, observer.node_name, nullptr, &observer) !=
+        NROS_RMW_RET_OK) {
+        (void)g_vt->destroy_session(&producer);
+        return 3;
+    }
+
+    // Two nodes, one namespaced, so the by-node filter has to compare both
+    // halves of a node's identity.
+    rmw_node_t talker{};
+    talker.name = "talker";
+    talker.namespace_ = "/";
+    talker.session = &producer;
+    rmw_node_t listener{};
+    listener.name = "listener";
+    listener.namespace_ = "/robot";
+    listener.session = &producer;
+    expect(g_vt->create_node(&producer, talker.name, talker.namespace_, &talker) == NROS_RMW_RET_OK,
+           "create_node(talker)");
+    expect(g_vt->create_node(&producer, listener.name, listener.namespace_, &listener) ==
+               NROS_RMW_RET_OK,
+           "create_node(listener)");
+
+    // TRANSIENT_LOCAL + depth 7: both differ from the profile defaults, so the
+    // QoS assertion below fails an implementation that reports zeros or echoes
+    // the asking side's request.
+    rmw_qos_profile_t qos{};
+    qos.reliability = NROS_RMW_RELIABILITY_RELIABLE;
+    qos.durability = NROS_RMW_DURABILITY_TRANSIENT_LOCAL;
+    qos.history = NROS_RMW_HISTORY_KEEP_LAST;
+    qos.depth = 7;
+
+    rmw_publisher_t pub{};
+    pub.topic_name = kTopic;
+    pub.type_name = kMsgType;
+    const rmw_message_type_support_t mts{kMsgType, ""};
+    if (g_vt->create_publisher(&talker, &mts, kTopic, domain, &qos, nullptr, &pub) !=
+        NROS_RMW_RET_OK) {
+        (void)g_vt->destroy_session(&observer);
+        (void)g_vt->destroy_session(&producer);
+        return 4;
+    }
+    rmw_subscription_t sub{};
+    sub.topic_name = kTopic;
+    sub.type_name = kMsgType;
+    if (g_vt->create_subscription(&listener, &mts, kTopic, domain, &qos, nullptr, &sub) !=
+        NROS_RMW_RET_OK) {
+        (void)g_vt->destroy_publisher(&pub);
+        (void)g_vt->destroy_session(&observer);
+        (void)g_vt->destroy_session(&producer);
+        return 4;
+    }
+
+#ifdef NROS_TEST_HAS_SERVICE
+    // The real service path: a server on one node, a client on another, so the
+    // server/client split (which side READS `rq/`) is observable.
+    rmw_node_t adder{};
+    adder.name = "adder";
+    adder.namespace_ = "/";
+    adder.session = &producer;
+    rmw_node_t caller{};
+    caller.name = "caller";
+    caller.namespace_ = "/";
+    caller.session = &producer;
+    expect(g_vt->create_node(&producer, adder.name, adder.namespace_, &adder) == NROS_RMW_RET_OK,
+           "create_node(adder)");
+    expect(g_vt->create_node(&producer, caller.name, caller.namespace_, &caller) == NROS_RMW_RET_OK,
+           "create_node(caller)");
+    rmw_service_t server{};
+    server.service_name = kService;
+    server.type_name = kSrvType;
+    const rmw_service_type_support_t sts{kSrvType, ""};
+    expect(g_vt->create_service(&adder, &sts, kService, domain, nullptr, &server) ==
+               NROS_RMW_RET_OK,
+           "create_service");
+    rmw_client_t client{};
+    client.service_name = kService;
+    client.type_name = kSrvType;
+    expect(g_vt->create_client(&caller, &sts, kService, domain, nullptr, &client) ==
+               NROS_RMW_RET_OK,
+           "create_client");
+#endif
+
+    // Poll to convergence: these slots report what has ALREADY been discovered
+    // and never block, so one sample right after creation is legitimately
+    // partial (RFC-0036).
+    bool ok = false;
+    for (int i = 0; i < 150 && !ok; ++i) {
+        ok = converged(&observer);
+        if (!ok) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    expect(ok, "the observer must discover the producer's topic, counts, endpoints and node "
+               "attribution");
+
+    // ---- names and types, demangled and raw ------------------------------
+    const std::vector<NameTypes> topics = topic_names(&observer, false);
+    const NameTypes* chatter = find_name(topics, "/gq_chatter");
+    expect(chatter != nullptr, "the ROS topic name must be demangled from `rt/gq_chatter`");
+    expect(has_type(chatter, kRosMsgType),
+           "the type must be demangled from `nros_test::msg::TestString`");
+    expect(find_name(topics, "ros_discovery_info") == nullptr,
+           "an unprefixed DDS topic is not a ROS topic and must not be listed");
+
+    const std::vector<NameTypes> raw = topic_names(&observer, true);
+    expect(find_name(raw, "rt/gq_chatter") != nullptr, "no_demangle must report the DDS spelling");
+    expect(find_name(raw, "/gq_chatter") == nullptr,
+           "no_demangle must NOT also report the demangled spelling");
+
+    // ---- counts ----------------------------------------------------------
+    size_t n = 0;
+    expect(g_vt->count_publishers(&observer, kTopic, &n) == NROS_RMW_RET_OK && n == 1,
+           "count_publishers must see the one publisher");
+    expect(g_vt->count_subscribers(&observer, kTopic, &n) == NROS_RMW_RET_OK && n == 1,
+           "count_subscribers must see the one subscription");
+    // The leading slash is the same ROS topic; both spellings mangle to one
+    // DDS name, exactly as `create_publisher` mangles them.
+    expect(g_vt->count_publishers(&observer, "/gq_chatter", &n) == NROS_RMW_RET_OK && n == 1,
+           "a leading slash names the same topic");
+    expect(g_vt->count_publishers(&observer, "gq_nobody_here", &n) == NROS_RMW_RET_OK && n == 0,
+           "a topic nobody publishes counts 0 — empty is an answer, not an error");
+
+    // ---- endpoint info ---------------------------------------------------
+    const std::vector<Endpoint> pubs =
+        endpoints(g_vt->get_publishers_info_by_topic, &observer, kTopic);
+    expect(pubs.size() == 1, "one publisher on the topic");
+    if (pubs.size() == 1) {
+        const Endpoint& e = pubs[0];
+        expect(e.node_name == "talker", "the publisher's OWNING NODE, from ros_discovery_info");
+        expect(e.node_namespace == "/", "the owning node's namespace");
+        expect(e.topic_type == kRosMsgType, "the endpoint's type, demangled");
+        expect(e.kind == RMW_ENDPOINT_PUBLISHER, "endpoint_type must say publisher");
+        expect(gid_nonzero(e.gid), "a gid of all zeroes identifies nothing");
+        expect(e.identifier == "cyclonedds", "a gid without its identifier cannot be compared");
+        expect(e.qos.durability == NROS_RMW_DURABILITY_TRANSIENT_LOCAL,
+               "the GRANTED durability, read off the remote's discovery sample");
+        expect(e.qos.depth == 7, "the granted history depth");
+        expect(e.qos.reliability == NROS_RMW_RELIABILITY_RELIABLE, "the granted reliability");
+    }
+    const std::vector<Endpoint> subs =
+        endpoints(g_vt->get_subscriptions_info_by_topic, &observer, kTopic);
+    expect(subs.size() == 1, "one subscription on the topic");
+    if (subs.size() == 1) {
+        expect(subs[0].node_name == "listener", "the subscription's owning node");
+        expect(subs[0].node_namespace == "/robot", "a namespaced node reports its namespace");
+        expect(subs[0].kind == RMW_ENDPOINT_SUBSCRIPTION, "endpoint_type must say subscription");
+    }
+
+    // ---- by node ---------------------------------------------------------
+    rmw_ret_t rc = NROS_RMW_RET_ERROR;
+    std::vector<NameTypes> t_pub =
+        by_node(g_vt->get_publisher_names_and_types_by_node, &observer, "talker", "/", &rc);
+    expect(rc == NROS_RMW_RET_OK, "publisher_names_and_types_by_node returned non-OK");
+    expect(find_name(t_pub, "/gq_chatter") != nullptr, "talker publishes /gq_chatter");
+    std::vector<NameTypes> t_sub =
+        by_node(g_vt->get_subscriber_names_and_types_by_node, &observer, "talker", "/", &rc);
+    expect(rc == NROS_RMW_RET_OK && t_sub.empty(), "talker subscribes to nothing");
+    std::vector<NameTypes> l_sub =
+        by_node(g_vt->get_subscriber_names_and_types_by_node, &observer, "listener", "/robot", &rc);
+    expect(rc == NROS_RMW_RET_OK, "subscriber_names_and_types_by_node returned non-OK");
+    expect(find_name(l_sub, "/gq_chatter") != nullptr, "listener subscribes to /gq_chatter");
+    // The namespace is part of the identity, not decoration.
+    std::vector<NameTypes> wrong_ns =
+        by_node(g_vt->get_subscriber_names_and_types_by_node, &observer, "listener", "/", &rc);
+    expect(rc == NROS_RMW_RET_OK && wrong_ns.empty(),
+           "a node is (name, namespace) — the same name in another namespace is another node");
+    std::vector<NameTypes> absent =
+        by_node(g_vt->get_publisher_names_and_types_by_node, &observer, "no_such_node", "/", &rc);
+    expect(rc == NROS_RMW_RET_OK && absent.empty(),
+           "a node nobody has seen is EMPTY, never UNSUPPORTED");
+
+#ifdef NROS_TEST_HAS_SERVICE
+    std::vector<NameTypes> svc;
+    rmw_names_and_types_visitor_t sv{collect_names, &svc};
+    expect(g_vt->get_service_names_and_types(&observer, sv) == NROS_RMW_RET_OK,
+           "get_service_names_and_types returned non-OK");
+    const NameTypes* add = find_name(svc, "/gq_add");
+    expect(add != nullptr, "the service name must be demangled from `rq/gq_addRequest`");
+    expect(has_type(add, kRosSrvType),
+           "the service type drops the _Request half: nros_test/srv/AddTwoInts");
+    std::vector<NameTypes> a_srv =
+        by_node_srv(g_vt->get_service_names_and_types_by_node, &observer, "adder", "/", &rc);
+    expect(rc == NROS_RMW_RET_OK, "service_names_and_types_by_node returned non-OK");
+    expect(find_name(a_srv, "/gq_add") != nullptr, "adder SERVES /gq_add");
+    std::vector<NameTypes> a_cli =
+        by_node_srv(g_vt->get_client_names_and_types_by_node, &observer, "adder", "/", &rc);
+    expect(rc == NROS_RMW_RET_OK && a_cli.empty(), "the server is not a client of its own service");
+    std::vector<NameTypes> c_cli =
+        by_node_srv(g_vt->get_client_names_and_types_by_node, &observer, "caller", "/", &rc);
+    expect(rc == NROS_RMW_RET_OK, "client_names_and_types_by_node returned non-OK");
+    expect(find_name(c_cli, "/gq_add") != nullptr, "caller CALLS /gq_add");
+    (void)g_vt->destroy_client(&client);
+    (void)g_vt->destroy_service(&server);
+#endif
+
+    (void)g_vt->destroy_subscription(&sub);
+    (void)g_vt->destroy_publisher(&pub);
+    (void)g_vt->destroy_session(&observer);
+    (void)g_vt->destroy_session(&producer);
+
+    if (g_bad == 0) {
+        std::printf("graph_query: OK (topics, types, counts, endpoint info + node attribution, "
+                    "by-node filters)\n");
+    }
+    return g_bad;
+}


### PR DESCRIPTION
phase-444 W3 — Cyclone filled ONE graph slot (`get_node_names`, phase-381 W5) and left the other eleven NULL, so on the backend that actually meets ROS 2 peers, "is anyone subscribed to this topic", "what types are on it" and "what does node X publish" all answered UNSUPPORTED.

**Carries #920 (W7)'s commit.** This branch is based on `work/444-w7-cyclone-node-set`, because W3 builds on the per-node graph records W7 added. The queue rebase-merges, so that commit drops by patch-id once #920 lands; review only the `feat(phase-444 W3)` commit here.

## What changed

`graph_query.cpp` fills ten slots from TWO sources, because neither alone is enough:

- the **DDS builtin topics** (`DCPSPublication` / `DCPSSubscription`) know every discovered endpoint — its topic, type, granted QoS and GUID — and know nothing about ROS nodes, because DDS has none;
- **`ros_discovery_info`** is where the node layer lives, so it supplies the endpoint → node edge that the four `*_by_node` slots and every endpoint info need.

Slots: `get_topic_names_and_types`, `get_service_names_and_types`, the four `*_names_and_types_by_node`, `get_{publishers,subscriptions}_info_by_topic`, `count_{publishers,subscribers}`.

The mangling is the inverse of `topic_prefix.hpp`'s and is matched against what stock `rmw_cyclonedds_cpp` puts on the wire, not only against ourselves: `rt/x` → `/x`, `rq/xRequest` → `/x`, `pkg::msg::dds_::T_` → `pkg/msg/T`, and a service type's `_Request` tail dropped. A service is reported where its SERVER is — the side that READS `rq/` — so a service nobody offers is not listed, and the client/server split is observable.

Contract kept (RFC-0036 "Static CONNECTION, dynamic GRAPH"): nothing blocks, empty means "nobody seen yet", and an inactive graph answers UNSUPPORTED, which stays distinct from empty.

**No allocator assumed.** Every visited string is borrowed from the loaned sample or a stack buffer; the one heap use is the transient sample batch via `ddsrt_malloc` (never libc — the RTOS heap is separate), bounded by `kScanMax` because Cyclone's reader API has no cursor to page with. That bound is documented at its definition.

**One mapping, not a second transcription:** `qos_from_dds` is extracted out of `read_entity_qos`, so a local entity's QoS and a remote endpoint's granted QoS fold through the same table — CLAUDE.md's hand-mirror class. Same reasoning put the new TU in BOTH source lists (CMake and the `-sys` build.rs) in one change, which is what issue 0984 is about.

## Tests

New CTest `nros_rmw_cyclonedds_graph_query`, asked from a **second participant**, so every answer crossed the wire — a test that queried the producing session would pass on a backend that only reported its own local entities:

- demangled names and types, and `no_demangle` giving the raw DDS spelling (and NOT both);
- counts that move, `0` for a topic nobody publishes, and a leading slash naming the same topic;
- endpoint info carrying its owning node (namespaced), gid + `cyclonedds` identifier, and the **granted** QoS — asserted on TRANSIENT_LOCAL + depth 7, values that differ from the profile defaults, so an implementation returning zeros or echoing the asker's request fails;
- `*_by_node` filtering on (name, namespace), and an unknown node returning an empty OK rather than UNSUPPORTED;
- the service half drives the real `create_service` / `create_client` where the generated AddTwoInts sources exist (`-DNROS_TEST_HAS_SERVICE=1`, confirmed active on this host).

**Negative controls, each built and run:**

| mutation | result |
| --- | --- |
| `demangle_topic` returns the raw name | 6 assertions fail, including convergence |
| node attribution disabled | 8 fail (every owning-node and by-node assertion) |
| by-node filter ignores namespace | exactly the namespace assertion fails |

## Slot count

`just check rmw-slot-producers`: **cyclonedds 41 → 51 slots, graph 1/12 → 11/12.**

Not 12/12, and that is deliberate: the twelfth is `node_get_graph_guard_condition`, which **no backend fills** (the Rust adapter also reads 11/12) and which the checker itself classifies `inert` — "nothing consumes graph change events". Filling it would mean firing a callback from Cyclone's own receive thread, which is the context `*_event_init` declines for exactly this reason (issues 0780/1164). RFC-0036 amended to say so.

## Local gates (this worktree)

- `just ci gate` — **passed**: "CI gate passed (compile + unit; no fixtures were built or needed)".
- `just check rmw-cyclonedds` — **passed**: "100% tests passed out of 30", including `graph_query` and W7's `graph_node_set`.
- `just check rmw-slot-producers` — **passed** (numbers above).

## Not verified live

This host has no ROS 2. The live acceptance is `native-graph-rust-cyclone-r2n` (`graph_interop`'s `cyclone_enumerates_a_stock_ros2_node`), whose `graph-probe` calls all eleven slots against a stock peer and prints `GRAPH_PROBE_ALL_SLOTS_OK` when none fail; it has NOT been run here. Everything above is asserted between two participants in one process, which exercises the wire but not a stock `rmw_cyclonedds_cpp` peer's naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7tie7AFCdqoRkxphQcqRx
