### PR TITLE
docs(phase-403): mark the W0 blocker section superseded — it was reversed the next day

### DIFF
--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -1,10 +1,18 @@
 # Phase 403 — the type's bound sizes every receive buffer, and third parties can say what they need
 
-**Status (2026-09-04). W1, W4 (one half), W6, W7, W7b, W8, W9 and steps 1-3
-are LANDED; W0, W2, W3 and W5 remain.** The 2026-08-30 line said "design,
-nothing landed" and outlived that by five days and eleven commits -- the body
-below had been recording `LANDED` per wave the whole time, so the phase read as
-unstarted to anyone who stopped at the header. Opened because
+**Status (2026-09-11). W0, W1, W4 (one half), W6, W7, W7b, W8, W9 and steps 1-3
+are LANDED; W2, W3 (the caller-supplied-buffer half) and W5 remain.** The
+2026-08-30 line said "design, nothing landed" and outlived that by five days and
+eleven commits -- the body below had been recording `LANDED` per wave the whole
+time, so the phase read as unstarted to anyone who stopped at the header. The
+2026-09-04 line then listed W0 as remaining while the body at "W0 -- (landed
+2026-08-31)" said otherwise; the header was wrong, not the body.
+
+Two further corrections, 2026-09-11. The "W0's blocker" section below is
+SUPERSEDED and now says so -- it was reversed the day after it was written and
+missed when its sibling was marked. And step 3's residue ("what is still owed is
+step 2's actual wiring") is CLOSED: phase-412 W3 carried the declared depths into
+the cargo env in `e4b576489`, which this doc never recorded. Opened because
 [phase 402](archived/phase-402-c-subscription-options-struct.md) delivered the PLUMBING
 for a per-type receive hint and stopped there: the hint now reaches the backend
 and changes nothing's size. Depends on
@@ -208,7 +216,33 @@ is RENAMED, not deleted, into `an_unbounded_type_is_refused_rather_than_defaulte
 and the compile-time half is a `compile_fail` doctest with a compiling positive
 control beside it.
 
-### W0's blocker: the `cap` escape hatch does not reach the bound
+### W0's blocker: the `cap` escape hatch does not reach the bound (2026-08-31, SUPERSEDED)
+
+> **This blocker was lifted the day after it was written, and this section was
+> missed when its sibling was marked.** The re-ruling is "The re-ruling: a cap
+> DOES set the bound (owner, 2026-08-31)" below, and the wiring shipped in
+> `1b3923523` ("an inline `cap` sets the bound"). The ruling now lives in code as
+> `StorageMode::cap_bounds_the_wire()`
+> (`packages/cli/rosidl-lower/src/config.rs`).
+>
+> Kept, not deleted, for the same reason the sibling section is kept: "a cap
+> cannot reach the bound" was load-bearing prose for a day, and a reader who
+> finds only the answer cannot tell which question it settles.
+>
+> **Every piece of evidence below is now false or misleading.** The
+> `diagnostic-msgs` claim is flatly false —
+> `generated/humble/nros-diagnostic-msgs/src/msg/key_value.rs` reads
+> `ty: ::nros_serdes::FieldType::BoundedString(32)`. The
+> `fingerprint-corpus` claim is true for the opposite reason: `Shapes.text` is
+> `mode = "view"`, so it stays unbounded deliberately, and the same corpus now
+> carries `inline` entries that DO bound. Consequence 1 ("codegen cannot be made
+> to REFUSE an unbounded type") is retired — W0 landed as "one build names every
+> unbounded member". Consequence 3 (the C++ `compute_serialized_size_max` never
+> reports unboundedness) was fixed by phase-408's C++ pack work (`5f3c08545`).
+>
+> Mechanically checkable: `git log -L 211,270` on this file returns exactly one
+> commit, `ac9e23969` — the commit before the reversal. The section has never
+> been edited since it was written.
 
 Decision 2 says a user MUST bound a type "in the `.msg` or as a `cap` in
 `nros-codegen.toml`". **The second half is not true today**, and until it is, the


### PR DESCRIPTION
## What

`phase-403`'s `### W0's blocker: the cap escape hatch does not reach the bound`
states a live blocker that was lifted the following day. Its sibling section got
a `SUPERSEDED and re-ruled` banner; this one was missed — so the file states a
blocker and its removal 300 lines apart with nothing connecting them.

## Why it is provable, not a judgement call

```
git log -L 211,270:docs/roadmap/phase-403-type-bound-rx-sizing.md
```

returns exactly one commit, `ac9e23969` — the commit **before** the reversal
(`1b3923523`, "an inline `cap` sets the bound"). The section has never been
edited since it was written.

All three of its cited evidence items are now false or misleading:

| claim | today |
| --- | --- |
| `diagnostic-msgs` caps `KeyValue.key` at 32 but `FIELDS` say `FieldType::String` | **false** — `key_value.rs:61` reads `FieldType::BoundedString(32)` |
| `fingerprint-corpus` caps `Shapes.text` and it stays unbounded | true for the **opposite** reason — `mode = "view"` is deliberate; the corpus now carries `inline` entries that DO bound |
| consequence 1: codegen cannot REFUSE an unbounded type | retired — W0 landed as "one build names every unbounded member" |
| consequence 3: C++ `compute_serialized_size_max` never reports unboundedness | fixed by phase-408's C++ pack work, `5f3c08545` |

## Also in this commit

* The status header listed **W0 as remaining** while the body said
  `W0 -- (landed 2026-08-31)`. The header was wrong, not the body.
* Step 3's residue ("what is still owed is step 2's actual wiring") is **closed**
  — phase-412 W3 carried the declared depths into the cargo env in `e4b576489`,
  which this doc never recorded.

The section is **kept, not deleted**, matching the sibling's own stated reason:
*"a cap is storage-only" was load-bearing prose for half a day, and a reader who
finds only the answer cannot tell which question it settles.*

## Testing

Docs only, one file. `check-doc-refs`, `check-doc-commit-citations` (215
citations resolve), `check-roadmap-status`, `check-roadmap-claims` and
`check-roadmap-boxes` all green.

Found while surveying the sizing campaign for RFC-0100 / phase-454, which follow
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1