### PR TITLE
docs(check): name the seam between check-doc-refs and check-prose-issue-refs

### DIFF
--- a/scripts/check-doc-refs.sh
+++ b/scripts/check-doc-refs.sh
@@ -23,6 +23,29 @@
 # MOVES a resolved issue under `archived/`. So a reference resolves if the file
 # is at the named path OR in that series' `archived/` directory, which is where
 # the same basename lands.
+#
+# NOT THE SAME CHECK AS `check-prose-issue-refs.py`, AND THE SEAM MATTERS
+#
+# That gate reads the form prose actually uses — a bare id, `see issue 0940`,
+# `(issues 0883/0884)` — which has no path for this one to resolve. Its header
+# carries the measurement: on 2026-09-02 THIS gate was green while `CLAUDE.md`
+# cited three ids with no file. Complements, not duplicates; neither subsumes
+# the other, and unifying them would lose one form or the other.
+#
+# They OVERLAP on exactly one spelling, `[issue NNNN](../issues/NNNN-slug.md)`,
+# which is a path AND a prose reference, so both gates fire on it. That is
+# harmless when the file exists and awkward when it does not, because only the
+# prose gate has a baseline for an IN-FLIGHT issue — one whose file is correct
+# but still sits on an open PR. This gate has none, deliberately: a dangling
+# PATH is always wrong, whereas a dangling id may be a citation worth keeping.
+#
+# So the convention, which is the whole of the distinction:
+#
+#   CITE AN IN-FLIGHT ISSUE BY BARE ID, NEVER AS A LINK.
+#
+# Add the row to `.config/prose-issue-ref-baseline.txt` naming the PR, and
+# convert it to a link when that PR merges. A link to a file that is not on
+# `main` yet cannot be baselined here and will block the docs lane.
 set -uo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Are they duplicates?

No — and `check-prose-issue-refs.py` already argues its side under a heading
literally called **"WHY `check-doc-refs` DOES NOT COVER THIS"**, with the
measurement: on 2026-09-02 `check-doc-refs` was green while `CLAUDE.md` cited
three ids with no file. One reads **paths**, the other reads the **bare-id** form
prose actually uses. Neither subsumes the other; unifying would lose a form.

`check-doc-refs.sh` said nothing about its complement, so a reader arriving from
that side sees a path checker and no reason to think a second gate exists. This
adds the cross-reference.

## The part neither header covered

They overlap on exactly one spelling:

```
[issue NNNN](../issues/NNNN-slug.md)
```

which is a path **and** a prose reference, so both fire. Measured with the link
form and no baseline row:

| gate | failures |
| --- | --- |
| `check-doc-refs` | 1 |
| `check-prose-issue-refs` | 2 |

Harmless while the file exists. Awkward when it does not, because **only the
prose gate has a baseline** for an in-flight issue — one whose citation is
correct but whose file is still on an open PR. `check-doc-refs` has none, and
should not: a dangling *path* is always wrong, whereas a dangling *id* may be a
citation worth keeping (0417/1080 sit in that baseline for exactly that reason).

So the convention is now written where someone hitting the failure will read it:

> **CITE AN IN-FLIGHT ISSUE BY BARE ID, NEVER AS A LINK.**

## How it was found

Filing RFC-0100 / phase-454 (#959), which cite issue 1319 — a file that lives on
#951. The link form blocked the docs lane; the bare form did not. That is a rule
the tree enforced without ever stating it.

## Testing

Comment only, no behaviour change. Both gates green, `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1