### PR TITLE
feat(phase-442 W3+W4): the freestanding mechanisms exist, and the shims get what the language guarantees

### DIFF
--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -75,6 +75,16 @@ the rest and do not depend on each other.
 * **W3 [cpp] — the two freestanding mechanisms**, sized by W0: a handle type
   behind the `X::SharedPtr` aliases, and a fixed-capacity inplace callable,
   both carrying the API's own minimal traits (RFC-0096 D3).
+  **The MECHANISMS landed 2026-09-12** — `nros/traits.hpp` (`nros::tr`),
+  `nros/handle.hpp` (`nros::Handle<T>`, one pointer, copyable, converts to
+  `Handle<const T>`) and `nros/inplace_fn.hpp`
+  (`nros::InplaceFn<Sig, Cap = NROS_CPP_CALLBACK_CAPACITY>`), gated by
+  `check-cpp-freestanding-mechanisms` on the fast line: three toolchain arms
+  and an over-budget probe whose DIAGNOSTIC TEXT is checked, not merely its
+  failure. **Putting them BEHIND the `X::SharedPtr` aliases and the callback
+  parameters is W8's job**, because it is the same edit — one API — and doing
+  half of it would leave the tree with two spellings of a handle, which is the
+  state this phase exists to end.
   *Acceptance:* an rclcpp-shaped node body — derived `rclcpp::Node`, a
   capturing-lambda subscription callback, and `Publisher<M>::SharedPtr` /
   `Subscription<M>::SharedPtr` / `TimerBase::SharedPtr` members — compiles in

--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -83,7 +83,7 @@ the rest and do not depend on each other.
   `static_assert` naming the knob. A prototype already does; this is that
   prototype made real.
 
-* **W4 [boards] — fix the two shim gaps.** The ThreadX `cxx-compat` shim's
+* **W4 [boards] — fix the two shim gaps. LANDED 2026-09-11.** The ThreadX `cxx-compat` shim's
   `<new>` omits the PLACEMENT forms, which are freestanding-guaranteed, so
   placement new does not compile against it at all; its `<type_traits>` is a
   58-line stub with `enable_if` but no `is_same` and no `decay`, and its
@@ -91,7 +91,26 @@ the rest and do not depend on each other.
   makes the API not depend on them — but both are traps for the next in-place
   construction, and one of them is a guaranteed facility.
   *Acceptance:* placement new compiles against the shim; a probe using the
-  freestanding-guaranteed `<type_traits>` contents compiles.
+  freestanding-guaranteed `<type_traits>` contents compiles. **Met, and the
+  reach widened twice on measurement.** The gaps were not two but three:
+  Zephyr's own minimal libcpp `<new>` is a stub that declares `nothrow_t` and
+  nothing else, so a Zephyr C++ build could not do placement new either —
+  `zephyr/cxx-compat/new` now supplies the forms, layered with `include_next`
+  and guarded on `__GLIBCXX__` / `_LIBCPP_VERSION` so it never replaces a real
+  library's. And the trait widening is MIRRORED into `zephyr/cxx-compat`,
+  whose own comment says it mirrors the board shim: two fallbacks that are one
+  implementation under two names, where a trait added to one and not the other
+  is a difference between boards nothing measures. `remove_reference` moved
+  from `<utility>` to `<type_traits>` in both, with `<utility>` including it,
+  so there is one definition and it is where the standard puts it.
+  Gated by `check-cxx-compat-shim-facilities` on the FAST line — its sibling
+  `cxx-compat-shim-coverage` asks whether every `std::` C-library name a source
+  spells is exported, which is a different question and cannot see a facility
+  nobody has written code against yet. It MEASURES by compiling a probe rather
+  than scanning text, because `decay` written as
+  `remove_cv_t<remove_reference_t<T>>` is right for scalars and wrong for
+  exactly the function and array types a callback signature uses, and runs two
+  negative controls on the normal path.
 
 * **W5 [cpp] — un-gate `NodeOptions` and `Rate`/`WallRate`.** 22 of
   `NodeOptions`' 23 members are `static_assert`-only and need no `std`; `Rate`'s

--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -121,6 +121,15 @@ the rest and do not depend on each other.
   `remove_cv_t<remove_reference_t<T>>` is right for scalars and wrong for
   exactly the function and array types a callback signature uses, and runs two
   negative controls on the normal path.
+  **And one thing the fix BROKE, caught before it merged.** `component.hpp`
+  carried its own hand-rolled placement `operator new` behind Zephyr's include
+  guard (issue 1317's workaround), so the moment the shim supplied the real
+  ones the two collided — `redefinition of 'void* operator new(size_t, void*)'`
+  on every Zephyr C++ component build. The local workaround is deleted, which
+  is the class fix 1317 could not make from inside one header, and the gate
+  gained a CONSUMER probe: it now compiles `nros/component.hpp` against the
+  Zephyr shim, not only a synthetic TU. The synthetic probe stayed green
+  through the whole collision, which is the argument for the second probe.
 
 * **W5 [cpp] — un-gate `NodeOptions` and `Rate`/`WallRate`.** 22 of
   `NodeOptions`' 23 members are `static_assert`-only and need no `std`; `Rate`'s

--- a/just/check/cmake.just
+++ b/just/check/cmake.just
@@ -188,6 +188,22 @@ cxx-compat-shim-coverage:
 cxx-compat-shim-facilities:
     @python3 scripts/check-cxx-compat-shim-facilities.py
 
+# phase-442 W3 — RFC-0096's claim is that one API can be freestanding AND be the
+# rclcpp API, and it rests on two mechanisms: a copyable non-owning handle behind
+# `X::SharedPtr`, and a fixed-capacity inplace callable behind a capturing-lambda
+# callback. A claim like that is worth the compile that backs it. Three arms,
+# each removing something different, and the 32-bit one is not redundant: the
+# capacity default and the storage alignment are expressed in POINTERS precisely
+# because a byte count is right on one word size and wrong on the other, and only
+# that arm catches a regression to a literal. The negative control is the design,
+# not a formality — an over-budget capture must be a compile error NAMING the
+# knob, and the diagnostic text is checked, because a probe that merely fails
+# passes on a typo. Fast line, not `check cpp`, for issue 1225's reason: that
+# lane is `build-serial` and no merge-gating event reaches it.
+[private]
+cpp-freestanding-mechanisms:
+    @python3 scripts/check-cpp-freestanding-mechanisms.py
+
 # phase-417 / issue 1225 — a capability probe may gate a METHOD, never `sizeof`.
 # MEASURED, not grepped: one `sizeof` probe TU per capability configuration over
 # every public type the umbrella exports, DERIVED from a clang AST rather than

--- a/just/check/cmake.just
+++ b/just/check/cmake.just
@@ -173,6 +173,21 @@ cpp-freestanding-includes:
 cxx-compat-shim-coverage:
     @python3 scripts/check-cxx-compat-shim-coverage.py
 
+# phase-442 W4 — the other half of the shim question. `cxx-compat-shim-coverage`
+# asks whether every `std::` C-library name a served SOURCE spells is exported;
+# this asks whether the shim supplies what the LANGUAGE guarantees freestanding,
+# whether or not a source spells it today. The two fail differently: a missing
+# `memchr` stops the line that wants it, while a missing placement `operator new`
+# stops code written months later against a header that looked complete, on a
+# cross build nobody runs per-push. Neither shim had the placement forms, and
+# `<type_traits>` had no `is_same` and no `decay`. MEASURED by compiling a probe,
+# not by scanning text: a trait can be present and wrong, and `decay` written as
+# `remove_cv_t<remove_reference_t<T>>` is right for scalars and wrong for exactly
+# the function and array types a callback signature uses.
+[private]
+cxx-compat-shim-facilities:
+    @python3 scripts/check-cxx-compat-shim-facilities.py
+
 # phase-417 / issue 1225 — a capability probe may gate a METHOD, never `sizeof`.
 # MEASURED, not grepped: one `sizeof` probe TU per capability configuration over
 # every public type the umbrella exports, DERIVED from a clang AST rather than

--- a/packages/api/nros-cpp/include/nros/component.hpp
+++ b/packages/api/nros-cpp/include/nros/component.hpp
@@ -482,30 +482,31 @@ constexpr ::nros::QoS qos_from_declared_depth(int declared) {
 
 // Zephyr's minimal libcpp ships a STUB <new> (guard
 // ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_) that declares nothrow_t but NOT placement
-// new — the NROS_COMPONENT factory's `new (storage) Class(...)` then fails
+// new — the NROS_COMPONENT factory's `new (storage) Class(...)` then failed
 // "no matching operator new(sizetype, void*&)" (first hit porting real
 // Autoware components to a Zephyr image; ASI's FVP build used a full-libcpp
-// toolchain and never saw it). Provide the standard non-allocating forms.
+// toolchain and never saw it).
 //
-// Issue 1317 — `<new>` is INCLUDED here rather than waited for. The guard
-// below is Zephyr's own include guard, so it is defined only once something
-// else has already pulled `<new>` in, and a translation unit that reaches
-// this header first got the shim compiled away and the factory failing. That
-// is a property of the CONSUMER's include order, which this header cannot
-// see: measured on a downstream where three of four component sources
-// happened to include `<new>` transitively and the fourth did not.
+// This header used to supply the missing forms ITSELF, behind Zephyr's own
+// include guard, and issue 1317 records why that could not work: the guard is
+// defined only once something else has pulled `<new>` in, so whether the fix
+// applied was a property of the CONSUMER's include order, which this header
+// cannot see. Measured on a downstream where three of four component sources
+// included `<new>` transitively and the fourth did not.
+//
+// phase-442 W4 fixed the CLASS instead: `zephyr/cxx-compat/new` supplies the
+// placement forms for every Zephyr C++ translation unit, layered over whatever
+// real `<new>` is reachable, and `check-cxx-compat-shim-facilities` compiles a
+// probe that proves it. So the local workaround is not merely redundant now —
+// it is a REDEFINITION, measured:
+//
+//     component.hpp:501: error: redefinition of 'void* operator new(size_t, void*)'
+//     zephyr/cxx-compat/new:46: note: previously defined here
+//
+// `<new>` is still included, because this header's factory uses placement new
+// and a header that needs a facility should say so rather than inherit it.
 #ifdef __ZEPHYR__
 #include <new>
-#endif
-#ifdef ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_
-inline void* operator new(::std::size_t, void* ptr) noexcept {
-    return ptr;
-}
-inline void* operator new[](::std::size_t, void* ptr) noexcept {
-    return ptr;
-}
-inline void operator delete(void*, void*) noexcept {}
-inline void operator delete[](void*, void*) noexcept {}
 #endif
 
 /// Inside a node constructor: subscribe `void Self::method(const Msg&)` to

--- a/packages/api/nros-cpp/include/nros/handle.hpp
+++ b/packages/api/nros-cpp/include/nros/handle.hpp
@@ -1,0 +1,109 @@
+// nros-cpp: the non-owning entity handle
+// Freestanding C++ — no exceptions, no STL required
+
+/**
+ * @file handle.hpp
+ * @ingroup grp_support
+ * @brief `nros::Handle<T>` — what `X::SharedPtr` is on every target.
+ */
+
+#ifndef NROS_CPP_HANDLE_HPP
+#define NROS_CPP_HANDLE_HPP
+
+#include "nros/traits.hpp"
+
+namespace nros {
+
+/// A copyable, non-owning reference to an entity — RFC-0096 D2.
+///
+/// WHAT IT REPLACES, AND WHY NOTHING IS LOST
+///
+/// `X::SharedPtr` is the name ported rclcpp code writes, so it has to exist on
+/// every target, and `std::shared_ptr` does not. What it has to DO was
+/// measured rather than assumed (phase-442 W0), over this tree and the porting
+/// corpus:
+///
+///   * handles are stored as members and one is passed by value
+///     (`diagnostic_updater::Updater`'s constructor);
+///   * there is no `weak_ptr`, no `.lock()`, no `use_count()`, no `reset()` and
+///     no custom deleter anywhere outside our own headers;
+///   * `rclcpp::Node::shared_from_this()` ALREADY returns
+///     `std::shared_ptr<Node>(std::shared_ptr<void>(), this)` — the aliasing
+///     constructor with an EMPTY owner, which observes and does not own.
+///
+/// So shared ownership was already fiction at the one site where it looked
+/// real, and a reference count would be a mechanism with no reader. Building
+/// one would be inventing work; RFC-0096 says so in as many words.
+///
+/// WHAT THAT COSTS A USER, STATED
+///
+/// Upstream's `shared_ptr` keeps the pointee alive; this does not. In this API
+/// the entity is owned by the node or the executor arena and outlives everything
+/// it is handed to, so the two behave identically — but a caller who stores a
+/// handle past its entity's lifetime gets a dangling pointer where upstream
+/// would have kept the object alive. That is the same envelope
+/// `shared_from_this()` has documented since phase-427, now the whole type's.
+///
+/// One pointer, trivially copyable, no allocation, no atomics. `sizeof` is
+/// `sizeof(void*)` on every target and follows no capability probe.
+template <typename T> class Handle {
+  public:
+    using element_type = T;
+
+    constexpr Handle() : p_(nullptr) {}
+    /// Null, spelled the way a ported file spells it (`X::SharedPtr p = nullptr`).
+    constexpr Handle(decltype(nullptr)) : p_(nullptr) {}
+    explicit constexpr Handle(T* p) : p_(p) {}
+
+    /// `Handle<T>` converts to `Handle<const T>`, the way `shared_ptr` does.
+    /// Constrained rather than open so that an unrelated `Handle<U>` is a
+    /// compile error at the call site instead of a surprise at the `static_cast`.
+    template <typename U,
+              typename tr::enable_if<tr::is_same<typename tr::remove_const<U>::type,
+                                                 typename tr::remove_const<T>::type>::value,
+                                     int>::type = 0>
+    constexpr Handle(const Handle<U>& other) : p_(other.get()) {}
+
+    constexpr T* get() const { return p_; }
+    constexpr T* operator->() const { return p_; }
+    constexpr T& operator*() const { return *p_; }
+
+    /// `if (sub)` / `if (!sub)`. `explicit` so a handle does not silently
+    /// convert to `bool` in arithmetic, which is what upstream's does too.
+    explicit constexpr operator bool() const { return p_ != nullptr; }
+
+    /// Release the reference. Does NOT destroy the entity — nothing here owns
+    /// one. Present because ported code writes `timer_.reset()` to mean "stop
+    /// referring to it"; where it meant "destroy it", the entity's own
+    /// lifetime verb (`Timer::cancel()`) is what that code wants, and this
+    /// leaves the object running rather than pretending otherwise.
+    void reset() { p_ = nullptr; }
+
+  private:
+    T* p_;
+};
+
+template <typename T, typename U>
+constexpr bool operator==(const Handle<T>& a, const Handle<U>& b) {
+    return a.get() == b.get();
+}
+template <typename T, typename U>
+constexpr bool operator!=(const Handle<T>& a, const Handle<U>& b) {
+    return a.get() != b.get();
+}
+template <typename T> constexpr bool operator==(const Handle<T>& a, decltype(nullptr)) {
+    return a.get() == nullptr;
+}
+template <typename T> constexpr bool operator!=(const Handle<T>& a, decltype(nullptr)) {
+    return a.get() != nullptr;
+}
+template <typename T> constexpr bool operator==(decltype(nullptr), const Handle<T>& a) {
+    return a.get() == nullptr;
+}
+template <typename T> constexpr bool operator!=(decltype(nullptr), const Handle<T>& a) {
+    return a.get() != nullptr;
+}
+
+} // namespace nros
+
+#endif // NROS_CPP_HANDLE_HPP

--- a/packages/api/nros-cpp/include/nros/inplace_fn.hpp
+++ b/packages/api/nros-cpp/include/nros/inplace_fn.hpp
@@ -1,0 +1,190 @@
+// nros-cpp: the fixed-capacity type-erased callable
+// Freestanding C++ — no exceptions, no STL required
+
+/**
+ * @file inplace_fn.hpp
+ * @ingroup grp_support
+ * @brief `nros::InplaceFn<Sig, Cap>` — a capturing lambda, with no heap.
+ */
+
+#ifndef NROS_CPP_INPLACE_FN_HPP
+#define NROS_CPP_INPLACE_FN_HPP
+
+#include <new> // the PLACEMENT forms only -- freestanding-guaranteed
+
+#include "nros/traits.hpp"
+
+/// How many bytes of capture a callback may carry — phase-442 W0.
+///
+/// MEASURED, not chosen. Every capture in this tree and in the porting corpus
+/// is a whole number of POINTERS, and the widest is three:
+///
+///   capture          x86_64   cortex-m3   riscv64
+///   []                    1           1         1
+///   [this]                8           4         8
+///   [this, state]        16           8        16
+///   [obj, method]        24          12        24
+///
+/// `[obj, method]` is `diagnostic_updater`'s, and it is wide because a
+/// pointer-to-member-function is TWO words on the Itanium ABI. The default is
+/// that widest shape plus one pointer of headroom.
+///
+/// SPELLED IN POINTERS, and that is the whole reason it is a `sizeof`
+/// expression rather than a number: a byte count is correct on one word size
+/// and wrong on the other, which is how a 32-bit target ends up either failing
+/// to compile idiomatic code or paying 64-bit prices for it.
+///
+/// Cost, measured on eight registered callbacks at `-Os`, freestanding:
+/// `align8(Cap) + 8` bytes of `.bss` each — 24 on cortex-m3 at this default, 40
+/// on riscv64 — and `.text` FLAT across every candidate capacity (256 -> 276
+/// bytes over capacities 8 through 48). Capacity is a `.bss` knob; raising it
+/// does not grow code.
+#ifndef NROS_CPP_CALLBACK_CAPACITY
+#define NROS_CPP_CALLBACK_CAPACITY (4 * sizeof(void*))
+#endif
+
+namespace nros {
+
+template <typename Sig, tr::size_type Cap = NROS_CPP_CALLBACK_CAPACITY> class InplaceFn;
+
+/// A callable with INLINE storage and a compile-time capacity — RFC-0096 D2.
+///
+/// WHAT IT IS FOR
+///
+/// The tree already had every non-owning form of a callback: a raw
+/// `void(*)(void*)` plus a context, typed function-pointer aliases, and the
+/// member-pointer-as-template-parameter `bind_*` family. What was missing is
+/// the CAPTURING LAMBDA, which is what ported rclcpp source actually writes:
+///
+/// ```cpp
+/// sub_ = this->create_subscription<Msg>("chatter", 10,
+///     [this](const Msg& m) { this->count_ += m.data; });
+/// ```
+///
+/// `std::function` supplies that hosted, at the price of a heap allocation and
+/// `<functional>`. This supplies it with neither: the capture is copied into
+/// storage that lives inside the entity, and dispatch is one indirect call
+/// through a function pointer that knows the capture's type.
+///
+/// AN OVER-LARGE CAPTURE IS A COMPILE ERROR, DELIBERATELY
+///
+/// The alternative designs are a silent heap fallback (which defeats the point
+/// on a target with no allocator, and hides the cost on one that has) or a
+/// runtime failure (which moves a compile-time fact to the field). A
+/// `static_assert` naming the knob is the mechanical edit RFC-0089 asks for:
+/// the compiler points at the exact callback and says which macro to raise.
+///
+/// NOT A `std::function`, AND NOT PRETENDING TO BE
+///
+/// It does not allocate, it does not throw, it has no `target()` and no
+/// `target_type()`, and an empty `InplaceFn` invoked is undefined rather than
+/// throwing `bad_function_call` — `valid()` is how a caller asks. Nothing in
+/// this API invokes one without having stored one.
+template <typename R, typename... A, tr::size_type Cap> class InplaceFn<R(A...), Cap> {
+  public:
+    /// The capacity this instantiation was built with, so a `static_assert` in
+    /// a consumer can name a number rather than re-deriving it.
+    static constexpr tr::size_type capacity = Cap;
+
+    constexpr InplaceFn() : invoke_(nullptr), destroy_(nullptr), storage_() {}
+    constexpr InplaceFn(decltype(nullptr)) : InplaceFn() {}
+
+    /// Store `f`. Constrained off the two special members so that a copy does
+    /// not bind here — an unconstrained template constructor is greedier than
+    /// the copy constructor and would recurse.
+    template <typename F,
+              typename tr::enable_if<!tr::is_same<typename tr::decay<F>::type, InplaceFn>::value,
+                                     int>::type = 0>
+    InplaceFn(F&& f)
+        : invoke_(&invoke_impl<typename tr::decay<F>::type>),
+          destroy_(&destroy_impl<typename tr::decay<F>::type>) {
+        using D = typename tr::decay<F>::type;
+        static_assert(sizeof(D) <= Cap,
+                      "callback capture too large -- raise NROS_CPP_CALLBACK_CAPACITY");
+        static_assert(alignof(D) <= alignof(MaxAlign),
+                      "callback capture is over-aligned for the inline storage");
+        new (static_cast<void*>(&storage_)) D(static_cast<F&&>(f));
+    }
+
+    ~InplaceFn() { clear(); }
+
+    InplaceFn(const InplaceFn&) = delete;
+    InplaceFn& operator=(const InplaceFn&) = delete;
+
+    /// Moves are a BYTE COPY of the storage plus a source reset, which is legal
+    /// here and not in general: the only things stored are lambda closures over
+    /// pointers and small trivially-copyable state, and a type whose move is
+    /// not a byte copy cannot fit the capacity in the first place. Stated
+    /// rather than assumed, because "trivially relocatable" is a property this
+    /// class cannot check in C++14.
+    InplaceFn(InplaceFn&& other) : invoke_(other.invoke_), destroy_(other.destroy_) {
+        copy_storage(other);
+        other.release();
+    }
+
+    InplaceFn& operator=(InplaceFn&& other) {
+        if (this != &other) {
+            clear();
+            invoke_ = other.invoke_;
+            destroy_ = other.destroy_;
+            copy_storage(other);
+            other.release();
+        }
+        return *this;
+    }
+
+    R operator()(A... args) const {
+        return invoke_(const_cast<Storage*>(&storage_), static_cast<A&&>(args)...);
+    }
+
+    /// Whether a callable is stored. An empty one must not be invoked.
+    constexpr bool valid() const { return invoke_ != nullptr; }
+    explicit constexpr operator bool() const { return invoke_ != nullptr; }
+
+    void clear() {
+        if (destroy_ != nullptr) {
+            destroy_(&storage_);
+        }
+        release();
+    }
+
+  private:
+    /// The widest fundamental alignment a small capture can need. `long long`
+    /// and `double` rather than `max_align_t`, which lives in `<cstddef>` and
+    /// is not what every shim provides.
+    union MaxAlign {
+        long long a;
+        double b;
+        void* c;
+        void (*d)();
+    };
+
+    struct alignas(MaxAlign) Storage {
+        unsigned char bytes[Cap];
+    };
+
+    template <typename D> static R invoke_impl(Storage* s, A... args) {
+        return (*reinterpret_cast<D*>(s))(static_cast<A&&>(args)...);
+    }
+
+    template <typename D> static void destroy_impl(Storage* s) { reinterpret_cast<D*>(s)->~D(); }
+
+    void copy_storage(const InplaceFn& other) {
+        for (tr::size_type i = 0; i < Cap; ++i) {
+            storage_.bytes[i] = other.storage_.bytes[i];
+        }
+    }
+
+    void release() {
+        invoke_ = nullptr;
+        destroy_ = nullptr;
+    }
+
+    R (*invoke_)(Storage*, A...);
+    void (*destroy_)(Storage*);
+    Storage storage_;
+};
+
+} // namespace nros
+
+#endif // NROS_CPP_INPLACE_FN_HPP

--- a/packages/api/nros-cpp/include/nros/traits.hpp
+++ b/packages/api/nros-cpp/include/nros/traits.hpp
@@ -1,0 +1,144 @@
+// nros-cpp: the API's own minimal type traits
+// Freestanding C++ — no exceptions, no STL required
+
+/**
+ * @file traits.hpp
+ * @ingroup grp_support
+ * @brief `nros::tr` — the handful of traits this API needs, carried rather
+ *        than borrowed.
+ */
+
+#ifndef NROS_CPP_TRAITS_HPP
+#define NROS_CPP_TRAITS_HPP
+
+namespace nros {
+
+/// The API's own traits — RFC-0096 D3.
+///
+/// WHY THIS EXISTS RATHER THAN `#include <type_traits>`
+///
+/// A freestanding API cannot assume a standard-library shim's SHAPE, and this
+/// is not a hypothetical: the threadx-qemu-riscv64 board's `<type_traits>` was
+/// a 58-line stub with `enable_if`, `integral_constant` and `is_convertible`
+/// and nothing else, and its `remove_reference` lived in `<utility>`. A header
+/// that leans on `std::decay` there compiles on every host and fails on one
+/// cross build, which is the reach-narrower-than-the-rule shape this repo keeps
+/// paying for.
+///
+/// phase-442 W4 filled both shims in, and that fix is worth having on its own —
+/// but it is a fix to OUR shims, and the rule is about targets generally. An
+/// API whose metaprogramming depends on a shim is one board away from the same
+/// failure. So the traits live here, in our namespace, where their shape is a
+/// property of this repository.
+///
+/// The set is deliberately the minimum the two W3 mechanisms need, not a
+/// re-implementation of `<type_traits>`. A trait nothing here uses is not
+/// carried; add one when a mechanism needs it, with the mechanism.
+namespace tr {
+
+/// `sizeof`'s type, without `<cstddef>`. `__SIZE_TYPE__` is the compiler's own
+/// answer, which is what makes it right on a 32-bit target where a hand-written
+/// `unsigned long` is not (measured, phase-442 W0).
+using size_type = __SIZE_TYPE__;
+
+template <typename T, T V> struct integral_constant {
+    static constexpr T value = V;
+    using value_type = T;
+    using type = integral_constant;
+    constexpr operator value_type() const { return value; }
+};
+
+using true_type = integral_constant<bool, true>;
+using false_type = integral_constant<bool, false>;
+
+template <typename T, typename U> struct is_same : false_type {};
+template <typename T> struct is_same<T, T> : true_type {};
+
+template <bool B, typename T, typename F> struct conditional {
+    using type = T;
+};
+template <typename T, typename F> struct conditional<false, T, F> {
+    using type = F;
+};
+
+template <bool B, typename T = void> struct enable_if {};
+template <typename T> struct enable_if<true, T> {
+    using type = T;
+};
+
+template <typename T> struct remove_reference {
+    using type = T;
+};
+template <typename T> struct remove_reference<T&> {
+    using type = T;
+};
+template <typename T> struct remove_reference<T&&> {
+    using type = T;
+};
+
+template <typename T> struct remove_const {
+    using type = T;
+};
+template <typename T> struct remove_const<const T> {
+    using type = T;
+};
+
+template <typename T> struct remove_volatile {
+    using type = T;
+};
+template <typename T> struct remove_volatile<volatile T> {
+    using type = T;
+};
+
+template <typename T> struct remove_cv {
+    using type = typename remove_const<typename remove_volatile<T>::type>::type;
+};
+
+template <typename T> struct remove_extent {
+    using type = T;
+};
+template <typename T> struct remove_extent<T[]> {
+    using type = T;
+};
+template <typename T, size_type N> struct remove_extent<T[N]> {
+    using type = T;
+};
+
+template <typename T> struct is_array : false_type {};
+template <typename T> struct is_array<T[]> : true_type {};
+template <typename T, size_type N> struct is_array<T[N]> : true_type {};
+
+template <typename T> struct is_function : false_type {};
+template <typename R, typename... A> struct is_function<R(A...)> : true_type {};
+template <typename R, typename... A> struct is_function<R(A..., ...)> : true_type {};
+
+/// What a by-value parameter does to a type.
+///
+/// Written out rather than approximated as `remove_cv<remove_reference<T>>`,
+/// because the two differ exactly where a callback signature is most likely to
+/// be written — a function type, or an array — and an approximation that is
+/// right for scalars is the gap the ThreadX shim already had.
+template <typename T> struct decay {
+  private:
+    using U = typename remove_reference<T>::type;
+
+  public:
+    using type = typename conditional<
+        is_array<U>::value, typename remove_extent<U>::type*,
+        typename conditional<is_function<U>::value, typename remove_reference<U>::type*,
+                             typename remove_cv<U>::type>::type>::type;
+};
+
+/// `static_cast<T&&>`, without `<utility>`.
+///
+/// Named `forward_rvalue` rather than `move` on purpose: `nros::tr::move` beside
+/// a `using namespace std` would be an overload-resolution coin flip in a ported
+/// file, and this namespace is not a `std` replacement.
+template <typename T> constexpr typename remove_reference<T>::type&& forward_rvalue(T&& v) {
+    return static_cast<typename remove_reference<T>::type&&>(v);
+}
+
+} // namespace tr
+} // namespace nros
+
+#endif // NROS_CPP_TRAITS_HPP

--- a/packages/api/nros-cpp/tests/compile/freestanding_mechanisms.cpp
+++ b/packages/api/nros-cpp/tests/compile/freestanding_mechanisms.cpp
@@ -1,0 +1,74 @@
+// phase-442 W3 — the two freestanding mechanisms, compiled.
+//
+// RFC-0096 D2 says the two capabilities the census called "genuinely hard" —
+// shared-looking ownership and type-erased callbacks — have freestanding
+// answers. This is the translation unit that makes that a measurement rather
+// than a claim, and `check-cpp-freestanding-mechanisms` compiles it in all
+// three configurations this project ships: hosted, `arm-none-eabi
+// -ffreestanding`, and the ThreadX `-nostdinc++` shim.
+//
+// Its negative half is `freestanding_mechanisms_overbudget_probe.cpp`, which
+// must FAIL with a `static_assert` naming the capacity knob.
+
+#include "nros/traits.hpp"
+#include "nros/handle.hpp"
+#include "nros/inplace_fn.hpp"
+
+namespace tr = nros::tr;
+static_assert(tr::is_same<tr::decay<const int&>::type, int>::value, "decay cv-ref");
+static_assert(tr::is_same<tr::decay<int[4]>::type, int*>::value, "decay array");
+static_assert(tr::is_same<tr::decay<void(int)>::type, void (*)(int)>::value, "decay function");
+
+struct Msg {
+    int data;
+};
+struct Sub {
+    int n = 0;
+};
+
+static Sub g_sub;
+
+// Handle
+static_assert(sizeof(nros::Handle<Sub>) == sizeof(void*), "one pointer");
+static void handle_ops() {
+    nros::Handle<Sub> a;
+    nros::Handle<Sub> b(&g_sub);
+    nros::Handle<Sub> c = b;       // copyable
+    nros::Handle<const Sub> d = c; // converts to const
+    a = c;                         // assignable
+    (void)(a == b);
+    (void)(a != nullptr);
+    if (a) {
+        a->n = d->n;
+        (*a).n = 1;
+    }
+    a.reset();
+}
+
+// InplaceFn — the shapes W0 measured
+static int g_state;
+struct Obj {
+    void method(const Msg&);
+};
+static Obj g_obj;
+
+using Cb = nros::InplaceFn<void(const Msg&)>;
+
+static Cb c_empty([](const Msg&) {});
+static Cb c_this([sub = &g_sub](const Msg& m) { sub->n += m.data; });
+static Cb c_two([sub = &g_sub, st = &g_state](const Msg& m) { sub->n = *st + m.data; });
+static Cb c_obj_method([o = &g_obj, mp = &Obj::method](const Msg& m) { (o->*mp)(m); });
+
+extern "C" int nros_w3_probe(const Msg& m) {
+    handle_ops();
+    c_empty(m);
+    c_this(m);
+    c_two(m);
+    c_obj_method(m);
+    Cb moved(static_cast<Cb&&>(c_this));
+    if (moved.valid()) {
+        moved(m);
+    }
+    moved.clear();
+    return g_sub.n + static_cast<int>(moved.valid());
+}

--- a/packages/api/nros-cpp/tests/compile/freestanding_mechanisms_overbudget_probe.cpp
+++ b/packages/api/nros-cpp/tests/compile/freestanding_mechanisms_overbudget_probe.cpp
@@ -1,0 +1,32 @@
+// phase-442 W3 — EXPECTED-FAILURE probe: a capture larger than the budget.
+//
+// RFC-0096 D5 enumerates the three things that are not drop-in, and this is the
+// third: a lambda capture larger than the declared capacity. It must be a
+// COMPILE ERROR naming the knob, because the alternatives are a silent heap
+// fallback (which defeats the point on a target with no allocator) or a runtime
+// failure (which moves a compile-time fact to the field).
+//
+// `check-cpp-freestanding-mechanisms` compiles this and requires that it FAIL,
+// with `NROS_CPP_CALLBACK_CAPACITY` in the diagnostic. A probe nobody compiles
+// is a comment; a probe whose failure text is not checked passes on the wrong
+// error.
+
+#include "nros/inplace_fn.hpp"
+
+struct Msg {
+    int data;
+};
+
+// Six pointers of capture against a four-pointer budget.
+struct Wide {
+    void* a;
+    void* b;
+    void* c;
+    void* d;
+    void* e;
+    void* f;
+};
+
+static Wide g_wide;
+
+nros::InplaceFn<void(const Msg&)> g_over([w = g_wide](const Msg&) { (void)w; });

--- a/packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat/new
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat/new
@@ -15,36 +15,71 @@ inline const nothrow_t nothrow{};
 
 } // namespace std
 
-inline void *operator new(size_t size) noexcept(false) {
+inline void* operator new(size_t size) noexcept(false) {
     return nros_platform_alloc(size);
 }
 
-inline void *operator new[](size_t size) noexcept(false) {
+inline void* operator new[](size_t size) noexcept(false) {
     return nros_platform_alloc(size);
 }
 
-inline void *operator new(size_t size, const std::nothrow_t &) noexcept {
+inline void* operator new(size_t size, const std::nothrow_t&) noexcept {
     return nros_platform_alloc(size);
 }
 
-inline void *operator new[](size_t size, const std::nothrow_t &) noexcept {
+inline void* operator new[](size_t size, const std::nothrow_t&) noexcept {
     return nros_platform_alloc(size);
 }
 
-inline void operator delete(void *ptr) noexcept {
+inline void operator delete(void* ptr) noexcept {
     nros_platform_dealloc(ptr);
 }
 
-inline void operator delete[](void *ptr) noexcept {
+inline void operator delete[](void* ptr) noexcept {
     nros_platform_dealloc(ptr);
 }
 
-inline void operator delete(void *ptr, size_t) noexcept {
+inline void operator delete(void* ptr, size_t) noexcept {
     nros_platform_dealloc(ptr);
 }
 
-inline void operator delete[](void *ptr, size_t) noexcept {
+inline void operator delete[](void* ptr, size_t) noexcept {
     nros_platform_dealloc(ptr);
 }
+
+// The PLACEMENT forms. These are not a convenience: [new.delete.placement] puts
+// them in the freestanding subset of `<new>`, so a conforming freestanding
+// implementation has them and code targeting freestanding is entitled to assume
+// it. This shim did not, so placement new did not compile against it at all —
+// which is a trap for any in-place construction, and phase-442 W3's inplace
+// callable is exactly that.
+//
+// `size_t` rather than a hand-written width, deliberately. Declaring these with
+// the wrong first parameter type is accepted on a 64-bit target and REJECTED on
+// a 32-bit one:
+//
+//     error: 'operator new' takes type 'size_t' ('unsigned int')
+//            as first parameter
+//
+// so the mistake is right on two of this project's three toolchains and silently
+// wrong on the embedded one (measured, phase-442 W0). `<stddef.h>` above is what
+// makes `size_t` the implementation's own.
+//
+// They allocate nothing and do nothing, by definition: the caller supplies the
+// storage. The placement DELETES exist so that a constructor throwing during a
+// placement new has a matching deallocation function to unwind through; every
+// build here is `-fno-exceptions`, so they are never called, and their absence
+// would still be a diagnostic on any build that is not.
+inline void* operator new(size_t, void* place) noexcept {
+    return place;
+}
+
+inline void* operator new[](size_t, void* place) noexcept {
+    return place;
+}
+
+inline void operator delete(void*, void*) noexcept {}
+
+inline void operator delete[](void*, void*) noexcept {}
 
 #endif // NROS_THREADX_RISCV64_CXX_COMPAT_NEW

--- a/packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat/type_traits
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat/type_traits
@@ -3,10 +3,24 @@
 // The system `riscv64-unknown-elf-g++` + picolibc ships no C++ standard
 // library headers, so the freestanding nros-cpp build (`-ffreestanding`,
 // `-isystem .../cxx-compat`) has no `<type_traits>`. nros-cpp `node.hpp` pulls
-// it (Phase 189.M3.3.e — SFINAE on the callback-style `create_service`). Only
-// `std::enable_if` and `std::is_convertible` are used; provide exactly those
-// (+ the `integral_constant` base) with a version-portable SFINAE
-// `is_convertible` (no GCC `__is_convertible` builtin dependency).
+// it (Phase 189.M3.3.e — SFINAE on the callback-style `create_service`). It carries
+// `enable_if`, `is_convertible` and the `integral_constant` base with a
+// version-portable SFINAE `is_convertible` (no GCC `__is_convertible` builtin
+// dependency), plus the small set below.
+//
+// phase-442 W4 — `is_same`, `remove_cv`, `conditional`, `remove_reference` and
+// `decay` were MISSING, and their absence was a trap rather than a limit: a shim
+// that answers some trait queries and not others reads as a `<type_traits>`, and
+// the omission surfaces only on this one cross build. `remove_reference` was the
+// sharpest case — it existed, in `<utility>`, which is not where the standard
+// puts it, so a source including only `<type_traits>` found nothing. It is
+// defined HERE now, and `<utility>` includes this header rather than carrying a
+// second definition.
+//
+// This does not make the API depend on the shim: RFC-0096 D3 has nros-cpp carry
+// its own traits precisely because a freestanding API cannot assume a shim's
+// shape. The gaps are still worth closing, because the next person to reach for
+// `std::decay` on this target should get it rather than a puzzle.
 #ifndef NROS_THREADX_RISCV64_CXX_COMPAT_TYPE_TRAITS
 #define NROS_THREADX_RISCV64_CXX_COMPAT_TYPE_TRAITS
 
@@ -52,6 +66,115 @@ struct is_convertible<
 
 template <class From, class To>
 constexpr bool is_convertible_v = is_convertible<From, To>::value;
+
+template <class T, class U>
+struct is_same : false_type {};
+template <class T>
+struct is_same<T, T> : true_type {};
+template <class T, class U>
+constexpr bool is_same_v = is_same<T, U>::value;
+
+template <bool B, class T, class F>
+struct conditional {
+    using type = T;
+};
+template <class T, class F>
+struct conditional<false, T, F> {
+    using type = F;
+};
+template <bool B, class T, class F>
+using conditional_t = typename conditional<B, T, F>::type;
+
+template <class T>
+struct remove_reference {
+    using type = T;
+};
+template <class T>
+struct remove_reference<T&> {
+    using type = T;
+};
+template <class T>
+struct remove_reference<T&&> {
+    using type = T;
+};
+template <class T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+template <class T>
+struct remove_const {
+    using type = T;
+};
+template <class T>
+struct remove_const<const T> {
+    using type = T;
+};
+
+template <class T>
+struct remove_volatile {
+    using type = T;
+};
+template <class T>
+struct remove_volatile<volatile T> {
+    using type = T;
+};
+
+template <class T>
+struct remove_cv {
+    using type = typename remove_const<typename remove_volatile<T>::type>::type;
+};
+template <class T>
+using remove_cv_t = typename remove_cv<T>::type;
+
+template <class T>
+struct remove_extent {
+    using type = T;
+};
+template <class T>
+struct remove_extent<T[]> {
+    using type = T;
+};
+template <class T, decltype(sizeof(0)) N>
+struct remove_extent<T[N]> {
+    using type = T;
+};
+
+template <class T>
+struct is_array : false_type {};
+template <class T>
+struct is_array<T[]> : true_type {};
+template <class T, decltype(sizeof(0)) N>
+struct is_array<T[N]> : true_type {};
+
+template <class T>
+struct is_function : false_type {};
+template <class R, class... A>
+struct is_function<R(A...)> : true_type {};
+template <class R, class... A>
+struct is_function<R(A..., ...)> : true_type {};
+
+template <class T>
+struct add_pointer {
+    using type = typename remove_reference<T>::type*;
+};
+
+// `decay` -- the conversion a by-value parameter performs. Written out rather
+// than approximated as `remove_cv_t<remove_reference_t<T>>`, because the two
+// differ exactly where a callback signature is most likely to be written (a
+// function type, or an array), and an approximation that is right for scalars
+// is the kind of gap this header already had.
+template <class T>
+struct decay {
+  private:
+    using U = typename remove_reference<T>::type;
+
+  public:
+    using type = typename conditional<
+        is_array<U>::value, typename remove_extent<U>::type*,
+        typename conditional<is_function<U>::value, typename add_pointer<U>::type,
+                             typename remove_cv<U>::type>::type>::type;
+};
+template <class T>
+using decay_t = typename decay<T>::type;
 
 }  // namespace std
 

--- a/packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat/utility
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat/utility
@@ -1,22 +1,13 @@
 #ifndef NROS_THREADX_RISCV64_CXX_COMPAT_UTILITY
 #define NROS_THREADX_RISCV64_CXX_COMPAT_UTILITY
 
+// phase-442 W4 — `remove_reference` used to be DEFINED here, which is not where
+// the standard puts it: a source including only `<type_traits>` found nothing.
+// It lives in `<type_traits>` now and this header consumes it, so there is one
+// definition and it is in the right place.
+#include <type_traits>
+
 namespace std {
-
-template <class T>
-struct remove_reference {
-    using type = T;
-};
-
-template <class T>
-struct remove_reference<T&> {
-    using type = T;
-};
-
-template <class T>
-struct remove_reference<T&&> {
-    using type = T;
-};
 
 template <class T>
 constexpr typename remove_reference<T>::type&& move(T&& value) noexcept {

--- a/scripts/check-cpp-freestanding-mechanisms.py
+++ b/scripts/check-cpp-freestanding-mechanisms.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""The two freestanding mechanisms compile on every toolchain we ship — phase-442 W3.
+
+WHAT IS BEING MEASURED
+
+RFC-0096's claim is that one API can be freestanding AND be the rclcpp API, and
+it rests on two mechanisms: a copyable non-owning handle behind `X::SharedPtr`,
+and a fixed-capacity inplace callable behind a capturing-lambda callback. A
+claim like that is worth exactly the compile that backs it, on the toolchains
+that actually differ.
+
+Three configurations, because each removes something different:
+
+  hosted `g++ -std=c++17`                    the reference
+  `arm-none-eabi -std=c++14 -ffreestanding`  no hosted library, 32-BIT
+  ThreadX shim, `-nostdinc++`                our own minimal `<new>`/traits
+
+The 32-bit arm is not redundant with the other two. Every capture size, the
+capacity default and the storage alignment are expressed in pointers precisely
+because a byte count is right on one word size and wrong on the other
+(phase-442 W0), and only this arm can catch a regression to a literal.
+
+THE NEGATIVE CONTROL IS THE POINT, NOT A FORMALITY
+
+An over-budget capture must be a COMPILE ERROR NAMING THE KNOB. That is the
+third item in RFC-0096 D5's list of what is not drop-in, and the design's whole
+answer to "what if a capture does not fit": not a silent heap fallback, which
+defeats the point on a target with no allocator, and not a runtime failure,
+which moves a compile-time fact to the field.
+
+So the probe must fail, and the DIAGNOSTIC TEXT is checked too. A probe that
+merely fails passes on any error — a typo, a missing header, a renamed type —
+and would go on "passing" after the `static_assert` it exists for was deleted.
+
+WHY THIS IS A FAST-LANE GATE AND NOT PART OF `check cpp`
+
+`check cpp` is `build-serial`, which no merge-gating event runs, so a gate
+living there gates nothing — issue 1225 moved `check-cpp-capability-layout` out
+for exactly this reason and named it. This needs no build: three `-fsyntax-only`
+compiles of one tracked TU.
+
+Usage::
+
+    check-cpp-freestanding-mechanisms.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+PROBE = "packages/api/nros-cpp/tests/compile/freestanding_mechanisms.cpp"
+OVERBUDGET = "packages/api/nros-cpp/tests/compile/freestanding_mechanisms_overbudget_probe.cpp"
+KNOB = "NROS_CPP_CALLBACK_CAPACITY"
+
+CPP_INCLUDE = "packages/api/nros-cpp/include"
+PLATFORM_API = "packages/platform/nros-platform-api/include"
+THREADX_SHIM = "packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat"
+
+ARM_GXX = os.path.expanduser(
+    "~/.nros/sdk/arm-none-eabi-gcc/13.2-nros1/bin/arm-none-eabi-g++")
+
+
+def arms():
+    """(label, argv-prefix, required). A cross arm absent from this host is a
+    reported SKIP, never a silent pass: the whole point of the arm is that it
+    differs from the host, so "the host compiler was used instead" answers a
+    different question."""
+    out = [("hosted g++ -std=c++17",
+            ["c++", "-std=c++17", "-fsyntax-only"], True)]
+
+    arm = ARM_GXX if os.path.exists(ARM_GXX) else shutil.which("arm-none-eabi-g++")
+    if arm:
+        out.append(("arm-none-eabi -std=c++14 -ffreestanding (32-bit)",
+                    [arm, "-std=c++14", "-ffreestanding", "-fno-exceptions", "-fno-rtti",
+                     "-mcpu=cortex-m3", "-mthumb", "-fsyntax-only"], True))
+    else:
+        out.append(("arm-none-eabi (32-bit)", None, False))
+
+    rv = shutil.which("riscv64-unknown-elf-g++") or "c++"
+    out.append(("ThreadX shim -nostdinc++",
+                [rv, "-std=c++14", "-ffreestanding", "-fno-exceptions", "-fno-rtti",
+                 "-nostdinc++", "-isystem", os.path.join(ROOT, THREADX_SHIM),
+                 "-I", os.path.join(ROOT, PLATFORM_API), "-fsyntax-only"], True))
+    return out
+
+
+def compile_tu(argv, tu):
+    cmd = list(argv) + ["-I", os.path.join(ROOT, CPP_INCLUDE), os.path.join(ROOT, tu)]
+    proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def selftest(arm_label, argv):
+    """The over-budget capture must FAIL, and fail for the stated reason.
+
+    Runs on the NORMAL path, every invocation (phase-395). Returns a list of
+    failures, empty when the probe was rejected with the knob named.
+    """
+    failures = []
+    rc, out = compile_tu(argv, OVERBUDGET)
+    if rc == 0:
+        failures.append(
+            "SELFTEST FAILED on %s: the over-budget capture COMPILED. The capacity "
+            "`static_assert` is not firing, so an over-large capture would be a silent "
+            "heap-free overwrite or a link-time surprise instead of a compile error." % arm_label)
+    elif KNOB not in out:
+        failures.append(
+            "SELFTEST FAILED on %s: the over-budget capture failed, but the diagnostic does "
+            "not name `%s`, so the failure is not the one this probe exists for. A probe "
+            "that merely fails passes on a typo.\n%s" % (arm_label, KNOB, out.strip()[:800]))
+    return failures
+
+
+def main():
+    for rel in (PROBE, OVERBUDGET):
+        if not os.path.exists(os.path.join(ROOT, rel)):
+            print("check-cpp-freestanding-mechanisms: %s is MISSING -- this gate would pass "
+                  "on absence" % rel, file=sys.stderr)
+            return 1
+
+    failures = []
+    ran = 0
+    for label, argv, _required in arms():
+        if argv is None:
+            print("check-cpp-freestanding-mechanisms: %s SKIPPED -- toolchain absent" % label)
+            ledger = os.environ.get("NROS_CHECK_SKIP_LEDGER")
+            if ledger:
+                with open(ledger, "a", encoding="utf8") as fh:
+                    fh.write("check-cpp-freestanding-mechanisms: %s: toolchain absent\n" % label)
+            continue
+
+        rc, out = compile_tu(argv, PROBE)
+        ran += 1
+        if rc != 0:
+            failures.append("%s: the mechanisms do NOT compile.\n%s" % (label, out.strip()))
+            continue
+        failures.extend(selftest(label, argv))
+
+    if failures:
+        print("", file=sys.stderr)
+        for f in failures:
+            print("FAIL: %s" % f, file=sys.stderr)
+        print("\nRFC-0096 rests on these two mechanisms being constructible without the "
+              "standard library. The probe is %s; its expected-failure half is %s."
+              % (PROBE, OVERBUDGET), file=sys.stderr)
+        return 1
+
+    print("check-cpp-freestanding-mechanisms: OK -- the handle and the inplace callable compile "
+          "on %d toolchain configuration(s), and an over-budget capture fails on each with a "
+          "diagnostic naming %s" % (ran, KNOB))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-cxx-compat-shim-facilities.py
+++ b/scripts/check-cxx-compat-shim-facilities.py
@@ -65,6 +65,8 @@ THREADX_SHIM = "packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat"
 ZEPHYR_SHIM = "zephyr/cxx-compat"
 ZEPHYR_MINIMAL = "zephyr-workspace/zephyr/lib/cpp/minimal/include"
 PLATFORM_API = "packages/platform/nros-platform-api/include"
+CPP_INCLUDE = "packages/api/nros-cpp/include"
+C_INCLUDE = "packages/api/nros-c/include"
 
 # The probe. Every assertion here is a facility the standard puts in the
 # freestanding subset, or a trait phase-442 W3's inplace callable and handle
@@ -108,6 +110,23 @@ extern "C" int nros_shim_facilities_probe() {
 }
 """
 
+# The CONSUMER probe. The synthetic probe above asks whether the shim supplies a
+# facility; this asks whether our own header that USES that facility still
+# compiles against it. The two are not the same question, and the gap between
+# them is measured rather than hypothetical: `component.hpp` carried its own
+# hand-rolled placement `operator new` behind Zephyr's include guard, so the
+# moment `zephyr/cxx-compat/new` supplied the real ones the two collided —
+#
+#     component.hpp:501: error: redefinition of 'void* operator new(size_t, void*)'
+#
+# — on every Zephyr C++ component build, while the synthetic probe stayed green.
+# `component.hpp` is the header whose factory uses placement new, so it is the
+# one this compiles.
+CONSUMER_PROBE = """
+#define __ZEPHYR__ 1
+#include <nros/component.hpp>
+"""
+
 # (label, compiler, extra include dirs beyond the shim). The ThreadX board is
 # built with `riscv64-unknown-elf-g++` (`cmake/toolchain/riscv64-threadx.cmake`);
 # the host `c++` is used where the cross compiler is absent, which still answers
@@ -126,14 +145,17 @@ def first_available(candidates):
     return None
 
 
-def compile_probe(cc, shim, extra_includes, workdir):
-    src = os.path.join(workdir, "shim_facilities_probe.cpp")
+def compile_probe(cc, shim, extra_includes, workdir, source=None, name="shim_facilities_probe"):
+    src = os.path.join(workdir, name + ".cpp")
     with open(src, "w", encoding="utf8") as fh:
-        fh.write(PROBE)
+        fh.write(PROBE if source is None else source)
     cmd = [cc] + FLAGS + ["-isystem", shim]
     for inc in extra_includes:
         cmd += ["-isystem", inc]
-    cmd += ["-I", os.path.join(ROOT, PLATFORM_API), src]
+    cmd += ["-I", os.path.join(ROOT, PLATFORM_API),
+            "-I", os.path.join(ROOT, CPP_INCLUDE),
+            "-I", os.path.join(ROOT, C_INCLUDE),
+            "-DNROS_PLATFORM_NUTTX", src]
     proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
     return proc.returncode, proc.stdout + proc.stderr
 
@@ -234,13 +256,24 @@ def main():
 
         zephyr_min = os.path.join(ROOT, ZEPHYR_MINIMAL)
         if os.path.isdir(zephyr_min):
-            rc, out = compile_probe(first_available(ZEPHYR_CC),
-                                    os.path.join(ROOT, ZEPHYR_SHIM), [zephyr_min], workdir)
+            zcc = first_available(ZEPHYR_CC)
+            zshim = os.path.join(ROOT, ZEPHYR_SHIM)
+            rc, out = compile_probe(zcc, zshim, [zephyr_min], workdir)
             if rc != 0:
                 failures.append("Zephyr shim over the minimal libcpp: the freestanding "
                                 "facility probe does NOT compile.\n%s" % out.strip())
             else:
                 notes.append("Zephyr shim + minimal libcpp: probe compiles")
+            rc, out = compile_probe(zcc, zshim, [zephyr_min], workdir,
+                                    source=CONSUMER_PROBE, name="consumer_probe")
+            if rc != 0:
+                failures.append("Zephyr shim over the minimal libcpp: `nros/component.hpp` -- "
+                                "the header whose factory USES placement new -- does NOT "
+                                "compile against it. A shim that supplies a facility our own "
+                                "header also supplies is a REDEFINITION, not a fix.\n%s"
+                                % out.strip())
+            else:
+                notes.append("Zephyr shim + minimal libcpp: nros/component.hpp compiles")
         else:
             notes.append("Zephyr arm SKIPPED: %s absent (west workspace not checked out)"
                          % ZEPHYR_MINIMAL)

--- a/scripts/check-cxx-compat-shim-facilities.py
+++ b/scripts/check-cxx-compat-shim-facilities.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Each `cxx-compat/` shim supplies the freestanding facilities our code is entitled to.
+
+THE SIBLING GATE ANSWERS A DIFFERENT QUESTION
+
+`check-cxx-compat-shim-coverage.py` asks whether every `std::` C-LIBRARY name a
+served source spells is exported — `memchr`, `abort`, `snprintf`. It harvests
+uses from sources and exports from the shim, which is right for a set that
+grows one name at a time as code is written.
+
+This gate asks the other half: whether the shim supplies what the LANGUAGE
+guarantees on a freestanding implementation, whether or not any source spells it
+today. Those two sets fail differently. A missing `memchr` is caught by the
+first line of code that wants it. A missing placement `operator new` is caught
+by the first line of code that wants it too — but the code that wants it is
+written months later, against a header that looks complete, and the error
+arrives on a cross build nobody runs per-push. `[new.delete.placement]` puts
+those forms in the freestanding subset of `<new>`, so a freestanding target is
+entitled to them and neither shim had them.
+
+WHAT IT MEASURES
+
+One probe translation unit, compiled against each shim exactly as that target's
+build reaches it (`-nostdinc++`, freestanding, the shim first on the include
+path). Not a text scan of the shim: a trait can be present and wrong, and
+`decay` in particular is easy to write as `remove_cv_t<remove_reference_t<T>>`,
+which is correct for scalars and wrong for exactly the function and array types
+a callback signature is written with. The probe `static_assert`s the answers.
+
+THE NEGATIVE CONTROLS RUN EVERY TIME
+
+Two, on the normal path (phase-395): the probe is re-compiled against a COPY of
+the ThreadX shim with the placement forms removed, and against a copy with
+`decay` removed. Both must FAIL. A gate that compiles a probe is otherwise
+indistinguishable from a gate whose probe compiles against anything.
+
+WHY BOTH SHIMS, AND WHY THE ZEPHYR ONE CAN SKIP
+
+`zephyr/cxx-compat` and the threadx-qemu-riscv64 board shim are one
+implementation under two names — the Zephyr header says so in its own comment,
+"Mirrors the threadx-qemu-riscv64 board shim" — so a facility added to one and
+not the other is a difference between two boards that nothing measures. The
+Zephyr arm layers over Zephyr's own minimal libcpp, which lives in the west
+workspace; when that workspace is not checked out the arm is reported as a SKIP
+through the `nros_check_skip` ledger rather than passing quietly, because a skip
+that reads like a pass is how the gap being fixed here survived.
+
+Usage::
+
+    check-cxx-compat-shim-facilities.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+THREADX_SHIM = "packages/boards/nros-board-threadx-qemu-riscv64/cxx-compat"
+ZEPHYR_SHIM = "zephyr/cxx-compat"
+ZEPHYR_MINIMAL = "zephyr-workspace/zephyr/lib/cpp/minimal/include"
+PLATFORM_API = "packages/platform/nros-platform-api/include"
+
+# The probe. Every assertion here is a facility the standard puts in the
+# freestanding subset, or a trait phase-442 W3's inplace callable and handle
+# need in order to be written without leaning on the shim's shape (RFC-0096 D3
+# says the API carries its own; this says the shim should still be honest).
+PROBE = r"""
+#include <new>
+#include <type_traits>
+#include <utility>
+
+struct Cell {
+    int v;
+    explicit Cell(int x) : v(x) {}
+};
+
+// [new.delete.placement] -- freestanding-guaranteed.
+alignas(Cell) static unsigned char storage[sizeof(Cell)];
+static Cell* make() { return new (static_cast<void*>(storage)) Cell(7); }
+
+static_assert(std::is_same<int, int>::value, "is_same");
+static_assert(!std::is_same<int, long>::value, "is_same discriminates");
+static_assert(std::is_same<std::remove_reference<int&>::type, int>::value, "remove_reference");
+static_assert(std::is_same<std::remove_cv<const volatile int>::type, int>::value, "remove_cv");
+static_assert(std::is_same<std::conditional<true, int, long>::type, int>::value, "conditional");
+
+// `decay`, at the three shapes that separate it from
+// `remove_cv_t<remove_reference_t<T>>`.
+static_assert(std::is_same<std::decay<const int&>::type, int>::value, "decay strips cv-ref");
+static_assert(std::is_same<std::decay<int[4]>::type, int*>::value, "decay array-to-pointer");
+static_assert(std::is_same<std::decay<void(int)>::type, void (*)(int)>::value,
+              "decay function-to-pointer");
+
+// The two the shims already had, so a widening cannot quietly drop them.
+static_assert(std::is_convertible<int, long>::value, "is_convertible");
+static_assert(std::enable_if<true, int>::type(0) == 0, "enable_if");
+
+extern "C" int nros_shim_facilities_probe() {
+    int a = 1;
+    int b = static_cast<int>(std::move(a)); // <utility> still provides move
+    return make()->v + b;
+}
+"""
+
+# (label, compiler, extra include dirs beyond the shim). The ThreadX board is
+# built with `riscv64-unknown-elf-g++` (`cmake/toolchain/riscv64-threadx.cmake`);
+# the host `c++` is used where the cross compiler is absent, which still answers
+# the question this gate asks, because every facility here is language-level.
+THREADX_CC = ["riscv64-unknown-elf-g++", "c++"]
+ZEPHYR_CC = ["c++"]
+
+FLAGS = ["-fsyntax-only", "-std=c++14", "-fno-exceptions", "-fno-rtti", "-ffreestanding",
+         "-nostdinc++"]
+
+
+def first_available(candidates):
+    for c in candidates:
+        if shutil.which(c):
+            return c
+    return None
+
+
+def compile_probe(cc, shim, extra_includes, workdir):
+    src = os.path.join(workdir, "shim_facilities_probe.cpp")
+    with open(src, "w", encoding="utf8") as fh:
+        fh.write(PROBE)
+    cmd = [cc] + FLAGS + ["-isystem", shim]
+    for inc in extra_includes:
+        cmd += ["-isystem", inc]
+    cmd += ["-I", os.path.join(ROOT, PLATFORM_API), src]
+    proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def mutate(shim, workdir, name, drop):
+    """A copy of `shim` with `drop(text)` applied to one header."""
+    dst = os.path.join(workdir, name)
+    shutil.copytree(os.path.join(ROOT, shim), dst)
+    header, transform = drop
+    path = os.path.join(dst, header)
+    with open(path, encoding="utf8") as fh:
+        text = fh.read()
+    new_text = transform(text)
+    if new_text == text:
+        return None  # the mutation did not apply -- caller reports it
+    with open(path, "w", encoding="utf8") as fh:
+        fh.write(new_text)
+    return dst
+
+
+def drop_placement_new(text):
+    """Delete the scalar placement `operator new`, whatever its formatting.
+
+    Matched by SIGNATURE and cut to the closing brace rather than by an exact
+    block of text: `clang-format` reflowed this header once and a literal
+    three-line marker stopped matching, which the gate correctly reported as a
+    BROKEN selftest rather than a pass. A mutation that silently stops applying
+    is a control that proves nothing.
+    """
+    sig = re.compile(r"^inline void\s*\*\s*operator new\(\s*size_t\s*,[^)]*\)[^{]*\{", re.M)
+    m = sig.search(text)
+    if m is None:
+        return text
+    end = text.index("\n}", m.end()) + len("\n}\n")
+    return text[:m.start()] + text[end:]
+
+
+def drop_decay(text):
+    start = text.find("template <class T>\nstruct decay {")
+    if start < 0:
+        return text
+    end = text.find("using decay_t", start)
+    if end < 0:
+        return text
+    end = text.find("\n", text.find(";", end)) + 1
+    return text[:start] + text[end:]
+
+
+def selftest(cc, workdir):
+    """Both gaps this gate exists for, re-introduced into a COPY of the shim.
+
+    Runs on the NORMAL path, every invocation (phase-395): a gate that compiles
+    a probe is otherwise indistinguishable from a gate whose probe compiles
+    against anything. Returns the list of failures, empty when both mutants were
+    correctly rejected.
+    """
+    failures = []
+    for label, header, transform in (
+        ("placement operator new removed", "new", drop_placement_new),
+        ("std::decay removed", "type_traits", drop_decay),
+    ):
+        mutated = mutate(THREADX_SHIM, workdir, "mutant_" + header, (header, transform))
+        if mutated is None:
+            failures.append("SELFTEST BROKEN: the '%s' mutation changed nothing, so the "
+                            "control proves nothing. The shim's text moved; update the "
+                            "mutation." % label)
+            continue
+        rc, _out = compile_probe(cc, mutated, [], workdir)
+        if rc == 0:
+            failures.append("SELFTEST FAILED: with %s the probe still COMPILED, so this gate "
+                            "cannot detect that gap." % label)
+    return failures
+
+
+def main():
+    failures = []
+    notes = []
+
+    threadx_cc = first_available(THREADX_CC)
+    if threadx_cc is None:
+        print("check-cxx-compat-shim-facilities: no C++ compiler found", file=sys.stderr)
+        return 1
+
+    shim_path = os.path.join(ROOT, THREADX_SHIM)
+    if not os.path.isdir(shim_path):
+        print("check-cxx-compat-shim-facilities: %s is MISSING -- this gate would pass on "
+              "absence" % THREADX_SHIM, file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory() as workdir:
+        # --- the measurement -------------------------------------------------
+        rc, out = compile_probe(threadx_cc, shim_path, [], workdir)
+        if rc != 0:
+            failures.append("ThreadX shim (%s): the freestanding facility probe does NOT "
+                            "compile.\n%s" % (threadx_cc, out.strip()))
+        else:
+            notes.append("ThreadX shim: probe compiles (%s)" % threadx_cc)
+
+        zephyr_min = os.path.join(ROOT, ZEPHYR_MINIMAL)
+        if os.path.isdir(zephyr_min):
+            rc, out = compile_probe(first_available(ZEPHYR_CC),
+                                    os.path.join(ROOT, ZEPHYR_SHIM), [zephyr_min], workdir)
+            if rc != 0:
+                failures.append("Zephyr shim over the minimal libcpp: the freestanding "
+                                "facility probe does NOT compile.\n%s" % out.strip())
+            else:
+                notes.append("Zephyr shim + minimal libcpp: probe compiles")
+        else:
+            notes.append("Zephyr arm SKIPPED: %s absent (west workspace not checked out)"
+                         % ZEPHYR_MINIMAL)
+            skip_ledger = os.environ.get("NROS_CHECK_SKIP_LEDGER")
+            if skip_ledger:
+                with open(skip_ledger, "a", encoding="utf8") as fh:
+                    fh.write("check-cxx-compat-shim-facilities: zephyr arm: %s absent\n"
+                             % ZEPHYR_MINIMAL)
+
+        # --- the negative controls, on the normal path -----------------------
+        failures.extend(selftest(threadx_cc, workdir))
+
+    for n in notes:
+        print("check-cxx-compat-shim-facilities: %s" % n)
+    if failures:
+        print("", file=sys.stderr)
+        for f in failures:
+            print("FAIL: %s" % f, file=sys.stderr)
+        print("\nA `cxx-compat/` shim IS the C++ library of the target it serves. A facility "
+              "the standard guarantees on a freestanding implementation must be there whether "
+              "or not any source spells it today -- the code that needs it is written later, "
+              "against a header that looks complete.", file=sys.stderr)
+        return 1
+
+    print("check-cxx-compat-shim-facilities: OK -- freestanding <new> placement forms and the "
+          "trait set both shims must carry, measured by compiling a probe, with 2 negative "
+          "control(s) that ran and failed as required")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr/cxx-compat/new
+++ b/zephyr/cxx-compat/new
@@ -1,0 +1,60 @@
+// `<new>`'s PLACEMENT forms for the nano-ros Zephyr module.
+//
+// Zephyr's minimal libcpp ships a `<new>`
+// (`zephyr/lib/cpp/minimal/include/new`) that is, in its own words, a "stub
+// header allowing compilation of `#include <new>`": it declares `nothrow_t`,
+// `nothrow` and `align_val_t` and NOTHING else. No allocation forms, and — the
+// part that matters here — no placement forms.
+//
+// [new.delete.placement] puts those in the FREESTANDING subset of `<new>`, so
+// code targeting freestanding is entitled to assume them, and a Zephyr C++
+// build could not do placement new at all. Same gap as the threadx-qemu-riscv64
+// board shim had (phase-442 W4); both are fixed together, because one fixed and
+// one not is a difference between two boards that nothing measures.
+//
+// Layered, not substituted: this defers to whatever real `<new>` is reachable
+// and only fills the gap when the header that answered was not a standard
+// library's. Defining these over a libstdc++ or libc++ that already defines
+// them would be a replacement the standard forbids, so the guard is on the
+// library's own version macro rather than on a probe of our own.
+#ifndef NROS_ZEPHYR_CXX_COMPAT_NEW
+#define NROS_ZEPHYR_CXX_COMPAT_NEW
+
+#if defined(__has_include_next) && __has_include_next(<new>)
+#include_next <new>
+#endif
+
+#include <cstddef>
+
+#if !defined(__GLIBCXX__) && !defined(_LIBCPP_VERSION)
+
+// `std::size_t` rather than a hand-written width. Declaring these with the
+// wrong first parameter type is accepted on a 64-bit target and REJECTED on a
+// 32-bit one —
+//
+//     error: 'operator new' takes type 'size_t' ('unsigned int')
+//            as first parameter
+//
+// so the mistake is right on two of this project's three toolchains and
+// silently wrong on the embedded one (measured, phase-442 W0).
+//
+// They allocate nothing: the caller supplies the storage. The placement
+// DELETES exist so a constructor that throws during a placement new has a
+// matching deallocation function to unwind through; every build here is
+// `-fno-exceptions`, so they are never called, and their absence would still be
+// a diagnostic on a build that is not.
+inline void* operator new(std::size_t, void* place) noexcept {
+    return place;
+}
+
+inline void* operator new[](std::size_t, void* place) noexcept {
+    return place;
+}
+
+inline void operator delete(void*, void*) noexcept {}
+
+inline void operator delete[](void*, void*) noexcept {}
+
+#endif // no standard library <new> answered
+
+#endif // NROS_ZEPHYR_CXX_COMPAT_NEW

--- a/zephyr/cxx-compat/type_traits
+++ b/zephyr/cxx-compat/type_traits
@@ -5,10 +5,13 @@
 // the include path via `zephyr_include_directories`, alongside the `<cstdint>` /
 // `<utility>` / `<cstdlib>` shims) has no `<type_traits>`. nros-cpp `node.hpp`
 // pulls it (Phase 189.M3.3.e — SFINAE on the callback-style `create_service`).
-// Only `std::enable_if` and `std::is_convertible` are used; provide exactly
-// those (+ the `integral_constant` base) with a version-portable SFINAE
-// `is_convertible` (no GCC `__is_convertible` builtin dependency). Mirrors the
-// threadx-qemu-riscv64 board shim.
+// It carries `enable_if`, `is_convertible` and the `integral_constant` base with
+// a version-portable SFINAE `is_convertible` (no GCC `__is_convertible` builtin
+// dependency), plus the set phase-442 W4 added. Mirrors the
+// threadx-qemu-riscv64 board shim, and the mirroring is the point: the two
+// fallbacks are one implementation under two names, so a trait added to one and
+// not the other is a difference between two boards that nothing measures. The
+// ThreadX copy carries the argument for each addition.
 // Defer to the toolchain's real <type_traits> when reachable; else the minimal shim.
 #if defined(__has_include_next) && __has_include_next(<type_traits>)
 #  include_next <type_traits>
@@ -57,6 +60,115 @@ struct is_convertible<
 
 template <class From, class To>
 constexpr bool is_convertible_v = is_convertible<From, To>::value;
+
+template <class T, class U>
+struct is_same : false_type {};
+template <class T>
+struct is_same<T, T> : true_type {};
+template <class T, class U>
+constexpr bool is_same_v = is_same<T, U>::value;
+
+template <bool B, class T, class F>
+struct conditional {
+    using type = T;
+};
+template <class T, class F>
+struct conditional<false, T, F> {
+    using type = F;
+};
+template <bool B, class T, class F>
+using conditional_t = typename conditional<B, T, F>::type;
+
+template <class T>
+struct remove_reference {
+    using type = T;
+};
+template <class T>
+struct remove_reference<T&> {
+    using type = T;
+};
+template <class T>
+struct remove_reference<T&&> {
+    using type = T;
+};
+template <class T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+template <class T>
+struct remove_const {
+    using type = T;
+};
+template <class T>
+struct remove_const<const T> {
+    using type = T;
+};
+
+template <class T>
+struct remove_volatile {
+    using type = T;
+};
+template <class T>
+struct remove_volatile<volatile T> {
+    using type = T;
+};
+
+template <class T>
+struct remove_cv {
+    using type = typename remove_const<typename remove_volatile<T>::type>::type;
+};
+template <class T>
+using remove_cv_t = typename remove_cv<T>::type;
+
+template <class T>
+struct remove_extent {
+    using type = T;
+};
+template <class T>
+struct remove_extent<T[]> {
+    using type = T;
+};
+template <class T, decltype(sizeof(0)) N>
+struct remove_extent<T[N]> {
+    using type = T;
+};
+
+template <class T>
+struct is_array : false_type {};
+template <class T>
+struct is_array<T[]> : true_type {};
+template <class T, decltype(sizeof(0)) N>
+struct is_array<T[N]> : true_type {};
+
+template <class T>
+struct is_function : false_type {};
+template <class R, class... A>
+struct is_function<R(A...)> : true_type {};
+template <class R, class... A>
+struct is_function<R(A..., ...)> : true_type {};
+
+template <class T>
+struct add_pointer {
+    using type = typename remove_reference<T>::type*;
+};
+
+// `decay` -- the conversion a by-value parameter performs. Written out rather
+// than approximated as `remove_cv_t<remove_reference_t<T>>`, because the two
+// differ exactly where a callback signature is most likely to be written (a
+// function type, or an array), and an approximation that is right for scalars
+// is the kind of gap this header already had.
+template <class T>
+struct decay {
+  private:
+    using U = typename remove_reference<T>::type;
+
+  public:
+    using type = typename conditional<
+        is_array<U>::value, typename remove_extent<U>::type*,
+        typename conditional<is_function<U>::value, typename add_pointer<U>::type,
+                             typename remove_cv<U>::type>::type>::type;
+};
+template <class T>
+using decay_t = typename decay<T>::type;
 
 }  // namespace std
 

--- a/zephyr/cxx-compat/utility
+++ b/zephyr/cxx-compat/utility
@@ -4,22 +4,13 @@
 #elif !defined(NROS_ZEPHYR_CXX_COMPAT_UTILITY)
 #define NROS_ZEPHYR_CXX_COMPAT_UTILITY
 
+// phase-442 W4 — `remove_reference` used to be DEFINED here, which is not where
+// the standard puts it: a source including only `<type_traits>` found nothing.
+// It lives in `<type_traits>` now and this header consumes it, so there is one
+// definition and it is in the right place. Same change as the ThreadX shim.
+#include <type_traits>
+
 namespace std {
-
-template <class T>
-struct remove_reference {
-    using type = T;
-};
-
-template <class T>
-struct remove_reference<T&> {
-    using type = T;
-};
-
-template <class T>
-struct remove_reference<T&&> {
-    using type = T;
-};
 
 template <class T>
 constexpr typename remove_reference<T>::type&& move(T&& value) noexcept {


### PR DESCRIPTION
Phase-442 W4 and W3 — the shims get what the language guarantees, and
RFC-0096's two mechanisms exist. Two commits, each independently green.

Sibling of #963 (W0/W1/W2), based on `main` rather than stacked on it: neither
commit here depends on those, and a stacked PR cannot arm auto-merge.

## W4 — the freestanding shims get placement new and the missing traits

A `cxx-compat/` shim IS the C++ library of the target it serves. Two of them
answered some of what the language guarantees freestanding and not the rest,
which reads as a complete header and fails months later on a cross build nobody
runs per-push.

**Placement new was missing on three sites, not two.**
`[new.delete.placement]` puts the placement forms in the FREESTANDING subset of
`<new>`, so code targeting freestanding is entitled to them. The
threadx-qemu-riscv64 shim had the allocating forms and not these. Measuring the
Zephyr side found the third: Zephyr's own minimal libcpp `<new>` is, in its own
words, a "stub header allowing compilation of `#include <new>`" — `nothrow_t`,
`nothrow`, `align_val_t`, nothing else. So a Zephyr C++ build could not do
placement new either. `zephyr/cxx-compat/new` supplies the forms, layered rather
than substituted: `include_next` first, definitions only when no standard
library answered, guarded on `__GLIBCXX__` / `_LIBCPP_VERSION`, because defining
these over a library that already defines them is a replacement the standard
forbids.

`size_t` rather than a hand-written width, and the reason is measured:
`operator new(unsigned long, void*)` is accepted on x86_64 and riscv64 and
REJECTED on cortex-m3 — *"'operator new' takes type 'size_t' ('unsigned int') as
first parameter"* — so the obvious hand-rolled form is right on two of this
project's three toolchains and silently wrong on the embedded one.

**`<type_traits>` had neither `is_same` nor `decay`.** A 58-line stub with
`enable_if`, `integral_constant` and `is_convertible`. It gains `is_same`,
`conditional`, `remove_cv` and its halves, `remove_extent`, `is_array`,
`is_function`, `add_pointer`, `decay` and the `_t` aliases. `decay` is written
out rather than approximated as `remove_cv_t<remove_reference_t<T>>`, because
the two differ exactly at the function and array types a callback signature uses.

`remove_reference` was the sharpest case because it EXISTED — in `<utility>`,
which is not where the standard puts it, so a source including only
`<type_traits>` found nothing. It moves, and `<utility>` includes that header.

**Mirrored, because the two shims are one implementation.**
`zephyr/cxx-compat/type_traits` says so itself ("Mirrors the
threadx-qemu-riscv64 board shim") and its fallback carried the same gaps. Fixing
one and not the other leaves a difference between two boards that nothing
measures. The added block is byte-identical in both.

**Gated:** `check-cxx-compat-shim-facilities`, fast line. Its sibling
`cxx-compat-shim-coverage` harvests `std::` C-library names from SOURCES, so it
can only see a facility someone has already written code against — which is why
it never saw this. The new gate asks whether the shim supplies what the LANGUAGE
guarantees, MEASURES by compiling a probe rather than scanning text (a trait can
be present and wrong), and runs two negative controls on the normal path.

One of those controls immediately earned its keep: `clang-format` reflowed the
ThreadX `<new>`, the mutation's exact-text match stopped applying, and the gate
reported SELFTEST BROKEN rather than passing. It matches by signature now.

## W3 — the two freestanding mechanisms

**`nros::Handle<T>`** — what `X::SharedPtr` is on every target. One pointer,
copyable, `->`, `*`, null comparisons, `Handle<T>` → `Handle<const T>`,
`explicit operator bool`. No control block, no atomics, no allocation.

The decisive measurement (from #963's W0) is that shared ownership was already
fiction at the one site where it looked real:
`rclcpp::Node::shared_from_this()` returns
`std::shared_ptr<Node>(std::shared_ptr<void>(), this)` — the aliasing
constructor with an empty owner. A ported file has been compiling against a
non-owning handle wearing `shared_ptr`'s spelling for two phases. The envelope
is stated on the type rather than discovered.

**`nros::InplaceFn<Sig, Cap>`** — the capturing lambda, with no heap. The tree
had every non-owning callback form already; what was missing is what ported
source writes. `NROS_CPP_CALLBACK_CAPACITY` defaults to `4 * sizeof(void*)`:
W0's measurement, the widest capture in the tree and the corpus
(`[obj, method]`, three pointers, wide because a pointer-to-member-function is
two words on the Itanium ABI) plus one pointer of headroom. Spelled in pointers
because a byte count is right on one word size and wrong on the other.

An over-large capture is a compile error naming the knob — chosen over a silent
heap fallback (defeats the point where there is no allocator) and a runtime
failure (moves a compile-time fact to the field).

**`nros::tr`** — the API carries its own traits (RFC-0096 D3). W4 is the
evidence for this, not the counter-argument: W4 fixed OUR shims, and an API
whose metaprogramming depends on a shim's shape is one board away from the same
failure.

**Gated:** `check-cpp-freestanding-mechanisms`, fast line, three arms —

| configuration | result |
| --- | --- |
| hosted `g++ -std=c++17` | rc=0 |
| `arm-none-eabi -std=c++14 -ffreestanding` (32-bit) | rc=0 |
| ThreadX shim, `-nostdinc++` | rc=0 |

— plus an expected-failure probe whose DIAGNOSTIC TEXT is checked, not merely
its failure: a probe that only fails passes on a typo, and would go on passing
after the `static_assert` it exists for was deleted. The 32-bit arm is not
redundant with the other two; it is the only one that can catch the capacity
default regressing to a literal.

Fast line rather than `check cpp` for issue 1225's reason: that lane is
`build-serial` and no merge-gating event reaches it, so a gate there gates
nothing.

**What W3 deliberately does not do:** put these behind the `X::SharedPtr`
aliases and the callback parameters. That is W8, because it is one edit — the
API becomes one API — and doing half would leave the tree with two spellings of
a handle, which is the state this phase exists to end.

## Verification

`just check fast` — 309 gates green, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A4bG1pAtNwG5BDJBFBtfb
