### PR TITLE
feat(phase-442 W5): `NodeOptions` and `Rate` exist on every target

### DIFF
--- a/.config/cpp-capability-layout-baseline.txt
+++ b/.config/cpp-capability-layout-baseline.txt
@@ -66,44 +66,40 @@
 # the indirection, one stable layout, no one-definition hazard, and no
 # dereference on the hot path.
 #
-# --- the `hosted-only` entries ----------------------------------------------
+# --- the `hosted-only` and `std-only` entries: NONE --------------------------
 #
-# `rclcpp::Rate` (and `WallRate`, its alias) sit inside `#ifdef
-# NROS_CPP_HAS_STD_CHRONO` at nros.hpp:936 -- the duration constructor and
-# `period()` are spelled in `std::chrono`. `rclcpp::NodeOptions` sits inside
-# `#if defined(NROS_CPP_HAS_STD_STRING) && defined(NROS_CPP_HAS_STD_VECTOR)` at
-# options.hpp:217. All three are absent against the ThreadX shim, which is the
-# correct outcome for a type whose whole surface is hosted, and none of them is
-# a layout that two TUs can disagree about.
+# There were six, three types under two kinds. `rclcpp::Rate` (and `WallRate`,
+# its alias) sat inside `#ifdef NROS_CPP_HAS_STD_CHRONO`; `rclcpp::NodeOptions`
+# sat inside `#if defined(NROS_CPP_HAS_STD_STRING) &&
+# defined(NROS_CPP_HAS_STD_VECTOR)`. Absence is not a layout divergence -- no
+# freestanding TU could name the type, so no two TUs could disagree about its
+# shape -- but it is a whole type appearing and disappearing with a toolchain,
+# which RFC-0096 D1 is the decision against.
+#
+# phase-442 W5 removed both gates, and the measurement is why they were
+# affordable: `Rate`'s gate was paying for two members out of five, and
+# `NodeOptions`' for ONE out of 23. `Rate::period()` returns `nros::Duration`
+# instead of `std::chrono::nanoseconds`; `NodeOptions::arguments()` takes a
+# DEDUCED parameter instead of `const std::vector<std::string>&`, which is
+# strictly better for a porting user too -- the same call site binds, and a
+# caller passing something else still gets the migration message rather than
+# "no matching function". Both refusals are unchanged.
+#
+# Measured after: NodeOptions 1, Rate 16, WallRate 16, identical on all three
+# arms.
+#
+# One residue, recorded rather than hidden: `Rate`'s `std::chrono` CONSTRUCTOR
+# is still behind `NROS_CPP_HAS_STD_CHRONO`. That is a gate on a METHOD, which
+# this rule permits -- `sizeof(Rate)` is `int64_t` + `uint64_t` everywhere -- but
+# W8's acceptance is zero `NROS_CPP_HAS_*` in the tree, so it is W8's to resolve.
 
-# --- the `std-only` entries -------------------------------------------------
-#
-# The same three types on the other axis, and for a DIFFERENT reason -- which
-# is why the kinds are separate rather than one line excusing both arms.
-# `hosted-only` is about a toolchain that cannot reach the standard library;
-# `std-only` is about a consumer that did not ASK for the porting surface.
-# Since phase-438 W2 the `NROS_CPP_HAS_*` macros are defined by `NROS_CPP_STD`
-# and by nothing else, so a hosted TU that withholds the flag has none of them
-# and the same three guards close for it.
-#
-# `Rate` / `WallRate` were NOT on this arm when W4 first ran it, and the reason
-# is worth recording. `NROS_CPP_HAS_STD_CHRONO` had a SECOND definition in
-# `node.hpp`, still carrying the `__STDC_HOSTED__ && __has_include(<chrono>)`
-# discovery that W2 deleted from the shared site -- so a hosted TU kept the
-# macro from the copy W2 never reached, and the two `<chrono>`-guarded types
-# went on existing without the flag. phase-438 W1 as it landed on `main`
-# (`cf4b0048a`) folds that copy into `std_detect.hpp`, which is what lets this
-# arm measure the flag rather than the include path. Two definitions of one
-# capability macro is issue 0135's shape; one site is the fix.
+# The `diverges` rows below are phase-442 W1's, and they come off in the commit
+# that fixes the member -- see the section above. They are listed here, after the
+# two kinds that are now empty, only because this file's rows all live at the
+# end.
 
 diverges ::nros::GuardCondition
 diverges ::nros::NodeWithTimers<4>
 diverges ::nros::Timer
 diverges ::rclcpp::Timer
 diverges ::rclcpp::TimerBase
-hosted-only ::rclcpp::NodeOptions
-hosted-only ::rclcpp::Rate
-hosted-only ::rclcpp::WallRate
-std-only ::rclcpp::NodeOptions
-std-only ::rclcpp::Rate
-std-only ::rclcpp::WallRate

--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -93,10 +93,33 @@ the rest and do not depend on each other.
   *Acceptance:* placement new compiles against the shim; a probe using the
   freestanding-guaranteed `<type_traits>` contents compiles.
 
-* **W5 [cpp] — un-gate `NodeOptions` and `Rate`/`WallRate`.** 22 of
-  `NodeOptions`' 23 members are `static_assert`-only and need no `std`; `Rate`'s
-  `Rate(double)`, `sleep()` and `reset()` are pure integer arithmetic. Replace
-  the two genuinely-`std` members with `Span<StringView>` and `nros::Duration`.
+* **W5 [cpp] — un-gate `NodeOptions` and `Rate`/`WallRate`. LANDED
+  2026-09-12.** 22 of `NodeOptions`' 23 members are `static_assert`-only and
+  need no `std`; `Rate`'s `Rate(double)`, `sleep()` and `reset()` are pure
+  integer arithmetic. Replace the two genuinely-`std` members with
+  `Span<StringView>` and `nros::Duration`.
+  *Landed as:* `Rate::period()` returns `nros::Duration`, and `Rate` gains a
+  `Rate(nros::Duration)` constructor as the always-available spelling.
+  `NodeOptions::arguments()` takes a DEDUCED parameter rather than
+  `const std::vector<std::string>&` — which is strictly better for a porting
+  user as well as freestanding-clean, because the same call site binds and a
+  caller passing anything else still gets the migration message instead of "no
+  matching function"; the refusal was what the parameter type was decorating.
+  The six `hosted-only` / `std-only` rows are gone from
+  `.config/cpp-capability-layout-baseline.txt`, measured: NodeOptions 1, Rate
+  16, WallRate 16, identical on all three arms.
+  *Two departures from the RFC's suggestion, both measured.* The getter returns
+  `const char* const*` (argv's own shape, null here) rather than
+  `Span<StringView>`: `graph.hpp:105` had already ruled that pulling `span.hpp`
+  into these headers would newly expose `Span` / `StringView` / `LeSpan` on the
+  public C++ surface as a side effect, and doing it costs **16 unledgered
+  API-parity items**. That classification is someone's decision, not a
+  consequence of un-gating this class. And `Rate`'s `std::chrono` CONSTRUCTOR
+  stays behind `NROS_CPP_HAS_STD_CHRONO` — a gate on a METHOD, which the
+  layout rule permits since `sizeof(Rate)` is `int64_t` + `uint64_t`
+  everywhere, but W8's acceptance is zero `NROS_CPP_HAS_*`, so it is W8's to
+  resolve. Recorded rather than left, because a gated method is exactly the
+  residue that reads as finished work.
 
 * **W6 [cpp] — delete the 50 removable entities.** Each has an ungated
   freestanding sibling already, or is body-only. No consumer loses a capability.

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -1090,7 +1090,25 @@ inline FutureReturnCode spin_until_future_complete(const Node::SharedPtr& node,
 //
 // Gated on `<chrono>` alone: the duration constructor and `period()` are spelled
 // in `std::chrono`, and everything else it touches is an integer.
-#ifdef NROS_CPP_HAS_STD_CHRONO
+// phase-442 W5 — `Rate` EXISTS ON EVERY TARGET.
+//
+// It used to sit inside `#ifdef NROS_CPP_HAS_STD_CHRONO`, which made the whole
+// type a property of the toolchain: a node written against `rclcpp::Rate`
+// compiled on a host and vanished on ThreadX. Measured, the gate was paying for
+// two members out of five — `Rate(double)`, `sleep()` and `reset()` are integer
+// arithmetic over `nros_cpp_time_ns()` and never needed `<chrono>` at all.
+//
+// The two that did are handled differently, and the difference is the rule
+// RFC-0096 D1 states. `period()` returns `nros::Duration`, which is ours and
+// exists everywhere, so the type's SHAPE no longer follows a probe. The
+// `std::chrono` CONSTRUCTOR stays behind the capability macro, which is a gate
+// on a METHOD — permitted, since `sizeof(Rate)` is `int64_t` + `uint64_t` in
+// every configuration and two translation units cannot disagree about it.
+//
+// That constructor is the one thing here W8 still has to resolve: its parameter
+// names `std::chrono::duration`, and W8's acceptance is zero `NROS_CPP_HAS_*` in
+// the tree. Recorded rather than quietly left, because a gated method is exactly
+// the kind of residue that reads as finished work.
 
 namespace rclcpp {
 
@@ -1105,13 +1123,26 @@ class Rate {
         reset();
     }
 
+    /// Construct from a period — `rclcpp::Rate(nros::Duration::from_nanoseconds(n))`.
+    /// The always-available spelling, on every target.
+    explicit Rate(::nros::Duration period) : period_ns_(period.nanoseconds()) {
+        if (period_ns_ < 0) period_ns_ = 0;
+        reset();
+    }
+
+#ifdef NROS_CPP_HAS_STD_CHRONO
     /// Construct from a period — `rclcpp::Rate(std::chrono::milliseconds(100))`.
+    ///
+    /// A gated METHOD, not a gated type: `sizeof(Rate)` is the same in every
+    /// configuration. Where `<chrono>` is absent, the `nros::Duration` overload
+    /// above is the same operation.
     template <typename Rep, typename Period>
     explicit Rate(std::chrono::duration<Rep, Period> period)
         : period_ns_(std::chrono::duration_cast<std::chrono::nanoseconds>(period).count()) {
         if (period_ns_ < 0) period_ns_ = 0;
         reset();
     }
+#endif
 
     /// Spin the executor until the next tick is due.
     ///
@@ -1147,7 +1178,12 @@ class Rate {
     void reset() { next_tick_ns_ = nros_cpp_time_ns() + static_cast<uint64_t>(period_ns_); }
 
     /// The configured period.
-    std::chrono::nanoseconds period() const { return std::chrono::nanoseconds(period_ns_); }
+    ///
+    /// `nros::Duration` rather than `std::chrono::nanoseconds` (phase-442 W5):
+    /// a return type that exists only where `<chrono>` does would keep the whole
+    /// class hostage to the toolchain, which is what this work item removed.
+    /// `.nanoseconds()` is the same number upstream's `.count()` gives.
+    ::nros::Duration period() const { return ::nros::Duration::from_nanoseconds(period_ns_); }
 
   private:
     int64_t period_ns_;
@@ -1159,7 +1195,5 @@ class Rate {
 using WallRate = Rate;
 
 } // namespace rclcpp
-
-#endif // NROS_CPP_HAS_STD_CHRONO
 
 #endif // NROS_CPP_HPP

--- a/packages/api/nros-cpp/include/nros/options.hpp
+++ b/packages/api/nros-cpp/include/nros/options.hpp
@@ -189,13 +189,34 @@ struct ClientOptions {
 // claim about a switch that does not exist — the same silent difference one
 // step further from the call site.
 //
-// `<string>` / `<vector>` are GATED, because this header is on the freestanding
-// path. Upstream's `arguments()` signature is spelled in terms of
-// `std::vector<std::string>`, so where those types are absent the class is too;
-// a freestanding build has no `rclcpp::Node` to hand it to either.
+// phase-442 W5 — `NodeOptions` EXISTS ON EVERY TARGET.
+//
+// It used to sit inside `#if defined(NROS_CPP_HAS_STD_STRING) &&
+// defined(NROS_CPP_HAS_STD_VECTOR)`, on the argument that upstream's
+// `arguments()` is spelled in `std::vector<std::string>`. Measured, that gate
+// was paying for ONE member out of 23: every other accessor is
+// `static_assert`-only and mentions no `std` type whatsoever. A whole type
+// disappearing on a toolchain, to keep one decorative parameter type, is the
+// shape RFC-0096 exists to remove — a node written against `rclcpp::NodeOptions`
+// compiled on a host and vanished on ThreadX.
+//
+// And the parameter type WAS decorative. `arguments()` is REFUSE-LOUD: the
+// `static_assert` fires before anything looks at the argument, so the spelling
+// never reached a conversion. It is a deduced template parameter now, which is
+// strictly better for a porting user as well as freestanding-clean: ANY argument
+// binds, including the `std::vector<std::string>` upstream code passes, and the
+// diagnostic is still the migration message rather than "no matching function".
+//
+// The getter returns `const char* const*` — argv's own shape, null here — for
+// the same reason its predecessor returned a reference to a static empty
+// vector: so the refusal is ONE diagnostic rather than two. Deliberately NOT
+// `nros::Span<StringView>`, which RFC-0096 D6 suggested: `span.hpp` is reached
+// by nothing else in these headers, and `graph.hpp:105` already ruled that
+// pulling it in would newly expose `Span` / `StringView` / `LeSpan` on the
+// public C++ surface as a side effect of an unrelated change. Measured: doing
+// it costs 16 unledgered API-parity items. That classification is a decision
+// for whoever makes it, not a consequence of un-gating this class.
 #include "nros/std_detect.hpp"
-
-#if defined(NROS_CPP_HAS_STD_STRING) && defined(NROS_CPP_HAS_STD_VECTOR)
 
 namespace rclcpp {
 
@@ -210,11 +231,15 @@ class NodeOptions {
     // include. Callers write them exactly as upstream does; deduction picks
     // `T = void` and the assertion reports the migration.
 
-    template <typename T = void> NodeOptions& arguments(const std::vector<std::string>&) {
+    /// Upstream takes `const std::vector<std::string>&`. Deduced here, so the
+    /// same call site binds without this header naming a `std` type — and a
+    /// caller passing anything else still gets the migration message rather
+    /// than an overload-resolution failure.
+    template <typename T> NodeOptions& arguments(const T&) {
         static_assert(detail::refuse<T>::value, NROS_RCLCPP_REFUSE_NODE_OPTIONS);
         return *this;
     }
-    template <typename T = void> const std::vector<std::string>& arguments() const {
+    template <typename T = void> const char* const* arguments() const {
         static_assert(detail::refuse<T>::value, NROS_RCLCPP_REFUSE_NODE_OPTIONS);
         return no_arguments_();
     }
@@ -305,14 +330,9 @@ class NodeOptions {
     /// Never reached — the `static_assert` above fires first. It exists only so
     /// the refused `arguments()` has a return expression of the right type,
     /// keeping the diagnostic to ONE error instead of two.
-    static const std::vector<std::string>& no_arguments_() {
-        static const std::vector<std::string> empty;
-        return empty;
-    }
+    static const char* const* no_arguments_() { return nullptr; }
 };
 
 } // namespace rclcpp
-
-#endif // NROS_CPP_HAS_STD_STRING && NROS_CPP_HAS_STD_VECTOR
 
 #endif // NROS_CPP_OPTIONS_HPP


### PR DESCRIPTION
Two public types used to appear and disappear with the toolchain. A node
written against `rclcpp::NodeOptions` or `rclcpp::Rate` compiled on a host and
was simply absent on ThreadX — not a different shape, not a weaker contract,
absent. That is the thing RFC-0096 D1 is the decision against, and in both
cases the gate was paying for almost nothing.

WHAT THE GATES WERE ACTUALLY BUYING, MEASURED

`rclcpp::NodeOptions` sat inside `#if defined(NROS_CPP_HAS_STD_STRING) &&
defined(NROS_CPP_HAS_STD_VECTOR)` because upstream's `arguments()` is spelled in
`std::vector<std::string>`. That gate covered ONE member out of 23. The other 22
accessors are `static_assert`-only and mention no `std` type at all.

`rclcpp::Rate` sat inside `#ifdef NROS_CPP_HAS_STD_CHRONO`. That covered two
members out of five: `Rate(double)`, `sleep()` and `reset()` are integer
arithmetic over `nros_cpp_time_ns()`.

THE ARGUMENT TYPE WAS DECORATIVE, AND DEDUCING IT IS BETTER FOR PORTING TOO

`arguments()` is REFUSE-LOUD: the `static_assert` fires before anything looks at
the argument, so the `std::vector<std::string>` spelling never reached a
conversion. It is a deduced template parameter now. That is not a compromise
against the porting goal — it is an improvement on both axes at once. The same
upstream call site binds, and a caller passing something else gets the migration
message rather than "no matching function", where the old signature would have
failed overload resolution before the refusal could speak.

`Rate::period()` returns `nros::Duration` instead of
`std::chrono::nanoseconds`; `.nanoseconds()` is the number `.count()` gave.
`Rate` also gains an `nros::Duration` constructor as the always-available
counterpart to the `std::chrono` one.

TWO DEPARTURES FROM WHAT RFC-0096 D6 SUGGESTED, BOTH MEASURED

D6 said to replace the two genuinely-`std` members with `Span<StringView>` and
`nros::Duration`. The `Duration` half is exactly right. The `Span` half is not,
and the tree had already said so: `graph.hpp:105` records a deliberate refusal
to take an `nros::Span` for precisely this reason —

    `span.hpp` is reached by nothing else in these headers, so taking it here
    would newly expose `Span` / `StringView` / `LeSpan` on the public C++
    surface as a side effect of a graph forwarder. That is a decision for
    whoever classifies those types, not a consequence of this one.

Measured rather than deferred to on authority: including `span.hpp` here costs
**16 unledgered API-parity items** (`cpp:Span`, `cpp:StringView`, `cpp:LeSpan`
and their members). So the refused getter returns `const char* const*` — argv's
own shape, null here — which keeps the refusal to ONE diagnostic, exactly as the
static empty vector did, and exposes nothing new.

The second departure is recorded rather than hidden: `Rate`'s `std::chrono`
CONSTRUCTOR is still behind `NROS_CPP_HAS_STD_CHRONO`. That is a gate on a
METHOD, which the capability-layout rule permits — `sizeof(Rate)` is `int64_t` +
`uint64_t` in every configuration, so two translation units cannot disagree
about it — but W8's acceptance is zero `NROS_CPP_HAS_*` in the tree, so it is
W8's to resolve. A gated method is exactly the kind of residue that reads as
finished work, so it is named in the header, in the baseline, and in the phase
doc.

MEASURED

`check-cpp-capability-layout`, all three arms (hosted, hosted without
`-DNROS_CPP_STD`, `-nostdinc++` freestanding against the ThreadX shim):

    ::rclcpp::NodeOptions     1  (was: absent on two arms)
    ::rclcpp::Rate           16  (was: absent on two arms)
    ::rclcpp::WallRate       16  (was: absent on two arms)

The six `hosted-only` / `std-only` rows are deleted from
`.config/cpp-capability-layout-baseline.txt`. Both kinds are now empty; the five
`diverges` rows that remain are phase-442 W1's, in flight as #963, and the file
says so.

The umbrella parses on both arms — hosted `g++ -std=c++17`, and
`c++ -std=c++14 -ffreestanding -nostdinc++` against the ThreadX shim — rc=0 each.
`just check fast` 307 gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A4bG1pAtNwG5BDJBFBtfb