### PR TITLE
docs(AGENTS): two worktree hazards that cost real work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -816,6 +816,26 @@ and verified.
   one cannot be fixed by generating it because the digests are prose. Read the
   list with `just issues --all --status resolved`, which is derived from the
   files and so cannot drift.
+- **`git stash` is SHARED ACROSS WORKTREES, and it is not a scratch buffer.**
+  The stash lives in the common `.git` dir, so `git stash` in one agent's
+  worktree pops into the same list every other worktree sees — two agents
+  stashing concurrently interleave entries nobody can attribute, and a
+  `git stash pop` in the wrong tree applies someone else's diff. Even
+  single-session it is sharper than it looks: it REWRITES every tracked file it
+  touches, so it is one of the fixture-mtime treadmill's triggers (same class as
+  a pull, a rebase or a `just format`), and an accidental `git stash` with
+  uncommitted work is a silent loss until you notice the tree is clean. Use a
+  branch and a commit, or `git diff > $project/tmp/x.patch`. If you do stash,
+  `git stash list` before and after, and pop immediately.
+- **An agent worktree INHERITS the parent checkout's `activate.sh` exports, so
+  gates measure the WRONG TREE.** `NROS_C_INCLUDE` / `NROS_CPP_INCLUDE` and the
+  rest are absolute paths baked into the environment when `activate.sh` ran;
+  entering a `git worktree` does not re-resolve them. A gate then reads headers
+  from the shared checkout while compiling sources from the worktree, and the
+  two disagree in whichever direction is hardest to see — a green that describes
+  someone else's tree. Re-source `./activate.sh` FROM the worktree after
+  entering it, and `just setup-cli` as well, for the same reason a branch switch
+  needs one (issue 0466: the CLI's source stamp is what fixtures key on).
 - **Write full logs of background builds/tests to files** and grep afterwards;
   `cmd | tail -N` swallows the mid-log error that explains the failure.
 - **`pkill -f <pattern>` matches your OWN wrapper shell** when the pattern


### PR DESCRIPTION
Both were hit in this repository rather than read about, and both are invisible
until they have already happened.

`git stash` IS SHARED ACROSS WORKTREES

The stash lives in the common `.git` directory, not the worktree, so a stash
taken in one agent's worktree lands in the same list every other worktree sees.
Two agents stashing concurrently interleave entries nobody can attribute, and a
`git stash pop` in the wrong tree applies someone else's diff.

It is sharper than that even single-session. A stash REWRITES every tracked file
it touches, which makes it one of the fixture-mtime treadmill's triggers — the
same class as a pull, a rebase or a `just format`, and not one of the three the
existing note names. And an accidental `git stash` over uncommitted work reads
as a clean tree, so the loss is silent until something else fails.

Recorded because it happened here: a `git stash` typed as part of a diagnostic
one-liner took a whole work item's uncommitted changes out of the tree, and the
only reason it was recovered is that the pop happened before anything else
touched the stash list.

AN AGENT WORKTREE INHERITS THE PARENT'S `activate.sh` EXPORTS

`NROS_C_INCLUDE` / `NROS_CPP_INCLUDE` and the rest are absolute paths baked into
the environment when `activate.sh` ran. Entering a `git worktree` does not
re-resolve them, so a gate compiles the worktree's sources against the shared
checkout's headers and reports a verdict about neither tree — a green that
describes somebody else's code, which is the hardest kind of false pass to
notice. Re-source `./activate.sh` from inside the worktree, and run
`just setup-cli` there too, for issue 0466's reason: the CLI source stamp is
what every fixture keys on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A4bG1pAtNwG5BDJBFBtfb