### PR TITLE
phase-428 W9: the supported QoS mask is derived, not authored

### DIFF
--- a/book/src/reference/rmw-feature-matrix.md
+++ b/book/src/reference/rmw-feature-matrix.md
@@ -68,7 +68,7 @@ downgrade**. Per-policy semantics: [RMW vs upstream §7](../design/rmw-vs-upstre
 | `LIFESPAN` | ✓ | ✓ |
 | `LIVELINESS_AUTOMATIC` | ✓ | ✓ |
 | `LIVELINESS_MANUAL_BY_TOPIC` | ✓ | ✓ |
-| `LIVELINESS_MANUAL_BY_NODE` | ✓ | ✓ |
+| `LIVELINESS_MANUAL_BY_NODE` | — | — |
 | `LIVELINESS_LEASE` | ✓ | ✓ |
 | `AVOID_ROS_NAMESPACE_CONVENTIONS` | — | ✓ |
 

--- a/docs/issues/1329-cffi-qos-mask-is-a-union-not-the-backends-answer.md
+++ b/docs/issues/1329-cffi-qos-mask-is-a-union-not-the-backends-answer.md
@@ -1,0 +1,78 @@
+---
+id: 1329
+title: "The cffi QoS mask is the UNION of three backends, so it over-claims for
+  each of them"
+status: open
+type: bug
+area: rmw
+severity: medium
+related: [1328]
+---
+
+## What happens
+
+`CffiSession::supported_qos_policies()` answers for whichever C backend is
+registered, and it has no way to ask that backend. The vtable has no
+`supported_qos_policies` slot, so the route returns the UNION of what any
+nros-supported RMW honours and relies on the backend surfacing
+`NROS_RMW_RET_INCOMPATIBLE_QOS` from its own create.
+
+Two of the three backends never surface it.
+
+Measured 2026-09-11 (phase-428 W9), per policy:
+
+| policy | cyclonedds | xrce | uorb |
+| --- | --- | --- | --- |
+| reliability | yes (`qos.cpp:38`) | yes, in the CREATE submessage (`session.c`) | no |
+| durability (both values) | yes (`qos.cpp:53`) | yes | no |
+| history / depth | yes (`qos.cpp:84`) | yes, deferred to the Agent | no |
+| deadline | yes (`qos.cpp:93`) | **dropped** (`optional_deadline_msec = false`) | no |
+| lifespan | yes (`qos.cpp:96`) | **dropped** | no |
+| liveliness kind + lease | yes, AUTOMATIC and MANUAL_BY_TOPIC | **dropped** — no field in `uxrQoS_t` | no |
+| avoid_ros_namespace_conventions | **no read site** — mangling is env-only (`NROS_RMW_CYCLONEDDS_SKIP_PREFIX`) | pub + sub only, not services | no |
+
+uorb binds the parameter as `const rmw_qos_profile_t * /*qos*/` at all four
+create slots and returns `NROS_RMW_RET_UNSUPPORTED` for services. It honours
+nothing and refuses nothing.
+
+So an application that asks cyclonedds for `avoid_ros_namespace_conventions`,
+or xrce for a deadline, is admitted by the runtime's pre-validate step and then
+silently ignored downstream — the no-silent-downgrade contract broken one layer
+below where it is enforced.
+
+## Why the obvious narrowing is not the fix
+
+Replacing the union with a per-backend table keyed on the registered name was
+tried on paper and rejected, because the intersection is empty and the
+per-backend rows break working builds:
+
+* xrce would lose `LIVELINESS_AUTOMATIC`. Every default profile in the C API
+  states `NROS_QOS_LIVELINESS_AUTOMATIC` (`packages/api/nros-c/src/qos.rs`), so
+  `required_policies()` demands the bit and **every C application on xrce would
+  fail at entity create**.
+* uorb would lose everything, and any stated profile — including
+  `QOS_PROFILE_DEFAULT` — would be refused, taking the PX4 path with it.
+
+Both are real refusals of policies those backends genuinely do not implement,
+which is the point; but landing them as a side effect of a mask change, on
+backends whose test lanes need submodules a plain worktree does not have, is
+not a safe way to discover that.
+
+## Fix
+
+Give the vtable the slot the TODO has asked for since phase 115: a
+`supported_qos_policies` callback the route queries, with each C backend
+returning what its own code honours. Then:
+
+1. the answer is the backend's, not a guess about it;
+2. the narrowings above land per backend, with each backend's own lane to
+   measure them;
+3. where a backend's honest mask would refuse a profile that works today
+   (xrce + `LIVELINESS_AUTOMATIC`), the choice becomes explicit — implement the
+   policy, or state the refusal — instead of being hidden by a union.
+
+Until then the over-claim is TRACKED rather than silent:
+`check-qos-mask-derivation` requires the cffi mask to declare
+`nros-qos-mux:` with the crates it routes to, and every bit in the union to be
+honoured by at least one of them. That is what caught issue 1328 — a bit in the
+union that no routed backend honoured at all.

--- a/docs/issues/archived/1328-qos-manual-by-node-advertised-nowhere-implemented.md
+++ b/docs/issues/archived/1328-qos-manual-by-node-advertised-nowhere-implemented.md
@@ -1,0 +1,58 @@
+---
+id: 1328
+title: "`LIVELINESS_MANUAL_BY_NODE` was advertised by every backend and implemented
+  by none"
+status: resolved
+type: bug
+area: rmw
+severity: medium
+related: [1329]
+---
+
+## What happened
+
+`Session::supported_qos_policies()` advertised `LIVELINESS_MANUAL_BY_NODE` on
+both masks in the tree — the zenoh shim and the cffi route — and no backend
+implemented the policy.
+
+Measured 2026-09-11, phase-428 W9:
+
+| backend | what it does with `MANUAL_BY_NODE` |
+| --- | --- |
+| zenoh | `shim/publisher.rs` matches `ManualByTopic \| ManualByNode` in one arm, so assertion is per PUBLISHER |
+| cyclonedds | `src/qos.cpp` folds it onto `DDS_LIVELINESS_MANUAL_BY_TOPIC`, with a comment saying so |
+| xrce | lowers no liveliness field at all — `uxrQoS_t` has four fields and none is liveliness |
+| uorb | reads no QoS field whatever |
+
+## Why it matters
+
+The two policies differ in WHO has to assert. `MANUAL_BY_TOPIC` requires the
+application to assert each publisher; `MANUAL_BY_NODE` says an assertion on any
+of a node's publishers keeps the node's whole set alive. Serving the second as
+the first is a downgrade in the LOSING direction: an application that asserts
+once per period, correctly, watches its other publishers cross the lease and
+report `LivelinessLost` — and its subscribers see them drop out of the graph.
+
+That is the exact failure the mask exists to prevent. The contract is "no
+silent downgrade: refuse at create instead", and the mask said the policy was
+available.
+
+Cyclone's fold is the sharper case, because it is what meets real ROS peers:
+upstream `rmw_cyclonedds_cpp` has the same fold, but it does not then tell the
+application that MANUAL_BY_NODE is supported.
+
+## Fix (landed, phase-428 W9)
+
+* The bit is withdrawn from both masks, so a request is refused with
+  `IncompatibleQos` at create.
+* The zenoh backend refuses it locally too (`shim/qos.rs`), for a caller who
+  reached the backend without the runtime's pre-validate step.
+* `check-qos-mask-derivation` makes the class un-repeatable: a bit may be
+  advertised only if a `nros-qos-honours:` claim is sited on code that reads
+  the mapped field. Re-advertising `MANUAL_BY_NODE` is one of the gate's own
+  live-tree mutation controls, so the red is re-demonstrated on every run.
+
+Nothing in the tree requested the policy, so the withdrawal changed no working
+build. Implementing it for real (per-node assertion tracking in the zenoh
+liveliness layer) is a separate piece of work, and the honest mask is the
+precondition for anyone noticing it is missing.

--- a/docs/roadmap/phase-428-api-porting-principle-sweep.md
+++ b/docs/roadmap/phase-428-api-porting-principle-sweep.md
@@ -248,6 +248,126 @@ W1–W6 stand for the user-facing C/C++/Rust APIs. The RMW layer adds:
   gated (a doc naming a slot that does not exist is mechanically checkable).
 
 
+## W9 outcome (2026-09-12) — the mask is derived, and the prediction was half wrong
+
+Landed: `check-qos-mask-derivation.py` (fast line, buildless, ~0.4 s). A bit may
+be advertised only if the backend carries a `nros-qos-honours: <BIT>` claim
+sited on code that READS the mapped profile field. Honouring is "applies the
+request or refuses a value it cannot serve" — both read the field, which is what
+makes the rule mechanical; handing the field to somebody else is not, so a file
+marked `nros-qos-discovery-only:` contributes no evidence.
+
+Every subject list is derived, because an authored one is what this campaign
+keeps finding broken: the policy vocabulary from `QoSPolicyMask`'s `pub const`
+block, the bit→(field, variant) mapping from `QoSProfile::required_policies`
+(a bit that function can never set is an error), the backend list from every
+`impl Session for` under `packages/**/src`. The cffi route declares
+`nros-qos-mux:` with the crates it routes to, and its union is checked against
+THEIR claims.
+
+**The negative control is the live tree, not a synthetic file.** Six mutations
+run on the normal path, each against the shipped sources in memory: delete the
+depth read from the zenoh admission function; delete the HISTORY claim; move
+the RELIABILITY claim into the discovery keyexpr; re-advertise the withdrawn
+liveliness bit; leave a stale claim; make an exempt session claim a subset.
+A synthetic backend only proves the matcher matches what its author wrote.
+
+### Measured per backend
+
+`--audit` prints this; it is not asserted anywhere else.
+
+| policy | zenoh | cffi union (cyclonedds / xrce / uorb) |
+| --- | --- | --- |
+| RELIABILITY | yes — `shim/qos.rs`, granted RELIABLE, over-delivery reported | cyclonedds `qos.cpp:38`, xrce `session.c` |
+| DURABILITY_VOLATILE | yes — `shim/qos.rs` | cyclonedds, xrce |
+| DURABILITY_TRANSIENT_LOCAL | **no** (unchanged) | cyclonedds, xrce |
+| HISTORY | yes — KEEP_ALL refused | cyclonedds, xrce |
+| DEPTH | yes — granted to the ring, grant published | cyclonedds, xrce (deferred to the Agent) |
+| DEADLINE | yes — `publisher.rs`, `subscriber.rs` | cyclonedds only |
+| LIFESPAN | yes — `subscriber.rs` | cyclonedds only |
+| LIVELINESS_AUTOMATIC | yes | cyclonedds only |
+| LIVELINESS_MANUAL_BY_TOPIC | yes | cyclonedds only |
+| **LIVELINESS_MANUAL_BY_NODE** | **withdrawn** | **withdrawn** |
+| LIVELINESS_LEASE | yes — publisher-side; a subscription lease is reported | cyclonedds only |
+| AVOID_ROS_NAMESPACE_CONVENTIONS | no (unchanged) | xrce pub+sub only |
+
+**The one withdrawal is `LIVELINESS_MANUAL_BY_NODE`, advertised by both masks in
+the tree and implemented by neither** (issue 1328). zenoh matches
+`ManualByTopic | ManualByNode` in one arm; cyclonedds folds the value onto
+MANUAL_BY_TOPIC in as many words; xrce lowers no liveliness field. The downgrade
+is in the LOSING direction — an application that correctly asserts once per node
+watches its other publishers cross the lease — which is exactly what the mask
+exists to refuse. Nothing in the tree requested it, so no build changed.
+
+### Where this item's own prediction was wrong
+
+The work item said the derived zenoh mask is `RELIABILITY | DURABILITY_VOLATILE
+| HISTORY`, that **`DEPTH` drops out**, and that "nothing that works today
+breaks". The first half is a fair reading of the tree as it stood — the four
+CORE policies had exactly one read between them, in `QosKeyExpr::to_qos_string`,
+under a comment claiming all four were honoured at the subscriber buffer. The
+second half is false, and `withdrawing_depth_would_refuse_the_default_profile`
+in `nros-rmw/src/traits.rs` is the measurement:
+
+`QOS_PROFILE_DEFAULT` states `depth: 10`, so `required_policies()` REQUIRES
+`DEPTH`; that profile is what every `create_publisher`/`create_subscription`
+with no explicit QoS passes. Withdrawing the bit refuses **every default entity
+on the backend**, not just the ones asking for more depth than the ring holds.
+Same for `QOS_PROFILE_SERVICES_DEFAULT` and `QOS_PROFILE_SENSOR_DATA`. Only
+`QOS_PROFILE_SYSTEM_DEFAULT` survives, because it states no depth at all.
+
+So the shim EARNS the bit instead of withdrawing it, which is also the honest
+reading: the bit says "I will not silently ignore this policy", and a depth lie
+lives in the VALUE. `shim/qos.rs::admit` returns the GRANTED profile, the entity
+is configured from it, and `create_*` puts THAT profile — not the request — into
+the `@ros2_lv` liveliness token. A peer reading our graph entry now sees the
+queue we keep; before, a caller asking for 100 got a four-slot ring and a graph
+entry advertising a hundred. History and depth are not RxO policies, so this
+changes no matching.
+
+### The `let _ = qos;` sites
+
+Two, both zenoh, both the service pair (`create_service`, `create_client`),
+under `TODO(193.1b)`. They discarded the caller's profile AND then built the
+liveliness token from a hardcoded `QoSProfile::services_default()` — so the
+graph advertised a profile nobody had asked for.
+
+"The requested service QoS cannot be applied" was narrower than the TODO
+claimed. zenoh-pico has no per-endpoint QoS slot on a queryable, so nothing
+reaches the WIRE — but the request ring is ours, the refusals are ours, and the
+graph declaration is ours. All three are applied now, and the token carries the
+admitted profile. This is a no-op for every default caller (`nros-node` passes
+`services_default()` at all ten service/action create sites) and correct for an
+explicit one.
+
+### A too-deep request
+
+Refused where refusing is honest, reported where it cannot be. `KEEP_ALL` and
+`TRANSIENT_LOCAL` and `MANUAL_BY_NODE` are refused with `IncompatibleQos` and a
+log line naming the policy. Depth cannot be refused — every stock preset asks
+for more than the default four-slot ring (10, 10, 1000) — so it is GRANTED down
+and the grant is (a) returned to the caller's entity, (b) published to the
+graph, and (c) reported once per process at WARN, naming the entity, both
+numbers and `ZPICO_SUBSCRIBER_RING_DEPTH`. Once per process, not per entity:
+the knob is global and a line per entity is a line a reader learns to skip.
+A BEST_EFFORT request is granted RELIABLE and reported at INFO — the severity
+encodes the direction, over-delivery being safe and under-delivery lossy.
+
+### Carried forward
+
+* **The trait default is `QoSPolicyMask::NONE`** (was `CORE`): four policies
+  granted by the trait to any implementation that had written no code. The two
+  sessions that relied on it — the mock and the metadata recorder — now declare
+  `nros-qos-exempt:` with a reason, and the gate requires an exemption to be
+  all-or-nothing, since "carries no traffic" cannot be true of a subset.
+* **The cffi mask is a UNION, so it over-claims for each backend** — issue 1329,
+  with the measured per-backend table. An app asking cyclonedds for
+  `avoid_ros_namespace_conventions`, or xrce for a deadline, is admitted and
+  then ignored downstream. The fix is the vtable slot the TODO has wanted since
+  phase 115; narrowing the union without one was checked and rejected, because
+  xrce would lose `LIVELINESS_AUTOMATIC` and every C default profile states it,
+  so every C app on xrce would fail at create.
+
 ## W10 outcome (2026-09-05) — one gate, and the sources it does not yet reach
 
 Landed: the SSoT is a `qos_profiles!` fence in `nros-rmw/src/traits.rs` stating

--- a/just/check/rmw.just
+++ b/just/check/rmw.just
@@ -108,6 +108,28 @@ declared-qos-header:
 qos-profile-ssot:
     @python3 scripts/check-qos-profile-ssot.py
 
+# phase-428 W9 — a backend may only advertise a QoS policy its code honours.
+#
+# `supported_qos_policies()` was a hand-written constant per backend, so it
+# claimed whatever it had claimed when it was written. Measured:
+# `LIVELINESS_MANUAL_BY_NODE` was advertised by the zenoh shim AND the cffi
+# route and implemented by neither (cyclonedds folds it onto MANUAL_BY_TOPIC in
+# as many words; xrce lowers no liveliness field), and the zenoh shim's four
+# CORE policies were read in exactly one place — the DISCOVERY keyexpr — under
+# a comment saying all four were honoured at the subscriber buffer.
+#
+# Every subject list is derived: the policy vocabulary from `QoSPolicyMask`,
+# what each bit MEANS from `QoSProfile::required_policies`, the backend list
+# from every `impl Session for` under packages/**/src. The negative control
+# mutates the REAL sources in memory (delete the depth read, delete a claim,
+# move a claim into the discovery-only file, re-advertise the withdrawn bit)
+# and requires a red each time, on the normal path.
+#
+# Buildless and ~0.4 s — it reads sources, nothing else.
+[private]
+qos-mask-derivation:
+    @python3 scripts/check-qos-mask-derivation.py
+
 # phase-403 W9 (issue 0965) — the per-kind CALLBACK SLOT cost has ONE
 # definition, tied to the registration sites that actually claim a slot.
 #

--- a/packages/core/nros-node/src/mock.rs
+++ b/packages/core/nros-node/src/mock.rs
@@ -279,9 +279,15 @@ impl Session for MockSession {
     type ServiceHandle = MockServiceServer;
     type ClientHandle = MockServiceClient;
 
-    /// The mock (test) backend supports every QoS policy, so QoS validation
-    /// never rejects a test entity (the default `CORE` mask can't even admit
-    /// the default profile's liveliness bit).
+    /// nros-qos-exempt: a TEST double with no transport. It delivers nothing,
+    /// so it can neither honour nor violate a policy, and admitting every
+    /// profile is what keeps a test about something else from being a test
+    /// about QoS validation.
+    ///
+    /// The comment here used to justify this by the default mask being too
+    /// narrow for the default profile's liveliness bit. That reason is gone —
+    /// phase-428 W9 made the default EMPTY — and the real reason was never
+    /// the default's width.
     fn supported_qos_policies(&self) -> nros_rmw::QoSPolicyMask {
         nros_rmw::QoSPolicyMask(u32::MAX)
     }

--- a/packages/core/nros-rmw/src/traits.rs
+++ b/packages/core/nros-rmw/src/traits.rs
@@ -1086,8 +1086,10 @@ qos_profiles! {
 //
 //   Every upstream-mirroring preset states AUTOMATIC where upstream states the
 //   SYSTEM_DEFAULT sentinel. MEASURED consequences, 2026-09-05:
-//     - cyclonedds: wire-identical. `nros_rmw_cyclonedds_qos_apply`
-//       (`qos.cpp:99-121`) calls `dds_qset_liveliness` only when the kind is
+//     - cyclonedds: wire-identical. `nros_rmw_cyclonedds::make_dds_qos`
+//       (`qos.cpp`; the name here read `nros_rmw_cyclonedds_qos_apply` until
+//       phase-428 W9 went looking for it — no such symbol has ever existed)
+//       calls `dds_qset_liveliness` only when the kind is
 //       NOT the sentinel, and Cyclone's own reader/writer default IS
 //       `DDS_LIVELINESS_AUTOMATIC` — so both spellings put AUTOMATIC on the
 //       wire.
@@ -1598,11 +1600,33 @@ pub trait Session {
     /// includes a policy the backend can't enforce. **No silent
     /// downgrade.**
     ///
-    /// Default returns [`QoSPolicyMask::CORE`] — reliability +
-    /// durability VOLATILE + history + depth. Backends override per
-    /// supported policy.
+    /// # The mask is DERIVED, not authored — phase-428 W9
+    ///
+    /// Every bit an implementation sets must be backed by a
+    /// `nros-qos-honours:` claim sited on the code that honours the policy,
+    /// and `check-qos-mask-derivation` re-measures those claims on every
+    /// push. Deleting the code deletes the claim, which is the property this
+    /// item exists to buy: before W9 this was a hand-written constant, so a
+    /// backend could advertise a policy it had never implemented and nothing
+    /// noticed. Three did — `LIVELINESS_MANUAL_BY_NODE` was advertised by
+    /// every backend in the tree and implemented by none.
+    ///
+    /// "Honours" means the backend reads the field and either APPLIES it or
+    /// REFUSES a value it cannot serve. Passing the field on to someone else
+    /// (a discovery keyexpr, a lowered C struct) is not honouring it, and the
+    /// gate does not count it: see `nros-qos-discovery-only`.
+    ///
+    /// # The default is EMPTY, deliberately
+    ///
+    /// It returned [`QoSPolicyMask::CORE`] until phase-428 W9 — four policies
+    /// granted to any implementation that had written no code at all, which
+    /// is precisely the lie above with the trait as its author. An
+    /// implementation now states what it honours or is told it honours
+    /// nothing; the failure is loud (`IncompatibleQos` at create) rather than
+    /// a silent downgrade at runtime, which is the direction this trait has
+    /// chosen everywhere else.
     fn supported_qos_policies(&self) -> QoSPolicyMask {
-        QoSPolicyMask::CORE
+        QoSPolicyMask::NONE
     }
 
     /// Phase 110.0 — backend's next internal-event deadline in
@@ -1896,9 +1920,11 @@ pub struct GraphEndpointInfo<'a> {
 /// Bitmask of QoS policies a backend can honour. See
 /// [`Session::supported_qos_policies`].
 ///
-/// `CORE` covers the policies every nano-ros backend implements:
-/// reliability, durability=VOLATILE, history, depth. Backends opt
-/// into additional policies by OR-ing the relevant flags.
+/// One bit per value `QoSProfile::required_policies` can request, and that
+/// function is the definition of what each bit MEANS — `check-qos-mask-
+/// derivation` reads the bit->field mapping out of its body rather than
+/// restating it, so a policy that gains a bit here and no arm there is a gate
+/// failure instead of a bit nothing can ever ask for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QoSPolicyMask(pub u32);
 
@@ -1916,7 +1942,18 @@ impl QoSPolicyMask {
     pub const LIVELINESS_LEASE: Self = Self(1 << 10);
     pub const AVOID_ROS_NAMESPACE_CONVENTIONS: Self = Self(1 << 11);
 
-    /// Policies every nano-ros backend implements.
+    /// Honours nothing. The default answer for an implementation that has not
+    /// said otherwise — phase-428 W9, see [`Session::supported_qos_policies`].
+    pub const NONE: Self = Self(0);
+
+    /// The four policies every `QoSProfile` states a value for.
+    ///
+    /// NOT "policies every nano-ros backend implements", which is what this
+    /// said until phase-428 W9 measured it: the zenoh shim honoured exactly
+    /// none of the four, serialising all four into a discovery keyexpr and
+    /// enforcing a build-time ring depth. The name describes the SHAPE of a
+    /// profile — a caller who states nothing else still states these — and a
+    /// backend still has to earn each bit.
     pub const CORE: Self =
         Self(Self::RELIABILITY.0 | Self::DURABILITY_VOLATILE.0 | Self::HISTORY.0 | Self::DEPTH.0);
 
@@ -1962,11 +1999,15 @@ impl QoSProfile {
     /// just never reached the four CORE ones.
     ///
     /// This RELAXES the mask, so it can only turn a rejection into an
-    /// acceptance, never the reverse — and it flips no verdict today: every
-    /// `supported_qos_policies` impl in the tree returns at least `CORE`
-    /// (`traits.rs` default impl, `nros-node/src/mock.rs:259`,
-    /// `nros-rmw-cffi/src/lib.rs:2580`, `nros-rmw-zenoh/src/shim/session.rs:1245`),
-    /// so a CORE bit has never been the reason for a failure.
+    /// acceptance, never the reverse.
+    ///
+    /// It used to say it flipped no verdict "because every
+    /// `supported_qos_policies` impl in the tree returns at least `CORE`".
+    /// That stopped being true in phase-428 W9: the trait default is
+    /// [`QoSPolicyMask::NONE`] now, so an implementation that claims nothing
+    /// is refused on the first CORE bit a caller states — which is the whole
+    /// point, and which makes THIS function's sentinel handling the thing
+    /// standing between `QOS_PROFILE_SYSTEM_DEFAULT` and a hard refusal.
     pub fn required_policies(&self) -> QoSPolicyMask {
         let mut mask = QoSPolicyMask(0);
         if self.reliability != QoSReliabilityPolicy::SystemDefault {
@@ -3352,6 +3393,68 @@ mod tests {
             QoSProfile::QOS_PROFILE_SYSTEM_DEFAULT
                 .validate_against(QoSPolicyMask(0))
                 .is_ok()
+        );
+    }
+
+    /// phase-428 W9 — the roadmap predicted that deriving zenoh's mask would
+    /// drop `DEPTH` and that "nothing that works today breaks". The second
+    /// half is FALSE, and this is the measurement that says so.
+    ///
+    /// `QOS_PROFILE_DEFAULT` states `depth: 10`, so it REQUIRES `DEPTH`; a
+    /// mask without that bit refuses it, and that profile is what every
+    /// `create_publisher` / `create_subscription` with no explicit QoS passes
+    /// (`nros-node/src/executor/node.rs:238,372`). Withdrawing the bit would
+    /// therefore refuse every default entity on the backend, not just the ones
+    /// asking for more depth than the ring holds.
+    ///
+    /// So the zenoh shim EARNS the bit instead of withdrawing it (phase-428
+    /// W9: `shim/qos.rs` reads the depth, grants what the ring can hold, and
+    /// publishes the GRANTED value to the graph). Which is the honest reading
+    /// of the mask anyway: the bit says "I will not silently ignore this
+    /// policy", and a depth lie lives in the VALUE, not in the bit.
+    #[test]
+    fn withdrawing_depth_would_refuse_the_default_profile() {
+        let without_depth = QoSPolicyMask(!QoSPolicyMask::DEPTH.0);
+        assert!(
+            QoSProfile::QOS_PROFILE_DEFAULT
+                .validate_against(without_depth)
+                .is_err(),
+            "QOS_PROFILE_DEFAULT states depth 10; a mask without DEPTH must refuse it"
+        );
+        // And the same for the two other presets a default caller reaches.
+        for qos in [
+            QoSProfile::QOS_PROFILE_SERVICES_DEFAULT,
+            QoSProfile::QOS_PROFILE_SENSOR_DATA,
+        ] {
+            assert!(qos.validate_against(without_depth).is_err());
+        }
+        // The sentinel profile is the one that survives, because it states no
+        // depth at all.
+        assert!(
+            QoSProfile::QOS_PROFILE_SYSTEM_DEFAULT
+                .validate_against(without_depth)
+                .is_ok()
+        );
+    }
+
+    /// phase-428 W9 — the trait default advertises NOTHING, so an
+    /// implementation that has written no QoS code refuses any stated policy.
+    ///
+    /// The default was `CORE` until W9: four policies granted to a backend
+    /// that had implemented none of them, by the trait itself.
+    #[test]
+    fn the_empty_mask_refuses_every_stated_policy_and_nothing_else() {
+        assert_eq!(QoSPolicyMask::NONE.0, 0);
+        assert!(
+            QoSProfile::QOS_PROFILE_DEFAULT
+                .validate_against(QoSPolicyMask::NONE)
+                .is_err()
+        );
+        assert!(
+            QoSProfile::QOS_PROFILE_SYSTEM_DEFAULT
+                .validate_against(QoSPolicyMask::NONE)
+                .is_ok(),
+            "an absence demands nothing, so it is admissible anywhere"
         );
     }
 

--- a/packages/rmw/cffi/src/lib.rs
+++ b/packages/rmw/cffi/src/lib.rs
@@ -2970,20 +2970,41 @@ impl Session for CffiSession {
         }
     }
 
-    /// Phase 115.K.2.5.1.2 — declare a permissive QoS-policy mask
-    /// here so backends behind the cffi vtable don't get rejected by
-    /// the runtime's pre-validate step before they ever see the
-    /// `create_publisher` / `create_subscription` call. The vtable
-    /// doesn't expose a per-backend policy mask yet; until it does,
-    /// the cffi route has to assume the registered backend supports
-    /// the union of every policy any nros-supported RMW honours.
-    /// Backends that don't support a policy MUST surface
-    /// `NROS_RMW_RET_INCOMPATIBLE_QOS` from `create_publisher` etc.
-    /// to keep the no-silent-degradation contract.
+    /// This session MULTIPLEXES: it has no QoS behaviour of its own, and the
+    /// mask is the UNION of what the backends it routes to honour.
     ///
-    /// TODO 115.K.2.x: extend `nros_rmw_vtable_t` with a
-    /// `supported_qos_policies()` callback so the runtime queries
-    /// the backend instead of guessing.
+    /// nros-qos-mux: packages/rmw/cyclonedds packages/rmw/xrce packages/rmw/uorb
+    ///
+    /// phase-428 W9 makes that union derived rather than guessed. Every bit
+    /// below is claimed by a `nros-qos-honours:` site in one of the crates
+    /// named above, and `check-qos-mask-derivation` re-measures it; the line
+    /// this replaced said the route "has to assume the registered backend
+    /// supports the union of every policy any nros-supported RMW honours",
+    /// which was an assumption nothing checked and which was wrong:
+    /// `LIVELINESS_MANUAL_BY_NODE` is advertised here and honoured by no
+    /// backend in the tree. cyclonedds folds it onto MANUAL_BY_TOPIC
+    /// (`qos.cpp`), xrce lowers no liveliness field at all, uorb reads no QoS
+    /// field whatever. It is withdrawn (issue 1328).
+    ///
+    /// # A union is still an OVER-claim for any one backend
+    ///
+    /// Measured 2026-09-11, per backend:
+    ///
+    /// | policy | cyclonedds | xrce | uorb |
+    /// | --- | --- | --- | --- |
+    /// | reliability / durability / history / depth | yes | yes (to the Agent) | no |
+    /// | deadline / lifespan | yes | no | no |
+    /// | liveliness kind + lease | yes (AUTOMATIC, MANUAL_BY_TOPIC) | no | no |
+    /// | avoid_ros_namespace_conventions | no | pub + sub only | no |
+    ///
+    /// So an app asking cyclonedds for `avoid_ros_namespace_conventions`, or
+    /// xrce for a deadline, is admitted here and then silently ignored
+    /// downstream — the no-silent-downgrade contract broken one layer below
+    /// where it is enforced. Closing it needs a per-backend answer, and the
+    /// vtable has no slot to ask through: that is **issue 1329**, which also
+    /// records why narrowing the union without one is not the fix (xrce would
+    /// lose `LIVELINESS_AUTOMATIC`, which every C default profile states, so
+    /// every C app on xrce would fail at create).
     fn supported_qos_policies(&self) -> nros_rmw::QoSPolicyMask {
         use nros_rmw::QoSPolicyMask;
         QoSPolicyMask::CORE
@@ -2993,7 +3014,6 @@ impl Session for CffiSession {
             | QoSPolicyMask::LIFESPAN
             | QoSPolicyMask::LIVELINESS_AUTOMATIC
             | QoSPolicyMask::LIVELINESS_MANUAL_BY_TOPIC
-            | QoSPolicyMask::LIVELINESS_MANUAL_BY_NODE
             | QoSPolicyMask::LIVELINESS_LEASE
     }
 }

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/qos.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/qos.cpp
@@ -35,6 +35,7 @@ dds_qos_t *make_dds_qos(const rmw_qos_profile_t *src) {
     // `RELIABILITY_SYSTEM_DEFAULT` on the `RELIABLE` case by fallthrough.
     // Cyclone is the backend that meets real ROS peers, and it was the one
     // picking the less safe side.
+    // nros-qos-honours: RELIABILITY
     dds_qset_reliability(
         q,
         src->reliability == NROS_RMW_RELIABILITY_BEST_EFFORT
@@ -50,6 +51,8 @@ dds_qos_t *make_dds_qos(const rmw_qos_profile_t *src) {
         // it through the reserved bytes if a tighter bound matters.
         DDS_SECS(1));
 
+    // nros-qos-honours: DURABILITY_VOLATILE
+    // nros-qos-honours: DURABILITY_TRANSIENT_LOCAL
     dds_qset_durability(
         q,
         src->durability == NROS_RMW_DURABILITY_TRANSIENT_LOCAL
@@ -76,6 +79,8 @@ dds_qos_t *make_dds_qos(const rmw_qos_profile_t *src) {
     // KEEP_ALL keeps its 0: it carries one legitimately (upstream's
     // `rmw_qos_profile_parameter_events` does) and the validator constrains
     // only the KEEP_LAST case.
+    // nros-qos-honours: HISTORY
+    // nros-qos-honours: DEPTH
     const bool keep_all = (src->history == NROS_RMW_HISTORY_KEEP_ALL);
     uint32_t depth = src->depth;
     if (!keep_all && depth == 0) {
@@ -89,13 +94,23 @@ dds_qos_t *make_dds_qos(const rmw_qos_profile_t *src) {
     // Phase-301 (issue 0241): `NROS_RMW_DURATION_INFINITE_MS` is the
     // explicit infinite spelling — semantically identical to 0 (no
     // check) at every duration comparison.
+    // nros-qos-honours: DEADLINE
     if (src->deadline_ms != 0 && src->deadline_ms != NROS_RMW_DURATION_INFINITE_MS) {
         dds_qset_deadline(q, DDS_MSECS(src->deadline_ms));
     }
+    // nros-qos-honours: LIFESPAN
     if (src->lifespan_ms != 0 && src->lifespan_ms != NROS_RMW_DURATION_INFINITE_MS) {
         dds_qset_lifespan(q, DDS_MSECS(src->lifespan_ms));
     }
 
+    // nros-qos-honours: LIVELINESS_AUTOMATIC
+    // nros-qos-honours: LIVELINESS_MANUAL_BY_TOPIC
+    // nros-qos-honours: LIVELINESS_LEASE
+    //
+    // MANUAL_BY_NODE is NOT claimed: the fold below serves it as
+    // MANUAL_BY_TOPIC, which asserts per topic where the caller asked for per
+    // node. phase-428 W9 withdrew the bit from every mask in the tree
+    // (issue 1328) rather than keep advertising a policy nobody implements.
     if (src->liveliness_kind != NROS_RMW_LIVELINESS_SYSTEM_DEFAULT) {
         dds_liveliness_kind_t k = DDS_LIVELINESS_AUTOMATIC;
         switch (src->liveliness_kind) {

--- a/packages/rmw/metadata/src/lib.rs
+++ b/packages/rmw/metadata/src/lib.rs
@@ -102,6 +102,20 @@ impl Session for MetadataSession {
     type ServiceHandle = MetadataService;
     type ClientHandle = MetadataClient;
 
+    /// nros-qos-exempt: this session carries no traffic, so no policy can be
+    /// honoured OR violated — it exists to RECORD which entities an image
+    /// declares (`nros::metadata_mode`) and never opens a transport.
+    ///
+    /// phase-428 W9 — it inherited the trait's old `CORE` default, which was
+    /// the wrong answer in both directions: it claimed four policies it does
+    /// not implement, and the new empty default would refuse every entity the
+    /// recorder exists to see, turning a build-time inventory into a build-time
+    /// failure. Accepting everything is right HERE and nowhere else, because
+    /// admitting a profile costs a peer nothing when there is no peer.
+    fn supported_qos_policies(&self) -> nros_rmw::QoSPolicyMask {
+        nros_rmw::QoSPolicyMask(u32::MAX)
+    }
+
     fn create_publisher(
         &mut self,
         topic: &TopicInfo<'_>,

--- a/packages/rmw/xrce/nros-rmw-xrce/src/publisher.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/publisher.c
@@ -62,6 +62,8 @@ rmw_ret_t xrce_publisher_create(const rmw_node_t* node,
     uxrObjectId pub_oid   = xrce_alloc_entity_id(st, UXR_PUBLISHER_ID);
     uxrObjectId dw_oid    = xrce_alloc_entity_id(st, UXR_DATAWRITER_ID);
 
+    /* nros-qos-honours: AVOID_ROS_NAMESPACE_CONVENTIONS — drops the `rt/`
+     * prefix from the DDS topic name (`xrce_dds_topic_name`). */
     int avoid_ros = 0;
     if (qos != NULL) {
         avoid_ros = qos->avoid_ros_namespace_conventions != 0;

--- a/packages/rmw/xrce/nros-rmw-xrce/src/session.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/session.c
@@ -272,6 +272,16 @@ uxrQoS_t xrce_map_qos(const rmw_qos_profile_t* qos) {
      * supplies its own. This backend genuinely has no depth of its own to
      * offer: every default on this path is the Agent's, so deferring is the
      * honest answer rather than a gap. */
+    /* nros-qos-honours: DURABILITY_VOLATILE
+     * nros-qos-honours: DURABILITY_TRANSIENT_LOCAL
+     * nros-qos-honours: RELIABILITY
+     * nros-qos-honours: HISTORY
+     * nros-qos-honours: DEPTH
+     *
+     * The four fields `uxrQoS_t` has. They ride the CREATE submessage to the
+     * Agent, whose DDS layer applies them (`create_entities_bin.c` sets the
+     * `qos_flags` bits and the optional depth). Deadline, lifespan and
+     * liveliness have no field here and are NOT claimed — phase-428 W9. */
     out.durability = (qos->durability == NROS_RMW_DURABILITY_TRANSIENT_LOCAL)
                          ? UXR_DURABILITY_TRANSIENT_LOCAL
                          : UXR_DURABILITY_VOLATILE;

--- a/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
@@ -121,6 +121,7 @@ xrce_subscription_create(const rmw_node_t* node, const rmw_message_type_support_
     uxrObjectId sub_oid = xrce_alloc_entity_id(st, UXR_SUBSCRIBER_ID);
     uxrObjectId dr_oid = xrce_alloc_entity_id(st, UXR_DATAREADER_ID);
 
+    /* nros-qos-honours: AVOID_ROS_NAMESPACE_CONVENTIONS — see publisher.c. */
     int avoid_ros = 0;
     if (qos != NULL) {
         avoid_ros = qos->avoid_ros_namespace_conventions != 0;

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/keyexpr.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/keyexpr.rs
@@ -182,6 +182,15 @@ pub trait QosKeyExpr {
     fn to_qos_string<const N: usize>(&self) -> heapless::String<N>;
 }
 
+// nros-qos-discovery-only: this serialiser puts a profile into the `@ros2_lv`
+// keyexpr for a peer's graph parser. It APPLIES nothing — phase-428 W9 found
+// four policies whose only read in the whole backend was this function, read
+// as evidence that the shim honoured them. `check-qos-mask-derivation` does
+// not count a read inside this region, so a policy cannot earn a mask bit by
+// being mentioned to somebody else.
+//
+// The profile reaching here is the GRANTED one (`shim/qos.rs`), so what a peer
+// reads is what this image does.
 impl QosKeyExpr for QoSProfile {
     fn to_qos_string<const N: usize>(&self) -> heapless::String<N> {
         let mut s = heapless::String::new();

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
@@ -40,6 +40,7 @@
 //! ```
 
 pub mod publisher;
+pub mod qos;
 pub mod service;
 pub mod session;
 pub mod subscriber;

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/publisher.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/publisher.rs
@@ -134,6 +134,10 @@ impl ZenohPublisher {
             _liveliness: liveliness,
             #[cfg(feature = "lending")]
             lend_arena: lending::LendArena::new(),
+            // nros-qos-honours: DEADLINE — carried onto the publisher and
+            // checked in `check_offered_deadline`, which fires
+            // `OfferedDeadlineMissed` (rate-limited to one per window). 0 and
+            // DURATION_INFINITE_MS both mean "no check".
             deadline_ms: qos.deadline_ms,
             last_publish_at_ms: core::cell::Cell::new(now),
             last_deadline_fire_ms: core::cell::Cell::new(now),

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/qos.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/qos.rs
@@ -130,12 +130,25 @@ pub(super) fn admit(
     // as the other inverts behaviour, it does not weaken it.
     match requested.history {
         QoSHistoryPolicy::KeepLast => {}
-        QoSHistoryPolicy::KeepAll | QoSHistoryPolicy::SystemDefault => {
+        QoSHistoryPolicy::KeepAll => {
             refuse(
                 kind,
                 name,
                 "history",
-                "KEEP_ALL — the shim's receive ring is KEEP_LAST only",
+                "KEEP_ALL — the receive ring is KEEP_LAST only",
+            );
+            return Err(TransportError::IncompatibleQos);
+        }
+        // A sentinel HERE means the caller skipped `resolve_system_default`,
+        // which is a caller bug and not a policy this backend declines. Saying
+        // "KEEP_ALL" would aim the reader at their profile instead of at the
+        // missing resolve.
+        QoSHistoryPolicy::SystemDefault => {
+            refuse(
+                kind,
+                name,
+                "history",
+                "SYSTEM_DEFAULT reached the backend unresolved",
             );
             return Err(TransportError::IncompatibleQos);
         }
@@ -148,12 +161,22 @@ pub(super) fn admit(
     // backend directly.
     match requested.durability {
         QoSDurabilityPolicy::Volatile => {}
-        QoSDurabilityPolicy::TransientLocal | QoSDurabilityPolicy::SystemDefault => {
+        QoSDurabilityPolicy::TransientLocal => {
             refuse(
                 kind,
                 name,
                 "durability",
                 "TRANSIENT_LOCAL — the shim keeps no historical samples",
+            );
+            return Err(TransportError::IncompatibleQos);
+        }
+        // See the history arm: an unresolved sentinel is the caller's bug.
+        QoSDurabilityPolicy::SystemDefault => {
+            refuse(
+                kind,
+                name,
+                "durability",
+                "SYSTEM_DEFAULT reached the backend unresolved",
             );
             return Err(TransportError::IncompatibleQos);
         }

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/qos.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/qos.rs
@@ -1,0 +1,386 @@
+//! QoS admission — what this backend GRANTS for what a caller requested.
+//!
+//! phase-428 W9. Every bit `ZenohSession::supported_qos_policies` sets is
+//! backed by a `nros-qos-honours:` claim, and a claim means the backend READS
+//! the field and either applies it or refuses a value it cannot serve.
+//! `check-qos-mask-derivation` re-measures that on every push, so the mask is
+//! derived from this file rather than asserted beside it.
+//!
+//! # What W9 measured here, and what changed
+//!
+//! Before this module the shim read four of its own CORE policies in exactly
+//! one place — `QosKeyExpr::to_qos_string`, the DISCOVERY keyexpr — and read
+//! them nowhere else. Reliability, durability, history and depth went onto the
+//! `@ros2_lv` token and changed no local behaviour whatever. A caller asking
+//! for `KEEP_LAST(100)` got a four-slot ring AND a graph entry telling every
+//! peer it had a hundred.
+//!
+//! Three of those four are now honoured for real, by refusing what the shim
+//! cannot do:
+//!
+//! * **history** — the ring is KEEP_LAST by construction (`subscriber.rs`
+//!   drops on a full ring), so `KEEP_ALL` is refused rather than silently
+//!   served as KEEP_LAST. Nothing in the tree requests it: no named preset is
+//!   KEEP_ALL since phase-428 W10.
+//! * **durability** — VOLATILE is what a shim with no historical-sample cache
+//!   does; TRANSIENT_LOCAL is refused (it was already outside the mask, this
+//!   makes the refusal local and loud for a direct caller).
+//! * **depth** — clamped to the ring, which is a build-time constant, and the
+//!   clamp is REPORTED: the granted value goes into the graph token, and the
+//!   first entity to lose depth says so once per session.
+//!
+//! The fourth, **reliability**, is granted RELIABLE whatever was asked,
+//! because zenoh-pico's publisher path sets `Z_CONGESTION_CONTROL_BLOCK`
+//! unconditionally. That is an OVER-delivery — a BEST_EFFORT reader is
+//! RxO-compatible with a RELIABLE writer, so it costs a peer nothing — and it
+//! is reported at INFO where the depth clamp is reported at WARN. The severity
+//! IS the direction: over-delivery is safe, under-delivery loses samples.
+//!
+//! # Why granting is not clamping
+//!
+//! A clamp changes what happens and tells nobody. This returns the profile the
+//! backend will actually run, the caller's entity is configured from it, and
+//! `create_*` puts THAT profile — not the request — into the liveliness token
+//! a `rmw_zenoh_cpp` peer parses. So the graph stops carrying a number we do
+//! not honour, which was the lie.
+
+use nros_rmw::{
+    DURATION_INFINITE_MS, QoSDurabilityPolicy, QoSHistoryPolicy, QoSLivelinessPolicy, QoSProfile,
+    QoSReliabilityPolicy, TransportError,
+};
+
+use crate::config::SUBSCRIBER_RING_DEPTH;
+
+use super::service::SERVICE_REQUEST_RING_DEPTH;
+
+/// Which create entry is asking. The granted profile differs by entity: the
+/// queue a depth names is a different array for a subscription and a service
+/// server, and a publisher has none at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum EntityKind {
+    Publisher,
+    Subscription,
+    Service,
+    Client,
+}
+
+impl EntityKind {
+    fn label(self) -> &'static str {
+        match self {
+            EntityKind::Publisher => "publisher",
+            EntityKind::Subscription => "subscription",
+            EntityKind::Service => "service",
+            EntityKind::Client => "client",
+        }
+    }
+
+    /// How many samples the entity's receive ring can hold, or `None` when the
+    /// entity has no ring.
+    ///
+    /// A publisher has none: zenoh-pico writes to the session on the calling
+    /// thread and queues no sample of its own, so there is no history for a
+    /// depth to bound and no sample a depth could cause it to drop. Any
+    /// requested depth is therefore satisfied — vacuously, but exactly.
+    fn ring_capacity(self) -> Option<u32> {
+        match self {
+            EntityKind::Publisher => None,
+            EntityKind::Subscription => Some(SUBSCRIBER_RING_DEPTH as u32),
+            EntityKind::Service | EntityKind::Client => Some(SERVICE_REQUEST_RING_DEPTH as u32),
+        }
+    }
+}
+
+/// Reported once per process, not once per entity.
+///
+/// Every stock preset asks for more depth than the default four-slot ring
+/// (`QOS_PROFILE_DEFAULT` and `QOS_PROFILE_SERVICES_DEFAULT` ask 10,
+/// `QOS_PROFILE_PARAMETERS` asks 1000), so a line per entity would be a line
+/// per entity in every image — noise that teaches a reader to skip it. The
+/// knob that fixes it is global, so one line naming the first entity to lose
+/// depth carries the whole message.
+static DEPTH_CLAMP_REPORTED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+/// Reported once per process, same reasoning: `QOS_PROFILE_SENSOR_DATA` and
+/// `QOS_PROFILE_BEST_EFFORT` are common, and the answer is the same every time.
+static RELIABILITY_GRANT_REPORTED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+fn first_time(flag: &core::sync::atomic::AtomicBool) -> bool {
+    !flag.swap(true, core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Resolve a requested profile into the one this backend will run, refusing
+/// what it cannot serve.
+///
+/// The caller must have resolved `SYSTEM_DEFAULT` first (issue 0829 —
+/// `QoSProfile::resolve_system_default`); a sentinel reaching here would be
+/// compared against a ring capacity as if it were a request.
+pub(super) fn admit(
+    kind: EntityKind,
+    name: &str,
+    requested: &QoSProfile,
+) -> Result<QoSProfile, TransportError> {
+    let mut granted = *requested;
+
+    // nros-qos-honours: HISTORY — the ring is KEEP_LAST by construction
+    // (`subscriber.rs` drops the arriving sample when `tail - head` reaches the
+    // ring depth), so KEEP_ALL is refused rather than served as its opposite.
+    // KEEP_ALL blocks a reliable writer where KEEP_LAST overwrites: serving one
+    // as the other inverts behaviour, it does not weaken it.
+    match requested.history {
+        QoSHistoryPolicy::KeepLast => {}
+        QoSHistoryPolicy::KeepAll | QoSHistoryPolicy::SystemDefault => {
+            refuse(
+                kind,
+                name,
+                "history",
+                "KEEP_ALL — the shim's receive ring is KEEP_LAST only",
+            );
+            return Err(TransportError::IncompatibleQos);
+        }
+    }
+
+    // nros-qos-honours: DURABILITY_VOLATILE — no historical-sample cache and no
+    // query-on-match, so VOLATILE is what the shim does and TRANSIENT_LOCAL is
+    // refused. The mask already withholds TRANSIENT_LOCAL, so the runtime
+    // refuses it first; this is the same refusal for a caller who reached the
+    // backend directly.
+    match requested.durability {
+        QoSDurabilityPolicy::Volatile => {}
+        QoSDurabilityPolicy::TransientLocal | QoSDurabilityPolicy::SystemDefault => {
+            refuse(
+                kind,
+                name,
+                "durability",
+                "TRANSIENT_LOCAL — the shim keeps no historical samples",
+            );
+            return Err(TransportError::IncompatibleQos);
+        }
+    }
+
+    // nros-qos-honours: RELIABILITY — read, granted RELIABLE, and the
+    // divergence reported. zenoh-pico publishes with
+    // `Z_CONGESTION_CONTROL_BLOCK`, so a BEST_EFFORT request is OVER-served,
+    // never under-served. Reported at INFO once: a BEST_EFFORT reader is
+    // RxO-compatible with a RELIABLE writer, so this costs a peer nothing.
+    if requested.reliability != QoSReliabilityPolicy::Reliable {
+        granted.reliability = QoSReliabilityPolicy::Reliable;
+        if first_time(&RELIABILITY_GRANT_REPORTED) {
+            nros_log::log_info!(
+                nros_log::get_logger("nros_rmw_zenoh"),
+                "qos: {} '{}' asked for BEST_EFFORT; zenoh-pico delivers reliably \
+                 (congestion control BLOCK), so RELIABLE is granted. Over-delivery, \
+                 not loss.",
+                kind.label(),
+                name
+            );
+        }
+    }
+
+    // nros-qos-honours: DEPTH — the requested depth meets the ring the shim
+    // actually has. The ring is a build-time constant
+    // (`ZPICO_SUBSCRIBER_RING_DEPTH`, default 4), so a bigger request cannot be
+    // served; what it must not do is vanish. The granted depth is what
+    // `create_*` puts in the liveliness token, so a peer reading our graph
+    // entry sees the queue we keep, and the first loss says so once.
+    if let Some(capacity) = kind.ring_capacity() {
+        if requested.depth > capacity {
+            granted.depth = capacity;
+            if first_time(&DEPTH_CLAMP_REPORTED) {
+                nros_log::log_warn!(
+                    nros_log::get_logger("nros_rmw_zenoh"),
+                    "qos: {} '{}' asked for KEEP_LAST({}); this image's receive ring \
+                     holds {}. Granting {} and advertising it to the graph. Raise \
+                     ZPICO_SUBSCRIBER_RING_DEPTH to keep more.",
+                    kind.label(),
+                    name,
+                    requested.depth,
+                    capacity,
+                    capacity
+                );
+            }
+        }
+    }
+
+    // nros-qos-honours: LIVELINESS_AUTOMATIC — the session declares an
+    // `@ros2_lv` token for the entity at create and holds it for the entity's
+    // life, which IS automatic assertion: the middleware asserts, the
+    // application does not. Read here so the claim has a site; nothing to
+    // apply, because unconditional is what AUTOMATIC asks for.
+    //
+    // nros-qos-honours: LIVELINESS_MANUAL_BY_TOPIC — `publisher.rs` runs the
+    // keepalive timer and fires `LivelinessLost` when the app misses a lease.
+    //
+    // MANUAL_BY_NODE is REFUSED, and was withdrawn from the mask in phase-428
+    // W9. The shim asserts per PUBLISHER; per-node semantics say one assertion
+    // covers every publisher of the node, so serving it as by-topic expires
+    // publishers the application correctly believed it had kept alive. That is
+    // a lie in the losing direction, which is why it is not a downgrade we are
+    // willing to make silently. (Cyclone folds the same value onto
+    // MANUAL_BY_TOPIC in `qos.cpp` — issue 1328.)
+    match requested.liveliness_kind {
+        QoSLivelinessPolicy::None
+        | QoSLivelinessPolicy::Automatic
+        | QoSLivelinessPolicy::ManualByTopic => {}
+        QoSLivelinessPolicy::ManualByNode => {
+            refuse(
+                kind,
+                name,
+                "liveliness",
+                "MANUAL_BY_NODE — the shim asserts per publisher, not per node",
+            );
+            return Err(TransportError::IncompatibleQos);
+        }
+    }
+
+    // nros-qos-honours: LIVELINESS_LEASE — `publisher.rs` gates and rate-limits
+    // `LivelinessLost` on it. The SUBSCRIBER side does not: its alive-state
+    // poll runs at a fixed interval (`LIVELINESS_POLL_DEFAULT_MS`), so a lease
+    // stated on a subscription buys nothing and is reported rather than
+    // pocketed.
+    if matches!(kind, EntityKind::Subscription)
+        && requested.liveliness_lease_ms != 0
+        && requested.liveliness_lease_ms != DURATION_INFINITE_MS
+    {
+        nros_log::log_warn!(
+            nros_log::get_logger("nros_rmw_zenoh"),
+            "qos: subscription '{}' stated a {} ms liveliness lease; the shim's \
+             alive-state poll runs at a fixed interval and does not use it. \
+             Publisher-side leases ARE honoured.",
+            name,
+            requested.liveliness_lease_ms
+        );
+    }
+
+    // deadline_ms and lifespan_ms need no admission step: both are applied
+    // verbatim by `publisher.rs` / `subscriber.rs`, and both take 0 and
+    // DURATION_INFINITE_MS as "off". Their `nros-qos-honours:` claims are sited
+    // on the code that checks them, which is where the honouring happens.
+
+    Ok(granted)
+}
+
+fn refuse(kind: EntityKind, name: &str, policy: &str, why: &str) {
+    nros_log::log_error!(
+        nros_log::get_logger("nros_rmw_zenoh"),
+        "qos: {} '{}' refused — {} {}",
+        kind.label(),
+        name,
+        policy,
+        why
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> QoSProfile {
+        QoSProfile::QOS_PROFILE_DEFAULT
+    }
+
+    #[test]
+    fn a_depth_the_ring_cannot_hold_is_granted_down_and_the_grant_is_returned() {
+        let mut qos = base();
+        qos.depth = 10_000;
+        let granted = admit(EntityKind::Subscription, "/t", &qos).expect("admissible");
+        assert_eq!(granted.depth, SUBSCRIBER_RING_DEPTH as u32);
+        // The REQUEST is untouched — the grant is a separate value, so a caller
+        // can see both.
+        assert_eq!(qos.depth, 10_000);
+    }
+
+    #[test]
+    fn a_depth_the_ring_can_hold_is_granted_verbatim() {
+        let mut qos = base();
+        qos.depth = 1;
+        let granted = admit(EntityKind::Subscription, "/t", &qos).expect("admissible");
+        assert_eq!(granted.depth, 1);
+    }
+
+    #[test]
+    fn a_publisher_has_no_ring_so_any_depth_is_granted() {
+        let mut qos = base();
+        qos.depth = 65_535;
+        let granted = admit(EntityKind::Publisher, "/t", &qos).expect("admissible");
+        assert_eq!(granted.depth, 65_535);
+    }
+
+    #[test]
+    fn keep_all_is_refused_not_served_as_keep_last() {
+        let mut qos = base();
+        qos.history = QoSHistoryPolicy::KeepAll;
+        assert!(matches!(
+            admit(EntityKind::Subscription, "/t", &qos),
+            Err(TransportError::IncompatibleQos)
+        ));
+    }
+
+    #[test]
+    fn transient_local_is_refused() {
+        let mut qos = base();
+        qos.durability = QoSDurabilityPolicy::TransientLocal;
+        assert!(matches!(
+            admit(EntityKind::Subscription, "/t", &qos),
+            Err(TransportError::IncompatibleQos)
+        ));
+    }
+
+    #[test]
+    fn manual_by_node_is_refused_and_manual_by_topic_is_not() {
+        let mut qos = base();
+        qos.liveliness_kind = QoSLivelinessPolicy::ManualByNode;
+        assert!(matches!(
+            admit(EntityKind::Publisher, "/t", &qos),
+            Err(TransportError::IncompatibleQos)
+        ));
+        qos.liveliness_kind = QoSLivelinessPolicy::ManualByTopic;
+        assert!(admit(EntityKind::Publisher, "/t", &qos).is_ok());
+    }
+
+    #[test]
+    fn best_effort_is_granted_reliable_rather_than_refused() {
+        let mut qos = base();
+        qos.reliability = QoSReliabilityPolicy::BestEffort;
+        let granted = admit(EntityKind::Publisher, "/t", &qos).expect("admissible");
+        assert_eq!(granted.reliability, QoSReliabilityPolicy::Reliable);
+    }
+
+    /// Every stock preset a default caller reaches must survive admission —
+    /// this is the regression the roadmap's "nothing that works today breaks"
+    /// claim needed and did not have.
+    #[test]
+    fn every_stock_preset_a_default_caller_reaches_is_admissible() {
+        let defaults = nros_rmw::QoSSystemDefaults {
+            reliability: QoSReliabilityPolicy::Reliable,
+            durability: QoSDurabilityPolicy::Volatile,
+            history: QoSHistoryPolicy::KeepLast,
+            depth: SUBSCRIBER_RING_DEPTH as u32,
+        };
+        for (label, qos) in [
+            ("default", QoSProfile::QOS_PROFILE_DEFAULT),
+            ("services", QoSProfile::QOS_PROFILE_SERVICES_DEFAULT),
+            ("sensor", QoSProfile::QOS_PROFILE_SENSOR_DATA),
+            ("parameters", QoSProfile::QOS_PROFILE_PARAMETERS),
+            ("parameter_events", QoSProfile::QOS_PROFILE_PARAMETER_EVENTS),
+            ("system_default", QoSProfile::QOS_PROFILE_SYSTEM_DEFAULT),
+            ("best_effort", QoSProfile::BEST_EFFORT),
+            ("reliable", QoSProfile::RELIABLE),
+        ] {
+            let qos = qos.resolve_system_default(&defaults);
+            for kind in [
+                EntityKind::Publisher,
+                EntityKind::Subscription,
+                EntityKind::Service,
+                EntityKind::Client,
+            ] {
+                assert!(
+                    admit(kind, "/t", &qos).is_ok(),
+                    "{label} refused for a {}",
+                    kind.label()
+                );
+            }
+        }
+    }
+}

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
@@ -1120,6 +1120,10 @@ impl Session for ZenohSession {
         // `best_available_qos` before the token exists, so its tokens never
         // carry a sentinel and neither may ours.
         let qos = qos.resolve_system_default(&ZENOH_SYSTEM_DEFAULTS);
+        // phase-428 W9 — and the GRANT before the keyexpr, for the same reason
+        // the resolve comes first: the token must carry what this backend does,
+        // not what it was asked to do.
+        let qos = super::qos::admit(super::qos::EntityKind::Publisher, topic.name, &qos)?;
         let mut publisher = ZenohPublisher::new(&self.context, topic, None, &qos)?;
         // Phase 268 W2 — ensure a per-node NN token for this publisher's node.
         if let Some(node_name) = topic.node_name {
@@ -1154,6 +1158,9 @@ impl Session for ZenohSession {
     ) -> Result<Self::SubscriptionHandle, Self::Error> {
         // issue 0829 — see `create_publisher`: resolve before the keyexpr.
         let qos = qos.resolve_system_default(&ZENOH_SYSTEM_DEFAULTS);
+        // phase-428 W9 — see `create_publisher`. This is the entity whose ring
+        // a depth actually meets.
+        let qos = super::qos::admit(super::qos::EntityKind::Subscription, topic.name, &qos)?;
         let mut subscriber = ZenohSubscriber::new(&self.context, topic, None, &qos)?;
         // Phase 268 W2 — ensure a per-node NN token for this subscriber's node.
         if let Some(node_name) = topic.node_name {
@@ -1186,11 +1193,17 @@ impl Session for ZenohSession {
         service: &ServiceInfo,
         qos: QoSProfile,
     ) -> Result<Self::ServiceHandle, Self::Error> {
-        // TODO(193.1b): zenoh-pico services have no endpoint-level QoS
-        // slot (the `None` below is the liveliness token, not QoS) — the
-        // requested service QoS cannot be applied to the queryable yet.
-        // Thread it through once zenoh-pico exposes per-endpoint QoS.
-        let _ = qos;
+        // phase-428 W9 — this was `let _ = qos;` under a TODO(193.1b), and a
+        // discarded argument is a silent lie about what was honoured. What is
+        // true is narrower than "cannot be applied": zenoh-pico has no
+        // per-endpoint QoS slot on a queryable, so nothing reaches the WIRE —
+        // but the request ring is ours, the refusals are ours, and the graph
+        // declaration is ours. All three are applied here, and the token below
+        // now carries the caller's granted profile instead of a hardcoded
+        // `QoSProfile::services_default()` that had nothing to do with what
+        // was asked for.
+        let qos = qos.resolve_system_default(&ZENOH_SYSTEM_DEFAULTS);
+        let qos = super::qos::admit(super::qos::EntityKind::Service, service.name, &qos)?;
         let mut server = ZenohServiceServer::new(&self.context, service, None)?;
         // Phase 268 W2 — ensure a per-node NN token for this server's node.
         if let Some(node_name) = service.node_name {
@@ -1209,7 +1222,7 @@ impl Session for ZenohSession {
                             service.namespace,
                             node_name,
                             service,
-                            &QoSProfile::services_default(),
+                            &qos,
                         )
                     })
                 })
@@ -1223,10 +1236,10 @@ impl Session for ZenohSession {
         service: &ServiceInfo,
         qos: QoSProfile,
     ) -> Result<Self::ClientHandle, Self::Error> {
-        // TODO(193.1b): zenoh-pico services have no endpoint-level QoS
-        // slot — the requested service QoS cannot be applied to the
-        // querier yet. Thread it once zenoh-pico exposes per-endpoint QoS.
-        let _ = qos;
+        // phase-428 W9 — see `create_service`: applied where it is ours to
+        // apply (refusals, request ring, graph declaration), not discarded.
+        let qos = qos.resolve_system_default(&ZENOH_SYSTEM_DEFAULTS);
+        let qos = super::qos::admit(super::qos::EntityKind::Client, service.name, &qos)?;
         // Phase 268 W2 — ensure a per-node NN token for this client's node.
         if let Some(node_name) = service.node_name {
             self.ensure_node_liveliness(service.domain_id, service.namespace, node_name);
@@ -1244,7 +1257,7 @@ impl Session for ZenohSession {
                             service.namespace,
                             node_name,
                             service,
-                            &QoSProfile::services_default(),
+                            &qos,
                         )
                     })
                 })
@@ -1474,36 +1487,38 @@ impl Session for ZenohSession {
         r
     }
 
+    /// phase-428 W9 — DERIVED. Every bit below is backed by a
+    /// `nros-qos-honours:` claim sited on the code that honours it, and
+    /// `check-qos-mask-derivation` re-measures them on every push; a claim
+    /// whose code is deleted takes the bit with it.
+    ///
+    /// What the comment here used to say, and what W9 measured:
+    ///
+    /// * *"Reliability maps to zenoh congestion-control"* — it did not.
+    ///   `zpico.c` sets `Z_CONGESTION_CONTROL_BLOCK` unconditionally and the
+    ///   field reached no publisher option. `shim/qos.rs` reads it now and
+    ///   GRANTS reliable, reporting the over-delivery.
+    /// * *"Durability VOLATILE / History / Depth honoured at the subscriber
+    ///   buffer level"* — none of the three were read outside the discovery
+    ///   keyexpr. The ring is KEEP_LAST at a build-time depth whatever was
+    ///   asked. `shim/qos.rs` refuses KEEP_ALL and TRANSIENT_LOCAL, grants the
+    ///   depth the ring can hold, and puts the GRANT in the token.
+    /// * `LIVELINESS_MANUAL_BY_NODE` is **withdrawn**. It was advertised here
+    ///   and folded onto MANUAL_BY_TOPIC — cyclonedds folds the same value in
+    ///   `qos.cpp`, and xrce drops liveliness entirely, so the policy was
+    ///   advertised by every backend in the tree and implemented by none
+    ///   (issue 1328). Asserting per publisher where the caller asked for per
+    ///   node expires publishers the application believed it had kept alive.
+    ///
+    /// AVOID_ROS_NAMESPACE_CONVENTIONS stays absent: key generation always
+    /// applies the ROS conventions and nothing reads the flag.
     fn supported_qos_policies(&self) -> nros_rmw::QoSPolicyMask {
-        // Phase 108.B/C — zenoh-pico's wire protocol has no native
-        // DDS QoS, so the shim emulates everything:
-        // - Reliability maps to zenoh congestion-control (CORE).
-        // - Durability VOLATILE / History / Depth honoured at the
-        //   subscriber buffer level (CORE).
-        // - DEADLINE: clock-based check at take_serialized (sub) /
-        //   publish_raw (pub). 108.C.zenoh.2.
-        // - LIFESPAN: subscriber filters samples whose attachment
-        //   timestamp is older than `now - lifespan_ms`. 108.C.zenoh.3.
-        // - LIVELINESS_AUTOMATIC: zenoh runtime declares the token
-        //   automatically when the publisher is created
-        //   (`Ros2Liveliness::publisher_keyexpr`); subscribers track
-        //   alive-state via a periodic poll of the wildcard liveliness
-        //   keyexpr. Per-publisher count surfaced via
-        //   `zpico_liveliness_get_count` (108.C.zenoh.4-followup).
-        // - LIVELINESS_MANUAL_BY_TOPIC / MANUAL_BY_NODE: shim-side
-        //   keepalive timer. `Publisher::assert_liveliness()`
-        //   refreshes the lease; `publish_raw` checks for expiry and
-        //   fires `LivelinessLost` rate-limited to ≤ 1 per lease.
-        //   (108.C.zenoh.4-followup).
-        // - LIVELINESS_LEASE: caller-supplied lease duration honoured
-        //   for all liveliness kinds.
         use nros_rmw::QoSPolicyMask;
         QoSPolicyMask::CORE
             | QoSPolicyMask::DEADLINE
             | QoSPolicyMask::LIFESPAN
             | QoSPolicyMask::LIVELINESS_AUTOMATIC
             | QoSPolicyMask::LIVELINESS_MANUAL_BY_TOPIC
-            | QoSPolicyMask::LIVELINESS_MANUAL_BY_NODE
             | QoSPolicyMask::LIVELINESS_LEASE
     }
 }

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
@@ -1049,7 +1049,12 @@ impl ZenohSubscriber {
             msg_lost_total: core::cell::Cell::new(0),
             msg_lost_cb: core::cell::Cell::new(None),
             pending_too_small: core::cell::Cell::new(false),
+            // nros-qos-honours: LIFESPAN — `take_serialized` drops a sample
+            // whose attachment timestamp is older than `now - lifespan_ms`
+            // instead of delivering it.
             lifespan_ms: qos.lifespan_ms,
+            // nros-qos-honours: DEADLINE — `check_deadline_and_fire` fires
+            // `RequestedDeadlineMissed` when no sample arrives in the window.
             deadline_ms: qos.deadline_ms,
             last_msg_at_ms: core::cell::Cell::new(now),
             last_deadline_fire_ms: core::cell::Cell::new(now),

--- a/scripts/check-qos-mask-derivation.py
+++ b/scripts/check-qos-mask-derivation.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+"""A backend may only advertise a QoS policy its code honours — phase-428 W9.
+
+WHAT WENT WRONG
+
+`Session::supported_qos_policies` returns a bitmask, and until W9 every one of
+them was a hand-written constant sitting several files away from any code that
+implemented anything. So the mask said whatever it had said when it was
+written, and drifted the only way an unbound constant can: toward claiming
+more.
+
+Measured over the tree on 2026-09-11:
+
+* `LIVELINESS_MANUAL_BY_NODE` was advertised by the zenoh shim AND by the cffi
+  route, and implemented by nobody. The zenoh publisher matches
+  `ManualByTopic | ManualByNode` together, so a per-node request got per-topic
+  assertion; `nros_rmw_cyclonedds`'s `qos.cpp` folds the value onto
+  MANUAL_BY_TOPIC in as many words; xrce lowers no liveliness field at all.
+  The lie is in the losing direction — an application that correctly asserted
+  its node's liveliness watches its other publishers expire.
+* The zenoh shim's four CORE policies had exactly one read between them, in
+  `QosKeyExpr::to_qos_string`, which builds a DISCOVERY keyexpr. Reliability,
+  durability, history and depth changed no local behaviour whatever; the
+  comment above the mask said all four were "honoured at the subscriber buffer
+  level".
+
+Neither is findable by reading a mask. Both are obvious once the question is
+"which line of code does this?".
+
+WHAT THIS CHECKS
+
+A bit may be advertised only if the backend carries a `nros-qos-honours:
+<BIT>` claim, sited on the code that honours the policy, in a file that READS
+the mapped profile field. Honouring means applying the request or refusing a
+value the backend cannot serve — both read the field, which is what makes the
+rule mechanical. Passing the field to someone else does not: a file marked
+`nros-qos-discovery-only:` contributes no evidence, because that was exactly
+the shape of the second finding above.
+
+WHY THE SUBJECT LISTS ARE ALL DERIVED
+
+This campaign's recurring failure is a gate whose own list of things to check
+is authored: the RMW parity map read green for 28 slots that had moved, and
+the layout gate checked three type names out of ninety. So nothing here is
+typed twice:
+
+* the POLICY VOCABULARY is read from `QoSPolicyMask`'s `pub const` block;
+* what each bit MEANS — which field, which variant — is read from
+  `QoSProfile::required_policies`, the function that decides when a caller has
+  asked for it, and a bit that function can never set is an error here;
+* the BACKEND LIST is every `impl Session for` in `packages/**/src`, so a new
+  backend is in scope the moment it exists;
+* a multiplexing session (the cffi route) names the crates it routes to and
+  its union is checked against THEIR claims.
+
+An implementation that honours nothing says so with `nros-qos-exempt:` and a
+reason — the mock and the metadata recorder, neither of which carries traffic.
+
+THE NEGATIVE CONTROL IS THE LIVE TREE
+
+Synthetic inputs prove the parser reads Rust. They do not prove the gate would
+notice a real regression, because a synthetic file is written by the same hand
+that wrote the matcher. So the controls below MUTATE THE REAL SOURCES in
+memory — delete the depth read from the zenoh admission function, delete a
+claim, move a claim into the discovery-only file, re-advertise the withdrawn
+liveliness bit — and require a red each time. They run on the normal path
+(`check-gate-selftests`), so "someone once demonstrated a red" stays a
+measurement.
+
+Usage::
+
+    check-qos-mask-derivation.py             # the gate (+ its selftest)
+    check-qos-mask-derivation.py --audit     # per backend, per bit, never fails
+    check-qos-mask-derivation.py --verbose-selftest
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TRAITS = ROOT / "packages" / "core" / "nros-rmw" / "src" / "traits.rs"
+
+SOURCE_SUFFIXES = (".rs", ".c", ".cc", ".cpp", ".h", ".hpp")
+
+CLAIM = re.compile(r"nros-qos-honours:\s*([A-Z][A-Z0-9_]*)")
+EXEMPT = re.compile(r"nros-qos-exempt:\s*(\S.*)")
+MUX = re.compile(r"nros-qos-mux:\s*(\S.*)")
+DISCOVERY_ONLY = re.compile(r"nros-qos-discovery-only:")
+
+IMPL_SESSION = re.compile(r"^\s*impl\s+(?:[\w:]+::)?Session\s+for\s+(\w+)", re.M)
+
+
+class Fail(Exception):
+    pass
+
+
+# --------------------------------------------------------------------------
+# Reading the definitions out of traits.rs
+# --------------------------------------------------------------------------
+
+
+def parse_bits(traits: str) -> tuple[dict[str, int], dict[str, set[str]]]:
+    """`pub const NAME: Self = ...` inside `impl QoSPolicyMask`.
+
+    Returns (atomic bits -> value, alias -> the atomic names it unions).
+    Split by SHAPE, not by a list of known names: `Self(1 << n)` is a policy,
+    `Self(A.0 | B.0)` is an alias for a set of them, `Self(0)` is the empty
+    mask. A fourth shape would be reported rather than guessed at.
+    """
+    block = _impl_block(traits, "impl QoSPolicyMask {")
+    if block is None:
+        raise Fail("traits.rs: no `impl QoSPolicyMask` block — the vocabulary has moved")
+
+    atomic: dict[str, int] = {}
+    alias: dict[str, set[str]] = {}
+    for m in re.finditer(r"pub const ([A-Z][A-Z0-9_]*)\s*:\s*Self\s*=\s*([^;]+);", block):
+        name, rhs = m.group(1), " ".join(m.group(2).split())
+        shift = re.fullmatch(r"Self\(1\s*<<\s*(\d+)\)", rhs)
+        if shift:
+            atomic[name] = 1 << int(shift.group(1))
+            continue
+        if re.fullmatch(r"Self\(0\)", rhs):
+            alias[name] = set()
+            continue
+        parts = re.findall(r"Self::([A-Z][A-Z0-9_]*)\.0", rhs)
+        if parts and re.fullmatch(r"Self\(\s*Self::[A-Z0-9_]+\.0(\s*\|\s*Self::[A-Z0-9_]+\.0)*\s*\)", rhs):
+            alias[name] = set(parts)
+            continue
+        raise Fail(
+            f"traits.rs: `QoSPolicyMask::{name}` has a shape this gate cannot read ({rhs!r}).\n"
+            "  Bits are `Self(1 << n)`, aliases are a union of `Self::X.0`, empty is `Self(0)`."
+        )
+    if not atomic:
+        raise Fail("traits.rs: `impl QoSPolicyMask` declares no `Self(1 << n)` policy bits")
+    return atomic, alias
+
+
+def _impl_block(text: str, header: str) -> str | None:
+    """The braced body following `header`, by brace matching."""
+    i = text.find(header)
+    if i < 0:
+        return None
+    i = text.index("{", i)
+    depth, j = 0, i
+    while j < len(text):
+        if text[j] == "{":
+            depth += 1
+        elif text[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[i + 1 : j]
+        j += 1
+    return None
+
+
+def parse_policy_fields(traits: str) -> dict[str, tuple[str, str | None]]:
+    """bit -> (profile field, enum variant or None), from `required_policies`.
+
+    That function is the definition of what a bit MEANS: it is what decides,
+    for a given profile, whether the caller asked for the policy. Reading the
+    mapping out of it rather than restating it here is the point — a policy
+    whose meaning moves moves this gate's expectations with it.
+    """
+    body = _fn_body(traits, "pub fn required_policies(&self) -> QoSPolicyMask {")
+    if body is None:
+        raise Fail("traits.rs: `required_policies` not found — the bit->field mapping has moved")
+
+    out: dict[str, tuple[str, str | None]] = {}
+    field: str | None = None
+    variant: str | None = None
+    for line in body.splitlines():
+        stripped = line.strip()
+        # A new `if`/`match` on a profile field rebinds the subject.
+        subject = re.search(r"\b(?:if|match)\b[^/]*?\bself\.(\w+)", stripped)
+        if subject:
+            field = subject.group(1)
+            variant = None
+        # An arm label may be a path (`QoSDurabilityPolicy::Volatile =>`) or a
+        # bare variant, and an or-pattern names several
+        # (`None | Automatic | ManualByTopic => {}`) — those set no bit, so the
+        # last name is as good as any.
+        arm = re.match(r"([\w:|\s]+?)\s*=>", stripped)
+        if arm:
+            variant = arm.group(1).split("::")[-1].split("|")[-1].strip()
+        for bit in re.findall(r"mask \|= QoSPolicyMask::([A-Z][A-Z0-9_]*)", stripped):
+            if field is None:
+                raise Fail(
+                    f"required_policies: `{bit}` is set with no `self.<field>` subject in scope"
+                )
+            out[bit] = (field, variant)
+        if stripped.endswith(",") or stripped == "}":
+            # An arm ends; the next `mask |=` without its own arm belongs to
+            # the enclosing `if`, not to this variant.
+            if arm is None and variant is not None and stripped.startswith("}"):
+                variant = None
+    return out
+
+
+def _fn_body(text: str, signature: str) -> str | None:
+    i = text.find(signature)
+    if i < 0:
+        return None
+    return _impl_block(text[i:], signature)
+
+
+# --------------------------------------------------------------------------
+# The tree
+# --------------------------------------------------------------------------
+
+
+def load_tree() -> dict[str, str]:
+    """Every tracked source file under a `packages/**/src/`.
+
+    `git ls-files`, not a walk: an index lookup skips the build output and the
+    generated trees for free, and `check-no-tracked-file-find` is right that a
+    walk stats every directory it considers pruning.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files", "-z", "--", "packages"],
+        capture_output=True,
+    )
+    if out.returncode != 0:
+        raise Fail(
+            "`git ls-files` failed, so the backend list would be derived from nothing. "
+            "A gate that examines no files reports a pass it never established."
+        )
+    files: dict[str, str] = {}
+    for rel in out.stdout.decode("utf8", "replace").split("\0"):
+        if not rel or "/src/" not in rel or not rel.endswith(SOURCE_SUFFIXES):
+            continue
+        if "/generated/" in rel:
+            continue
+        try:
+            files[rel] = (ROOT / rel).read_text(encoding="utf8", errors="replace")
+        except OSError:
+            continue
+    if not files:
+        raise Fail("no tracked sources under packages/**/src — the file scan is broken")
+    return files
+
+
+def crate_root(rel: str) -> str:
+    """The directory holding the `src/` this file lives under."""
+    parts = rel.split("/")
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i] == "src":
+            return "/".join(parts[:i])
+    return os.path.dirname(rel)
+
+
+class Backend:
+    def __init__(self, file: str, type_name: str):
+        self.file = file
+        self.type_name = type_name
+        self.crate = crate_root(file)
+        self.bits: set[str] | None = None  # None = the trait default
+        self.all_bits = False  # `QoSPolicyMask(u32::MAX)`
+        self.exempt: str | None = None
+        self.mux: list[str] = []
+
+    def scopes(self) -> list[str]:
+        return [self.crate] + self.mux
+
+    def __repr__(self):
+        return f"<{self.type_name} in {self.crate}>"
+
+
+def find_backends(files: dict[str, str], atomic, alias) -> list[Backend]:
+    out: list[Backend] = []
+    for rel, text in sorted(files.items()):
+        if not rel.endswith(".rs"):
+            continue
+        for m in IMPL_SESSION.finditer(text):
+            block = _impl_block(text[m.start() :], m.group(0))
+            if block is None:
+                continue
+            be = Backend(rel, m.group(1))
+            _read_mask(be, block, atomic, alias)
+            out.append(be)
+    return out
+
+
+def _read_mask(be: Backend, block: str, atomic, alias) -> None:
+    sig = "fn supported_qos_policies(&self) -> "
+    i = block.find(sig)
+    if i < 0:
+        return  # inherits the trait default
+    # The doc comment above the fn carries the exempt / mux declarations.
+    head = block[:i]
+    doc = head[head.rfind("\n\n") :] if "\n\n" in head else head
+    ex = EXEMPT.search(doc)
+    if ex:
+        be.exempt = ex.group(1).strip()
+    mx = MUX.search(doc)
+    if mx:
+        be.mux = [d.strip().rstrip("/") for d in mx.group(1).split() if d.strip()]
+
+    body = _impl_block(block[i:], sig)
+    if body is None:
+        raise Fail(f"{be.type_name}: could not read the body of supported_qos_policies")
+    if re.search(r"QoSPolicyMask\(\s*u32::MAX\s*\)", body):
+        be.all_bits = True
+        be.bits = set(atomic)
+        return
+    names = re.findall(r"QoSPolicyMask::([A-Z][A-Z0-9_]*)", body)
+    if not names:
+        if re.search(r"QoSPolicyMask\(\s*0\s*\)", body):
+            be.bits = set()
+            return
+        raise Fail(
+            f"{be.type_name} ({be.file}): supported_qos_policies returns an expression this\n"
+            f"  gate cannot read. Write a union of `QoSPolicyMask::<BIT>` terms."
+        )
+    bits: set[str] = set()
+    for n in names:
+        if n in atomic:
+            bits.add(n)
+        elif n in alias:
+            bits |= alias[n]
+        else:
+            raise Fail(f"{be.type_name}: `QoSPolicyMask::{n}` is not a declared policy or alias")
+    be.bits = bits
+
+
+def claims_in(files: dict[str, str], scopes: list[str]) -> dict[str, list[str]]:
+    """bit -> the files claiming to honour it, within these scope dirs."""
+    out: dict[str, list[str]] = {}
+    for rel, text in files.items():
+        if not any(rel == s or rel.startswith(s + "/") for s in scopes):
+            continue
+        for bit in CLAIM.findall(text):
+            out.setdefault(bit, []).append(rel)
+    return out
+
+
+def c_spelling(variant: str) -> str:
+    """`TransientLocal` -> `TRANSIENT_LOCAL`, so a C claim site is readable too."""
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", variant).upper()
+
+
+def reads_field(text: str, field: str, variant: str | None) -> bool:
+    if DISCOVERY_ONLY.search(text):
+        return False
+    if not re.search(r"(?:\.|->)\s*" + re.escape(field) + r"\b", text):
+        return False
+    if variant is None:
+        return True
+    # The C spelling is a SUFFIX of the ABI enumerator
+    # (`NROS_RMW_DURABILITY_TRANSIENT_LOCAL`), so it gets no leading word
+    # boundary — `_` is a word character, and requiring one here made every
+    # C-backend claim read as unevidenced.
+    return bool(
+        re.search(r"\b" + re.escape(variant) + r"\b", text)
+        or re.search(re.escape(c_spelling(variant)) + r"\b", text)
+    )
+
+
+# --------------------------------------------------------------------------
+# The rules
+# --------------------------------------------------------------------------
+
+
+def check(files: dict[str, str]) -> tuple[list[str], list[Backend]]:
+    traits = files.get(str(TRAITS.relative_to(ROOT)))
+    if traits is None:
+        raise Fail(f"{TRAITS.relative_to(ROOT)} not found")
+    atomic, alias = parse_bits(traits)
+    fields = parse_policy_fields(traits)
+    backends = find_backends(files, atomic, alias)
+    errs: list[str] = []
+
+    # R1 — every declared bit is one a caller can actually request. A bit
+    # `required_policies` never sets is a claim nothing can exercise.
+    for bit in sorted(set(atomic) - set(fields)):
+        errs.append(
+            f"QoSPolicyMask::{bit} is declared but `required_policies` never sets it — "
+            "no profile can request it, so no backend can honour it"
+        )
+    for bit in sorted(set(fields) - set(atomic)):
+        errs.append(f"`required_policies` sets `{bit}`, which is not a declared policy bit")
+
+    if not backends:
+        errs.append("no `impl Session for` found under packages/**/src — the scan is broken")
+
+    claimed_anywhere: dict[str, set[str]] = {}
+    for be in backends:
+        if be.bits is None:
+            continue  # trait default: NONE, nothing to justify
+        if be.exempt:
+            if not be.all_bits and be.bits != set(atomic):
+                errs.append(
+                    f"{be.type_name} ({be.file}) declares nros-qos-exempt but advertises a "
+                    "SUBSET of the policies. An exemption says the session carries no traffic, "
+                    "so it can only be all or nothing — state a mask and drop the exemption."
+                )
+            continue
+        if be.all_bits:
+            errs.append(
+                f"{be.type_name} ({be.file}) advertises every policy via "
+                "`QoSPolicyMask(u32::MAX)` with no nros-qos-exempt reason. A blanket claim is "
+                "the failure this gate exists to catch; say why the session carries no traffic."
+            )
+            continue
+
+        claims = claims_in(files, be.scopes())
+        for bit in sorted(be.bits):
+            field, variant = fields.get(bit, (None, None))
+            sites = claims.get(bit, [])
+            if not sites:
+                errs.append(
+                    f"{be.type_name} ({be.file}) advertises {bit} with no "
+                    f"`nros-qos-honours: {bit}` claim under {', '.join(be.scopes())}"
+                )
+                continue
+            if field is None:
+                continue  # already reported by R1
+            good = [s for s in sites if reads_field(files[s], field, variant)]
+            if not good:
+                want = f"`qos.{field}`" + (f" and `{variant}`" if variant else "")
+                errs.append(
+                    f"{be.type_name} ({be.file}) advertises {bit}, and the claim(s) at "
+                    f"{', '.join(sites)} read no {want}. A claim is sited on code that APPLIES "
+                    "the policy or REFUSES a value it cannot serve; a file marked "
+                    "nros-qos-discovery-only contributes nothing."
+                )
+        for bit, sites in claims.items():
+            claimed_anywhere.setdefault(bit, set()).update(sites)
+
+    # R5 — a claim for a bit nothing advertises. Stale exemptions read as
+    # tracked debt while being inert (the issue-0743 class); a stale CLAIM
+    # reads as an implemented policy while being unreachable.
+    # An EXEMPT session's blanket mask is not a claim that anything is
+    # honoured, so it must not launder a stale claim into looking live.
+    advertised: set[str] = set()
+    for be in backends:
+        if be.bits and not be.exempt:
+            advertised |= be.bits
+    for rel, text in files.items():
+        for bit in set(CLAIM.findall(text)):
+            if bit not in atomic:
+                errs.append(f"{rel}: `nros-qos-honours: {bit}` names no declared policy bit")
+            elif bit not in advertised:
+                errs.append(
+                    f"{rel}: claims to honour {bit}, which no backend advertises. Either the "
+                    "mask lost the bit and the claim is stale, or the mask should have it."
+                )
+    return errs, backends
+
+
+# --------------------------------------------------------------------------
+# Negative controls — synthetic for the parser, LIVE for the rule
+# --------------------------------------------------------------------------
+
+SYNTH_TRAITS = """
+impl QoSPolicyMask {
+    pub const RELIABILITY: Self = Self(1 << 0);
+    pub const DEPTH: Self = Self(1 << 1);
+    pub const NONE: Self = Self(0);
+    pub const CORE: Self = Self(Self::RELIABILITY.0 | Self::DEPTH.0);
+}
+
+impl QoSProfile {
+    pub fn required_policies(&self) -> QoSPolicyMask {
+        let mut mask = QoSPolicyMask(0);
+        if self.reliability != QoSReliabilityPolicy::SystemDefault {
+            mask |= QoSPolicyMask::RELIABILITY;
+        }
+        if self.depth != DEPTH_SYSTEM_DEFAULT {
+            mask |= QoSPolicyMask::DEPTH;
+        }
+        mask
+    }
+}
+"""
+
+
+def _parser_self_test(verbose: bool) -> int:
+    atomic, alias = parse_bits(SYNTH_TRAITS)
+    if set(atomic) != {"RELIABILITY", "DEPTH"}:
+        raise Fail(f"selftest: bit vocabulary misread: {sorted(atomic)}")
+    if alias.get("CORE") != {"RELIABILITY", "DEPTH"} or alias.get("NONE") != set():
+        raise Fail(f"selftest: aliases misread: {alias}")
+
+    fields = parse_policy_fields(SYNTH_TRAITS)
+    if fields != {"RELIABILITY": ("reliability", None), "DEPTH": ("depth", None)}:
+        raise Fail(f"selftest: bit->field mapping misread: {fields}")
+
+    # The LIVE mapping must cover every live bit, variants included. This is
+    # the assertion that would have caught a policy gaining a bit and no arm.
+    live = parse_policy_fields(TRAITS.read_text(encoding="utf8"))
+    if live.get("DURABILITY_TRANSIENT_LOCAL") != ("durability", "TransientLocal"):
+        raise Fail(f"selftest: variant arms misread: {live.get('DURABILITY_TRANSIENT_LOCAL')}")
+    if live.get("LIVELINESS_MANUAL_BY_NODE") != ("liveliness_kind", "ManualByNode"):
+        raise Fail(f"selftest: variant arms misread: {live.get('LIVELINESS_MANUAL_BY_NODE')}")
+    if live.get("DEADLINE") != ("deadline_ms", None):
+        raise Fail(f"selftest: `if` arms misread: {live.get('DEADLINE')}")
+
+    if c_spelling("ManualByTopic") != "MANUAL_BY_TOPIC":
+        raise Fail("selftest: C spelling of a variant is wrong")
+    if verbose:
+        print("  parser controls passed")
+    return 6
+
+
+def _mutation_self_test(files: dict[str, str], verbose: bool) -> int:
+    """Break the REAL tree four ways and require a red each time.
+
+    A synthetic backend proves nothing about whether this gate would notice a
+    regression in the backend we ship, because the synthetic one is written to
+    match the matcher. These are the shipped sources with one thing removed.
+    """
+    ran = 0
+
+    def red(label: str, mutated: dict[str, str], needle: str) -> None:
+        nonlocal ran
+        ran += 1
+        errs, _ = check(mutated)
+        if not any(needle in e for e in errs):
+            raise Fail(
+                f"selftest mutation {label!r} produced no error mentioning {needle!r}.\n"
+                f"  Got: {errs or '(clean)'}"
+            )
+
+    zenoh_qos = "packages/rmw/zenoh/nros-rmw-zenoh/src/shim/qos.rs"
+    zenoh_session = "packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs"
+    keyexpr = "packages/rmw/zenoh/nros-rmw-zenoh/src/keyexpr.rs"
+    for required in (zenoh_qos, zenoh_session, keyexpr):
+        if required not in files:
+            raise Fail(
+                f"selftest: {required} is missing, so the live mutations cannot run. "
+                "A control that silently examines nothing is the vacuous-test class."
+            )
+
+    # 1. The backend stops READING the depth: the claim survives, the honouring
+    #    does not. This is the regression the whole item is about.
+    m = dict(files)
+    m[zenoh_qos] = re.sub(r"(?:\.|->)\s*depth\b", ".NOT_DEPTH", m[zenoh_qos])
+    red("zenoh stops reading qos.depth", m, "advertises DEPTH")
+
+    # 2. The claim is deleted while the code stays. The bit loses its site.
+    m = dict(files)
+    for f in (zenoh_qos, zenoh_session):
+        m[f] = m[f].replace("nros-qos-honours: HISTORY", "(claim deleted)")
+    red("zenoh drops its HISTORY claim", m, "advertises HISTORY with no")
+
+    # 3. A claim sited in the DISCOVERY serialiser buys nothing — the exact
+    #    shape that made four policies look honoured before W9.
+    m = dict(files)
+    m[zenoh_qos] = m[zenoh_qos].replace("nros-qos-honours: RELIABILITY", "(moved)")
+    m[keyexpr] = m[keyexpr].replace(
+        "impl QosKeyExpr for QoSProfile {",
+        "// nros-qos-honours: RELIABILITY\nimpl QosKeyExpr for QoSProfile {",
+    )
+    red("RELIABILITY claimed in the discovery keyexpr", m, "read no `qos.reliability`")
+
+    # 4. Re-advertising the withdrawn liveliness bit, with no site anywhere.
+    m = dict(files)
+    m[zenoh_session] = m[zenoh_session].replace(
+        "| QoSPolicyMask::LIVELINESS_LEASE",
+        "| QoSPolicyMask::LIVELINESS_MANUAL_BY_NODE\n            | QoSPolicyMask::LIVELINESS_LEASE",
+        1,
+    )
+    red("MANUAL_BY_NODE re-advertised", m, "advertises LIVELINESS_MANUAL_BY_NODE")
+
+    # 5. A stale claim for a bit nobody advertises.
+    m = dict(files)
+    m[zenoh_qos] = m[zenoh_qos] + "\n// nros-qos-honours: LIVELINESS_MANUAL_BY_NODE\n"
+    red("stale claim", m, "which no backend advertises")
+
+    # 6. An exemption cannot be a subset claim.
+    m = dict(files)
+    m["packages/rmw/metadata/src/lib.rs"] = m["packages/rmw/metadata/src/lib.rs"].replace(
+        "nros_rmw::QoSPolicyMask(u32::MAX)", "nros_rmw::QoSPolicyMask::CORE"
+    )
+    red("exempt session claiming a subset", m, "declares nros-qos-exempt but advertises a SUBSET")
+
+    if verbose:
+        print(f"  {ran} live-tree mutation controls passed")
+    return ran
+
+
+def self_test(files: dict[str, str], verbose: bool = False) -> None:
+    n = _parser_self_test(verbose)
+    n += _mutation_self_test(files, verbose)
+    if verbose:
+        print(f"  {n} controls total")
+
+
+# --------------------------------------------------------------------------
+
+
+def audit(files: dict[str, str]) -> int:
+    traits = files[str(TRAITS.relative_to(ROOT))]
+    atomic, alias = parse_bits(traits)
+    fields = parse_policy_fields(traits)
+    backends = find_backends(files, atomic, alias)
+    print(f"{len(atomic)} policy bits, {len(backends)} Session impl(s)\n")
+    for be in sorted(backends, key=lambda b: b.file):
+        if be.bits is None:
+            print(f"{be.type_name:24} {be.crate}\n    (trait default — advertises nothing)")
+            continue
+        if be.exempt:
+            print(f"{be.type_name:24} {be.crate}\n    exempt: {be.exempt}")
+            continue
+        claims = claims_in(files, be.scopes())
+        print(f"{be.type_name:24} {be.crate}")
+        for bit in sorted(atomic):
+            field, variant = fields.get(bit, (None, None))
+            sites = [s for s in claims.get(bit, []) if reads_field(files[s], field, variant)]
+            mark = "yes" if bit in be.bits else " no"
+            where = ", ".join(sorted({os.path.basename(s) for s in sites})) if sites else "-"
+            print(f"    {mark}  {bit:36} {where}")
+        print()
+    return 0
+
+
+def main() -> int:
+    verbose = any(a.startswith("--verbose-self") for a in sys.argv[1:])
+    try:
+        files = load_tree()
+        if "--audit" in sys.argv:
+            return audit(files)
+        # On the NORMAL path — `check-gate-selftests` requires it, and a
+        # control nobody runs decays into a comment.
+        self_test(files, verbose=verbose)
+        errs, backends = check(files)
+    except Fail as exc:
+        print(f"check-qos-mask-derivation: {exc}", file=sys.stderr)
+        return 1
+
+    if errs:
+        print(f"check-qos-mask-derivation: {len(errs)} problem(s):\n", file=sys.stderr)
+        for e in errs:
+            print(f"  - {e}", file=sys.stderr)
+        print(
+            "\n  A backend advertises a QoS policy by SITING a `nros-qos-honours: <BIT>`\n"
+            "  claim on the code that applies it or refuses a value it cannot serve.\n"
+            "  `check-qos-mask-derivation.py --audit` prints the whole picture.",
+            file=sys.stderr,
+        )
+        return 1
+
+    n_claiming = sum(1 for b in backends if b.bits and not b.exempt)
+    print(
+        f"check-qos-mask-derivation: OK ({len(backends)} Session impl(s), "
+        f"{n_claiming} advertising a derived mask)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
phase-428 W9. `supported_qos_policies()` was a hand-written constant per
backend, so it claimed whatever it had claimed when it was written. This makes
it derived, and measures what the derivation says.

## What it measured

`LIVELINESS_MANUAL_BY_NODE` was advertised by **both** masks in the tree and
implemented by **none** of the four backends — zenoh matches
`ManualByTopic | ManualByNode` in one arm, cyclonedds folds it onto
MANUAL_BY_TOPIC in as many words, xrce lowers no liveliness field, uorb reads
no QoS field at all. The downgrade is in the losing direction: an application
that correctly asserts once per node watches its other publishers cross the
lease. Withdrawn (issue 1328); nothing in the tree requested it.

The zenoh shim's four CORE policies had exactly **one** read between them, in
`QosKeyExpr::to_qos_string` — the discovery keyexpr — under a comment saying
all four were honoured at the subscriber buffer. A caller asking for
KEEP_LAST(100) got a four-slot ring and a graph entry advertising a hundred.

## The mechanism (acceptance 1)

`check-qos-mask-derivation` (fast line, buildless, ~0.4 s): a bit may be
advertised only if a `nros-qos-honours: <BIT>` claim is sited on code that
READS the mapped profile field. Honouring is "applies it or refuses a value it
cannot serve" — both read the field. A file marked `nros-qos-discovery-only:`
contributes nothing, because that is the exact shape of the second finding.

Every subject list is derived: the vocabulary from `QoSPolicyMask`, the
bit→(field, variant) mapping from `QoSProfile::required_policies`, the backend
list from every `impl Session for` under `packages/**/src`. The cffi route
declares `nros-qos-mux:` with the crates it routes to and its union is checked
against **their** claims.

**The negative control is the live tree.** Six mutations run on the normal
path against the shipped sources in memory — delete the depth read, delete a
claim, move a claim into the discovery-only file, re-advertise the withdrawn
bit, leave a stale claim, make an exempt session claim a subset — each must go
red. Synthetic cases are kept for the parser only.

The trait default is `QoSPolicyMask::NONE` now (was `CORE`): four policies
granted by the trait to an implementation that had written no code.

## Where this work item was wrong

W9 predicted `DEPTH` drops out of the zenoh mask and that "nothing that works
today breaks". The second half is false and
`withdrawing_depth_would_refuse_the_default_profile` is the measurement:
`QOS_PROFILE_DEFAULT` states `depth: 10`, so it REQUIRES the bit, and it is
what every create with no explicit QoS passes. Withdrawing it refuses **every
default entity**. So the shim earns the bit instead — `shim/qos.rs` reads the
depth, grants what the ring can hold, and publishes the GRANT to the graph.

## `let _ = qos;` (acceptance 2)

Two sites, both zenoh, both the service pair. "Cannot be applied" was narrower
than the TODO claimed: no per-endpoint QoS reaches the wire, but the request
ring, the refusals and the graph declaration are ours. All three applied; the
liveliness token carries the admitted profile instead of a hardcoded
`services_default()`. A no-op for every default caller.

## A too-deep request (acceptance 3)

KEEP_ALL, TRANSIENT_LOCAL and MANUAL_BY_NODE are refused with
`IncompatibleQos` and a log line naming the policy. Depth cannot be refused —
every stock preset asks for more than the four-slot ring — so it is granted
down, the grant is returned, published to the graph, and reported once per
process at WARN with both numbers and `ZPICO_SUBSCRIBER_RING_DEPTH`. A
BEST_EFFORT request is granted RELIABLE and reported at INFO; the severity
encodes the direction.

## Carried forward

Issue 1329: the cffi mask is a UNION and over-claims for each backend. The fix
is the vtable slot the TODO has wanted since phase 115; narrowing without one
was checked and rejected (xrce would lose `LIVELINESS_AUTOMATIC`, which every
C default profile states).

## Verification

`just check fast` (3 reds, all pre-existing/environmental in an agent
worktree: `doc-commit-citations` on `docs/issues/1304-*`, and the two xrce
gates wanting submodules), `just test-unit` (1437 passed, 1 skipped
precondition), `cargo test -p nros-rmw --lib`, `cargo test -p nros-rmw-zenoh
--lib` (88 passed incl. 8 new), clippy `-D warnings` on all five changed
crates, `rmw-api-parity`, `rmw-abi-shape`, `qos-profile-ssot`,
`cbindgen-headers`, `api-parity`, `api-parity-ledger`, `gate-selftests`,
`gate-lists`. No API-parity ledger row changed subject or disposition — the
change is RMW-internal. `book/src/reference/rmw-feature-matrix.md` is
regenerated and picked the withdrawal up on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bgWmbrBZbCbYfbKMmzaYy
