### PR TITLE
fix(check): dep-chain never built the resolver `nros sync` refuses to skip

### DIFF
--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -1541,6 +1541,18 @@ dep-chain:
             nros_check_skip dep-chain "ROS 2 not sourced (AMENT_PREFIX_PATH unset)"; exit 0
         fi
     fi
+    # `setup-launch-resolve` too, since phase-445 W3b, for the reason
+    # `scaffold-journey` states: an example leaf carries a `system.toml`, so
+    # `nros sync` — which step 2b of the script runs to write the leaf's
+    # `[patch.crates-io]` table — resolves its SystemModel through
+    # `nros-launch-resolve` and REFUSES to skip it. Without the resolver every
+    # cell reported `no matching package named 'nros' found` from `cargo tree`,
+    # three steps downstream of the actual refusal; post-submit was red on all
+    # 8 cells from 2026-09-10 to 2026-09-11 with that as its only symptom.
+    # Called from the BODY, not listed beside a dependency: a dependency list is
+    # an ORDER to `check-lane-contracts` (issue 1030), and nothing here needs to
+    # run before it.
+    just setup-launch-resolve
     source scripts/build/cargo.sh
     NROS="$(nros_cli_bin)" scripts/ci/dep-chain-check.sh
 

--- a/scripts/ci/dep-chain-check.sh
+++ b/scripts/ci/dep-chain-check.sh
@@ -129,10 +129,18 @@ for cell in "${CELLS[@]}"; do
         #     named 'nros' found`. The check has to perform the setup step it is
         #     validating, exactly as it already does for `nros setup` above.
         if [ -f "$ex/package.xml" ] || [ -f "$ex/Cargo.toml" ]; then
-            if ( cd "$ex" && NROS_SKIP_VERSION_CHECK=1 "$NROS" sync >/dev/null 2>&1 ); then
+            sync_out=""
+            if sync_out="$( cd "$ex" && NROS_SKIP_VERSION_CHECK=1 "$NROS" sync 2>&1 )"; then
                 : # .cargo/config.toml patch table now present
             else
+                # PRINT the refusal. Swallowing it cost a day: `nros sync`
+                # refusing for want of `nros-launch-resolve` surfaced only as
+                # `cargo tree` saying `no matching package named 'nros' found`
+                # three steps later, which reads like a manifest defect and is
+                # not one. The reason a step failed belongs in the log of the
+                # run that failed.
                 echo "  [warn] nros sync did not complete for $ex (dep resolution may fail below)"
+                printf '%s\n' "$sync_out" | sed 's/^/      /'
             fi
         fi
 


### PR DESCRIPTION
`post-submit` has been red on `main` since 2026-09-10T20:53 — **every run, all 8 board×rmw cells**, with one symptom:

```
[FAIL] cargo tree did not resolve (default features):
    error: no matching package named `nros` found
```

That reads like a manifest defect. It isn't one.

## The real cause

Three steps upstream, the same log says once per cell:

```
[warn] nros sync did not complete for examples/native/rust/talker (dep resolution may fail below)
```

…and the reason was discarded (`>/dev/null 2>&1`). Running that same command unredirected on a clean `origin/main` worktree:

```
Error: sync: 1 SystemModel(s) need resolving but `nros-launch-resolve` is not next to the `nros` binary:
  native_talker — build/nros/models/talker/system_model.yaml is missing (system.launch.xml)
```

phase-445 W3b's class, one lane over. An example leaf carries a `system.toml`, so it is a self-pkg bringup; `nros sync` resolves its SystemModel through `nros-launch-resolve` and refuses to continue without it. Step 2b of `dep-chain-check.sh` runs that sync to write the leaf's `[patch.crates-io]` table — the only thing that makes `nros = { version = "*" }` resolve to this checkout (RFC-0048 W9). No table, no `nros`, and `cargo tree` reports it in the vocabulary of a missing crate.

The workflow job inits `play_launch` and builds the CLI binary. It never builds the resolver, and neither did the recipe.

## Fix — both halves mechanical

- **`check::dep-chain` calls `just setup-launch-resolve`**, exactly as `scaffold-journey` and `acceptance` have since phase-445 W3b, and from the recipe **body** for the reason `scaffold-journey` states: a dependency list is an ORDER to `check-lane-contracts` (issue 1030), and nothing here needs to run before it. This fixes the CI job without touching the workflow, and makes `just check dep-chain` self-sufficient on a fresh clone.
- **`dep-chain-check.sh` prints sync's output when sync fails.** The refusal was already precise and named its own remedy; discarding it is what turned a one-line diagnosis into a day of red. Warn-and-continue behaviour is unchanged.

## Verified

On a clean `origin/main` worktree, ROS humble sourced, `play_launch` initialised at its recorded pin `07f0461e0c51` (no pin moved):

| step | before | after |
|---|---|---|
| `nros sync` in the talker leaf | exits 1, writes no `.cargo/config.toml` | exits 0, writes the patch table |
| `cargo tree -e no-dev` (what CI reports) | `no matching package named 'nros'` | exits 0 |
| `just check dep-chain` | 8 cells fail | **`dep-chain: 8 passed, 0 failed (of 8 cells)`** |

`just check fast` is green on this branch (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
