### PR TITLE
refactor(phase-442 W6+W7): 27 mechanical `std` uses go, and the freestanding API measures as already `std`-free

### DIFF
--- a/docs/design/0096-cpp-freestanding-core-and-porting-layer.md
+++ b/docs/design/0096-cpp-freestanding-core-and-porting-layer.md
@@ -372,6 +372,72 @@ making it unconditional removes all five divergent subjects at zero cost and
 ends the px4 mixed-layout exposure immediately. Independent of everything else;
 land it first.
 
+### D8 — A name parameter is DEDUCED, so `std::string` stays drop-in (amendment, 2026-09-12)
+
+This decision was missing, and implementing W6 is what surfaced it. Stated here
+because W7 and W8 cannot proceed without it.
+
+**The gap.** Every hosted `create_*` in `nros.hpp` takes `const std::string&`,
+which is upstream's spelling, and the whole family sits behind
+`NROS_CPP_NODE_HOSTED`. W8's acceptance is zero `NROS_CPP_HAS_*` in the tree, so
+those overloads cannot survive as gated methods. But D5 — "what is NOT drop-in,
+enumerated" — does not list `std::string` arguments, and deleting the overloads
+would silently add a fourth item to that list: every ported call site holding a
+`std::string` name would need `.c_str()`.
+
+Three candidate answers, and only one satisfies both halves of the goal:
+
+| | freestanding-clean | `std::string` call site still compiles |
+| --- | --- | --- |
+| keep the overloads, gated | no | yes |
+| delete them, require `.c_str()` | yes | **no** — a fourth D5 item |
+| **deduce the parameter** | **yes** | **yes** |
+
+**The decision: the parameter is deduced, and one overload set converts it.**
+
+```cpp
+namespace nros { namespace detail {
+inline const char* as_c_str(const char* s) { return s; }
+template <typename S> auto as_c_str(const S& s) -> decltype(s.c_str()) { return s.c_str(); }
+}}
+
+template <typename M, typename S>
+Publisher<M>::SharedPtr create_publisher(const S& topic, const QoS& qos);
+```
+
+The header names no `std` type. A caller passing a string literal, a
+`std::string`, our `FixedString`, our `HeapString`, or anything else with
+`c_str()` all bind. This is the same move W5 already made for
+`NodeOptions::arguments()`, generalised — and there it was measured to be
+strictly better for a porting user as well, because the refusal could speak
+where an overload-resolution failure used to happen first.
+
+**Measured**, not reasoned — one probe, three configurations:
+
+```
+hosted g++ -std=c++17, caller passes std::string          rc=0
+ThreadX shim -nostdinc++, no <string> reachable at all    rc=0
+arm-none-eabi -std=c++14 -ffreestanding (32-bit)          rc=0
+```
+
+**One cost, stated.** An argument that is neither a `const char*` nor a type
+with `c_str()` produces a diagnostic one frame inside the template rather than
+at the call site:
+
+```
+error: no matching function for call to 'as_c_str(const NotAName&)'
+note: required from here    <-- the call site, one frame up
+```
+
+`as_c_str` is an overload SET rather than a trait precisely to keep that to one
+frame; W8 should add a `static_assert` in front of it so the first line names
+the parameter instead.
+
+**What this does not do.** It does not make a `std::string` RETURN drop-in —
+`get_fully_qualified_name` and friends are a separate question, and they are
+returns rather than parameters, so a caller writing `auto` is unaffected while a
+caller writing `std::string s = ...` is not. That is W8's to enumerate.
+
 ## What this corrects in existing documents
 
 Three statements are wrong in the tree today and are corrected here rather than

--- a/docs/design/0096-cpp-freestanding-core-and-porting-layer.md
+++ b/docs/design/0096-cpp-freestanding-core-and-porting-layer.md
@@ -438,6 +438,64 @@ the parameter instead.
 returns rather than parameters, so a caller writing `auto` is unaffected while a
 caller writing `std::string s = ...` is not. That is W8's to enumerate.
 
+### D9 — Entity STORAGE is the open problem W8 has to solve first (amendment, 2026-09-12)
+
+The handle in D2 answers *what `X::SharedPtr` is*. It does not answer *what the
+handle points at*, and on the hosted path today that second question has an
+answer this design removes.
+
+**What the hosted path does now.** `create_publisher<M>(topic, qos)` calls
+`std::make_shared<Publisher<M>>(...)` and pushes the result into
+`detail::NodeHosted::owned_entities`, a `std::vector<std::shared_ptr<void>>`
+with eight `push_back` sites across `nros.hpp`, `node.hpp` and `timer.hpp`, no
+`erase`, no `clear`, and one drain in `~Node()`. The census already established
+that this models ADDRESS STABILITY rather than shared ownership. But address
+stability is a real requirement, not a fiction: the executor arena holds a raw
+pointer as its dispatch context and has no unregister path, so the entity must
+outlive the caller's handle whatever the caller does with it.
+
+**So a freestanding `create_*` needs somewhere to put the entity**, and neither
+`make_shared` nor an unbounded vector is available. This is not a detail of W8;
+it is W8's first decision, and the sizes make it consequential:
+
+| entity | `sizeof` (all three arms) |
+| --- | --- |
+| `Timer` | 32 |
+| `Service<int>` | 560 |
+| `Publisher<int>` | 824 |
+| `Subscription<int>` | 888 |
+| `Client<int>` | **4 672** |
+
+A fixed pool sized for the worst case in every node would be the wrong default
+by an order of magnitude — one unused `Client` slot costs more than a node.
+
+**Three candidates, and the tree already contains material for the third.**
+
+1. *Caller-owned storage, no pool.* The out-ref family
+   (`create_publisher(out, topic, qos)`) already works this way and is ungated
+   today. It is the cheapest and it is NOT drop-in: the ported spelling is
+   `auto pub = node->create_publisher<M>(...)`, which needs a returned handle.
+2. *One fixed pool per entity kind, a template parameter on the node.*
+   `nros::NodeWithTimers<N>` is exactly this shape already, and phase-427 W4
+   introduced it for exactly this reason. Generalising it means the node type a
+   user writes carries its entity counts, which upstream's does not.
+3. *Counts DERIVED from the contract, not authored.* phase-412's derived-counts
+   machinery already computes per-image entity counts from declarations, and
+   `NROS_CPP_EXECUTOR_STORAGE_SIZE` is already a generated number in
+   `nros_cpp_config_generated.h`. An entity arena sized the same way costs the
+   user nothing to write and is measured per image rather than guessed.
+
+(3) is the direction that fits what this repository already does, and it is the
+one that keeps `auto pub = node->create_publisher<M>(...)` drop-in. It is also
+the one with a real cost to measure — `just mem-report` on a node before and
+after — which is why it is stated here as a decision to make with numbers rather
+than made here.
+
+**W8 does not start until this is settled.** Recording it as an open decision is
+deliberate: the rest of W8 is mechanical once it is answered, and mechanical
+work done on top of an unanswered lifetime question is how a use-after-free
+ships.
+
 ## What this corrects in existing documents
 
 Three statements are wrong in the tree today and are corrected here rather than

--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -182,8 +182,33 @@ the rest and do not depend on each other.
   resolve. Recorded rather than left, because a gated method is exactly the
   residue that reads as finished work.
 
-* **W6 [cpp] — delete the 50 removable entities.** Each has an ungated
-  freestanding sibling already, or is body-only. No consumer loses a capability.
+* **W6 [cpp] — delete the 50 removable entities. LANDED 2026-09-12.** Each has
+  an ungated freestanding sibling already, or is body-only. No consumer loses a
+  capability.
+  *What it removed, counted as SITES rather than as the RFC's entity buckets,
+  because sites are what a grep can re-measure.* 27 `std::` uses across eight
+  headers, plus the `component.hpp` placement-new workaround that W4's class fix
+  made redundant:
+  - 13 `std::move` -> `nros::tr::forward_rvalue`;
+  - 3 `std::forward` -> `nros::tr::relay`, which is a SEPARATE helper and not a
+    synonym: forwarding preserves an lvalue as an lvalue where a move hands the
+    callee an rvalue it may gut, and collapsing the two is the classic way a
+    forwarding wrapper steals from its caller;
+  - 14 `std::size_t` / `std::uint8_t` / `std::int32_t` / `std::uint32_t` ->
+    the bare spellings the rest of this API already writes. `transport.hpp` is
+    now entirely `std`-free;
+  - `result.hpp`'s `<utility>` include, verified unused by removing it and
+    recompiling rather than by reading.
+  *What it deliberately did NOT remove:* the hosted diagnostics (`fprintf`,
+  `fopen`, `getenv`, `ostringstream`, `abort`, 13 sites), which are genuinely
+  body-only and already carry a freestanding `#else` -- `result.hpp`'s
+  `NROS_TRY_LOG` is the pattern. Those are not the phase's target; a `std` call
+  inside a hosted-only body changes no signature and no layout.
+  *Acceptance:* all three arms compile (hosted, hosted with `-DNROS_CPP_STD=1`,
+  `-nostdinc++` freestanding against the ThreadX shim), `just check fast` green.
+  Remaining after this pass, and each is W7's or W8's by construction:
+  `shared_ptr`/`unique_ptr`/`make_shared` 38, `string`/`vector`/
+  `initializer_list` ~55, `chrono` 9, `function` 2.
 
 * **W7 [cpp] — replace the 27 with in-tree freestanding equivalents**
   (`Span`, `StringView`, `FixedString`, `Seq`, `Duration`). Includes the one gap

--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -254,6 +254,24 @@ the rest and do not depend on each other.
 * **W8 [cpp] — the remaining `rclcpp::` surface moves onto the mechanisms**, and
   the nine gates and `cmake/compat/` are deleted. This is where the API becomes
   one API.
+  **BLOCKED on one decision, and the block is deliberate (2026-09-12).** W7's
+  measurement says the job is to collapse **129 gated sites** into one ungated
+  API. Two of the three things that needs are done — RFC-0096 D8 settles how a
+  name parameter is typed, W3 built the handle and the inplace callable. The
+  third is not: **where does the entity a returned handle points AT live?**
+  Today `create_publisher<M>(topic, qos)` does `std::make_shared` and pushes
+  into `owned_entities`, and the census established that models ADDRESS
+  STABILITY rather than shared ownership — but address stability is a real
+  requirement, because the executor arena holds a raw dispatch pointer and has
+  no unregister path. RFC-0096 D9 states the three candidates and the measured
+  sizes that make the choice consequential (`Client<int>` is 4 672 bytes against
+  `Timer`'s 32, so a uniform worst-case pool is wrong by an order of magnitude).
+  The direction that fits this repository is entity counts DERIVED the way
+  phase-412 already derives `NROS_CPP_EXECUTOR_STORAGE_SIZE`, and it needs a
+  `just mem-report` before/after rather than a decision at the keyboard.
+  *Nothing mechanical in W8 should start before that is answered*: the rest is
+  substitution, and substitution on top of an unanswered lifetime question is
+  how a use-after-free ships.
   *Acceptance:* zero `NROS_CPP_HAS_*`, zero `NROS_CPP_STD`, zero
   `NROS_CPP_NODE_HOSTED` in the tree; the per-header parse loop at `fail=0` on
   every toolchain; the FreeRTOS, Zephyr, NuttX and ThreadX C++ builds green.

--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -214,6 +214,42 @@ the rest and do not depend on each other.
   (`Span`, `StringView`, `FixedString`, `Seq`, `Duration`). Includes the one gap
   the census found: `ComponentNode` has no `Seq<T,N>` parameter overload, so its
   `std::vector` form has no sibling to fall back to and one must be added.
+  **MET BY MEASUREMENT 2026-09-12, and the measurement is the deliverable**, so
+  this is recorded rather than claimed as work done.
+
+  After W6, the remaining 134 `std::` sites in `nros-cpp/include` split like
+  this — a comment-stripping scan that tracks `#if` nesting, so a site inside a
+  capability gate is counted as gated:
+
+  | | sites |
+  | --- | --- |
+  | behind `NROS_CPP_STD` / `NROS_CPP_HAS_*` / `NROS_CPP_NODE_HOSTED` | **129** |
+  | ungated | **5** |
+
+  And all five ungated are legitimate:
+
+  * `log.hpp:237-238` — string LITERALS inside a diagnostic message, not uses.
+  * `nros.hpp:319,363` — `std::abort()`, which `[compliance]` puts in the
+    freestanding subset and both shims export.
+  * `parameter.hpp:85` — `std::initializer_list`, whose header is
+    freestanding-guaranteed because it is core language support for braced
+    initialisation, not a library convenience.
+
+  So **the freestanding API is already `std`-free**, and there is nothing on
+  that path left to replace. The census's 27 "replaceable" already have their
+  siblings, checked pair by pair in `parameter.hpp`: `declare_parameter` has
+  `Seq<T,N>` at :274 beside `std::vector<T>` at :284, `get_parameter` :322
+  beside :350, `set_parameter` :372 beside :378, and the string form's
+  freestanding sibling is the `char* out, size_t max_len` overload at :308. The
+  gap the census predicted — a missing `Seq` form — does not exist; and
+  `ComponentNode`, which the census named as the holder of it, was deleted by
+  phase-427 W7.
+
+  *What this hands W8.* The remaining work is not "replace 27 types" but
+  "collapse 129 gated sites into one ungated API", using RFC-0096 D8's deduced
+  parameter and W3's two mechanisms. That is a different and larger job than
+  W7's text describes, and naming it here is the point of recording the
+  measurement.
 
 * **W8 [cpp] — the remaining `rclcpp::` surface moves onto the mechanisms**, and
   the nine gates and `cmake/compat/` are deleted. This is where the API becomes

--- a/packages/api/nros-cpp/include/nros/bridge.hpp
+++ b/packages/api/nros-cpp/include/nros/bridge.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+#include "nros/traits.hpp"
 #include "nros/bridge.h"
 #include "nros/result.hpp"
 
@@ -35,23 +36,23 @@ namespace nros {
 struct SessionSpec {
     std::string rmw;
     std::string locator;
-    std::uint32_t domain_id = 0;
+    uint32_t domain_id = 0;
     std::string node_name;
     std::string namespace_;
 
     SessionSpec(std::string rmw_, std::string locator_)
-        : rmw(std::move(rmw_)), locator(std::move(locator_)) {}
+        : rmw(::nros::tr::forward_rvalue(rmw_)), locator(::nros::tr::forward_rvalue(locator_)) {}
 
-    SessionSpec& with_domain_id(std::uint32_t id) {
+    SessionSpec& with_domain_id(uint32_t id) {
         domain_id = id;
         return *this;
     }
     SessionSpec& with_node_name(std::string name) {
-        node_name = std::move(name);
+        node_name = ::nros::tr::forward_rvalue(name);
         return *this;
     }
     SessionSpec& with_namespace(std::string ns) {
-        namespace_ = std::move(ns);
+        namespace_ = ::nros::tr::forward_rvalue(ns);
         return *this;
     }
 };
@@ -114,8 +115,8 @@ namespace bridge {
 
 /// Per-pump counters mirroring `nros_pump_stats_t`.
 struct PumpStats {
-    std::size_t forwarded = 0;
-    std::size_t dropped_echo = 0;
+    size_t forwarded = 0;
+    size_t dropped_echo = 0;
 };
 
 /// RAII pubsub bridge — forwards raw samples from a source Node
@@ -161,7 +162,7 @@ class PubSubBridge {
     /// Drain every queued sample and forward to the destination.
     /// Returns the number actually forwarded (samples dropped by the
     /// dedup window are not counted).
-    std::size_t pump() {
+    size_t pump() {
         if (handle_ == nullptr) return 0;
         return nros_pubsub_bridge_pump(handle_);
     }

--- a/packages/api/nros-cpp/include/nros/node.hpp
+++ b/packages/api/nros-cpp/include/nros/node.hpp
@@ -25,6 +25,7 @@
 // its local redefinitions.
 #include "nros_cpp_ffi.h"
 
+#include "nros/traits.hpp"
 #include "nros/result.hpp"
 #include "nros/hosted_block.hpp"
 #include "nros/nros_cpp_config_generated.h"
@@ -2413,7 +2414,7 @@ inline ResultOf<::rclcpp::Node> make_node(const char* name, const char* ns = nul
     ::rclcpp::Node n;
     Result r = create_node(n, name, ns);
     if (!r.ok()) return ResultOf<::rclcpp::Node>::error(r);
-    return ResultOf<::rclcpp::Node>::ok(::std::move(n));
+    return ResultOf<::rclcpp::Node>::ok(::nros::tr::forward_rvalue(n));
 }
 
 // -- Executor::create_node implementation (requires full Node definition) --

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -17,6 +17,7 @@
 // fallback definitions in favor of the canonical types.
 #include "nros_cpp_ffi.h"
 
+#include "nros/traits.hpp"
 #include "nros/log.hpp"
 #include "nros/result.hpp"
 // Issue 0789 — the clock / time / duration surface. `node.now()` and
@@ -579,7 +580,7 @@ template <typename M, typename Cb>
 inline ::std::shared_ptr<Subscription<M>> Node::create_subscription(const ::std::string& topic,
                                                                     const ::nros::QoS& qos, Cb cb) {
     auto cell = ::std::make_shared<::rclcpp::detail::SubscriptionCallback<M>>();
-    cell->fn = ::std::move(cb);
+    cell->fn = ::nros::tr::forward_rvalue(cb);
     ::rclcpp::detail::require_created(
         ::nros::create_subscription_raw(*this, topic.c_str(), M::TYPE_NAME,
                                         &::rclcpp::detail::SubscriptionCallback<M>::trampoline,
@@ -597,7 +598,7 @@ template <typename M, typename Cb>
 inline ::std::shared_ptr<Subscription<M>> Node::create_subscription(const ::std::string& topic,
                                                                     ::size_t depth, Cb cb) {
     return this->create_subscription<M>(topic, ::nros::QoS(static_cast<uint32_t>(depth)),
-                                        ::std::move(cb));
+                                        ::nros::tr::forward_rvalue(cb));
 }
 } // namespace rclcpp
 
@@ -628,7 +629,7 @@ template <typename Rep, typename Period, typename Cb>
 inline ::std::shared_ptr<::nros::Timer>
 Node::create_wall_timer(::std::chrono::duration<Rep, Period> period, Cb cb) {
     auto t = ::std::make_shared<::rclcpp::detail::WallTimer>();
-    t->callback = ::std::move(cb);
+    t->callback = ::nros::tr::forward_rvalue(cb);
     const auto ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(period).count();
     // A null return would be silent HERE above all: a ported node stores the
     // timer handle and never dereferences it, so a dead timer would simply
@@ -832,7 +833,7 @@ inline ::std::shared_ptr<::nros::Timer>
 create_timer(NodeT&& node, ::nros::Clock* clock, ::nros::Duration period, CallbackT&& callback) {
     ::rclcpp::Node& n = detail::as_node_ref(node);
     auto t = ::std::make_shared<detail::WallTimer>();
-    t->callback = ::std::forward<CallbackT>(callback);
+    t->callback = ::nros::tr::relay<CallbackT>(callback);
     const int64_t ns = period.nanoseconds();
     const uint64_t ms = ns > 0 ? static_cast<uint64_t>(ns / 1000000) : uint64_t(0);
     // Same refusal as the seven `create_*` verbs: `rclcpp::create_timer` is a
@@ -860,9 +861,9 @@ inline ::std::shared_ptr<::nros::Timer> create_timer(NodeT&& node, ::nros::Clock
                                                      ::std::chrono::duration<Rep, Period> period,
                                                      CallbackT&& callback) {
     const auto ns = ::std::chrono::duration_cast<::std::chrono::nanoseconds>(period).count();
-    return create_timer(::std::forward<NodeT>(node), clock,
+    return create_timer(::nros::tr::relay<NodeT>(node), clock,
                         ::nros::Duration::from_nanoseconds(static_cast<int64_t>(ns)),
-                        ::std::forward<CallbackT>(callback));
+                        ::nros::tr::relay<CallbackT>(callback));
 }
 #endif // NROS_CPP_HAS_STD_CHRONO
 

--- a/packages/api/nros-cpp/include/nros/publisher.hpp
+++ b/packages/api/nros-cpp/include/nros/publisher.hpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <string.h> // memcpy — `<cstring>` isn't in Zephyr's minimal libcpp
 
+#include "nros/traits.hpp"
 #include "nros/config.hpp"
 #include "nros/result.hpp"
 // RFC-0088 D5 — NROS_CPP_ASSERT_MESSAGE_FORMAT, expanded in the creator below.
@@ -409,7 +410,7 @@ inline ResultOf<Publisher<M>> create_publisher(::rclcpp::Node& node, const char*
     Publisher<M> p;
     Result r = node.create_publisher<M>(p, topic, qos);
     if (!r.ok()) return ResultOf<Publisher<M>>::error(r);
-    return ResultOf<Publisher<M>>::ok(std::move(p));
+    return ResultOf<Publisher<M>>::ok(::nros::tr::forward_rvalue(p));
 }
 
 } // namespace nros

--- a/packages/api/nros-cpp/include/nros/result.hpp
+++ b/packages/api/nros-cpp/include/nros/result.hpp
@@ -13,7 +13,8 @@
 #define NROS_CPP_RESULT_HPP
 
 #include <cstdint>
-#include <utility>
+
+#include "nros/traits.hpp"
 #if defined(NROS_CPP_STD) || (__STDC_HOSTED__ + 0)
 #include <cstdio>
 #endif
@@ -329,7 +330,7 @@ template <typename T> class NROS_NODISCARD ResultOf {
     static ResultOf ok(T value) {
         ResultOf e;
         e.ok_ = true;
-        e.value_ = ::std::move(value);
+        e.value_ = ::nros::tr::forward_rvalue(value);
         return e;
     }
     static ResultOf error(ErrorCode code) {
@@ -345,7 +346,7 @@ template <typename T> class NROS_NODISCARD ResultOf {
 
     T& value() & { return value_; }
     const T& value() const& { return value_; }
-    T&& value() && { return ::std::move(value_); }
+    T&& value() && { return ::nros::tr::forward_rvalue(value_); }
 
     ErrorCode error() const { return error_; }
     Result error_as_result() const { return Result(error_); }
@@ -377,7 +378,7 @@ class NROS_NODISCARD [[deprecated("nros::Expected<T> is now nros::ResultOf<T>; o
     : public ResultOf<T> {
   public:
     Expected(const ResultOf<T>& r) : ResultOf<T>(r) {}
-    Expected(ResultOf<T>&& r) : ResultOf<T>(::std::move(r)) {}
+    Expected(ResultOf<T>&& r) : ResultOf<T>(::nros::tr::forward_rvalue(r)) {}
 };
 
 } // namespace nros

--- a/packages/api/nros-cpp/include/nros/subscription.hpp
+++ b/packages/api/nros-cpp/include/nros/subscription.hpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <string.h> // memcpy — `<cstring>` isn't in Zephyr's minimal libcpp
 
+#include "nros/traits.hpp"
 #include "nros/config.hpp"
 #include "nros/result.hpp"
 #include "nros/size_bound.hpp" // nros::rx_buffer_capacity<M> — the receive-buffer size
@@ -871,7 +872,7 @@ inline ResultOf<Subscription<M>> create_subscription(::rclcpp::Node& node, const
     Subscription<M> s;
     Result r = node.create_subscription<M>(s, topic, qos);
     if (!r.ok()) return ResultOf<Subscription<M>>::error(r);
-    return ResultOf<Subscription<M>>::ok(std::move(s));
+    return ResultOf<Subscription<M>>::ok(::nros::tr::forward_rvalue(s));
 }
 
 #if defined(NANO_ROS_SAFETY_E2E)

--- a/packages/api/nros-cpp/include/nros/traits.hpp
+++ b/packages/api/nros-cpp/include/nros/traits.hpp
@@ -129,13 +129,26 @@ template <typename T> struct decay {
                              typename remove_cv<U>::type>::type>::type;
 };
 
-/// `static_cast<T&&>`, without `<utility>`.
+/// `std::move`, without `<utility>`.
 ///
 /// Named `forward_rvalue` rather than `move` on purpose: `nros::tr::move` beside
 /// a `using namespace std` would be an overload-resolution coin flip in a ported
 /// file, and this namespace is not a `std` replacement.
 template <typename T> constexpr typename remove_reference<T>::type&& forward_rvalue(T&& v) {
     return static_cast<typename remove_reference<T>::type&&>(v);
+}
+
+/// `std::forward`, without `<utility>` — perfect forwarding, both overloads.
+///
+/// Distinct from `forward_rvalue` and not a synonym for it: forwarding
+/// preserves an lvalue argument as an lvalue, where a move would hand the
+/// callee an rvalue it is entitled to gut. Collapsing the two is the classic
+/// way a forwarding wrapper silently steals from its caller, so both exist.
+template <typename T> constexpr T&& relay(typename remove_reference<T>::type& v) {
+    return static_cast<T&&>(v);
+}
+template <typename T> constexpr T&& relay(typename remove_reference<T>::type&& v) {
+    return static_cast<T&&>(v);
 }
 
 } // namespace tr

--- a/packages/api/nros-cpp/include/nros/transport.hpp
+++ b/packages/api/nros-cpp/include/nros/transport.hpp
@@ -37,10 +37,10 @@ namespace nros {
 ///     reinterpret_cast<MyUart*>(ctx)->open(); return 0;
 /// };
 /// ops.close = [](void* ctx) { reinterpret_cast<MyUart*>(ctx)->close(); };
-/// ops.write = [](void* ctx, const uint8_t* buf, std::size_t len) -> int {
+/// ops.write = [](void* ctx, const uint8_t* buf, size_t len) -> int {
 ///     return reinterpret_cast<MyUart*>(ctx)->write(buf, len);
 /// };
-/// ops.read  = [](void* ctx, uint8_t* buf, std::size_t len, uint32_t to) -> std::int32_t {
+/// ops.read  = [](void* ctx, uint8_t* buf, size_t len, uint32_t to) -> int32_t {
 ///     return reinterpret_cast<MyUart*>(ctx)->read(buf, len, to);
 /// };
 /// nros::set_custom_transport(ops);
@@ -52,10 +52,8 @@ struct TransportOps {
     void* user_data = nullptr;
     nros_cpp_transport_ret_t (*open)(void* user_data, const void* params) = nullptr;
     void (*close)(void* user_data) = nullptr;
-    nros_cpp_transport_ret_t (*write)(void* user_data, const std::uint8_t* buf,
-                                      std::size_t len) = nullptr;
-    std::int32_t (*read)(void* user_data, std::uint8_t* buf, std::size_t len,
-                         std::uint32_t timeout_ms) = nullptr;
+    nros_cpp_transport_ret_t (*write)(void* user_data, const uint8_t* buf, size_t len) = nullptr;
+    int32_t (*read)(void* user_data, uint8_t* buf, size_t len, uint32_t timeout_ms) = nullptr;
 };
 
 /// Phase 115.D — register a custom transport. Must be called before


### PR DESCRIPTION
Phase-442 W6 and W7, plus the two RFC-0096 decisions W8 needs before it can
start.

**Carries #963, #964 and #965's commits** (W0–W5), because W6 uses W3's
`nros::tr`. Those drop by patch-id on the queue's rebase once the three land —
the pattern CLAUDE.md records for #699, #550 and #626. Review the last four
commits; the first six are already under review elsewhere.

## W6 — 27 `std` uses that never needed to be `std`

The removable bucket, separated from W7 and W8 because none of it is a design
question: every site already had a freestanding spelling in this tree or in the
language, and no consumer loses a capability.

- 13 `std::move` → `nros::tr::forward_rvalue`
- 3 `std::forward` → `nros::tr::relay`
- 14 `std::size_t` / `std::uint8_t` / `std::int32_t` / `std::uint32_t` → the
  bare spellings the rest of this API already writes. `transport.hpp` is now
  entirely `std`-free — it had nothing but std-spelled C types in a struct of
  function pointers.
- `result.hpp`'s `<utility>` include, verified unused by removing it and
  recompiling rather than by reading.

**`relay` is not `forward_rvalue`, and that is why there are two.** The obvious
economy — one helper for both — is wrong in the direction that does not announce
itself: forwarding preserves an lvalue as an lvalue, a move hands the callee an
rvalue it may gut, and a forwarding wrapper that moves silently steals from its
caller. Both exist, with the distinction written on the one that is easy to
misuse.

**Deliberately left:** the hosted diagnostics (`fprintf`, `fopen`, `getenv`,
`ostringstream`, `abort`, 13 sites). They are genuinely body-only and already
carry a freestanding `#else` — `result.hpp`'s `NROS_TRY_LOG` is the pattern. A
`std` call inside a hosted-only body changes no signature and no layout.

## W7 — met by measurement, and the measurement is the deliverable

W7 asked for 27 entities to be replaced with in-tree equivalents. They already
have them. After W6, the remaining 134 `std::` sites split:

| | sites |
| --- | --- |
| behind `NROS_CPP_STD` / `NROS_CPP_HAS_*` / `NROS_CPP_NODE_HOSTED` | **129** |
| ungated | **5** |

All five ungated are legitimate: two are string *literals* inside a diagnostic
message (which is why this is a comment-stripping scan and not a grep), two are
`std::abort()`, and one is `std::initializer_list` — whose header is
freestanding-guaranteed because it is core language support for braced
initialisation, not a library convenience.

**So the freestanding API is already `std`-free.** The census's predicted gap — a
`std::vector` overload with no `Seq` sibling — does not exist; checked pair by
pair in `parameter.hpp` (:274/:284, :322/:350, :372/:378, and :308 for the
string form). Its named holder, `ComponentNode`, was deleted by phase-427 W7.

That reframes W8: not "replace 27 types" but "collapse 129 gated sites into one
ungated API".

## RFC-0096 D8 — a name parameter is deduced, so `std::string` stays drop-in

A decision the RFC was missing, surfaced by W6. Every hosted `create_*` takes
`const std::string&` behind `NROS_CPP_NODE_HOSTED`, and W8's acceptance is zero
`NROS_CPP_HAS_*` — but D5's list of what is *not* drop-in does not include
`std::string` arguments. Deleting those overloads would have added a fourth item
to that list silently.

The parameter is deduced, and a two-overload `detail::as_c_str` converts it. The
header names no `std` type; a caller passing a literal, a `std::string`, our
`FixedString` or our `HeapString` all bind. This is W5's `NodeOptions::arguments()`
move generalised, and there it was measured to be *better* for a porting user
too. Measured here on three configurations:

| | |
| --- | --- |
| hosted `g++ -std=c++17`, caller passes `std::string` | rc=0 |
| ThreadX shim `-nostdinc++`, no `<string>` reachable | rc=0 |
| `arm-none-eabi -std=c++14 -ffreestanding` (32-bit) | rc=0 |

One cost, stated: a wrong argument type diagnoses one frame inside the template.
`as_c_str` is an overload set rather than a trait to keep it to one frame; W8
should add a `static_assert` so the first line names the parameter.

## RFC-0096 D9 — W8's first decision is entity storage, and it is not made yet

D2 says what `X::SharedPtr` *is*. It never said what the handle points *at*.

Today `create_publisher<M>(topic, qos)` does `std::make_shared` and pushes into
`owned_entities` — eight `push_back` sites, no `erase`, one drain in `~Node()`.
The census called that address stability wearing a `shared_ptr` face, and it was
right. But address stability is a **requirement**, not a fiction: the executor
arena holds a raw dispatch pointer and has no unregister path, so the entity must
outlive the caller's handle. Removing `make_shared` removes the mechanism, not
the requirement.

Why it is not a detail:

| entity | `sizeof` |
| --- | --- |
| `Timer` | 32 |
| `Service<int>` | 560 |
| `Publisher<int>` | 824 |
| `Subscription<int>` | 888 |
| `Client<int>` | **4 672** |

A uniform worst-case pool is wrong by an order of magnitude — one unused
`Client` slot costs more than twenty timers. D9 states three candidates;
the one that fits this repository is entity counts **derived** the way
phase-412 already derives `NROS_CPP_EXECUTOR_STORAGE_SIZE`, and it needs a
`just mem-report` before/after rather than a decision at the keyboard.

**W8 should not start before this is answered.** The remaining 129 sites are
substitution once it is, and substitution on top of an unanswered lifetime
question is how a use-after-free ships.

## Verification

`just check fast` — 309 gates green, 1 skipped. All three compile arms green
(hosted, hosted `-DNROS_CPP_STD=1`, `-nostdinc++` freestanding against the
ThreadX shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A4bG1pAtNwG5BDJBFBtfb
