### PR TITLE
feat(phase-455 W1, #0902): a refused zenoh reply slot is counted, and said once

### DIFF
--- a/docs/issues/0902-action-goal-completion-is-variable.md
+++ b/docs/issues/0902-action-goal-completion-is-variable.md
@@ -5,7 +5,7 @@ title: "action goals complete between 20 % and 90 % of the time on the same buil
 status: open
 type: bug
 area: rmw
-related: [issue-0912, issue-0882, issue-0879, issue-0852, phase-444]
+related: [issue-0912, issue-0882, issue-0879, issue-0852, phase-444, phase-455]
 ---
 
 ## Measurement
@@ -298,3 +298,55 @@ together with phase-444.
 **What would close it:** item 1's measurement at or near 10/10 on a fresh image
 closes the issue. A residual failure rate reopens the second candidate, and
 items 2 and 3 are what would make that residual diagnosable.
+
+## Status 2026-09-12 — the failure has an observable now (phase-455 W1)
+
+Item 3 above said there is no regression test, and gave the reason: reaching
+either leak arm needs a query delivered to a queryable, which needs a router.
+Item 1 said the symptom was never re-measured. Those two are the same problem
+seen from opposite ends — the only evidence available was a RATE, and a rate
+answers "did results arrive", never "did a slot run out".
+
+**The image says it now.** `query_handler`'s reply-slot allocation is
+`zpico_reply_slot_pick`, which COUNTS a refusal and latches the transition
+into exhaustion:
+
+* `zpico_reply_slot_stats(session, handle, *refusals, *capacity)` — slots
+  currently held as the return value, cumulative refusals beside it, shaped
+  after `zpico_graph_entry_count`'s `out_dropped`. **Zero refusals is a
+  statement** — "this server has never run out" — which `last_reply_seq == -1`
+  could not make, because that value also means "no query pending". That
+  conflation is the whole of this issue.
+* `zpico_reply_slot_take_announcement(session, handle)` — take-and-clear, so
+  the saturation is reported ONCE per transition rather than once per spin
+  (phase-444 W6's correction, on the Cyclone parameter services).
+* `send_response` no longer folds a negative seq into
+  `TransportError::ServiceReplyFailed`. Nothing was attempted, so "the reply
+  failed" was false; it returns a `Backend` diagnostic naming the knob, and
+  `nros_log` emits one line at the transition. The log is on the RUST side
+  deliberately: `printk` is a no-op under `ZPICO_SMOLTCP`/`ZPICO_SERIAL`, the
+  bare-metal serial board this issue was measured on, so a C-side print would
+  have reached nothing on the one target where the defect was found.
+
+The four swallow sites (`action_core.rs:695`, `:706-710`, `arena.rs:1925`,
+`nros-cpp/src/action.rs:529-532`) are unchanged and still recorded here.
+
+**Item 5 re-measured rather than re-read.** `ZPICO_MAX_PENDING_REPLIES` is
+still `#ifndef`-guarded and a raw `-D` still overrides it:
+`CFLAGS="-DZPICO_MAX_PENDING_REPLIES=0" cargo build -p zpico-sys` fails on the
+file's own `#error "ZPICO_MAX_PENDING_REPLIES must be >= 1"` (zpico.c:383),
+with the flag visible last on the cc-rs command line. Still no Kconfig, cmake
+or env producer sets it. The regression test does not rely on it — the pure
+pick takes `cap` as a parameter, so any capacity is drivable without a rebuild.
+
+**The tool this issue cites was never in version control.**
+`experiments/serial-interop/serial-tap.py` appears in no commit in full
+history, under no other name, and in no checkout on this disk; the captured
+dumps are likewise absent. So the "two free checks, before any hardware" in the
+09-04 section read data that nobody now has, and item 2 above cannot be
+discharged by anyone but the person who ran the tap. Recorded here rather than
+left for the next reader to search for.
+
+**What still stands.** Item 1's measurement — the completion rate on a fresh
+image — is phase-455 W2. Item 4, the `buffer_index`/queryable-handle desync,
+is unchanged.

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/service.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/service.rs
@@ -530,6 +530,50 @@ impl ServiceTrait for ZenohServiceServer {
         // Get context reference
         let context = unsafe { &*self.context };
 
+        /* issue 0902 / phase-455 W1 — a NEGATIVE seq is not "the reply
+         * failed"; it is "there was never a reply slot to fail with". The C
+         * shim clones each query into one of `ZPICO_MAX_PENDING_REPLIES`
+         * slots BEFORE the callback runs, and hands -1 on when the table is
+         * full. Folding that into `ServiceReplyFailed` is what made a
+         * saturated server read as a broken one — the same conflation issue
+         * 1088 removed one layer up (`arena.rs`, where a `WouldBlock` from a
+         * saturated `take_request` stopped being rewritten), and the reason
+         * 0902's 20-90 % completion spread had no observable cause.
+         *
+         * Say it ONCE. The transition is latched in the C shim, which is the
+         * only place that sees the allocation, and taken here — so a
+         * permanently saturated table costs one line, not one per spin
+         * (phase-444 W6 landed exactly this on the Cyclone parameter
+         * services). `nros_log`, never `eprintln!`: this crate reaches
+         * `no_std` targets, and std stdio SIGSEGVs a Zephyr native_sim image
+         * (issue 0589). The C shim does not print it either — `printk`
+         * compiles to a no-op under `ZPICO_SMOLTCP` / `ZPICO_SERIAL`, which is
+         * the bare-metal serial board 0902 was measured on. */
+        if sequence_number < 0 {
+            let handle = self._queryable.handle();
+            if context.take_reply_slot_announcement(handle) {
+                let (held, refusals, capacity) =
+                    context.reply_slot_stats(handle).unwrap_or((0, 0, 0));
+                nros_log::log_error!(
+                    nros_log::get_logger("nros_rmw_zenoh"),
+                    "zenoh reply-slot table exhausted on queryable {}: {}/{} slots held by \
+                     deferred replies, {} request(s) refused. Every later request on this \
+                     server is accepted and never answered until a slot is released. Raise \
+                     ZPICO_MAX_PENDING_REPLIES if this server fields more concurrent \
+                     in-flight requests than that.",
+                    handle,
+                    held,
+                    capacity,
+                    refusals
+                );
+            }
+            return Err(TransportError::Backend(
+                "zenoh reply-slot table exhausted — the query this reply answers was never \
+                 cloned into one of ZPICO_MAX_PENDING_REPLIES slots, so there is nothing to \
+                 reply to. Distinct from a failed reply: nothing was attempted.",
+            ));
+        }
+
         // Phase 237 — `sequence_number` selects the cloned query the C shim is
         // holding for this request (the reply-slot index from `take_request`),
         // so a deferred get_result reply reaches the original requester even

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
@@ -44,9 +44,10 @@ use zpico_sys::{
     zpico_declare_subscriber_with_attachment, zpico_get_zid, zpico_init, zpico_init_with_config,
     zpico_is_open, zpico_open, zpico_publish, zpico_publish_with_attachment,
     zpico_publish_with_attachment_aliased, zpico_query_reply, zpico_queryable_take_reply_seq,
-    zpico_session_acquire, zpico_session_release, zpico_session_t, zpico_spin_once,
-    zpico_undeclare_liveliness, zpico_undeclare_publisher, zpico_undeclare_queryable,
-    zpico_undeclare_subscriber, zpico_uses_polling,
+    zpico_reply_slot_stats, zpico_reply_slot_take_announcement, zpico_session_acquire,
+    zpico_session_release, zpico_session_t, zpico_spin_once, zpico_undeclare_liveliness,
+    zpico_undeclare_publisher, zpico_undeclare_queryable, zpico_undeclare_subscriber,
+    zpico_uses_polling,
 };
 
 // ============================================================================
@@ -842,6 +843,40 @@ impl Context {
     /// synchronous query callback; -1 if the reply table was full.
     pub fn queryable_take_reply_seq(&self, queryable_handle: i32) -> i64 {
         unsafe { zpico_queryable_take_reply_seq(self.handle, queryable_handle) }
+    }
+
+    /// issue 0902 / phase-455 W1 — one queryable's reply-slot table:
+    /// `(held, refusals, capacity)`, or `None` for an invalid handle.
+    ///
+    /// `refusals` is the count of allocations the C shim refused because every
+    /// slot was held. Zero means this server has never run out; the -1 that
+    /// `queryable_take_reply_seq` returns cannot say that, and that conflation
+    /// is what made issue 0902's 20-90 % completion spread unfalsifiable.
+    /// `capacity` is `ZPICO_MAX_PENDING_REPLIES` as the C TU was compiled with
+    /// it, so a caller reads the effective size instead of assuming a `-D`
+    /// arrived.
+    pub fn reply_slot_stats(&self, queryable_handle: i32) -> Option<(u32, u32, u32)> {
+        let mut refusals: u32 = 0;
+        let mut capacity: u32 = 0;
+        let held = unsafe {
+            zpico_reply_slot_stats(self.handle, queryable_handle, &mut refusals, &mut capacity)
+        };
+        if held < 0 {
+            return None;
+        }
+        Some((held as u32, refusals, capacity))
+    }
+
+    /// issue 0902 / phase-455 W1 — true exactly once per TRANSITION of this
+    /// queryable's reply-slot table into exhaustion; the pending flag is
+    /// cleared by the read.
+    ///
+    /// The once-ness lives in the C shim (`zpico_reply_slot_pick`), which is
+    /// the only place that sees the allocation. Latching again here would be a
+    /// second spelling of one rule, which is how a permanent failure ends up
+    /// reported per spin (phase-444 W6, on the Cyclone parameter services).
+    pub fn take_reply_slot_announcement(&self, queryable_handle: i32) -> bool {
+        unsafe { zpico_reply_slot_take_announcement(self.handle, queryable_handle) == 1 }
     }
 
     /// Start a non-blocking query (for async service client).

--- a/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
+++ b/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
@@ -274,6 +274,41 @@ typedef void (*ZpicoQueryCallback)(const char *keyexpr,
  * deferred-reply seq); call from inside the synchronous query callback.
  */
 /**
+ * issue 0902 / phase-455 W1 — read one queryable's reply-slot table.
+ *
+ * Returns the number of slots currently HELD (cloned queries awaiting a
+ * deferred reply), or `ZPICO_ERR_INVALID`. `out_refusals` receives the
+ * cumulative count of allocations refused because the table was full —
+ * the condition `zpico_queryable_take_reply_seq`'s -1 could not
+ * distinguish from "no query pending", which is the whole of issue 0902.
+ * `out_capacity` receives `ZPICO_MAX_PENDING_REPLIES` as the C TU sees
+ * it, so a caller reads the effective capacity rather than assuming one.
+ *
+ * Per-session AND per-queryable, so it is its own accessor rather than
+ * two more entries in the process-global `zpico_get_diag_counters`.
+ */
+/**
+ * issue 0902 / phase-455 W1 — take the pending "this table just
+ * saturated" announcement, clearing it. 1 = announce now, 0 = nothing
+ * pending, `ZPICO_ERR_INVALID` for a bad handle.
+ *
+ * The once-ness lives here and nowhere else (phase-444 W6's correction:
+ * a permanent failure asked six times per spin). A second latch on the
+ * Rust side would be a second spelling of the same rule.
+ */
+/**
+ * issue 0902 / phase-455 W1 — the PURE half of the reply-slot
+ * allocation, exported like `zpico_entry_at` / `zpico_graph_set_apply` so
+ * the accounting is reachable from a host test with no session, no router
+ * and no live peer.
+ *
+ * Returns the first free index in `valid[0..cap)`, `ZPICO_ERR_FULL` when
+ * every slot is held, or `ZPICO_ERR_INVALID` for a NULL argument or
+ * `cap == 0`. Does NOT mark the slot taken. `*refusals` is incremented on
+ * a refusal (saturating at `u32::MAX`); `*saturated` latches so
+ * `*out_announce` is true exactly on the TRANSITION into exhaustion.
+ */
+/**
  * Phase 108.C.zenoh.4-followup — count of liveliness-token
  * replies on this slot. Used by the subscriber-side
  * `LivelinessChanged` bridge to surface `alive_count > 1`.
@@ -738,6 +773,34 @@ int32_t zpico_query_reply(struct zpico_session_t *_session,
  * Stub returns -1 (no slot) in the pure-Rust no-op build.
  */
 int64_t zpico_queryable_take_reply_seq(struct zpico_session_t *_session, int32_t _queryable_handle);
+
+/**
+ * issue 0902 / phase-455 W1 — how many reply slots this queryable holds,
+ * and how many allocations it has refused because the table was full.
+ * `out_capacity` reports `ZPICO_MAX_PENDING_REPLIES` as the C TU sees it.
+ */
+int32_t zpico_reply_slot_stats(struct zpico_session_t *_session,
+                               int32_t _queryable_handle,
+                               uint32_t *_out_refusals,
+                               uint32_t *_out_capacity);
+
+/**
+ * issue 0902 / phase-455 W1 — take the pending "this reply-slot table
+ * just saturated" announcement, clearing it. 1 = announce, 0 = nothing.
+ */
+int32_t zpico_reply_slot_take_announcement(struct zpico_session_t *_session,
+                                           int32_t _queryable_handle);
+
+/**
+ * issue 0902 / phase-455 W1 — the PURE half of the reply-slot
+ * allocation: pick a free slot and account for a refusal. Split out like
+ * `zpico_entry_at` so the accounting is testable without a session.
+ */
+int32_t zpico_reply_slot_pick(const bool *_valid,
+                              uint32_t _cap,
+                              uint32_t *_refusals,
+                              bool *_saturated,
+                              bool *_out_announce);
 
 /**
  * Send a query and wait for reply (blocking, for service client).

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -521,6 +521,20 @@ struct zpico_session {
     bool stored_query_valid[ZPICO_MAX_QUERYABLES][ZPICO_MAX_PENDING_REPLIES];
     int64_t last_reply_seq[ZPICO_MAX_QUERYABLES];
 
+    /* issue 0902 / phase-455 W1 — the reply-slot table was the one bounded
+     * resource in this file with no counter. Exhaustion and "no query pending"
+     * were the SAME value (`last_reply_seq == -1`), and that IS the defect: a
+     * goal was accepted, executed and never answered, while nothing anywhere
+     * recorded that a slot had been refused. The tree already has the shape —
+     * `zpico_graph_entry_count`'s `out_dropped` and the request ring's own
+     * `dropped` both report what a bounded resource discarded.
+     *
+     * Per QUERYABLE, not per session and not process-global: each server holds
+     * its own table, so a summed number cannot say which one saturated. */
+    uint32_t reply_slot_refusals[ZPICO_MAX_QUERYABLES];
+    bool reply_slot_saturated[ZPICO_MAX_QUERYABLES];
+    bool reply_slot_announce[ZPICO_MAX_QUERYABLES];
+
     // Non-blocking z_get slot pool.
     pending_get_slot_t pending_gets[ZPICO_MAX_PENDING_GETS];
 
@@ -912,6 +926,61 @@ static void zpico_format_session_zid(char out[37], const uint8_t bytes[ZPICO_ZID
  */
 static void _zpico_release_reply_slot(struct zpico_session* s, int32_t handle, int64_t seq);
 
+/* issue 0902 / phase-455 W1 — the PURE half of `query_handler`'s reply-slot
+ * allocation, split out for exactly the reason `zpico_entry_at` and
+ * `zpico_graph_set_apply` were: it is the piece a test can drive WITHOUT a
+ * session, a router and a live peer. Issue 0902 item 3 records why that
+ * matters — both leak fixes landed with no regression test, because reaching
+ * either arm needs a query delivered to a queryable, and nothing under
+ * `packages/testing` referenced this table at all.
+ *
+ * Picks the first free slot in `valid[0..cap)` and ACCOUNTS for a refusal. It
+ * deliberately does not mark the slot taken: the caller does that only once
+ * the clone succeeds, which is the one remaining step that can fail.
+ *
+ * `*refusals` counts allocations refused because every slot was held. It is
+ * cumulative for the life of the queryable, so a reader can tell "this server
+ * has never run out" (0) from "it ran out" (>0) — the distinction the -1
+ * return value cannot carry, and the whole of what made the 20-90 % completion
+ * spread unfalsifiable. Saturates at UINT32_MAX rather than wrapping to 0,
+ * because wrapping to 0 is indistinguishable from "never happened".
+ *
+ * `*saturated` latches the state so `*out_announce` is true exactly on the
+ * TRANSITION into exhaustion, never on every refused query. phase-444 W6
+ * landed the same correction on the Cyclone parameter services, where a
+ * permanent failure was reported six times per spin. A successful pick clears
+ * the latch, so a table that drains and saturates again announces again: that
+ * is a new event, not a repeat of the old one.
+ *
+ * Returns the slot index, `ZPICO_ERR_FULL` when every slot is held, or
+ * `ZPICO_ERR_INVALID` for a NULL argument or `cap == 0`.
+ */
+int32_t zpico_reply_slot_pick(const bool* valid, uint32_t cap, uint32_t* refusals, bool* saturated,
+                              bool* out_announce) {
+    if (out_announce != NULL) {
+        *out_announce = false;
+    }
+    if (valid == NULL || refusals == NULL || saturated == NULL || cap == 0) {
+        return ZPICO_ERR_INVALID;
+    }
+    for (uint32_t j = 0; j < cap; ++j) {
+        if (!valid[j]) {
+            *saturated = false;
+            return (int32_t)j;
+        }
+    }
+    if (*refusals != 0xFFFFFFFFu) {
+        (*refusals)++;
+    }
+    if (!*saturated) {
+        *saturated = true;
+        if (out_announce != NULL) {
+            *out_announce = true;
+        }
+    }
+    return ZPICO_ERR_FULL;
+}
+
 static void query_handler(z_loaned_query_t* query, void* arg) {
     struct zpico_session* s = _zpico_unpack_session(arg);
     int idx = _zpico_unpack_slot(arg);
@@ -948,15 +1017,34 @@ static void query_handler(z_loaned_query_t* query, void* arg) {
     // reply can be sent after this callback returns (deferred get_result) even
     // if more queries land meanwhile. Record the slot index as the reply seq for
     // `zpico_queryable_take_reply_seq` to hand to the (synchronous) callback.
+    //
+    // issue 0902 / phase-455 W1 — the pick and its accounting are
+    // `zpico_reply_slot_pick`, so the refusal is COUNTED and announced ONCE,
+    // and so the state machine is reachable from a host test.
     int64_t reply_seq = -1;
-    for (int j = 0; j < ZPICO_MAX_PENDING_REPLIES; ++j) {
-        if (!s->stored_query_valid[idx][j]) {
-            if (z_query_clone(&s->stored_queries[idx][j], query) == 0) {
-                s->stored_query_valid[idx][j] = true;
-                reply_seq = j;
-            }
-            break;
+    bool announce = false;
+    int32_t slot =
+        zpico_reply_slot_pick(s->stored_query_valid[idx], (uint32_t)ZPICO_MAX_PENDING_REPLIES,
+                              &s->reply_slot_refusals[idx], &s->reply_slot_saturated[idx],
+                              &announce);
+    if (slot >= 0) {
+        /* The clone is a refcount increment, not an allocation — issue 0902
+         * ruled it out as a failure mode against `refcount.h:70-72` — so a -1
+         * reply_seq means "the table was full" and nothing else. That is what
+         * keeps the refusal counter's meaning exact, and why a clone failure
+         * is not folded into it. */
+        if (z_query_clone(&s->stored_queries[idx][slot], query) == 0) {
+            s->stored_query_valid[idx][slot] = true;
+            reply_seq = slot;
         }
+    }
+    if (announce) {
+        /* Latched here, said by the RUST side (`shim/service.rs`). `printk` is
+         * a NO-OP on `ZPICO_SMOLTCP` / `ZPICO_SERIAL` — the bare-metal serial
+         * board issue 0902 was measured on — so a C-side print would reach
+         * nothing on the one target where this was found. `nros_log` reaches
+         * every platform (issue 0589). */
+        s->reply_slot_announce[idx] = true;
     }
     s->last_reply_seq[idx] = reply_seq;
 
@@ -1233,6 +1321,11 @@ int32_t zpico_init_with_config(zpico_session_t* session, const char* locator, co
     memset(s->stored_query_valid, 0, sizeof(s->stored_query_valid));
     for (int i = 0; i < ZPICO_MAX_QUERYABLES; i++) {
         s->last_reply_seq[i] = -1;
+        // issue 0902 / phase-455 W1 — the refusal counters belong to the table
+        // they describe, so they are re-armed with it.
+        s->reply_slot_refusals[i] = 0;
+        s->reply_slot_saturated[i] = false;
+        s->reply_slot_announce[i] = false;
         for (int j = 0; j < ZPICO_MAX_PENDING_REPLIES; j++) {
             z_internal_query_null(&s->stored_queries[i][j]);
         }
@@ -3072,7 +3165,80 @@ int32_t zpico_undeclare_queryable(zpico_session_t* session, int32_t handle) {
         }
     }
     s->last_reply_seq[handle] = -1;
+    // issue 0902 / phase-455 W1 — the counters describe THIS queryable's
+    // table, and the handle is reused by the next server declared into the
+    // slot; leaving them set would credit one server's exhaustion to another.
+    s->reply_slot_refusals[handle] = 0;
+    s->reply_slot_saturated[handle] = false;
+    s->reply_slot_announce[handle] = false;
     return ZPICO_OK;
+}
+
+/* issue 0902 / phase-455 W1 — read the reply-slot table of one queryable.
+ *
+ * Shaped after `zpico_graph_entry_count`, which is the file's existing answer
+ * to "a bounded resource must report what it discarded": the live count is the
+ * return value, the discard count is reported beside it rather than folded in.
+ *
+ * A new accessor rather than two more entries in `zpico_get_diag_counters`:
+ * those 18 counters are file-scope `static volatile uint32_t`, i.e. PROCESS-
+ * global and all 18 on the client-side `zpico_get*` path, while this table is
+ * per-session AND per-queryable — a summed number could not name the server
+ * that saturated. The array also binds in Rust as a bare `*mut u32` whose
+ * length lives only in the C prototype, so growing `out[18]` is an
+ * undiagnosable overrun for any caller not recompiled with it.
+ *
+ * Returns the number of slots currently HELD (cloned queries awaiting a
+ * reply), or `ZPICO_ERR_INVALID` for a bad session or handle.
+ * `out_refusals` receives the cumulative count of allocations refused because
+ * the table was full — zero means "this server has never run out", which is
+ * precisely what `last_reply_seq == -1` could not say.
+ * `out_capacity` receives `ZPICO_MAX_PENDING_REPLIES` as this TU sees it, so a
+ * caller reads the effective capacity instead of assuming a `-D` arrived.
+ */
+int32_t zpico_reply_slot_stats(zpico_session_t* session, int32_t queryable_handle,
+                               uint32_t* out_refusals, uint32_t* out_capacity) {
+    struct zpico_session* s = (struct zpico_session*)session;
+    if (s == NULL || queryable_handle < 0 || queryable_handle >= ZPICO_MAX_QUERYABLES) {
+        return ZPICO_ERR_INVALID;
+    }
+    if (out_refusals != NULL) {
+        *out_refusals = s->reply_slot_refusals[queryable_handle];
+    }
+    if (out_capacity != NULL) {
+        *out_capacity = (uint32_t)ZPICO_MAX_PENDING_REPLIES;
+    }
+    int32_t held = 0;
+    for (int j = 0; j < ZPICO_MAX_PENDING_REPLIES; j++) {
+        if (s->stored_query_valid[queryable_handle][j]) {
+            held++;
+        }
+    }
+    return held;
+}
+
+/* issue 0902 / phase-455 W1 — take the pending "this table just saturated"
+ * announcement, clearing it.
+ *
+ * A take-and-clear, like `zpico_queryable_take_reply_seq`, so the once-ness
+ * lives in exactly ONE place: `zpico_reply_slot_pick` decides when a
+ * transition happened, and whoever asks first gets it. A second latch on the
+ * Rust side would be a second spelling of the same rule, which is how a
+ * permanent failure ends up reported per spin again.
+ *
+ * Returns 1 when an announcement was pending, 0 when not, `ZPICO_ERR_INVALID`
+ * for a bad session or handle. Deliberately separate from
+ * `zpico_reply_slot_stats`: a stats read must not consume the event, or the
+ * probe that samples the counter silences the log line.
+ */
+int32_t zpico_reply_slot_take_announcement(zpico_session_t* session, int32_t queryable_handle) {
+    struct zpico_session* s = (struct zpico_session*)session;
+    if (s == NULL || queryable_handle < 0 || queryable_handle >= ZPICO_MAX_QUERYABLES) {
+        return ZPICO_ERR_INVALID;
+    }
+    bool pending = s->reply_slot_announce[queryable_handle];
+    s->reply_slot_announce[queryable_handle] = false;
+    return pending ? 1 : 0;
 }
 
 // ============================================================================

--- a/packages/rmw/zenoh/zpico-sys/src/ffi.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/ffi.rs
@@ -679,6 +679,43 @@ mod cbindgen_stubs {
         -1
     }
 
+    /// issue 0902 / phase-455 W1 — how many reply slots this queryable holds,
+    /// and how many allocations it has refused because the table was full.
+    /// `out_capacity` reports `ZPICO_MAX_PENDING_REPLIES` as the C TU sees it.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_reply_slot_stats(
+        _session: *mut zpico_session_t,
+        _queryable_handle: i32,
+        _out_refusals: *mut u32,
+        _out_capacity: *mut u32,
+    ) -> i32 {
+        -1 // stub: not available
+    }
+
+    /// issue 0902 / phase-455 W1 — take the pending "this reply-slot table
+    /// just saturated" announcement, clearing it. 1 = announce, 0 = nothing.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_reply_slot_take_announcement(
+        _session: *mut zpico_session_t,
+        _queryable_handle: i32,
+    ) -> i32 {
+        -1 // stub: not available
+    }
+
+    /// issue 0902 / phase-455 W1 — the PURE half of the reply-slot
+    /// allocation: pick a free slot and account for a refusal. Split out like
+    /// `zpico_entry_at` so the accounting is testable without a session.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_reply_slot_pick(
+        _valid: *const bool,
+        _cap: u32,
+        _refusals: *mut u32,
+        _saturated: *mut bool,
+        _out_announce: *mut bool,
+    ) -> i32 {
+        -1 // stub: not available
+    }
+
     /// Send a query and wait for reply (blocking, for service client).
     ///
     /// # Parameters

--- a/packages/rmw/zenoh/zpico-sys/src/lib.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/lib.rs
@@ -317,6 +317,55 @@ unsafe extern "C" {
         queryable_handle: i32,
     ) -> i64;
 
+    /// issue 0902 / phase-455 W1 — read one queryable's reply-slot table.
+    ///
+    /// Returns the number of slots currently HELD (cloned queries awaiting a
+    /// deferred reply), or `ZPICO_ERR_INVALID`. `out_refusals` receives the
+    /// cumulative count of allocations refused because the table was full —
+    /// the condition `zpico_queryable_take_reply_seq`'s -1 could not
+    /// distinguish from "no query pending", which is the whole of issue 0902.
+    /// `out_capacity` receives `ZPICO_MAX_PENDING_REPLIES` as the C TU sees
+    /// it, so a caller reads the effective capacity rather than assuming one.
+    ///
+    /// Per-session AND per-queryable, so it is its own accessor rather than
+    /// two more entries in the process-global `zpico_get_diag_counters`.
+    pub fn zpico_reply_slot_stats(
+        session: *mut zpico_session_t,
+        queryable_handle: i32,
+        out_refusals: *mut u32,
+        out_capacity: *mut u32,
+    ) -> i32;
+
+    /// issue 0902 / phase-455 W1 — take the pending "this table just
+    /// saturated" announcement, clearing it. 1 = announce now, 0 = nothing
+    /// pending, `ZPICO_ERR_INVALID` for a bad handle.
+    ///
+    /// The once-ness lives here and nowhere else (phase-444 W6's correction:
+    /// a permanent failure asked six times per spin). A second latch on the
+    /// Rust side would be a second spelling of the same rule.
+    pub fn zpico_reply_slot_take_announcement(
+        session: *mut zpico_session_t,
+        queryable_handle: i32,
+    ) -> i32;
+
+    /// issue 0902 / phase-455 W1 — the PURE half of the reply-slot
+    /// allocation, exported like `zpico_entry_at` / `zpico_graph_set_apply` so
+    /// the accounting is reachable from a host test with no session, no router
+    /// and no live peer.
+    ///
+    /// Returns the first free index in `valid[0..cap)`, `ZPICO_ERR_FULL` when
+    /// every slot is held, or `ZPICO_ERR_INVALID` for a NULL argument or
+    /// `cap == 0`. Does NOT mark the slot taken. `*refusals` is incremented on
+    /// a refusal (saturating at `u32::MAX`); `*saturated` latches so
+    /// `*out_announce` is true exactly on the TRANSITION into exhaustion.
+    pub fn zpico_reply_slot_pick(
+        valid: *const bool,
+        cap: u32,
+        refusals: *mut u32,
+        saturated: *mut bool,
+        out_announce: *mut bool,
+    ) -> i32;
+
     // Service client (queries)
     pub fn zpico_get(
         session: *mut zpico_session_t,
@@ -664,6 +713,150 @@ mod tests {
             )
         };
         assert_eq!((rc, tcount, tlen, tdropped), (0, 0, 0, 1));
+    }
+
+    /// issue 0902 / phase-455 W1 — drive a reply-slot table past its capacity
+    /// and read the refusal back, against the REAL C function.
+    ///
+    /// The defect this gates is that exhaustion and "no query pending" were
+    /// the SAME value: `query_handler` computed `reply_seq = -1` for a full
+    /// table, handed it on, and recorded nothing. A goal was then accepted,
+    /// executed and never answered, with the error discarded at four layers.
+    /// So the three properties asserted here are exactly the three the issue
+    /// says were missing — the refusal is COUNTED, the count is DISTINCT from
+    /// "nothing pending", and the announcement fires ONCE per transition
+    /// rather than per query (phase-444 W6's correction, one backend over).
+    #[test]
+    fn reply_slot_exhaustion_is_counted_and_announced_once() {
+        unsafe extern "C" {
+            fn zpico_reply_slot_pick(
+                valid: *const bool,
+                cap: u32,
+                refusals: *mut u32,
+                saturated: *mut bool,
+                out_announce: *mut bool,
+            ) -> i32;
+        }
+
+        /// One queryable's table, as `struct zpico_session` holds it.
+        struct Table {
+            valid: [bool; 4],
+            refusals: u32,
+            saturated: bool,
+        }
+
+        impl Table {
+            fn new() -> Self {
+                Self {
+                    valid: [false; 4],
+                    refusals: 0,
+                    saturated: false,
+                }
+            }
+
+            /// `(slot_or_error, announce)` — the pick, plus whether THIS call
+            /// is the one that should say something.
+            fn pick(&mut self) -> (i32, bool) {
+                let mut announce = false;
+                let rc = unsafe {
+                    zpico_reply_slot_pick(
+                        self.valid.as_ptr(),
+                        self.valid.len() as u32,
+                        &mut self.refusals,
+                        &mut self.saturated,
+                        &mut announce,
+                    )
+                };
+                (rc, announce)
+            }
+
+            /// What `query_handler` does after a successful clone.
+            fn take(&mut self, slot: i32) {
+                self.valid[slot as usize] = true;
+            }
+
+            /// What `_zpico_release_reply_slot` does when a reply goes out.
+            fn release(&mut self, slot: usize) {
+                self.valid[slot] = false;
+            }
+        }
+
+        let mut t = Table::new();
+
+        // An empty table hands out every slot and refuses nothing. This is the
+        // arm that makes the counter MEAN something: a server that has never
+        // run out reads 0, which `last_reply_seq == -1` could never say.
+        for expected in 0..4 {
+            let (slot, announce) = t.pick();
+            assert_eq!(slot, expected, "slot {expected} must be handed out");
+            assert!(!announce, "a successful pick announces nothing");
+            t.take(slot);
+        }
+        assert_eq!(t.refusals, 0, "four successful picks are not a refusal");
+
+        // Full table. The FIRST refusal is the transition, and it is the only
+        // one that announces.
+        let (rc, announce) = t.pick();
+        assert_eq!(rc, ZPICO_ERR_FULL, "a full table must refuse, not wrap");
+        assert!(announce, "the transition into exhaustion is announced");
+        assert_eq!(t.refusals, 1, "the refusal is COUNTED");
+
+        // Every later refusal counts and stays quiet. This is the property
+        // phase-444 W6 landed on the Cyclone parameter services: a PERMANENT
+        // failure asked six times per spin reported six times per spin.
+        for n in 2..=20u32 {
+            let (rc, announce) = t.pick();
+            assert_eq!(rc, ZPICO_ERR_FULL);
+            assert!(!announce, "refusal {n} must not re-announce");
+            assert_eq!(t.refusals, n, "every refusal is counted");
+        }
+
+        // A table that drains and saturates AGAIN is a new event, not a repeat
+        // of the old one, so it announces again — and the cumulative count is
+        // never reset behind the reader's back.
+        t.release(2);
+        let (slot, announce) = t.pick();
+        assert_eq!(slot, 2, "the freed slot is handed out");
+        assert!(!announce);
+        t.take(slot);
+        assert_eq!(t.refusals, 20, "a successful pick does not clear the count");
+
+        let (rc, announce) = t.pick();
+        assert_eq!(rc, ZPICO_ERR_FULL);
+        assert!(announce, "re-saturation announces again");
+        assert_eq!(t.refusals, 21);
+
+        // Argument refusals, so a NULL from a caller is a refusal rather than
+        // a write through a null pointer.
+        let mut refusals = 0u32;
+        let mut saturated = false;
+        let mut announce = true;
+        let rc = unsafe {
+            zpico_reply_slot_pick(
+                core::ptr::null(),
+                4,
+                &mut refusals,
+                &mut saturated,
+                &mut announce,
+            )
+        };
+        assert_eq!(rc, ZPICO_ERR_INVALID, "a NULL table is refused");
+        assert!(!announce, "a refused argument announces nothing");
+
+        let valid = [false; 4];
+        assert_eq!(
+            unsafe {
+                zpico_reply_slot_pick(
+                    valid.as_ptr(),
+                    0,
+                    &mut refusals,
+                    &mut saturated,
+                    core::ptr::null_mut(),
+                )
+            },
+            ZPICO_ERR_INVALID,
+            "cap 0 is refused; `out_announce` may be NULL"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implements **phase-455 W1**. Closes the observability half of
[issue 0902](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/issues/0902-action-goal-completion-is-variable.md).

## The defect this makes visible

`query_handler` computed `reply_seq = -1` when `stored_query_valid[idx][*]` was
full and passed it on **with no record**. Exhaustion and "no query pending" were
the SAME value — and that conflation *is* the defect 0902 measured: a goal is
accepted, executed, and never answered, the error discarded at four layers, with
the C++ side printing "Goal succeeded" over it.

A completion RATE cannot separate that from a timeout, a slow peer or a
scheduling artefact, which is why 0902's 20–90 % spread stayed unfalsifiable for
a month. Measured 2026-09-11 and still true at this branch point: `zpico_get_diag_counters`
carries 18 counters and all 18 are the client-side `zpico_get*` path; nothing in
the image could answer the direct question.

## What landed

| | |
| --- | --- |
| `zpico_reply_slot_pick(valid, cap, *refusals, *saturated, *announce)` | the PURE allocation + accounting, exported |
| `zpico_reply_slot_stats(session, handle, *refusals, *capacity) -> held` | read one queryable's table |
| `zpico_reply_slot_take_announcement(session, handle)` | take-and-clear the "just saturated" event |

Plus the Rust bindings (`zpico-sys` extern decls + cbindgen stubs + regenerated
`c/include/zpico.h`), safe wrappers on `Context`, and the `send_response` change
below.

### Why a new accessor, not new `zpico_get_diag_counters` entries

The phase doc left this choice to W1, to be made against how a test reaches it
and what the `no_std` binding can express. Three reasons, all read off the code:

1. Those 18 counters are file-scope `static volatile uint32_t` — **process-global**,
   and `lib.rs` documents them so. This table is per-session **and** per-queryable
   (`s->stored_query_valid[idx][j]`), so a summed number cannot name the server
   that saturated, and two sessions' independent tables would add up into one
   meaningless figure.
2. `zpico_get_diag_counters(uint32_t out[18])` binds in Rust as a bare `*mut u32`.
   The length lives only in the C prototype, so growing it to 20 is an
   **undiagnosable overrun** for any caller not recompiled with it — the
   hand-mirrored-FFI class one layer over.
3. `zpico_graph_entry_count(session, uint32_t *out_dropped)` is this file's
   existing answer to "a bounded resource must report what it discarded": live
   count as the return value, discards beside it. The test reaches the new
   accessor exactly the way `shim/session.rs:250` already reaches that one.

The accounting itself is split into a PURE function exported like `zpico_entry_at`
and `zpico_graph_set_apply` — whose own comments say they exist so the logic is
testable **without a session**. That is what makes a regression test affordable
here at all: 0902 item 3 records that both leak fixes landed untested, because
reaching either arm needs a query delivered to a queryable, which needs a router.

### The two required properties

* **Exhaustion is DISTINCT from "no query pending."** `out_refusals` is cumulative
  for the life of the queryable and **saturates at `u32::MAX` rather than wrapping**
  — wrapping to 0 is indistinguishable from "never happened". Zero means *this
  server has never run out*, the statement `last_reply_seq == -1` could not make.
* **Said ONCE, not per spin.** `*saturated` latches inside the pick, so the
  announcement is true exactly on the TRANSITION into exhaustion.
  `zpico_reply_slot_take_announcement` is a take-and-clear — like the file's own
  `zpico_queryable_take_reply_seq` — so the once-ness has exactly ONE spelling and
  the Rust side keeps no second latch. phase-444 W6 landed this same correction on
  the Cyclone parameter services. A table that drains and re-saturates announces
  again: a new event, not a repeat.

The line is emitted on the **Rust** side via `nros_log`, not in C. `printk` is a
no-op under `ZPICO_SMOLTCP` / `ZPICO_SERIAL` — the bare-metal serial board 0902 was
measured on — so a C-side print would have reached nothing on the one target where
this defect was found. `nros_log` reaches every platform (issue 0589).

### The Rust side stops discarding it

`send_response` mapped every failure to `TransportError::ServiceReplyFailed`. A
negative seq is not "the reply failed"; it is "there was never a slot to fail
with", so it now returns a `TransportError::Backend` naming the knob — the same
conflation issue 1088 removed one layer up in `arena.rs`, where a saturated
`take_request` stopped being rewritten into `ServiceReplyFailed`.

**Out of scope, per the phase doc:** the executor's four swallow sites
(`action_core.rs:695`, `:706-710`, `arena.rs:1925`, `nros-cpp/src/action.rs:529-532`)
are untouched and stay recorded in 0902.

## Acceptance

`cargo test -p zpico-sys reply_slot` drives a table past capacity through the real
C function and asserts the counter moves, that a successful pick does not clear the
count, that re-saturation announces again, and that the announcement fires **once**
across 20 consecutive refusals.

**Negative control — counter and latch removed from `zpico_reply_slot_pick`:**

```
running 1 test
test tests::reply_slot_exhaustion_is_counted_and_announced_once ... FAILED

---- tests::reply_slot_exhaustion_is_counted_and_announced_once stdout ----
thread 'tests::reply_slot_exhaustion_is_counted_and_announced_once' panicked at
packages/rmw/zenoh/zpico-sys/src/lib.rs:801:9:
the transition into exhaustion is announced

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out
```

Restored: `test result: ok. 1 passed; 0 failed`.

**`-D` override re-MEASURED, not re-read** (0902 Status item 5 corrected an earlier
claim). `CFLAGS="-DZPICO_MAX_PENDING_REPLIES=0" cargo build -p zpico-sys`:

```
zpico.c:383:2: error: #error "ZPICO_MAX_PENDING_REPLIES must be >= 1: it sizes a fixed C array (issue 1015)"
  error occurred in cc-rs: ... "-DZPICO_MAX_PENDING_GETS=4" ... "-DZPICO_MAX_PENDING_REPLIES=0" ...
```

The flag reaches the TU and overrides the `#ifndef`. The test does **not** depend on
that — `cap` is a parameter of the pure function, so any capacity is drivable with no
rebuild.

## Sweep — the class, not the site

```
grep -n 'ZPICO_ERR_FULL' packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
```

Every other bounded pool in this file reports exhaustion as a RETURN CODE from its
entry point (publishers, subscribers, liveliness, queryables, sessions, pending
gets — 13 sites), and the graph cache reports `dropped` beside its count. The
reply-slot table was the only one whose exhaustion travelled as a magic value
inside a DATA channel that also means "nothing here".

## Local checks, verbatim

`just check c-fmt`:

```
Checking C formatting... (/home/aeon/.nros/sdk/clang-format/17.0.6-nros1/bin/clang-format)
C formatting OK.
```

`just ci gate` — **`check::cli-fresh` ok, `check::fast` ok, `check::build` FAILED**:

```
check-fast (parallel): 306 gate(s) ran at -P4 (1 test-thread(s)/gate), 2 SKIPPED; slowest api-parity 219715ms
  [SKIPPED] ivc-fsp: NV_SPE_FSP_DIR unset — the NVIDIA Orin SPE FSP tree is not provisioned here (phase-418 418.4)
  [SKIPPED] leaf-lockfiles: tree not synced — 2 leaf crate(s) NOT checked: .../nros-nuttx-ffi .../nros-nuttx-riscv-ffi
...
check-build (parallel): 4 of 21 gate(s) FAILED
```

`check::fast` is the half that gates a pull request, and it is green. **The four
`check::build` reds are this agent worktree's missing provisioning, proven against
the base commit rather than asserted:**

* 3 of 4 (`test-targets` ×2 under `workspace-all`, `workspace-features`) are one
  cause — `third-party/dds/cyclonedds` is not initialised here:

  ```
  thread 'main' panicked at packages/rmw/cyclonedds/cyclonedds-sys/build.rs:24:9:
  cyclonedds-sys: source dir .../third-party/dds/cyclonedds has no CMakeLists.txt — source not provisioned.
  ```

  On the base commit `160ed2d9c0`, with this branch checked out nowhere:
  `cargo build -p cyclonedds-sys` → `rc=101`, `source not provisioned`. Identical.

* 1 of 4 (`cli-tests`) failed on `a_cargo_image_generates_an_entry_from_the_launch_file`
  with `nros-launch-resolve not found` — another agent's `ci gate` was building
  `packages/cli/target` concurrently in a sibling worktree. The same test binary
  passes 32/32 on BOTH the base commit `160ed2d9c0` and this branch when run
  directly, and **`just check cli-tests` re-run alone on this branch is green**:

  ```
  test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  CLI tests passed!
  ```

  So the red is not attributable to this diff.

This diff touches only `packages/rmw/zenoh/**` and `docs/issues/0902-*.md`; neither
`cyclonedds-sys` nor `nros-cli-core` is reachable from it.

## Not verified

* **No live run.** The counter has not yet been driven by a real router, a real
  queryable and a real peer — that is phase-455 W2, which reads this counter and
  asserts it is zero over a goal-completion probe.
* No embedded target was built; `check::build`, which is the only place the C/C++
  backends compile, did not complete here for the provisioning reasons above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7tie7AFCdqoRkxphQcqRx
