### PR TITLE
test(phase-455 W3): the actions family had a live peer, and both cells were Cyclone

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -820,8 +820,53 @@ test-group = "host-dds-ros2-interop"
 slow-timeout = { period = "60s", terminate-after = 3 }
 retries = 2
 
+# phase-455 W3 — the ZENOH half of the ACTIONS live-peer lane.
+#
+# THIS OVERRIDE MUST STAY HERE, ahead of the `binary(=ros2_action_e2e)` one
+# immediately below and therefore ahead of every broader row further down
+# (`binary(interop_e2e)`, and the `binary(~zephyr)`-class blanket near the end
+# of this file). nextest applies the FIRST matching override per setting and
+# `binary(x)` is a SUBSTRING match, so an anchored-but-later row loses: the row
+# below matches `ros2_action_e2e` exactly, zenoh cases included, and would hand
+# them `host-dds-ros2-interop`. That blanket has already claimed three cells
+# this way.
+#
+# GROUP `ros2-interop`, not `host-dds-ros2-interop`, and the two cases split
+# from their Cyclone siblings for a reason the group names describe exactly:
+# these start no RTPS participant at all. Their peer is `rmw_zenoh_cpp` against
+# a `ZenohRouter::start_unique` router, so they join no DDS domain and compete
+# for none of the 232 slots that group bounds. What they DO touch is the ros2cli
+# daemon singleton, which is keyed on `ROS_DOMAIN_ID` alone — and these cases
+# must run on domain 0, because the nano side's domain is a compile-time bake
+# and the `linux/rust/zenoh` action fixtures bake no value (the test file says
+# this at length). A shared daemon on a shared domain is precisely what
+# `ros2-interop`'s `max-threads = 1` exists for, and it is where every other
+# zenoh cell in the tree already is.
+#
+# BUDGET: 90s × 3. The additive worst case is a router start, up to 20 s of
+# `ros2 action list` discovery polling and a `timeout 60` on the goal itself,
+# so the default `30s × 2` would terminate the test before its own timeout
+# fired and replace an assertion's diagnostic with a nextest timeout — the
+# shape PR #627 found on this very binary when it had no override.
+#
+# NO RETRIES, deliberately, and unlike the Cyclone row below. The question
+# these cells exist to answer is whether an action goal COMPLETES over zenoh,
+# and issue 0902 measured exactly that completing between 20 % and 90 % of the
+# time. A retry converts "failed once, passed on the second attempt" into a
+# green, which is the reading this lane exists to refuse — the same argument
+# `binary(qos_event_interop)` further down already carries. The Cyclone row's
+# `retries` is not there either; its host-DDS siblings' retries re-roll a
+# PID→domain collision, which is a hazard these cases do not have.
+[[profile.default.overrides]]
+filter = "binary(=ros2_action_e2e) and test(zenoh)"
+test-group = "ros2-interop"
+slow-timeout = { period = "90s", terminate-after = 3 }
+
 # phase-433 W6 — the ACTIONS live-peer lane, routed exactly like the cyclone
 # half of `interop_e2e` above and for the same two reasons.
+#
+# Since phase-455 W3 this row is the CYCLONE half only: the anchored
+# `and test(zenoh)` row above claims the two zenoh cases first.
 #
 # GROUP: it stands up a real RTPS participant on a `unique_ros_domain_id`
 # domain, so it competes for the same 232-slot space the group exists to bound.

--- a/just/native.just
+++ b/just/native.just
@@ -915,10 +915,33 @@ test-ros2-graph verbose="":
 # added this lane predates that helper and carried its own copy of the
 # skip-accounting tail; a second spelling of the same accounting is the #282 ->
 # #326 shape, so the copy went and the helper stayed.
-# Runs `ros2_action_e2e`; needs ROS 2 + `rmw_cyclonedds_cpp` + the native action fixtures.
+# Since phase-455 W3 the binary carries FOUR cells, two per backend, and the
+# two backends have different preconditions — the zenoh pair wants
+# `rmw_zenoh_cpp` plus a `rmw_zenohd`, the cyclone pair wants
+# `rmw_cyclonedds_cpp`. This recipe still runs all four (each half skips on its
+# own); `test-ros2-action-zenoh` below aims at the zenoh half alone.
+# Runs `ros2_action_e2e`; needs ROS 2 + `rmw_cyclonedds_cpp`/`rmw_zenoh_cpp` + the native action fixtures.
 [group("debug")]
 test-ros2-action verbose="":
     @just _test-focused 'binary(=ros2_action_e2e)' {{verbose}}
+
+# The ZENOH half of the actions live-peer lane — phase-455 W3, cells
+# `native-action-rust-zenoh-{r2n,n2r}`. Until W3 the ACTIONS family had no
+# zenoh interop cell at all, so the backend whose reply-slot table issue 0902
+# exhausted had never met a stock ROS 2 peer on this path.
+#
+# Aimed separately from its Cyclone siblings because the peer is different:
+# these two need the distro's `rmw_zenoh_cpp` and a `rmw_zenohd` the fixture
+# starts (`ZenohRouter::start_unique`), where the Cyclone pair needs
+# `rmw_cyclonedds_cpp` and no router. On a host with only one of the two, the
+# blanket recipe above reports the other half as `[SKIPPED]` — readable, but
+# this is the aim you want when you are answering a question about zenoh.
+# The n2r direction additionally needs
+# `ros-<distro>-examples-rclcpp-minimal-action-server` for its peer.
+# Runs the zenoh cases of `ros2_action_e2e`; needs ROS 2 + `rmw_zenoh_cpp` + `rmw_zenohd`.
+[group("debug")]
+test-ros2-action-zenoh verbose="":
+    @just _test-focused 'binary(=ros2_action_e2e) and test(zenoh)' {{verbose}}
 
 # A QoS STATUS EVENT fires against a live peer and reaches an application
 # callback — phase-433 W6. The four event slots are `produced` and had never met

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -312,6 +312,35 @@ pub const CELLS: &[InteropCell] = &[
        c(Linux, Rust, Cyclonedds, Action, Interop, Runtime),
        NativeFixtures, RosEdition(Cyclonedds), NanoToRos, "ros2_action_e2e"),
 
+    // ── phase-455 W3 — the SAME two directions over zenoh ────────────────
+    // The rows above are the whole of the ACTIONS family's live-peer
+    // coverage and both are Cyclone, so the backend phase-455 is about —
+    // zenoh-pico, whose `ZPICO_MAX_PENDING_REPLIES` reply-slot table is the
+    // bounded resource issue 0902 exhausted — had never met a stock ROS 2
+    // peer on the action path at all. The only zenoh action coverage is
+    // `ros_editions_e2e`, which is the docker EDITION axis and deliberately
+    // outside this list (see the module header).
+    //
+    // Not a duplicate of the Cyclone pair: the two backends share none of
+    // the code under test on this path. Cyclone's action wire goes through
+    // `service.cpp`'s five CDR adapters; zenoh's goes through a queryable
+    // per service, which is what makes a SendGoal, a GetResult and a
+    // CancelGoal each consume one of the four reply slots — the resource
+    // whose exhaustion has no observable today (phase-455 W1). A green on
+    // one backend is no evidence about the other, the same argument
+    // `native-graph-rust-{zenoh,cyclone}-r2n` already carries one workload
+    // over.
+    //
+    // BOTH directions, ONE coordinate, exactly as above: `coords_for`
+    // collapses direction, so `assert_test_bound` in `ros2_action_e2e.rs`
+    // names `(Linux, Rust, Zenoh, Action)` once for the pair.
+    ic("native-action-rust-zenoh-r2n",
+       c(Linux, Rust, Zenoh, Action, Interop, Runtime),
+       NativeFixtures, RosEdition(Zenoh), RosToNano, "ros2_action_e2e"),
+    ic("native-action-rust-zenoh-n2r",
+       c(Linux, Rust, Zenoh, Action, Interop, Runtime),
+       NativeFixtures, RosEdition(Zenoh), NanoToRos, "ros2_action_e2e"),
+
     // ── Native nano XRCE ↔ Agent ↔ fastrtps ─────────────────────────────
     // tests/xrce_ros2_interop.rs.
     ic("native-pubsub-rust-xrce-n2r",
@@ -561,9 +590,15 @@ pub const NO_CELL: &str = "(no cell — evidence for none)";
 /// One CASE of a shared interop binary and the cell it is evidence FOR —
 /// issue 1191.
 ///
-/// Eleven binaries host the nineteen Runtime cells, and four of them host more
-/// than one: `interop_e2e` (5), `graph_interop` (2), `ros2_action_e2e` (2),
-/// `xrce_ros2_interop` (2). Until this table existed, the verdict ledger
+/// Several binaries host more than one Runtime cell, and those are the ones
+/// [`CASE_CELLS`] must map: `interop_e2e`, `graph_interop`,
+/// `rust_multi_node_per_node_graph`, `ros2_action_e2e` (four cells since
+/// phase-455 W3 added the zenoh pair) and `xrce_ros2_interop`. A TOTAL is not
+/// written here on purpose — this sentence carried "eleven binaries host the
+/// nineteen Runtime cells" while the list held 27, which is what a hand-kept
+/// count does. The mapping itself is gated from both ends, below.
+///
+/// Until this table existed, the verdict ledger
 /// (`scripts/check-interop-verdicts.py`) attributed a junit case to the BINARY,
 /// so every case of `interop_e2e` was evidence — and counter-evidence — for all
 /// five of its cells at once: one failing case (issue 1190's
@@ -665,13 +700,27 @@ pub const CASE_CELLS: &[CaseOwner] = &[
     co("rust_multi_node_per_node_graph", "rust_multi_node_entry_per_node_graph_nodes_cyclonedds",
        "native-multinode-rust-cyclone"),
 
-    // ── ros2_action_e2e — ONE coordinate, two directions ────────────────
+    // ── ros2_action_e2e — TWO coordinates, two directions each ──────────
     // The pair no coordinate can separate: which side drives is the whole
-    // difference between the two cells, and it is what each case does.
+    // difference between the two cells of a backend, and it is what each
+    // case does. phase-455 W3 added the zenoh backend, so this binary now
+    // hosts four Runtime cells and the map is what keeps a zenoh result
+    // from being recorded as Cyclone evidence.
+    //
+    // The two Cyclone cases are NOT renamed to match the `_over_zenoh`
+    // suffix, and that asymmetry is deliberate: `.config/interop-verdicts.toml`
+    // cites them by name, and this file's own gate treats a cited case whose
+    // `fn` no longer exists as INERT evidence that still reads as coverage
+    // (the issue-0743 class). A cosmetic rename would silently retract two
+    // recorded passes.
     co("ros2_action_e2e", "a_stock_ros2_client_drives_the_nano_ros_action_server",
        "native-action-rust-cyclone-r2n"),
     co("ros2_action_e2e", "the_nano_ros_action_client_drives_a_stock_ros2_server",
        "native-action-rust-cyclone-n2r"),
+    co("ros2_action_e2e", "a_stock_ros2_client_drives_the_nano_ros_action_server_over_zenoh",
+       "native-action-rust-zenoh-r2n"),
+    co("ros2_action_e2e", "the_nano_ros_action_client_drives_a_stock_ros2_server_over_zenoh",
+       "native-action-rust-zenoh-n2r"),
 
     // ── xrce_ros2_interop — pubsub, service, and three cases with no cell ─
     co("xrce_ros2_interop", "test_xrce_to_ros2_pubsub",      "native-pubsub-rust-xrce-n2r"),

--- a/packages/testing/nros-tests/tests/ros2_action_e2e.rs
+++ b/packages/testing/nros-tests/tests/ros2_action_e2e.rs
@@ -21,10 +21,18 @@
 //! service half — migrating `service.cpp` to a blob sertype would change the
 //! action wire format, and nothing in the tree could tell.
 //!
-//! Interop cells: `native-action-rust-cyclone-r2n` and
-//! `native-action-rust-cyclone-n2r` (`nros_tests::interop::CELLS`). This file is
-//! the ACTIONS family's only live-peer coverage — every action row in
-//! `matrix::CELLS` is nano-to-nano.
+//! Interop cells: `native-action-rust-cyclone-{r2n,n2r}` and, since phase-455
+//! W3, `native-action-rust-zenoh-{r2n,n2r}` (`nros_tests::interop::CELLS`).
+//! This file is the ACTIONS family's only live-peer coverage — every action row
+//! in `matrix::CELLS` is nano-to-nano.
+//!
+//! **The zenoh half is a different subject, not a second copy.** Its cells were
+//! added because the reply-slot table issue 0902 exhausted lives in
+//! zenoh-pico's queryable path, which none of the Cyclone cases above touches:
+//! a service server IS a queryable there, so a SendGoal, a GetResult and a
+//! CancelGoal each consume one of four `ZPICO_MAX_PENDING_REPLIES` slots. Their
+//! setup and their `nextest` group differ accordingly; the block before those
+//! two cases says how and why.
 
 use std::{
     process::Command,
@@ -33,8 +41,9 @@ use std::{
 
 use nros_tests::{
     fixtures,
+    output::{ACTION_FEEDBACK_PREFIX, ACTION_RESULT_PREFIX},
     ros_env::{HostRosEnv, Middleware, RosEnv},
-    ros2::{DEFAULT_ROS_DISTRO, is_ros2_package_available, require_ros2_cyclonedds},
+    ros2::{DEFAULT_ROS_DISTRO, is_ros2_package_available, require_ros2, require_ros2_cyclonedds},
 };
 
 /// The stock ROS 2 action server the nano-ros CLIENT direction drives.
@@ -310,26 +319,270 @@ fn the_nano_ros_action_client_drives_a_stock_ros2_server() {
     // Fibonacci(10). Asserted as the whole sequence: a reshaped result decodes
     // to wrong numbers rather than failing, so a substring like "Result" would
     // pass on garbage.
+    //
+    // Through `nros_tests::output::*`, not a literal — this half of the string
+    // is OUR example's banner and the tree slims those (phase-277 broke ~10
+    // tests grepping retired markers). The sequence after it is the payload and
+    // stays written out here, because that is what the assertion is about.
     assert!(
-        text.contains("Result received: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]"),
+        text.contains(&format!(
+            "{ACTION_RESULT_PREFIX} [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]"
+        )),
         "the result from a stock server must decode to Fibonacci(10).\n{text}"
     );
     // Feedback travels a different message than the result, and only the
     // feedback path exercises the server's own periodic publish.
     assert!(
-        text.contains("Next number in sequence received"),
+        text.contains(ACTION_FEEDBACK_PREFIX),
         "feedback from a stock server must reach the nano-ros client.\n{text}"
     );
 }
 
-// phase-433 W6 — bind this file to `interop::CELLS`. Both directions sit on ONE
-// coordinate (directions collapse, per `interop::coords_for`), so the list
-// below stays a single entry however many directions the file grows. Drift
-// between the cases here and the rows there turns this RED. Needs no fixtures
-// and no ROS 2 — it runs in tier 1.
+// ── phase-455 W3 — the same two directions over zenoh ───────────────────────
+//
+// Interop cells `native-action-rust-zenoh-r2n` / `-n2r`. The two Cyclone cases
+// above were the whole of the ACTIONS family's live-peer coverage, so
+// zenoh-pico — the backend whose reply-slot table phase-455 is about — had
+// never met a stock ROS 2 peer on this path at all.
+//
+// THREE things differ from the Cyclone half, and each is a property of zenoh
+// rather than a style choice:
+//
+// 1. **A router.** `rmw_zenoh_cpp` peers meet at a `rmw_zenohd`, not by
+//    multicast discovery, so every case here starts one with
+//    `ZenohRouter::start_unique` (ephemeral port, multicast off) and hands both
+//    sides the same locator. That unique port — NOT a domain — is the
+//    isolation: it is what keeps a concurrent run's traffic out.
+//
+// 2. **ROS domain 0, deliberately.** `unique_ros_domain_id()` cannot be used
+//    here: the nano side's domain is a COMPILE-TIME bake
+//    (`option_env!("NROS_DOMAIN_ID")`, read in `nros`'s build script), the
+//    `linux/rust/zenoh` action fixtures bake no value, and the domain is the
+//    FIRST segment of an `rmw_zenoh` keyexpr — so a peer on any other domain
+//    simply never sees the node. Giving the peer a unique domain would produce
+//    a silent no-discovery that reads exactly like a delivery bug. This is the
+//    same choice `interop_e2e`'s zenoh cells make through
+//    `ros2_env_setup_with_locator`, which passes 0 for the same reason.
+//
+//    The cost is that these two cases share the ros2cli daemon singleton, which
+//    is keyed on `ROS_DOMAIN_ID` alone. That is why they belong to the
+//    single-threaded `ros2-interop` nextest group rather than to
+//    `host-dds-ros2-interop` with their Cyclone siblings — see the override in
+//    `.config/nextest.toml`, which must sit ABOVE the `binary(=ros2_action_e2e)`
+//    one because nextest takes the FIRST match per setting.
+//
+// 3. **No `dds_isolation`.** Issue 1009's profile pin is a Fast-DDS / Cyclone
+//    mechanism; there is no RTPS participant anywhere in these two cases, and
+//    applying it would pin nothing while reading as if it did.
+
+/// The ROS domain the zenoh cells run on. See point 2 above — this is a
+/// CHOICE, not an omission, and `unique_ros_domain_id()` would be wrong here.
+const ZENOH_CELL_DOMAIN: u8 = 0;
+
+/// A `HostRosEnv` whose `ros2` commands speak `rmw_zenoh_cpp` through `locator`.
+fn zenoh_env(locator: &str) -> HostRosEnv {
+    HostRosEnv::new(
+        DEFAULT_ROS_DISTRO,
+        Middleware::Zenoh {
+            locator: locator.to_string(),
+            domain_id: ZENOH_CELL_DOMAIN,
+        },
+    )
+}
+
+/// A real ROS 2 client drives a goal on the nano-ros zenoh action server.
+///
+/// The zenoh twin of `a_stock_ros2_client_drives_the_nano_ros_action_server`,
+/// and not redundant with it: the two backends share no code on this path. The
+/// Cyclone cell's subject is `service.cpp`'s five CDR adapters; this one's is
+/// the zenoh-pico queryable a service server IS — where a SendGoal, a
+/// GetResult and a CancelGoal each take one of the four
+/// `ZPICO_MAX_PENDING_REPLIES` slots whose exhaustion issue 0902 measured and
+/// phase-455 W1 gives an observable.
+///
+/// Interop cell: `native-action-rust-zenoh-r2n`.
+#[test]
+fn a_stock_ros2_client_drives_the_nano_ros_action_server_over_zenoh() {
+    if !require_ros2() {
+        nros_tests::skip!("ROS 2 + rmw_zenoh_cpp not available");
+    }
+
+    let server_bin = fixtures::build_native_rust_example_rmw(
+        "action-server",
+        "action-server",
+        fixtures::Rmw::Zenoh,
+    )
+    .unwrap_or_else(|e| {
+        nros_tests::skip!("native rust zenoh action-server fixture: {e}");
+    });
+
+    let router = fixtures::or_skip(fixtures::ZenohRouter::start_unique());
+    let locator = router.locator();
+
+    let mut server = Command::new(&server_bin)
+        .env("RUST_LOG", "info")
+        .env("NROS_LOCATOR", &locator)
+        .spawn()
+        .expect("start the nano-ros zenoh action server");
+
+    let env = zenoh_env(&locator);
+
+    // Same discovery gate as the Cyclone half, and the same reason: a flat
+    // sleep turns a slow-discovery run into a missing `Goal accepted`, which
+    // reads as a wire-format defect.
+    await_fibonacci_action(&env, "nano-ros");
+
+    let out = env
+        .run("timeout 60 ros2 action send_goal /fibonacci example_interfaces/action/Fibonacci '{order: 5}'")
+        .expect("run ros2 action send_goal");
+
+    let died = server.try_wait().ok().flatten();
+    let _ = server.kill();
+    let _ = server.wait();
+
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        died.is_none(),
+        "the nano-ros zenoh action server exited on its own ({died:?}) before \
+         the goal finished — the client output below is about a dead peer, not \
+         about the wire format.\n{text}"
+    );
+    assert!(
+        text.contains("Goal accepted"),
+        "a stock ROS 2 client must get the goal ACCEPTED over zenoh — the \
+         server has to answer the SendGoal query, which is one reply slot.\n{text}"
+    );
+    assert!(
+        text.contains("SUCCEEDED"),
+        "the goal must reach SUCCEEDED, not merely be accepted. A goal that is \
+         accepted and never completes is issue 0902's exact symptom: the result \
+         travels a SECOND query (GetResult) and therefore a second reply \
+         slot.\n{text}"
+    );
+    // Fibonacci(5), asserted as values rather than as a marker: a result that
+    // decoded wrongly produces numbers, not an error.
+    for n in ["0", "1", "2", "3", "5"] {
+        assert!(
+            text.contains(&format!("- {n}")),
+            "the result sequence must contain {n}; a reshaped result decodes \
+             to the wrong numbers rather than failing.\n{text}"
+        );
+    }
+}
+
+/// The nano-ros zenoh action CLIENT drives a stock ROS 2 action server.
+///
+/// The reverse direction, and the one where nano-ros is the QUERIER rather than
+/// the queryable — so it exercises the other half of the zenoh service path:
+/// `zpico_get*`'s own reply handling, which is what the 18 existing
+/// `zpico_get_diag_counters` entries already count, against bytes a real
+/// `rmw_zenoh_cpp` server produced.
+///
+/// Interop cell: `native-action-rust-zenoh-n2r`.
+#[test]
+fn the_nano_ros_action_client_drives_a_stock_ros2_server_over_zenoh() {
+    if !require_ros2() {
+        nros_tests::skip!("ROS 2 + rmw_zenoh_cpp not available");
+    }
+    // Same separate-package guard as the Cyclone n2r cell: without it a host
+    // that has ROS 2 and `rmw_zenoh_cpp` but not this peer reports a
+    // wire-format red instead of a skip.
+    if !is_ros2_package_available(DEFAULT_ROS_DISTRO, PEER_ACTION_SERVER_PKG) {
+        nros_tests::skip!(
+            "ROS 2 peer package `{PEER_ACTION_SERVER_PKG}` not installed \
+             (apt: ros-{DEFAULT_ROS_DISTRO}-examples-rclcpp-minimal-action-server)"
+        );
+    }
+
+    let client_bin = fixtures::build_native_rust_example_rmw(
+        "action-client",
+        "action-client",
+        fixtures::Rmw::Zenoh,
+    )
+    .unwrap_or_else(|e| {
+        nros_tests::skip!("native rust zenoh action-client fixture: {e}");
+    });
+
+    let router = fixtures::or_skip(fixtures::ZenohRouter::start_unique());
+    let locator = router.locator();
+    let env = zenoh_env(&locator);
+
+    // `RosPeer` kills the whole process group on drop, so a failed assertion
+    // cannot leave a `ros2` server behind for the next run to collide with.
+    let mut server = env
+        .spawn(
+            "minimal_action_server",
+            &format!("ros2 run {PEER_ACTION_SERVER_PKG} action_server_member_functions"),
+        )
+        .expect("start the stock ROS 2 action server");
+
+    await_fibonacci_action(&env, "stock ROS 2");
+
+    // Spawned DIRECTLY rather than through `env.run`, unlike the Cyclone
+    // sibling: the nano side needs `NROS_LOCATOR` and nothing whatsoever from
+    // the ROS environment, and running it under `source setup.bash` would put
+    // a `LD_LIBRARY_PATH` it does not use in front of the binary. The
+    // `timeout` is still mandatory and for the Cyclone case's reason — the
+    // client blocks on an undiscovered server and a test that cannot fail in
+    // bounded time is not a test.
+    let out = Command::new("timeout")
+        .arg("60")
+        .arg(&client_bin)
+        .env("RUST_LOG", "info")
+        .env("NROS_LOCATOR", &locator)
+        .output()
+        .expect("run the nano-ros zenoh action client");
+
+    let peer_alive = server.is_running();
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        peer_alive,
+        "the stock ROS 2 action server exited before the goal finished — the \
+         client output below is about a dead peer, not about the wire \
+         format.\n{text}"
+    );
+    assert!(
+        text.contains("Goal accepted"),
+        "a real `rmw_zenoh_cpp` server must ACCEPT the goal nano-ros wrote.\n{text}"
+    );
+    assert!(
+        text.contains(&format!(
+            "{ACTION_RESULT_PREFIX} [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]"
+        )),
+        "the result from a stock server must decode to Fibonacci(10). A client \
+         that prints feedback and never a result is the nano-ros-side shape of \
+         issue 0902 — accepted, then nothing.\n{text}"
+    );
+    assert!(
+        text.contains(ACTION_FEEDBACK_PREFIX),
+        "feedback from a stock server must reach the nano-ros client.\n{text}"
+    );
+}
+
+// phase-433 W6 — bind this file to `interop::CELLS`. Directions collapse (per
+// `interop::coords_for`), so each BACKEND is one entry however many directions
+// the file grows: four cells, two coordinates. phase-455 W3 added the zenoh
+// one. Drift between the cases here and the rows there turns this RED. Needs no
+// fixtures and no ROS 2 — it runs in tier 1.
 #[test]
 fn cases_bound_to_interop_cells() {
     #[allow(unused_imports)]
     use nros_tests::matrix::{Lang::*, PlatformId::*, Rmw::*, Workload::*};
-    nros_tests::interop::assert_test_bound("ros2_action_e2e", &[(Linux, Rust, Cyclonedds, Action)]);
+    nros_tests::interop::assert_test_bound(
+        "ros2_action_e2e",
+        &[
+            (Linux, Rust, Cyclonedds, Action),
+            (Linux, Rust, Zenoh, Action),
+        ],
+    );
 }


### PR DESCRIPTION
## phase-455 W3 — the Zenoh action interop cells that never existed

`nros_tests::interop::CELLS` carried exactly **two** action rows and both were
Cyclone (`native-action-rust-cyclone-{r2n,n2r}`). There was no Zenoh action
interop cell at all — so the backend phase-455 is about, zenoh-pico, whose
`ZPICO_MAX_PENDING_REPLIES` reply-slot table is the bounded resource
[issue 0902](docs/issues/0902-action-goal-completion-is-variable.md) exhausted,
had **never met a stock ROS 2 peer on the action path**. The only zenoh action
coverage is `ros_editions_e2e`, which is the docker EDITION axis and
deliberately outside the cell model (`interop.rs:19-21`).

### The two cells

| id | coordinate | peer | dir | test |
|---|---|---|---|---|
| `native-action-rust-zenoh-r2n` | `(Linux, Rust, Zenoh, Action)` | `RosEdition(Zenoh)` | `RosToNano` | `ros2_action_e2e` |
| `native-action-rust-zenoh-n2r` | `(Linux, Rust, Zenoh, Action)` | `RosEdition(Zenoh)` | `NanoToRos` | `ros2_action_e2e` |

Both are **cases of the existing `ros2_action_e2e` binary**, not a new file
(AGENTS.md: "new runtime tests join a matrix, not a new file"). `coords_for`
collapses direction, so the pair is ONE coordinate and `assert_test_bound` gains
one entry:

```rust
nros_tests::interop::assert_test_bound(
    "ros2_action_e2e",
    &[(Linux, Rust, Cyclonedds, Action), (Linux, Rust, Zenoh, Action)],
);
```

Not a second copy of the Cyclone pair — the two backends share no code on this
path. Cyclone's action wire goes through `service.cpp`'s five CDR adapters;
zenoh's goes through a queryable per service, which is what makes a SendGoal, a
GetResult and a CancelGoal each consume one of four reply slots. Same argument
`native-graph-rust-{zenoh,cyclone}-r2n` already carries one workload over.

### Three things the zenoh half does differently, each a property of zenoh

1. **A router.** `rmw_zenoh_cpp` peers meet at a `rmw_zenohd`, not by multicast,
   so each case starts `ZenohRouter::start_unique()` and hands both sides the
   locator. That ephemeral port — **not** a domain — is the isolation.
2. **ROS domain 0, deliberately.** `unique_ros_domain_id()` cannot be used: the
   nano side's domain is a COMPILE-TIME bake (`option_env!("NROS_DOMAIN_ID")`,
   read in `nros`'s build script), the `linux/rust/zenoh` action fixtures bake no
   value, and the domain is the FIRST segment of an `rmw_zenoh` keyexpr — so a
   peer on any other domain silently never discovers the node, which reads as a
   delivery bug. `interop_e2e`'s zenoh cells make the same choice for the same
   reason (`ros2_env_setup_with_locator` passes 0).
3. **No `dds_isolation`.** Issue 1009's profile pin is a Fast-DDS / Cyclone
   mechanism and there is no RTPS participant in these two cases; applying it
   would pin nothing while reading as if it did.

### The nextest override, and where it sits

Because the zenoh cases must run on domain 0 they share the ros2cli daemon
singleton, so they belong in the serial `ros2-interop` group and not in their
siblings' `host-dds-ros2-interop`. nextest applies the FIRST matching override
per setting and `binary(x)` is a SUBSTRING match, so the new row sits **above**
the existing anchored `binary(=ros2_action_e2e)` row (line 861 vs 882) and
therefore above every broader row below it (`binary(interop_e2e)`, and the
`binary(~zephyr)`-class blanket at ~1060 that has already claimed three cells
this way):

```toml
[[profile.default.overrides]]
filter = "binary(=ros2_action_e2e) and test(zenoh)"
test-group = "ros2-interop"
slow-timeout = { period = "90s", terminate-after = 3 }

# phase-433 W6 — the ACTIONS live-peer lane, routed exactly like the cyclone
# half of `interop_e2e` above and for the same two reasons.
#
# Since phase-455 W3 this row is the CYCLONE half only: the anchored
# `and test(zenoh)` row above claims the two zenoh cases first.
...
[[profile.default.overrides]]
filter = "binary(=ros2_action_e2e)"
test-group = "host-dds-ros2-interop"
slow-timeout = { period = "60s", terminate-after = 3 }
```

Verified by asking nextest rather than by reading the file — `cargo nextest
show-config test-groups -p nros-tests -E 'binary(=ros2_action_e2e)'`:

```
group: host-dds-ros2-interop (max threads = 3)
  * override for default profile with filter 'binary(=ros2_action_e2e)':
      nros-tests::ros2_action_e2e:
          a_stock_ros2_client_drives_the_nano_ros_action_server
          cases_bound_to_interop_cells
          the_nano_ros_action_client_drives_a_stock_ros2_server
...
group: ros2-interop (max threads = 1)
  * override for default profile with filter 'binary(=ros2_action_e2e) and test(zenoh)':
      nros-tests::ros2_action_e2e:
          a_stock_ros2_client_drives_the_nano_ros_action_server_over_zenoh
          the_nano_ros_action_client_drives_a_stock_ros2_server_over_zenoh
```

**No `retries`, deliberately.** The question these cells answer is whether a goal
COMPLETES over zenoh, and issue 0902 measured exactly that at 20–90 %. A retry
would render "failed once, passed on the second attempt" green, which is the
reading the lane exists to refuse — the same argument `binary(qos_event_interop)`
already carries.

### The focused runner

`just native test-ros2-action-zenoh` →
`_test-focused 'binary(=ros2_action_e2e) and test(zenoh)'`. Separate from the
blanket `test-ros2-action` because the two halves now want different peers
(`rmw_zenoh_cpp` + a router vs `rmw_cyclonedds_cpp`); the blanket still runs all
four and each half skips on its own.

### Verdict ledger

**Both cells are DECLARED AND UNRUN, which is the correct starting state.** This
host has no ROS 2, so no verdict row was added — absence is the default and needs
no line. `check-interop-verdicts.py --report`:

```
  NEVER  —                 native-action-rust-zenoh-n2r                ros2_action_e2e  (runner: just/native.just:926)
  NEVER  —                 native-action-rust-zenoh-r2n                ros2_action_e2e  (runner: just/native.just:926)
```

### Also in this change, for the "fix the class" rule

The two pre-existing Cyclone assertions grepped the nano client's banners as
LITERALS. They now go through `nros_tests::output::{ACTION_RESULT_PREFIX,
ACTION_FEEDBACK_PREFIX}`, which is what phase-277's slimming class asks for. The
Cyclone CASE NAMES are **not** renamed to match the new `_over_zenoh` suffix:
`.config/interop-verdicts.toml` cites them, and `check-interop-verdicts` treats a
cited case whose `fn` is gone as inert evidence that still reads as coverage — a
cosmetic rename would silently retract two recorded passes.

`interop::CASE_CELLS`'s header sentence ("Eleven binaries host the nineteen
Runtime cells") was stale against a list of 27; it is replaced by a statement
that names the shared binaries without a hand-kept total.

### Local checks

| step | result |
|---|---|
| `just check::cli-fresh` | **ok** (inside `just ci gate`) |
| `just check::fast` | **ok** (inside `just ci gate`; again in the `pre-push` hook — 302 gates at -P4, 6 SKIPPED for absent toolchains) |
| `just check::build` | **FAILED, 2 of 21 gates — both provisioning, see below** |
| `just check api-parity` | **ok** — `every divergence carries a ledger entry` |
| `just test-unit` | **ok** — 1429 ran, 0 deselected, 3 skipped (`no ROS zenoh router`), `All failures were [SKIPPED] preconditions — treating as pass` |
| `just test-lane-contracts` | **ok** — 17 tests run, 17 passed, 0 skipped |
| `matrix_fixture_coverage` G1–G5 | **ok** — 11/11 incl. `interop_bindings_g5_cells_are_lane_narrowable` |
| `interop::tests::*` | **ok** — 6/6 incl. `every_shared_binary_maps_all_of_its_cells` |
| `ros2_action_e2e::cases_bound_to_interop_cells` | **ok** |
| `scripts/check-interop-cell-runners.py` | `OK — 27/27 Runtime cell(s) have a named runner (17/17 test binaries), 0 awaiting a lane` |
| `scripts/check-interop-verdicts.py` | `OK — 20/27 … (20 pass, 0 fail, 7 NEVER RUN)` |
| `scripts/check-nextest-binary-filters.py` | `OK (566 test targets known)` |

**The `check::build` red is this worktree's provisioning, not this change.** The
first `just ci gate` run failed 4 of 21 gates, all on `third-party/dds/cyclonedds`
being an uninitialised submodule (`cyclonedds-sys: source dir … has no
CMakeLists.txt — source not provisioned`). After
`git submodule update --init third-party/dds/cyclonedds packages/rmw/zenoh/zpico-sys/mbedtls`
it is 2 of 21, and both name a host fact rather than a source fact:

* `check rmw-cyclonedds` → `error: rosidl_adapter is not importable by this
  build's interpreter` on every generated `.idl`. Measured here:
  `python3 -c "import rosidl_adapter"` → `ModuleNotFoundError`, and `ros2` is not
  on PATH. **This host has no ROS 2**, so the gate cannot pass on any commit.
* `check cli-tests` → `codegen_system_bakes_self_bringup_component_pkg` panics
  with `no nano-ros SDK root found … Inside a checkout, source ./activate.sh`.
  `NROS_REPO_DIR` is unset in this worktree (1180 of 1181 cases pass).

Neither gate reads, compiles or links any of the four files this PR touches —
the whole diff is `.config/nextest.toml`, `just/native.just` and two files under
`packages/testing/nros-tests/`, and nothing under `packages/cli/` or
`packages/rmw/cyclonedds/`. The gate that *does* compile `nros-tests` across
feature combinations, `check workspace-all` (663 s, the run's slowest), passed.

### What is NOT verified

* **Neither cell has been run against a live peer.** No ROS 2 on this host. Every
  assertion inside them, and the whole `ros2 action list` discovery path over
  `rmw_zenoh_cpp`, is unexercised.
* The nano-ros zenoh service server does declare an `SS` liveliness token
  (`shim/session.rs:1199-1217`), which is what makes `ros2 action list` able to
  see `/fibonacci` — read, not measured.
* The domain-0 ros2cli daemon is a known shared-state hazard for these two
  cases; `ros2-interop`'s `max-threads = 1` is the mitigation the tree already
  uses for every other zenoh cell, not a proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7tie7AFCdqoRkxphQcqRx
