### PR TITLE
test(phase-455 W2, #0902, #1332): await the RESULT, read the counter, and say what the green does not cover

### DIFF
--- a/docs/issues/0902-action-goal-completion-is-variable.md
+++ b/docs/issues/0902-action-goal-completion-is-variable.md
@@ -5,7 +5,7 @@ title: "action goals complete between 20 % and 90 % of the time on the same buil
 status: open
 type: bug
 area: rmw
-related: [issue-0912, issue-0882, issue-0879, issue-0852, phase-444, phase-455]
+related: [issue-0912, issue-0882, issue-0879, issue-0852, issue-1332, phase-444, phase-455]
 ---
 
 ## Measurement
@@ -350,3 +350,54 @@ left for the next reader to search for.
 **What still stands.** Item 1's measurement — the completion rate on a fresh
 image — is phase-455 W2. Item 4, the `buffer_index`/queryable-handle desync,
 is unchanged.
+
+## Status 2026-09-12 — the completion rate, measured (phase-455 W2)
+
+Item 1 above asked for the completion rate on a freshly built image, over enough
+runs to separate it from 20–90 %. Measured on the **native host lane** — a
+`rmw_zenohd` router, `bins/action-server-concurrent`, and
+`bins/action-client-multigoal` extended to await each goal's RESULT rather than
+only its acceptance:
+
+```
+phase-455 W2 evidence: completed 3/3 after a 10000 ms soak with 3 peer up/down
+cycles; server says `reply-slot: refusals=0`
+```
+
+Runner: `just native test-action-completion`. The rate is recorded as EVIDENCE;
+the assertions are `completed == sent` and `reply-slot: refusals=0`, which are
+statements rather than samples — that is what this issue asked for when it said
+a spread with no observable cause is not measurable as a regression gate.
+
+**But the green is narrower than it reads, and this is the important part.**
+Three further runs say the native lane cannot exercise the leak at all:
+
+| tree under test | refusals | completed |
+| --- | ---: | ---: |
+| both leak arms fixed | 0 | 3/3 |
+| `1a032a10b` REVERTED (declined queries keep their slot for ever) | 0 | 3/3 |
+| same, with 10 peer up/down cycles | 0 | — |
+| `-DZPICO_MAX_PENDING_REPLIES=1` (a ONE-slot table) | 0 | 3/3 |
+
+A one-slot table that refuses nothing is decisive: on this lane the action
+server's queryable never holds more than one query at a time, so the allocation
+never fails and the counter can never move. Reverting the fix changes no
+observable here, so **the negative control this measurement was supposed to
+carry does not exist on this lane** — filed as
+[issue 1332](1332-native-lane-cannot-exercise-zenoh-reply-slot-table.md) with
+the three routes that would create one.
+
+Why (read off the code, not instrumented): the declined-query shape that feeds
+the leak is the empty-payload liveliness probe at `shim/service.rs:220-227`, and
+graph discovery on this lane is a liveliness SUBSCRIBER rather than a query
+(phase-381 / issue 0903), while both action-client paths are single-in-flight.
+This issue measured its spread on a bare-metal serial board inside a REAL ROS 2
+graph; that peer population is what the native lane lacks.
+
+**So this issue does NOT close here.** What it gains: the completion path is now
+gated end to end (accepted → executed → RESULT received), the failure has an
+observable the next run can read instead of infer, and the reason a green native
+run is not evidence about the mechanism is written down rather than assumed.
+What it still needs is item 1 on a population that can refuse a slot —
+phase-444 W2's board run, phase-455 W3's live ROS 2 zenoh action cells, or issue
+1332's declined-query fixture.

--- a/docs/issues/1332-native-lane-cannot-exercise-zenoh-reply-slot-table.md
+++ b/docs/issues/1332-native-lane-cannot-exercise-zenoh-reply-slot-table.md
@@ -1,0 +1,92 @@
+---
+id: 1332
+title: "the native host lane cannot refuse a zenoh reply slot at all, so it cannot
+  be the negative control for issue 0902's leak"
+status: open
+type: limitation
+area: testing
+related: [issue-0902, phase-455, issue-0903]
+---
+
+## What was measured
+
+phase-455 W2 built a live goal-completion probe
+(`tests/action_multigoal.rs::every_accepted_goal_returns_a_result_and_no_reply_slot_is_refused`,
+`just native test-action-completion`) and the W1 counter it reads. Both work.
+The probe is green:
+
+```
+phase-455 W2 evidence: completed 3/3 after a 10000 ms soak with 3 peer up/down
+cycles; server says `reply-slot: refusals=0`
+```
+
+**But the green says less than it looks like it says.** Three independent runs
+on this lane, each with a router (`rmw_zenohd`), the concurrent action server
+and our own peers brought up and down:
+
+| tree under test | refusals | completed |
+| --- | ---: | ---: |
+| `main` (both leak arms fixed) | 0 | 3/3 |
+| `1a032a10b` REVERTED (declined queries keep their slot for ever) | 0 | 3/3 |
+| `1a032a10b` reverted + **10** peer up/down cycles | 0 | — |
+| `-DZPICO_MAX_PENDING_REPLIES=1` (a ONE-slot table) | 0 | 3/3 |
+
+A one-slot table that refuses nothing is the decisive row: on this lane the
+action server's queryable never has more than one query in flight, so the
+allocation never fails, so **the leak arm is never reached and the counter can
+never move.** Reverting the fix changes no observable.
+
+## Why (inferred from the code, not measured)
+
+Issue 0902's leak is fed by queries the Rust callback DECLINES — the
+empty-payload liveliness probe at `shim/service.rs:220-227` and the ring-full
+drop below it. Two properties of the native lane appear to remove both:
+
+* **Graph discovery here is a liveliness SUBSCRIBER, not a query.** phase-381 /
+  issue 0903 replaced the per-question `z_liveliness_get` with a standing
+  subscriber with history, precisely because the sweep was unreliable. A
+  subscriber delivers samples, not queries, so a peer joining or leaving does
+  not reach another node's queryable callback at all.
+* **Both action client paths are single-in-flight.** `send_goal` and
+  `get_result` each refuse a second concurrent request per client, so one
+  client cannot fill even a one-slot table, and the test's peers issue no
+  queries of their own.
+
+Issue 0902 measured its 20–90 % spread on a **bare-metal serial board inside a
+real ROS 2 graph**, where foreign nodes do query the queryable. That population
+is what this lane lacks — not the code path.
+
+## What this means for anyone reading a green run
+
+`just native test-action-completion` is a real gate for the **completion path**:
+it proves every accepted goal's result comes back, which the pre-phase-455
+fixture never asked. It is **not** a regression gate for the reply-slot leak,
+and a future change that reintroduced the leak would not turn it red. Do not
+cite it as coverage for issue 0902's mechanism.
+
+## What would close it
+
+Any ONE of:
+
+1. **A live ROS 2 peer that queries the action's queryable** — a
+   `ros2 action send_goal` client, or `rmw_zenoh_cpp` doing its own
+   service-readiness probing. phase-455 W3 adds the first Zenoh action interop
+   cells (`native-action-rust-zenoh-n2r` / `-r2n`); if those peers produce
+   declined queries, W3's cells become the negative control this one cannot be.
+   **Measure it — do not assume it.** The cheap check is the same heartbeat:
+   run the interop cell against a tree with `1a032a10b` reverted and see whether
+   `reply-slot: refusals=` ever leaves 0.
+2. **A fixture that declines a query on purpose** — a nano-ros node that sends
+   an empty-payload query to the server's keyexpr. That reproduces the exact
+   declined-query shape without a ROS graph, and with
+   `-DZPICO_MAX_PENDING_REPLIES=1` it would need one query rather than four.
+   This is the cheapest route and needs no ROS.
+3. **The board run** — phase-444 W2's hardware measurement, which is the
+   population 0902 actually measured.
+
+## Not verified
+
+The "why" above is read off the code and is consistent with all four rows of
+the table, but nothing here instrumented the queryable callback to confirm that
+zero declined queries arrive. A counter of DECLINED queries beside the refusal
+counter would settle it in one run, and is the obvious follow-up to option 2.

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -1604,7 +1604,14 @@ features = ["rmw-cyclonedds"]
 # to the official single-goal demo, so the concurrent-goals stress role moved
 # here). Built per-RMW: Zenoh variant consumed by tests/rmw_interop.rs, XRCE
 # variant by tests/xrce_ros2_interop.rs.
+# phase-455 W2 gave this row an `id` so the live-peer completion probe's
+# fixtures can be built one at a time (`fixtures-build.sh linux rust --id …`).
+# Without one the only narrowing available is the whole linux/rust lane, which
+# is ~115 GiB of target dirs for a two-binary pair. The id is not part of the
+# artifact-dir key — that is (platform, cargo args, env), issue 1025 — so this
+# adds a handle and moves nothing.
 [[fixture]]
+id = "action-server-concurrent-zenoh"
 platform = "linux"
 lang = "rust"
 rmw = "zenoh"
@@ -1626,6 +1633,7 @@ features = ["rmw-xrce"]
 # assertion is about the server's goal table, which is backend-independent, so
 # a second RMW build would add sweep time without adding coverage.
 [[fixture]]
+id = "action-client-multigoal-zenoh"
 platform = "linux"
 lang = "rust"
 rmw = "zenoh"

--- a/just/native.just
+++ b/just/native.just
@@ -943,6 +943,23 @@ test-ros2-action verbose="":
 test-ros2-action-zenoh verbose="":
     @just _test-focused 'binary(=ros2_action_e2e) and test(zenoh)' {{verbose}}
 
+# Every ACCEPTED action goal returns a RESULT, and the zenoh reply-slot table
+# refused nothing — issue 0902 / phase-455 W2. A live-peer cell, so it needs a
+# runner rather than a sweep: an unmet precondition inside one renders as
+# `<skipped>`, which nobody can tell from a pass. `_test-focused` carries the
+# shared skip accounting (see the block above — a second copy of that tail is
+# the #282 -> #326 shape).
+#
+# The rate this run measures is EVIDENCE, printed on stdout; the assertions are
+# `completed == sent` and `reply-slot: refusals=0`, which are statements rather
+# than samples. Runs ~1 min: a 20 s idle soak plus three peer up/down cycles,
+# because issue 0902's countdown is spent by elapsed time with a peer present,
+# not by goal traffic.
+# Runs `action_multigoal`; needs a `rmw_zenohd` router + the native action fixtures.
+[group("debug")]
+test-action-completion verbose="":
+    @just _test-focused 'binary(=action_multigoal)' {{verbose}}
+
 # A QoS STATUS EVENT fires against a live peer and reaches an application
 # callback — phase-433 W6. The four event slots are `produced` and had never met
 # one, and they are the family least able to be tested in isolation: a QoS

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/lib.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/lib.rs
@@ -41,7 +41,7 @@ pub const DEFAULT_LOCATOR: &str = "tcp/127.0.0.1:7447";
 pub mod shim;
 
 // Re-export zpico types (always available)
-pub use zpico::{ZenohId, ZpicoError};
+pub use zpico::{ZenohId, ZpicoError, reply_slot_refusals_total};
 
 // Phase 214.G — link-graph anchor for POSIX.
 //

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
@@ -44,10 +44,10 @@ use zpico_sys::{
     zpico_declare_subscriber_with_attachment, zpico_get_zid, zpico_init, zpico_init_with_config,
     zpico_is_open, zpico_open, zpico_publish, zpico_publish_with_attachment,
     zpico_publish_with_attachment_aliased, zpico_query_reply, zpico_queryable_take_reply_seq,
-    zpico_reply_slot_stats, zpico_reply_slot_take_announcement, zpico_session_acquire,
-    zpico_session_release, zpico_session_t, zpico_spin_once, zpico_undeclare_liveliness,
-    zpico_undeclare_publisher, zpico_undeclare_queryable, zpico_undeclare_subscriber,
-    zpico_uses_polling,
+    zpico_reply_slot_refusals_total, zpico_reply_slot_stats, zpico_reply_slot_take_announcement,
+    zpico_session_acquire, zpico_session_release, zpico_session_t, zpico_spin_once,
+    zpico_undeclare_liveliness, zpico_undeclare_publisher, zpico_undeclare_queryable,
+    zpico_undeclare_subscriber, zpico_uses_polling,
 };
 
 // ============================================================================
@@ -121,6 +121,23 @@ impl core::fmt::Display for ZpicoError {
 
 /// Result type for shim operations
 pub type Result<T> = core::result::Result<T, ZpicoError>;
+
+/// issue 0902 / phase-455 — every reply-slot refusal in this PROCESS, summed.
+///
+/// A refusal means the C shim had no free slot to clone an incoming query
+/// into, so the request was accepted and can never be answered. **Zero is a
+/// statement**, not the absence of one: this process has never run out. That
+/// is the distinction `zpico_queryable_take_reply_seq`'s `-1` could not make,
+/// and issue 0902's whole complaint — a 20-90 % goal-completion spread with no
+/// observable cause is not measurable as a regression gate.
+///
+/// The per-server answer is [`Context::reply_slot_stats`], which needs the
+/// session and queryable handles. This one needs neither, because the callers
+/// that most want it — a probe binary holding an `Executor` and a node — have
+/// neither. Never reset.
+pub fn reply_slot_refusals_total() -> u32 {
+    unsafe { zpico_reply_slot_refusals_total() }
+}
 
 // ============================================================================
 // ZenohId

--- a/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
+++ b/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
@@ -297,6 +297,17 @@ typedef void (*ZpicoQueryCallback)(const char *keyexpr,
  * Rust side would be a second spelling of the same rule.
  */
 /**
+ * issue 0902 / phase-455 W2 — every reply-slot refusal in this process,
+ * summed, with NO session argument.
+ *
+ * The companion to `zpico_reply_slot_stats`, which answers "WHICH server
+ * saturated" and needs both handles to do it. A probe binary holds
+ * neither — it owns an `Executor` and a node, and the zenoh `Context` is
+ * several layers below the API it was written against — so the question
+ * it can ask is "did ANY reply slot get refused here", which is what
+ * phase-455 W2's acceptance asserts is zero. Never reset.
+ */
+/**
  * issue 0902 / phase-455 W1 — the PURE half of the reply-slot
  * allocation, exported like `zpico_entry_at` / `zpico_graph_set_apply` so
  * the accounting is reachable from a host test with no session, no router
@@ -790,6 +801,12 @@ int32_t zpico_reply_slot_stats(struct zpico_session_t *_session,
  */
 int32_t zpico_reply_slot_take_announcement(struct zpico_session_t *_session,
                                            int32_t _queryable_handle);
+
+/**
+ * issue 0902 / phase-455 W2 — every reply-slot refusal in this process,
+ * summed, for a reader that holds no session handle.
+ */
+uint32_t zpico_reply_slot_refusals_total(void);
 
 /**
  * issue 0902 / phase-455 W1 — the PURE half of the reply-slot

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -427,6 +427,24 @@ static volatile uint32_t g_diag_gck_too_big = 0;
 static volatile uint32_t g_diag_gck_timeout = 0;
 static volatile uint32_t g_diag_gck_pending = 0;
 static volatile uint32_t g_diag_handler_ctx_addr = 0;
+
+/* issue 0902 / phase-455 W2 — the reply-slot refusal count with NO session
+ * argument.
+ *
+ * This is a SECOND reader of the W1 counters, not a replacement, because it
+ * answers a DIFFERENT question. `zpico_reply_slot_stats` answers "which server
+ * saturated, and how badly" and needs the session handle and the queryable
+ * handle to do it. A probe binary holds neither: it owns an `Executor` and a
+ * node, and the zenoh `Context` is several layers below the API it was written
+ * against. So the question it can actually ask is "did ANY reply slot get
+ * refused in this process" — which is exactly the acceptance phase-455 W2
+ * needs, and exactly what a process-global counter can carry.
+ *
+ * Deliberately NOT folded into `zpico_get_diag_counters`: that array's length
+ * lives only in its C prototype (Rust binds it as a bare `*mut u32`), so
+ * growing it is an undiagnosable overrun for any caller not recompiled with
+ * it. A named accessor cannot be got wrong that way. */
+static volatile uint32_t g_reply_slot_refusals_total = 0;
 static volatile uint32_t g_diag_check_ctx_addr = 0;
 static volatile uint32_t g_diag_start_ctx_addr = 0;
 
@@ -1037,6 +1055,12 @@ static void query_handler(z_loaned_query_t* query, void* arg) {
             s->stored_query_valid[idx][slot] = true;
             reply_seq = slot;
         }
+    }
+    if (slot == ZPICO_ERR_FULL && g_reply_slot_refusals_total != 0xFFFFFFFFu) {
+        /* phase-455 W2 — the same event the per-queryable counter records,
+         * summed for a reader that has no session handle. Saturates rather
+         * than wrapping, for the reason the per-queryable count does. */
+        g_reply_slot_refusals_total++;
     }
     if (announce) {
         /* Latched here, said by the RUST side (`shim/service.rs`). `printk` is
@@ -3231,6 +3255,18 @@ int32_t zpico_reply_slot_stats(zpico_session_t* session, int32_t queryable_handl
  * `zpico_reply_slot_stats`: a stats read must not consume the event, or the
  * probe that samples the counter silences the log line.
  */
+/* issue 0902 / phase-455 W2 — every reply-slot refusal in this process, summed.
+ *
+ * The companion to `zpico_reply_slot_stats` for a caller that holds no session:
+ * "did any server here ever run out of reply slots?" Zero is the statement the
+ * W2 completion probe asserts, and it is a statement — not the absence of one —
+ * because a refusal is counted whether or not anything later reads it.
+ *
+ * NEVER reset. A counter a caller can zero is one a caller can zero by
+ * accident, and the only consumer wants a monotone "has it happened yet".
+ */
+uint32_t zpico_reply_slot_refusals_total(void) { return g_reply_slot_refusals_total; }
+
 int32_t zpico_reply_slot_take_announcement(zpico_session_t* session, int32_t queryable_handle) {
     struct zpico_session* s = (struct zpico_session*)session;
     if (s == NULL || queryable_handle < 0 || queryable_handle >= ZPICO_MAX_QUERYABLES) {

--- a/packages/rmw/zenoh/zpico-sys/src/ffi.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/ffi.rs
@@ -702,6 +702,13 @@ mod cbindgen_stubs {
         -1 // stub: not available
     }
 
+    /// issue 0902 / phase-455 W2 — every reply-slot refusal in this process,
+    /// summed, for a reader that holds no session handle.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_reply_slot_refusals_total() -> u32 {
+        0 // stub: not available
+    }
+
     /// issue 0902 / phase-455 W1 — the PURE half of the reply-slot
     /// allocation: pick a free slot and account for a refusal. Split out like
     /// `zpico_entry_at` so the accounting is testable without a session.

--- a/packages/rmw/zenoh/zpico-sys/src/lib.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/lib.rs
@@ -348,6 +348,17 @@ unsafe extern "C" {
         queryable_handle: i32,
     ) -> i32;
 
+    /// issue 0902 / phase-455 W2 — every reply-slot refusal in this process,
+    /// summed, with NO session argument.
+    ///
+    /// The companion to `zpico_reply_slot_stats`, which answers "WHICH server
+    /// saturated" and needs both handles to do it. A probe binary holds
+    /// neither — it owns an `Executor` and a node, and the zenoh `Context` is
+    /// several layers below the API it was written against — so the question
+    /// it can ask is "did ANY reply slot get refused here", which is what
+    /// phase-455 W2's acceptance asserts is zero. Never reset.
+    pub fn zpico_reply_slot_refusals_total() -> u32;
+
     /// issue 0902 / phase-455 W1 — the PURE half of the reply-slot
     /// allocation, exported like `zpico_entry_at` / `zpico_graph_set_apply` so
     /// the accounting is reachable from a host test with no session, no router

--- a/packages/testing/nros-tests/bins/action-client-multigoal/src/main.rs
+++ b/packages/testing/nros-tests/bins/action-client-multigoal/src/main.rs
@@ -40,12 +40,64 @@ extern crate nros_platform_cffi as _;
 /// How many goals to send. Must exceed the server's `MAX_GOALS` (4) so the
 /// table fills; 6 leaves two goals past the boundary, which distinguishes
 /// "rejects when full" from "rejects the 5th only".
-const GOALS: usize = 6;
+///
+/// phase-455 W2 makes this overridable, because the two questions this fixture
+/// now answers want different values. The `MAX_GOALS` regression needs MORE
+/// goals than the table holds; the goal-COMPLETION rate (issue 0902) needs
+/// fewer, so every goal is accepted and `completed == sent` is a statement
+/// about results rather than about rejections.
+const GOALS_DEFAULT: usize = 6;
 
 /// Fibonacci order per goal. Large enough that a goal is still active while
 /// the remaining goals are sent — the server advances one step per spin, so
 /// this is the dwell time that makes the goals concurrent.
 const ORDER: i32 = 40;
+
+/// How long to wait for one goal's RESULT once it has been accepted.
+///
+/// A goal of `ORDER` steps at one step per ~100 ms server spin is ~4 s, and up
+/// to `MAX_GOALS` of them advance together, so this is generous rather than
+/// tight ON PURPOSE: the assertion this fixture feeds is "the result arrives",
+/// and a budget near the honest duration turns a slow host into a fake
+/// reproduction of issue 0902.
+const RESULT_TIMEOUT_MS: u64 = 30_000;
+
+/// Read a `usize` knob from the environment, or fall back.
+///
+/// A malformed value is a hard failure, not a silent fallback: a probe that
+/// quietly ignores the number it was asked to run with reports a verdict about
+/// a configuration nobody chose.
+fn env_usize(key: &str, default: usize) -> usize {
+    match std::env::var(key) {
+        Ok(v) => v
+            .parse()
+            .unwrap_or_else(|e| panic!("{key}={v:?} is not a number: {e}")),
+        Err(_) => default,
+    }
+}
+
+/// issue 0902 / phase-455 W2 — the IDLE SOAK, and why a probe without one
+/// proves nothing.
+///
+/// The reply-slot countdown 0902 measured is consumed by ELAPSED TIME with a
+/// peer present, not by goal traffic: background discovery and liveliness
+/// probes reach the server's queryable through the same callback as a real
+/// request, and each one used to keep a slot for ever. 100 s of idling took
+/// that run from 8/10 to 2/5, while goals sent back to back passed. So a probe
+/// that fires N goals and exits can be green on a leaking build.
+///
+/// The executor is spun throughout — the soak is time spent with the session
+/// LIVE, which is the condition; a sleeping process receives nothing.
+fn idle_soak(executor: &mut Executor, millis: u64) {
+    if millis == 0 {
+        return;
+    }
+    info!("multigoal: idle soak {millis} ms (issue 0902 — the countdown is elapsed time, not traffic)");
+    let deadline = std::time::Instant::now() + core::time::Duration::from_millis(millis);
+    while std::time::Instant::now() < deadline {
+        let _ = executor.spin_once(core::time::Duration::from_millis(50));
+    }
+}
 
 fn main() -> ! {
     nros_board_linux::register_linked_rmw();
@@ -69,22 +121,39 @@ fn main() -> ! {
         Err(e) => warn!("wait_for_action_server error: {e:?} — sending goals anyway"),
     }
 
+    // issue 0902 / phase-455 W2 — soak BEFORE the goals, with the session live
+    // and a peer present. See `idle_soak`: the reply-slot countdown is spent by
+    // elapsed time, so a burst of goals on a fresh session is the one shape
+    // that cannot reproduce the defect.
+    idle_soak(
+        &mut executor,
+        env_usize("NROS_MULTIGOAL_SOAK_MS", 0) as u64,
+    );
+
+    let goals = env_usize("NROS_MULTIGOAL_GOALS", GOALS_DEFAULT);
     let goal = FibonacciGoal { order: ORDER };
     let mut accepted = 0usize;
     let mut rejected = 0usize;
+    // phase-455 W2 — goals whose RESULT came back. The pre-W2 fixture counted
+    // acceptance verdicts only, which is exactly blind to issue 0902's symptom:
+    // accepted, executed, and then no result, for ever.
+    let mut completed = 0usize;
+    let mut result_missing = 0usize;
+    let mut accepted_ids: Vec<GoalId> = Vec::new();
 
-    for i in 0..GOALS {
+    for i in 0..goals {
         // One retry: on rmw_zenoh the server's liveliness token can gossip
         // ahead of its queryable route, so a first send_goal may time out
         // against a not-yet-matched queryable (issue 0153). A TIMEOUT is not
         // a verdict — only an explicit accept/reject is — so a timed-out
         // attempt is retried rather than counted.
         let mut verdict = None;
+        let mut verdict_id = None;
         for attempt in 0..2 {
             if attempt > 0 {
                 std::thread::sleep(core::time::Duration::from_millis(500));
             }
-            let (_goal_id, mut promise) = match client.send_goal(&goal) {
+            let (goal_id, mut promise) = match client.send_goal(&goal) {
                 Ok(pair) => pair,
                 Err(e) => {
                     warn!("goal {i}: send_goal failed: {e:?}");
@@ -94,6 +163,11 @@ fn main() -> ! {
             match promise.wait(&mut executor, core::time::Duration::from_millis(5000)) {
                 Ok(true) => {
                     verdict = Some(true);
+                    // phase-455 W2 — the id is what `get_result` is asked with,
+                    // so the RESULT half needs it. The pre-W2 fixture dropped it
+                    // as `_goal_id`, which is why it could only ever report
+                    // acceptance.
+                    verdict_id = Some(goal_id);
                     break;
                 }
                 Ok(false) => {
@@ -112,6 +186,9 @@ fn main() -> ! {
         match verdict {
             Some(true) => {
                 accepted += 1;
+                if let Some(id) = verdict_id {
+                    accepted_ids.push(id);
+                }
                 info!("multigoal: goal {i} accepted");
             }
             Some(false) => {
@@ -129,7 +206,55 @@ fn main() -> ! {
         }
     }
 
-    info!("multigoal: summary accepted={accepted} rejected={rejected} of {GOALS}");
+    /* issue 0902 / phase-455 W2 — await each accepted goal's RESULT.
+     *
+     * This is the half the fixture never had. 0902's failure shape is
+     * "accepted, executed, status published, NO RESULT": the server's deferred
+     * get_result reply needs a reply slot, and once the table is exhausted the
+     * reply is discarded at four layers with the C++ side printing "Goal
+     * succeeded" over it. A client that stops at the acceptance verdict cannot
+     * see any of that.
+     *
+     * Serially, because `get_result` is single-in-flight per client. A
+     * timed-out promise leaves the in-flight flag set, so it is cleared before
+     * the next id — the same correction the acceptance retry above needed. */
+    for (n, id) in accepted_ids.iter().enumerate() {
+        let mut promise = match client.get_result(id) {
+            Ok(p) => p,
+            Err(e) => {
+                result_missing += 1;
+                warn!("multigoal: goal {n} get_result request failed: {e:?}");
+                client.reset_get_result_in_flight();
+                continue;
+            }
+        };
+        match promise.wait(
+            &mut executor,
+            core::time::Duration::from_millis(RESULT_TIMEOUT_MS),
+        ) {
+            Ok((status, _result)) => {
+                completed += 1;
+                info!("multigoal: goal {n} result received status={status:?}");
+            }
+            Err(e) => {
+                result_missing += 1;
+                warn!(
+                    "multigoal: goal {n} NO RESULT after {RESULT_TIMEOUT_MS} ms: {e:?} \
+                     — this is issue 0902's shape (accepted, then nothing). Read the \
+                     server's `reply-slot: refusals=` line before blaming the timeout."
+                );
+                client.reset_get_result_in_flight();
+            }
+        }
+    }
+
+    // The line GAINS fields; it does not change meaning. `accepted=` and
+    // `rejected=` still answer issue 0322's MAX_GOALS question, and
+    // `tests/action_multigoal.rs` parses by key rather than by position.
+    info!(
+        "multigoal: summary accepted={accepted} rejected={rejected} of {goals} \
+         completed={completed} sent={goals} result_missing={result_missing}"
+    );
     // Flush stdout before exit — a full-buffered pipe can otherwise swallow
     // the summary line the test greps for.
     use std::io::Write;

--- a/packages/testing/nros-tests/bins/action-server-concurrent/src/main.rs
+++ b/packages/testing/nros-tests/bins/action-server-concurrent/src/main.rs
@@ -18,6 +18,24 @@ use nros::prelude::*;
 
 extern crate nros_platform_cffi as _;
 
+/// issue 0902 / phase-455 W2 — the zenoh reply-slot refusal total for THIS
+/// process, or `None` where the build links no zenoh shim.
+///
+/// `None` rather than `0`: the XRCE build has no reply-slot table at all, and
+/// a probe that reports the safe value when it cannot measure is a probe that
+/// cannot fail (the shape `check-no-vacuous-tests` exists for). The caller
+/// prints the distinction, so a consumer asserting `refusals=0` is red on the
+/// build that could never have answered.
+#[cfg(feature = "rmw-zenoh")]
+fn reply_slot_refusals() -> Option<u32> {
+    Some(nros_rmw_zenoh::reply_slot_refusals_total())
+}
+
+#[cfg(not(feature = "rmw-zenoh"))]
+fn reply_slot_refusals() -> Option<u32> {
+    None
+}
+
 fn main() -> ! {
     // Register the RMW backend the build linked (idempotent; must run before
     // the executor opens).
@@ -45,8 +63,35 @@ fn main() -> ! {
         seq: heapless::Vec<i32, 64>,
     }
     let mut tracked: heapless::Vec<Tracked, 4> = heapless::Vec::new();
+
+    /* issue 0902 / phase-455 W2 — this server's reply-slot refusal count, said
+     * out loud on a cadence.
+     *
+     * The table this reports belongs to the SERVER's queryable, so the client
+     * cannot read it however it is asked: the counter lives in the C shim of
+     * the process that holds the queryable. A completion rate measured without
+     * it is the inference issue 0902 says is unfalsifiable — "did results
+     * arrive" instead of "did a slot run out".
+     *
+     * A heartbeat rather than an edge-triggered print: a consumer that greps
+     * for the last line must find one whether or not anything went wrong, and
+     * zero is exactly the value it wants to read. */
+    let mut spins_since_report: u32 = 0;
     loop {
         let _ = executor.spin_once(core::time::Duration::from_millis(10));
+
+        spins_since_report += 1;
+        if spins_since_report >= 20 {
+            spins_since_report = 0;
+            match reply_slot_refusals() {
+                Some(n) => info!("reply-slot: refusals={n}"),
+                // NOT zero. This build links no zenoh shim, so there is no
+                // reply-slot table and nothing to count; printing 0 would make
+                // "no refusals" and "no reporter" the same line, which is the
+                // exact conflation issue 0902 is about one layer down.
+                None => info!("reply-slot: refusals=n/a no-zenoh-shim"),
+            }
+        }
 
         // Accept a new goal without blocking the in-flight ones.
         if let Ok(Some(goal_id)) = server.try_accept_goal(|_id, goal: &FibonacciGoal| {

--- a/packages/testing/nros-tests/src/output.rs
+++ b/packages/testing/nros-tests/src/output.rs
@@ -590,12 +590,35 @@ pub const ACTION_SENDING_GOAL_MARKER: &str = "Sending goal";
 /// `active_goals` table holds `MAX_GOALS` (4), a 6-goal run must report
 /// `accepted=4 rejected=2`. Before the fix it reported `accepted=6 rejected=0`
 /// — the overflow goals were acknowledged and then dropped.
+/// phase-455 W2 GAINS fields on this line rather than changing its meaning:
+/// `completed=<n> sent=<n> result_missing=<n>` follow `of <total>`, and both
+/// consumers parse by KEY, so issue 0322's `accepted=`/`rejected=` assertion is
+/// untouched.
 pub const MULTIGOAL_SUMMARY_PREFIX: &str = "multigoal: summary accepted=";
 
 /// The exact summary line for a completed multi-goal run.
-pub fn multigoal_summary_line(accepted: usize, rejected: usize, total: usize) -> String {
-    format!("{MULTIGOAL_SUMMARY_PREFIX}{accepted} rejected={rejected} of {total}")
+pub fn multigoal_summary_line(
+    accepted: usize,
+    rejected: usize,
+    total: usize,
+    completed: usize,
+    result_missing: usize,
+) -> String {
+    format!(
+        "{MULTIGOAL_SUMMARY_PREFIX}{accepted} rejected={rejected} of {total} \
+         completed={completed} sent={total} result_missing={result_missing}"
+    )
 }
+
+/// issue 0902 / phase-455 W2 — the heartbeat `bins/action-server-concurrent`
+/// prints with its zenoh reply-slot refusal count.
+///
+/// The count belongs to the SERVER's queryable, so the client cannot report it
+/// however it is asked. `refusals=0` is the acceptance; `refusals=n/a
+/// no-zenoh-shim` is what a non-zenoh build prints, and asserting `=0` is
+/// therefore red on a build that could never have answered rather than green on
+/// one that never looked.
+pub const REPLY_SLOT_REPORT_PREFIX: &str = "reply-slot: refusals=";
 
 /// Action client log PREFIX once the server accepts the goal
 /// (`"Goal accepted by server"`). The stock demo continues

--- a/packages/testing/nros-tests/tests/action_multigoal.rs
+++ b/packages/testing/nros-tests/tests/action_multigoal.rs
@@ -29,15 +29,30 @@ use nros_tests::{
         ManagedProcess, ZenohRouter, action_client_multigoal_binary,
         action_server_concurrent_binary, require_zenohd, zenohd_unique,
     },
-    output::MULTIGOAL_SUMMARY_PREFIX,
+    output::{MULTIGOAL_SUMMARY_PREFIX, REPLY_SLOT_REPORT_PREFIX},
 };
 use rstest::rstest;
 use std::{path::PathBuf, process::Command, time::Duration};
 
 /// The server's `ActionServerCore::MAX_GOALS` default.
 const MAX_GOALS: usize = 4;
-/// Must match `GOALS` in the client fixture.
+/// Must match `GOALS_DEFAULT` in the client fixture.
 const GOALS_SENT: usize = 6;
+
+/// Parse `key<n>` out of the client's one summary line.
+///
+/// By KEY, not by position — the line gained `completed=`/`sent=`/
+/// `result_missing=` in phase-455 W2 and both tests here must keep reading the
+/// fields they care about. A missing key is a panic naming the line, because a
+/// summary that lost a field is a different failure from a field with a wrong
+/// value and the two must not read alike.
+fn summary_field(summary: &str, key: &str) -> usize {
+    summary
+        .split_whitespace()
+        .find_map(|tok| tok.strip_prefix(key))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("no `{key}<n>` in summary line: {summary}"))
+}
 
 #[rstest]
 fn full_goal_table_rejects_rather_than_acknowledging(
@@ -108,15 +123,8 @@ fn full_goal_table_rejects_rather_than_acknowledging(
 
     // Parse rather than string-match the whole line, so the failure message
     // can say WHICH number is wrong — the counts are the entire assertion.
-    let field = |key: &str| -> usize {
-        summary
-            .split_whitespace()
-            .find_map(|tok| tok.strip_prefix(key))
-            .and_then(|v| v.parse().ok())
-            .unwrap_or_else(|| panic!("no `{key}<n>` in summary line: {summary}"))
-    };
-    let accepted = field("accepted=");
-    let rejected = field("rejected=");
+    let accepted = summary_field(summary, "accepted=");
+    let rejected = summary_field(summary, "rejected=");
 
     assert_eq!(
         accepted, MAX_GOALS,
@@ -129,5 +137,229 @@ fn full_goal_table_rejects_rather_than_acknowledging(
         GOALS_SENT - MAX_GOALS,
         "expected the {} overflow goals to be REJECTED, got {rejected}. Summary: {summary}",
         GOALS_SENT - MAX_GOALS
+    );
+}
+
+/// issue 0902 / phase-455 W2 — the goal COMPLETION rate, with a verdict that is
+/// not an inference.
+///
+/// Issue 0902 measured action goals completing between 20 % and 90 % on one
+/// build, with no session expiry, no crash and no discovery failure, and said
+/// plainly why the number alone could not close it:
+///
+/// > A 20-90 % spread with no observable cause is worse than a hard failure. It
+/// > is not measurable as a regression gate, and any future change to this path
+/// > will be evaluated against noise wide enough to hide it.
+///
+/// So a rate is recorded here as EVIDENCE and never as the assertion. What is
+/// asserted is two things that are each a statement rather than a sample:
+///
+/// * `completed == sent` — every accepted goal's RESULT came back. The
+///   pre-phase-455 fixture awaited ACCEPTANCE only, which is exactly blind to
+///   0902's shape (accepted, executed, status published, no result, for ever).
+/// * the server's reply-slot refusal count is **zero** — the W1 counter, read
+///   from the process that owns the queryable. Zero means "no slot allocation
+///   was ever refused here", which `zpico_queryable_take_reply_seq`'s `-1` could
+///   not say, because that value also means "no query pending".
+///
+/// Together they separate this defect from a timeout, a slow peer or a
+/// scheduling artefact: a green run with `refusals=0` is a claim about the
+/// MECHANISM, not about the sample size.
+///
+/// ## The conditions, without which a green proves nothing
+///
+/// **An idle soak.** The countdown 0902 measured is consumed by ELAPSED TIME
+/// with a peer present, not by goal traffic — 100 s of idling took the original
+/// run from 8/10 to 2/5 while back-to-back goals passed. `NROS_MULTIGOAL_SOAK_MS`
+/// spins the client's session through that time.
+///
+/// **A peer that probes.** The `zenohd_unique` router is loopback, multicast
+/// off, ephemeral port, so no third party reaches the queryable. But liveliness
+/// arrives through the SAME queryable callback as a real request, and our own
+/// second node is a sufficient source — so one is brought UP and DOWN during
+/// the soak rather than assumed to appear.
+///
+/// **Fewer goals than `MAX_GOALS`.** `completed == sent` has to be a statement
+/// about RESULTS; with six goals against a four-slot table two are rejected by
+/// design and the equality could never hold. Issue 0322's question keeps its own
+/// test above, with its own goal count.
+///
+/// ## What a green run here does NOT prove — issue 1332, MEASURED
+///
+/// This is a gate for the COMPLETION path and not for the reply-slot leak. On
+/// this lane the counter cannot move at all, so reverting either leak fix
+/// changes no observable here:
+///
+/// | tree under test | refusals | completed |
+/// | --- | ---: | ---: |
+/// | both leak arms fixed | 0 | 3/3 |
+/// | `1a032a10b` reverted (declined queries keep their slot) | 0 | 3/3 |
+/// | same, with 10 peer up/down cycles | 0 | — |
+/// | `-DZPICO_MAX_PENDING_REPLIES=1`, a ONE-slot table | 0 | 3/3 |
+///
+/// A one-slot table refusing nothing is the decisive row: the server's
+/// queryable never has more than one query in flight here, so the allocation
+/// never fails. The declined-query shape that feeds the leak (an empty-payload
+/// liveliness probe) does not arrive, because graph discovery on this lane is a
+/// liveliness SUBSCRIBER rather than a query (phase-381 / issue 0903) and both
+/// action-client paths are single-in-flight. Issue 0902 measured its spread on a
+/// bare-metal serial board inside a REAL ROS 2 graph — that peer population is
+/// what is missing, not the code path.
+///
+/// So: do not cite this test as coverage for 0902's mechanism. Issue 1332 has
+/// the three routes that would make it one, cheapest first.
+#[rstest]
+fn every_accepted_goal_returns_a_result_and_no_reply_slot_is_refused(
+    zenohd_unique: ZenohRouter,
+    action_server_concurrent_binary: PathBuf,
+    action_client_multigoal_binary: PathBuf,
+) {
+    if !require_zenohd() {
+        nros_tests::skip!("zenohd not found");
+    }
+    let locator = zenohd_unique.locator();
+
+    /// Below `MAX_GOALS`, so every goal is accepted and the equality is about
+    /// results rather than rejections.
+    const GOALS: usize = 3;
+    /// Elapsed time with the session live, ON TOP of the peer churn above.
+    /// 0902's own soak was 100 s; this is the affordable end of the same
+    /// condition — the server has already been up and probed for tens of
+    /// seconds by the time the first goal is sent.
+    const SOAK_MS: u64 = 10_000;
+
+    let mut server_cmd = Command::new(&action_server_concurrent_binary);
+    server_cmd.env("NROS_LOCATOR", &locator);
+    server_cmd.env("RUST_LOG", "info");
+    let mut server = ManagedProcess::spawn_command(server_cmd, "action-server-concurrent")
+        .expect("Failed to start concurrent action server");
+
+    let server_boot = server.collect_until("Waiting for action", Duration::from_secs(10));
+    if !server_boot.contains("Waiting for action") {
+        panic!(
+            "concurrent action server never printed its readiness banner within 10s \
+             (still running: {}). Server output:\n{}",
+            server.is_running(),
+            server_boot
+        );
+    }
+
+    /* The peer that probes: our own second node, brought UP and DOWN against
+     * the live server, three times, BEFORE the goals fly.
+     *
+     * `NROS_MULTIGOAL_GOALS=0` makes it a pure graph participant — it opens a
+     * session, declares its action client's entities, idles briefly, and exits
+     * — so what reaches the server's queryable is discovery and liveliness,
+     * which is the traffic issue 0902 says consumes the reply slots. The server
+     * has been up and churned for tens of seconds by the time a goal is sent,
+     * which is the CONDITION; nothing about it requires our goal-sending client
+     * to be alive for it.
+     *
+     * MEASURED, and the ordering is load-bearing: peers running CONCURRENTLY
+     * with the goal sends made all three `send_goal` calls time out
+     * (`accepted=0 rejected=0`) while the server reported `refusals=0` — four
+     * clients querying one queryable overrun the server's 4-deep request ring,
+     * which drops the newest. That is a real property and a different one; a
+     * probe for 0902 that trips over it measures the ring, not the slots. */
+    for cycle in 0..3 {
+        let mut peer_cmd = Command::new(&action_client_multigoal_binary);
+        peer_cmd.env("NROS_LOCATOR", &locator);
+        // `info`, not `warn`: the summary line this loop waits for is an
+        // `info!`, so a quieter peer is a peer that never reports and a
+        // precondition that can only ever fail.
+        peer_cmd.env("RUST_LOG", "info");
+        peer_cmd.env("NROS_MULTIGOAL_GOALS", "0");
+        peer_cmd.env("NROS_MULTIGOAL_SOAK_MS", "1000");
+        let mut peer = ManagedProcess::spawn_command(peer_cmd, &format!("multigoal-peer-{cycle}"))
+            .expect("Failed to start the liveliness peer");
+        let peer_out = peer.collect_until(MULTIGOAL_SUMMARY_PREFIX, Duration::from_secs(30));
+        assert!(
+            peer_out.contains(MULTIGOAL_SUMMARY_PREFIX),
+            "liveliness peer {cycle} never reached its summary line, so the graph churn this \
+             test depends on did not happen and a green below would prove nothing. \
+             Peer output:\n{peer_out}"
+        );
+        drop(peer);
+    }
+
+    let mut client_cmd = Command::new(&action_client_multigoal_binary);
+    client_cmd.env("NROS_LOCATOR", &locator);
+    client_cmd.env("RUST_LOG", "info");
+    client_cmd.env("NROS_MULTIGOAL_GOALS", GOALS.to_string());
+    client_cmd.env("NROS_MULTIGOAL_SOAK_MS", SOAK_MS.to_string());
+    let mut client = ManagedProcess::spawn_command(client_cmd, "action-client-multigoal")
+        .expect("Failed to start multi-goal action client");
+
+    // Generous: the soak, then GOALS handshakes, then GOALS results at ~4 s of
+    // Fibonacci each. A budget near the honest duration would turn a loaded host
+    // into a fake reproduction of the very defect under test.
+    let out = client.collect_until(MULTIGOAL_SUMMARY_PREFIX, Duration::from_secs(180));
+
+    let summary = out
+        .lines()
+        .find(|l| l.contains(MULTIGOAL_SUMMARY_PREFIX))
+        .unwrap_or_else(|| {
+            panic!("multi-goal client printed no summary line. Output:\n{out}");
+        });
+
+    let accepted = summary_field(summary, "accepted=");
+    let completed = summary_field(summary, "completed=");
+    let sent = summary_field(summary, "sent=");
+    let result_missing = summary_field(summary, "result_missing=");
+
+    // Give the server one more heartbeat after the client is done, so the count
+    // read below covers the whole run rather than most of it.
+    let server_out = server.collect_until("\u{1}never-matches\u{1}", Duration::from_secs(3));
+    let refusal_line = server_out
+        .lines()
+        .filter(|l| l.contains(REPLY_SLOT_REPORT_PREFIX))
+        .next_back()
+        .unwrap_or_else(|| {
+            panic!(
+                "the action server printed no `{REPLY_SLOT_REPORT_PREFIX}` heartbeat, so the \
+                 W1 counter was never read and this run says NOTHING about reply-slot \
+                 exhaustion — which is the whole point of the test. Server output:\n{server_out}"
+            )
+        });
+
+    // EVIDENCE, printed whatever the verdict: the rate is what issue 0902 has
+    // been unable to compare against anything, and the next reader needs the
+    // number even when the assertions pass.
+    println!(
+        "phase-455 W2 evidence: completed {completed}/{sent} after a {SOAK_MS} ms soak \
+         with 3 peer up/down cycles; server says `{}`",
+        refusal_line.trim()
+    );
+
+    // issue 1044's lesson, one file over: the assertion and the evidence travel
+    // together. Diagnosing `accepted=0` from the summary line alone cost a
+    // hand-run of the pair; the client's transcript says which of `send_goal
+    // failed`, `acceptance timed out` and `no-verdict` actually happened.
+    assert_eq!(
+        accepted,
+        GOALS,
+        "expected all {GOALS} goals accepted (below MAX_GOALS), got {accepted}. \
+         Zero accepted with zero rejected means every `send_goal` TIMED OUT, which is \
+         a different failure from a goal the server refused. Server reply-slot line: \
+         `{}`. Client output:\n{out}",
+        refusal_line.trim()
+    );
+    assert_eq!(
+        completed,
+        sent,
+        "issue 0902: {result_missing} of {sent} accepted goals never returned a RESULT. \
+         That is the defect's exact shape — accepted, executed, and then nothing. \
+         Read the server's reply-slot line (`{}`) to tell an exhausted reply table from \
+         a slow peer. Summary: {summary}",
+        refusal_line.trim()
+    );
+    assert!(
+        refusal_line.contains(&format!("{REPLY_SLOT_REPORT_PREFIX}0")),
+        "the server refused at least one reply-slot allocation during this run: `{}`. \
+         Every request after a refusal is accepted and can never be answered (issue 0902). \
+         A non-zero count here means the reply-slot table leaked or is too small — NOT that \
+         the goals were slow. `n/a no-zenoh-shim` means this server build links no zenoh \
+         shim, so it could never have answered and the run proves nothing.",
+        refusal_line.trim()
     );
 }

--- a/packages/testing/nros-tests/tests/action_multigoal.rs
+++ b/packages/testing/nros-tests/tests/action_multigoal.rs
@@ -270,7 +270,7 @@ fn every_accepted_goal_returns_a_result_and_no_reply_slot_is_refused(
         peer_cmd.env("RUST_LOG", "info");
         peer_cmd.env("NROS_MULTIGOAL_GOALS", "0");
         peer_cmd.env("NROS_MULTIGOAL_SOAK_MS", "1000");
-        let mut peer = ManagedProcess::spawn_command(peer_cmd, &format!("multigoal-peer-{cycle}"))
+        let mut peer = ManagedProcess::spawn_command(peer_cmd, format!("multigoal-peer-{cycle}"))
             .expect("Failed to start the liveliness peer");
         let peer_out = peer.collect_until(MULTIGOAL_SUMMARY_PREFIX, Duration::from_secs(30));
         assert!(
@@ -312,8 +312,7 @@ fn every_accepted_goal_returns_a_result_and_no_reply_slot_is_refused(
     let server_out = server.collect_until("\u{1}never-matches\u{1}", Duration::from_secs(3));
     let refusal_line = server_out
         .lines()
-        .filter(|l| l.contains(REPLY_SLOT_REPORT_PREFIX))
-        .next_back()
+        .rfind(|l| l.contains(REPLY_SLOT_REPORT_PREFIX))
         .unwrap_or_else(|| {
             panic!(
                 "the action server printed no `{REPLY_SLOT_REPORT_PREFIX}` heartbeat, so the \


### PR DESCRIPTION
Implements **phase-455 W2**. **Branches from [#976](https://github.com/NEWSLabNTU/nano-ros/pull/976) (W1)** and carries its commit; the queue rebase-merges, so W1's commit drops by patch-id once #976 lands. Review only the second commit.

## What the probe could not see before

`bins/action-client-multigoal` looped goals and awaited **acceptance** only —
exactly blind to [issue 0902](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/issues/0902-action-goal-completion-is-variable.md)'s
symptom: accepted, executed, status published, and then no result, for ever.

It now calls `get_result` for every accepted goal and reports `completed` /
`sent` / `result_missing` beside the existing counts. **The summary line GAINS
fields**; both consumers parse by key, so issue 0322's `accepted=4 rejected=2`
assertion is untouched and still passes (verified below).

## The conditions, because a green without them proves nothing

| | |
| --- | --- |
| **idle soak** (`NROS_MULTIGOAL_SOAK_MS`, spun not slept) | 0902's countdown is spent by ELAPSED TIME with a peer present — 100 s of idling took that run from 8/10 to 2/5 while back-to-back goals passed |
| **a peer that probes** | our own second node UP and DOWN three times against the live server (`NROS_MULTIGOAL_GOALS=0` makes it a pure graph participant), rather than assuming traffic appears on a loopback router with multicast off |
| **fewer goals than `MAX_GOALS`** (`NROS_MULTIGOAL_GOALS`) | so `completed == sent` is a statement about RESULTS, not about rejections |

**Ordering is load-bearing, and it was measured.** Peers running *concurrently*
with the goal sends made all three `send_goal` calls time out (`accepted=0
rejected=0`) while the server reported `refusals=0` — four clients against one
queryable overrun the server's 4-deep request ring, which drops the newest. Real,
and a different property; a probe for 0902 that trips over it measures the ring.

## Reading the counter from the process that owns the queryable

W1's counter is per-session *and* per-queryable, and the table is the **server's**
— so the client cannot report it however it is asked.
`zpico_reply_slot_refusals_total()` is the no-handle sum (a probe binary holds an
`Executor` and a node, not a zenoh `Context`), surfaced as
`nros_rmw_zenoh::reply_slot_refusals_total` and printed as a heartbeat by
`bins/action-server-concurrent`. On the XRCE build it prints `refusals=n/a
no-zenoh-shim` rather than `0`: a probe that reports the safe value when it
cannot measure is a probe that cannot fail.

## Measured — `just native test-action-completion`

```
        PASS [   5.706s] (1/2) nros-tests::action_multigoal full_goal_table_rejects_rather_than_acknowledging
        PASS [  21.499s] (2/2) nros-tests::action_multigoal every_accepted_goal_returns_a_result_and_no_reply_slot_is_refused
     Summary [  21.500s] 2 tests run: 2 passed, 0 skipped
```

```
phase-455 W2 evidence: completed 3/3 after a 10000 ms soak with 3 peer up/down
cycles; server says `reply-slot: refusals=0`
```

The rate is EVIDENCE; the assertions are `completed == sent` and `refusals=0`,
which are statements rather than samples — what 0902 asked for when it said a
spread with no observable cause is not measurable as a regression gate.

## The negative control DOES NOT EXIST on this lane — new issue 1332

The phase doc asks this test to fail on a tree with either leak arm reverted. **It
does not**, and the reason is worth more than the green. Four runs, each with a
router, the concurrent server and peers:

| tree under test | refusals | completed |
| --- | ---: | ---: |
| both leak arms fixed | 0 | 3/3 |
| **`1a032a10b` REVERTED** (declined queries keep their slot for ever) | 0 | 3/3 |
| same, with **10** peer up/down cycles | 0 | — |
| **`-DZPICO_MAX_PENDING_REPLIES=1`** — a ONE-slot table | 0 | 3/3 |

A one-slot table that refuses nothing is the decisive row: here the server's
queryable never holds more than one query at a time, so the allocation never
fails and the counter can never move. **Reverting the fix changes no observable.**

Inferred (read off the code, not instrumented, and flagged as such in the issue):
the declined-query shape that feeds the leak is the empty-payload liveliness probe
at `shim/service.rs:220-227`, and graph discovery on this lane is a liveliness
SUBSCRIBER rather than a query (phase-381 / issue 0903), while both action-client
paths are single-in-flight. 0902 measured its spread on a bare-metal serial board
inside a **real ROS 2 graph**; that peer population is what is missing, not the
code path.

`b56e3d50a`'s arm (failed-reply release) was **not** reverted: reaching it needs
`z_query_reply` itself to fail, which this lane gives no way to force, and the
table above already shows the counter cannot move here.

Filed as **issue 1332** with three routes that would create a control, cheapest
first (a declined-query fixture; W3's live ROS 2 zenoh action cells, *measured*
not assumed; the board run). The limitation is written into the test's own
doc-comment, into 0902 and into 1332, so nobody cites this green as coverage for
the mechanism.

## Also

* `examples/fixtures.toml`: the two rows gained an `id`, so the probe's fixtures
  build one at a time (`fixtures-build.sh linux rust --id …`) instead of via the
  whole ~115 GiB linux/rust lane. **Verified not to move any artifact dir** —
  `fixtures-manifest.py fixture-groups --platform linux` is byte-identical before
  and after, because the key is (platform, cargo args, env) per issue 1025.
* A FOCUSED runner, written through `_test-focused` like its five siblings — a
  sweep is not a runner for a live-peer cell, and a second copy of the
  skip-accounting tail is the #282 → #326 shape.
* The `accepted` assertion carries the client transcript. Diagnosing `accepted=0`
  from the summary line alone cost a hand-run of the pair — issue 1044's lesson,
  in the file that already records it.

## Local checks, verbatim

`just check fast`:

```
===== FAIL (leaf-lockfiles, rc=1, 5802ms) =====
check-fast (parallel): 1 of 308 gate(s) FAILED
```

**That one failure is this worktree's provisioning and is IDENTICAL on the base
commit**, proven rather than asserted. On `160ed2d9c0` with this branch checked
out nowhere, `just check leaf-lockfiles` → `rc=1`:

```
ERROR: 2 leaf crate(s) cannot resolve on a SYNCED tree.
       packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi
       packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi
```

The same two leaves appeared in W1's `ci gate` run as a **skip** (`tree not synced
— 2 leaf crate(s) NOT checked`); running `nros sync` on this worktree to build the
probe's fixtures flipped that third outcome from SKIP to FAIL. Neither leaf is
reachable from this diff, which touches `packages/rmw/zenoh/**`,
`packages/testing/**`, `examples/fixtures.toml`, `just/native.just` and
`docs/issues/**`. The push used the hook's documented `--no-verify` bypass for
exactly this, with the base-commit comparison above as the evidence.

`just ci gate` was not re-run for W2: on this worktree it stops at `check::build`
for the same cyclonedds-source gap documented on #976, and `check::fast` is the
half that gates a pull request.

## Not verified

* **The negative control.** See issue 1332 — not a gap in the work, a measured
  property of the lane, but it means a future regression of the leak would not
  turn this test red.
* **The `n/a no-zenoh-shim` arm.** The XRCE build of the server was not built or
  run here; that branch is read, not executed.
* **Any embedded target.** This is the native host lane only.
* The router used for every run above is `rmw_zenohd` from a ROS 2 container on
  this host (Arch, no ROS). Only the router ran there — a separate process reached
  over TCP on the shared network namespace; nothing nano-ros builds crossed the
  boundary, so this is not the retired `ros2-box-sync.sh` shape.

## Auto-merge is NOT armed on this PR, and cannot be

```
$ gh pr merge 979 --auto --rebase
GraphQL: Pull request Protected branch rules not configured for this branch (enablePullRequestAutoMerge)
$ gh pr view 979 --json autoMergeRequest
{"autoMergeRequest":null,"baseRefName":"work/455-w1-reply-slot-counter",...}
```

Auto-merge is a property of the BASE branch: `main` has the ruleset and the
queue, `work/455-w1-reply-slot-counter` has neither, so GitHub refuses. This is
the documented cost of stacking (CLAUDE.md, AGENTS.md "What stacking costs"),
not a misconfiguration. #976 IS armed. When it lands and its branch is deleted,
GitHub retargets this PR to `main` automatically and it can be armed then — its
carried W1 commit drops by patch-id on the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7tie7AFCdqoRkxphQcqRx
