### PR TITLE
feat(phase-454 W3, #1256): three QoS policies were stated, resolved, and dropped — and `keep_all` was priced

### DIFF
--- a/cmake/NanoRosEntityInventory.cmake
+++ b/cmake/NanoRosEntityInventory.cmake
@@ -166,12 +166,31 @@
 #                                         publishers that stated a depth
 #   NROS_ENTITY_UNDECLARED_DEPTH_COUNT_PUBLISHER
 #                                         the same, publishers only
+#   NROS_ENTITY_DECLARED_QOS_STATUS       resolved | refused (phase-454 W3)
+#   NROS_ENTITY_DECLARED_QOS_REASON       prose, when refused
+#   NROS_ENTITY_DECLARED_<P>              SUBSCRIPTION `type|topic=value`, for
+#                                         P in RELIABILITY, DURABILITY, HISTORY
+#   NROS_ENTITY_DECLARED_<P>_PUBLISHER    the publisher list
+#   NROS_ENTITY_UNDECLARED_<P>_COUNT_SUBSCRIPTION
+#   NROS_ENTITY_UNDECLARED_<P>_COUNT_PUBLISHER
+#                                         endpoints of that kind that did NOT
+#                                         state that policy
 #
 # A consumer that sizes from depth must refuse while the UNDECLARED count FOR
 # ITS OWN KIND is non-zero. The broad count answers no term's question: one
 # unannotated endpoint of the other kind would pin both terms on the worst case
 # forever, which is what issue 1227 measured (18 against 11 on the reference
-# island, all eleven subscriptions declaring).
+# island, all eleven subscriptions declaring). The same rule applies per POLICY
+# to the three lists above -- an image can state `reliability` on every
+# subscription and `durability` on none.
+#
+# phase-454 W3 -- NROS_ENTITY_DECLARED_DEPTH_STATUS can now read `refused` for a
+# reason that has nothing to do with the composition: some endpoint declared
+# `history: keep_all`, which has NO STATIC BOUND, so a depth stated beside it
+# prices nothing (RFC-0100 D6). The refusal is per FACT -- the policy lists and
+# the entity counts stay resolved, and `NROS_ENTITY_DECLARED_QOS_REASON` is not
+# set -- so a consumer must read the status of the fact IT reads, never one
+# status for the fragment.
 #
 # A derived value is a DEFAULT. Every consumer applies it only where nothing
 # else stated a number -- see `_nros_resolve_derivable_knob` in
@@ -211,7 +230,18 @@ include_guard(GLOBAL)
 # because the first variable's DEFINITION narrowed and the second one's absence
 # in a version-3 fragment is an older CLI's silence, not "no publisher
 # declared".
-set(NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED 4 CACHE INTERNAL
+#
+# **5** (phase-454 W3, issue 1256) added the OTHER THREE QoS policies --
+# `NROS_ENTITY_DECLARED_{RELIABILITY,DURABILITY,HISTORY}[_PUBLISHER]` with a
+# per-policy, per-kind undeclared count and their own `_QOS_STATUS`. The
+# contract has stated them per endpoint for four phases and nano-ros dropped
+# them at `depth_of`. Bumps for the usual reason -- an absent list in a
+# version-4 fragment is an older CLI's silence, not "nobody declared one" --
+# and for one that is NOT merely additive: `NROS_ENTITY_DECLARED_DEPTH_STATUS`
+# can now say `refused` because an endpoint declared `history: keep_all`, and a
+# version-4 reader that had never seen that reason would keep sizing from a
+# depth that has stopped bounding anything.
+set(NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED 5 CACHE INTERNAL
     "phase-403 W9: the nros_entity_inventory fragment schema this tree reads")
 
 # nros_entity_inventory_knobs_file(<out_var>)
@@ -320,6 +350,24 @@ function(nros_derive_entity_inventory_knobs)
                NROS_ENTITY_DECLARED_DEPTHS_PUBLISHER
                NROS_ENTITY_DECLARED_DEPTH_COUNT_PUBLISHER
                NROS_ENTITY_UNDECLARED_DEPTH_COUNT_PUBLISHER
+               # phase-454 W3 -- the other three policies. Written out here and
+               # in the republish loop below rather than built by
+               # interpolation: a knob name assembled from a variable is the
+               # name that silently resolves EMPTY (the rule the parameter
+               # block at the end of this list already states).
+               NROS_ENTITY_DECLARED_QOS_STATUS NROS_ENTITY_DECLARED_QOS_REASON
+               NROS_ENTITY_DECLARED_RELIABILITY
+               NROS_ENTITY_DECLARED_RELIABILITY_PUBLISHER
+               NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_SUBSCRIPTION
+               NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_PUBLISHER
+               NROS_ENTITY_DECLARED_DURABILITY
+               NROS_ENTITY_DECLARED_DURABILITY_PUBLISHER
+               NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_SUBSCRIPTION
+               NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_PUBLISHER
+               NROS_ENTITY_DECLARED_HISTORY
+               NROS_ENTITY_DECLARED_HISTORY_PUBLISHER
+               NROS_ENTITY_UNDECLARED_HISTORY_COUNT_SUBSCRIPTION
+               NROS_ENTITY_UNDECLARED_HISTORY_COUNT_PUBLISHER
                NROS_PARAM_DECLARATION_STATUS NROS_PARAM_DECLARATION_REASON
                NROS_PARAM_DECLARED_COUNT
                NROS_DERIVED_MAX_PARAMETERS NROS_DERIVED_MAX_PARAM_NAME_LEN
@@ -485,7 +533,23 @@ function(nros_derive_entity_inventory_knobs)
                    DECLARED_DEPTH_COUNT UNDECLARED_DEPTH_COUNT
                    UNDECLARED_DEPTH_COUNT_SUBSCRIPTION
                    DECLARED_DEPTHS_PUBLISHER DECLARED_DEPTH_COUNT_PUBLISHER
-                   UNDECLARED_DEPTH_COUNT_PUBLISHER)
+                   UNDECLARED_DEPTH_COUNT_PUBLISHER
+                   # phase-454 W3 (issue 1256) -- the other three policies, on
+                   # the same terms. `reliability` gates XRCE's two 64 KiB
+                   # `*_reliable_buf`, `durability` is publisher-side retention
+                   # and `history` is the one that REFUSES: `keep_all` has no
+                   # static bound, so the depth table above says `refused` and
+                   # these lists stay resolved (RFC-0100 D6, refusal per fact).
+                   DECLARED_QOS_STATUS DECLARED_QOS_REASON
+                   DECLARED_RELIABILITY DECLARED_RELIABILITY_PUBLISHER
+                   UNDECLARED_RELIABILITY_COUNT_SUBSCRIPTION
+                   UNDECLARED_RELIABILITY_COUNT_PUBLISHER
+                   DECLARED_DURABILITY DECLARED_DURABILITY_PUBLISHER
+                   UNDECLARED_DURABILITY_COUNT_SUBSCRIPTION
+                   UNDECLARED_DURABILITY_COUNT_PUBLISHER
+                   DECLARED_HISTORY DECLARED_HISTORY_PUBLISHER
+                   UNDECLARED_HISTORY_COUNT_SUBSCRIPTION
+                   UNDECLARED_HISTORY_COUNT_PUBLISHER)
         if(DEFINED NROS_ENTITY_${_field})
             _nros_entity_publish(NROS_ENTITY_${_field} "${NROS_ENTITY_${_field}}")
         endif()
@@ -606,6 +670,24 @@ if(CMAKE_SCRIPT_MODE_FILE AND
         NROS_ENTITY_DECLARED_DEPTH_COUNT_PUBLISHER
         NROS_ENTITY_UNDECLARED_DEPTH_COUNT_PUBLISHER
         NROS_ENTITY_DECLARED_DEPTH_REASON
+        # phase-454 W3 (issue 1256) -- the other three QoS policies. Printed
+        # for the reason the block above says: a value that crosses the
+        # function boundary and is NOT printed here is untestable and
+        # invisible, which is how half a publish survives a review.
+        NROS_ENTITY_DECLARED_QOS_STATUS
+        NROS_ENTITY_DECLARED_QOS_REASON
+        NROS_ENTITY_DECLARED_RELIABILITY
+        NROS_ENTITY_DECLARED_RELIABILITY_PUBLISHER
+        NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_SUBSCRIPTION
+        NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_PUBLISHER
+        NROS_ENTITY_DECLARED_DURABILITY
+        NROS_ENTITY_DECLARED_DURABILITY_PUBLISHER
+        NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_SUBSCRIPTION
+        NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_PUBLISHER
+        NROS_ENTITY_DECLARED_HISTORY
+        NROS_ENTITY_DECLARED_HISTORY_PUBLISHER
+        NROS_ENTITY_UNDECLARED_HISTORY_COUNT_SUBSCRIPTION
+        NROS_ENTITY_UNDECLARED_HISTORY_COUNT_PUBLISHER
         NROS_PARAM_DECLARATION_STATUS
         NROS_PARAM_DECLARATION_REASON
         NROS_PARAM_DECLARED_COUNT

--- a/docs/issues/1256-contract-qos-carries-depth-only.md
+++ b/docs/issues/1256-contract-qos-carries-depth-only.md
@@ -67,8 +67,32 @@ config source first, rather than adding three more literals.
 
 ## Acceptance
 
-- The inventory carries all four fields per endpoint; an unknown value is an
-  error, never a skip.
-- KEEP_ALL without a stated cap refuses at build time, naming the endpoint.
-- The declared-QoS header and boot check cover reliability and durability.
-- ROS default values are read from one config source, not from code literals.
+- **DONE** (phase-454 W1) — ROS default values are read from one config source,
+  not from code literals. `QoSProfile`'s `qos_profiles!` table is the one
+  authored site; every site that can read Rust reads it, and the six that cannot
+  (a Kconfig `default`, two C headers, a C++ header, a C source) are compared
+  field by field by `check-qos-profile-ssot.py`.
+- **DONE** (phase-454 W3) — the inventory carries all four fields per endpoint.
+  `EntityDecl` gained `reliability` / `durability` / `history` beside `depth`,
+  `EntityInventory::from_model` reads all four out of both endpoint maps, and
+  they reach a build through `NROS_ENTITY_DECLARED_{RELIABILITY,DURABILITY,
+  HISTORY}[_PUBLISHER]` with a per-policy, per-kind undeclared count.
+- **DONE** (phase-454 W3) — an unknown value is an error, never a skip.
+  `reject_unknown_qos_values` refuses at the two places a model reaches
+  `from_model`, naming the endpoint, what was written and what is accepted.
+  Both roads, because a check on one of two is issue 1199's shape.
+- **DONE** (phase-454 W3) — KEEP_ALL refuses at build time, naming the endpoint.
+  Stronger than this line asked: it refuses **whether or not** a cap is stated
+  beside it, because a `depth:` written next to KEEP_ALL is not a cap on the
+  queue (RFC-0100 D6). The refusal is per fact — the depth-derived numbers go,
+  the entity counts, the type sets and the policy table itself stay.
+- **OPEN** — the declared-QoS header and boot check cover reliability and
+  durability. This one is NOT W3's. `NROS_ASSERT_DECLARED_DEPTH` compares a
+  call site's QoS against a generated `(type, topic) -> depth` table, and
+  widening that table is the same edit as widening it to the languages it does
+  not reach today (`_nros_declared_qos_arm` returns early for Rust and INTERFACE
+  targets, and C has no equivalent macro at all). Both halves are phase-454 W10,
+  which exists for exactly that surface. Note what this bullet is and is not: a
+  code/contract disagreement on reliability or durability is an INTEROP failure
+  (an incompatible-QoS match never delivers), not a sizing one, so it does not
+  hold up any of the derivations above.

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -2422,6 +2422,16 @@ fn resolve_image(
             .map_err(|e| format!("reading {}: {e}", model_path.display()))?;
         let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(&raw)
             .map_err(|e| format!("parsing {}: {e}", model_path.display()))?;
+        // phase-454 W3 -- a QoS value this build cannot read refuses the SEED
+        // too. `from_model` parses `reliability:` / `durability:` / `history:`
+        // and an unreadable spelling parses to `None`, which is the spelling
+        // for NOBODY SAID -- so without this the seed would compose an image
+        // whose declaration had been silently dropped. The verb fatals on the
+        // same model a moment later; here it is a refusal reason, because a
+        // seed that cannot answer is a normal state and a seed that answers
+        // WRONGLY is not.
+        crate::cmd::entity_inventory::reject_unknown_qos_values(&model)
+            .map_err(|e| format!("{e}"))?;
         // `None` is "no wiring described", which is a DECLARATION GAP and not
         // an error: 5 of the tree's 114 resolvable models describe wiring, and
         // they are exactly the 5 with a contract sidecar (issue 0973).

--- a/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
@@ -231,6 +231,11 @@ pub fn run(args: EntityInventoryArgs) -> Result<()> {
         let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(&raw)
             .wrap_err_with(|| format!("parse model `{}`", model_path.display()))?;
         reject_zero_depths(&model).wrap_err_with(|| format!("model `{}`", model_path.display()))?;
+        // phase-454 W3 -- and a QoS VALUE this build does not model. Same place
+        // and same reason as the zero depth above: this is the one point a model
+        // enters the verb and the only one with an error channel.
+        reject_unknown_qos_values(&model)
+            .wrap_err_with(|| format!("model `{}`", model_path.display()))?;
         if args.output_params_header.is_some() {
             params_header = Some(crate::declared_params_header::render(
                 Some(&model),
@@ -345,6 +350,98 @@ fn reject_zero_depths(model: &ros_launch_manifest_model::SystemModel) -> Result<
                  of 0 states nothing -- KEEP_LAST(0) holds no sample. Omit `depth:` to say \
                  \"not declared\", which is a different claim and the one that makes a size \
                  consumer REFUSE rather than guess."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// A contract may not state a QoS value this build does not model
+/// (phase-454 W3, issue 1256).
+///
+/// The issue's own acceptance says it: *"an unknown value is an error, never a
+/// skip."* `Qos::{reliability, durability, history}` are free-form `String`s in
+/// the model -- the resolver carries whatever the contract wrote -- so
+/// `reliability: best-effort` (a hyphen) or `reliability: BestEffort` parses,
+/// resolves, and would reach [`EntityInventory::from_model`]'s
+/// `parse_reliability` as `None`, which is the spelling for NOBODY SAID. A
+/// misspelling would then be indistinguishable from silence: the endpoint would
+/// be counted as undeclared, every consumer would refuse on the safe side, and
+/// the author would never learn that the line they wrote does nothing.
+///
+/// Refused HERE and not in `from_model`, for exactly the reason
+/// [`reject_zero_depths`] is: that function returns `Option` to say "no wiring
+/// described" and has no channel for "what you wrote is wrong".
+///
+/// The accepted spellings come from `nros_orchestration_ir::qos_override`, the
+/// module that already owned this vocabulary for `qos_overrides.*` parameters.
+/// One vocabulary, two surfaces -- which is also what will let phase-454 W7
+/// compare the two statements for agreement (RFC-0100 D8) rather than compare
+/// two spellings of two parsers.
+/// `pub(crate)` because the verb is not the only road a model reaches
+/// `from_model` on: `nros build`'s stage-3.5 seed (`cmd::build`) composes the
+/// same inventory from the same model, and a check that guards one of two roads
+/// is the shape issue 1199 names. That road records the refusal rather than
+/// failing the process, because a seed that cannot answer is a normal state --
+/// the configure-time producer is where the same value becomes fatal.
+pub(crate) fn reject_unknown_qos_values(
+    model: &ros_launch_manifest_model::SystemModel,
+) -> Result<()> {
+    use nros_orchestration_ir::qos_override as qos;
+
+    let subs = model
+        .contracts
+        .sub_endpoints
+        .iter()
+        .map(|(ep, c)| ("subscriber", ep, c.qos.as_ref()));
+    let pubs = model
+        .contracts
+        .pub_endpoints
+        .iter()
+        .map(|(ep, c)| ("publisher", ep, c.qos.as_ref()));
+    for (side, ep, q) in subs.chain(pubs) {
+        let Some(q) = q else { continue };
+        // `(policy name, what the contract wrote, did it parse, accepted)`.
+        // Written as a table so a fourth policy is a row, and so that no policy
+        // can be checked in one place and forgotten in the other -- the
+        // `filter_map`-away shape `qos_override`'s own header warns about.
+        let checks: [(&str, Option<&str>, bool, &str); 3] = [
+            (
+                "reliability",
+                q.reliability.as_deref(),
+                q.reliability
+                    .as_deref()
+                    .is_none_or(|v| qos::parse_reliability(v).is_some()),
+                qos::RELIABILITY_VALUES,
+            ),
+            (
+                "durability",
+                q.durability.as_deref(),
+                q.durability
+                    .as_deref()
+                    .is_none_or(|v| qos::parse_durability(v).is_some()),
+                qos::DURABILITY_VALUES,
+            ),
+            (
+                "history",
+                q.history.as_deref(),
+                q.history
+                    .as_deref()
+                    .is_none_or(|v| qos::parse_history(v).is_some()),
+                qos::HISTORY_VALUES,
+            ),
+        ];
+        for (policy, written, ok, accepted) in checks {
+            if ok {
+                continue;
+            }
+            bail!(
+                "contract {side} endpoint `{ep}` states `qos: {{ {policy}: {} }}`, which is not \
+                 a {policy} this build models (expected {accepted}). It is REFUSED rather than \
+                 ignored: an unreadable value would be counted as \"not declared\", every size \
+                 consumer would refuse on the safe side, and you would never learn that the \
+                 line does nothing.",
+                written.unwrap_or("")
             );
         }
     }
@@ -645,6 +742,209 @@ contracts:
         )
         .expect("model fixture parses");
         reject_zero_depths(&model).expect("a stated depth and a silent endpoint are both legal");
+    }
+
+    /// phase-454 W3 (issue 1256) -- an unknown QoS VALUE is an error, never a
+    /// skip.
+    ///
+    /// The issue's acceptance in one sentence, and the reason it has to be an
+    /// error: `reliability:` is a free-form `String` in the model, so a
+    /// misspelling parses to `None` inside `from_model`, which is the spelling
+    /// for NOBODY SAID. Silence and a typo would then be the same fact -- every
+    /// size consumer would refuse on the safe side, the build would succeed,
+    /// and the author would never learn that the line does nothing.
+    ///
+    /// All three policies, because a check written once per policy is a check
+    /// that gets written for two of them (`qos_override`'s own header: both
+    /// producers `filter_map`ed an unrecognised policy away, and the copies
+    /// disagreed).
+    #[test]
+    fn an_unknown_qos_spelling_is_rejected_before_it_can_be_dropped() {
+        // (the line to write, the fragment the message must name, the accepted
+        // spellings it must offer)
+        let cases: &[(&str, &str, &str)] = &[
+            (
+                "reliability: best-effort",
+                "best-effort",
+                "`best_effort` or `reliable`",
+            ),
+            (
+                "durability: TransientLocal",
+                "TransientLocal",
+                "`volatile` or `transient_local`",
+            ),
+            ("history: keep-all", "keep-all", "`keep_last` or `keep_all`"),
+        ];
+        for (line, written, accepted) in cases {
+            let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(&format!(
+                r#"
+meta: {{ version: 1 }}
+structure:
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      sub: [/listener/chatter]
+contracts:
+  sub_endpoints:
+    /listener/chatter:
+      qos: {{ {line} }}
+"#
+            ))
+            .expect("model fixture parses");
+            let err = reject_unknown_qos_values(&model).unwrap_err().to_string();
+            assert!(
+                err.contains("/listener/chatter"),
+                "names the endpoint: {err}"
+            );
+            assert!(err.contains(written), "quotes what was written: {err}");
+            assert!(err.contains(accepted), "names what is accepted: {err}");
+            assert!(
+                err.contains("not declared"),
+                "and says what the silent drop would have looked like: {err}"
+            );
+        }
+    }
+
+    /// ...on the PUBLISHER side too. W2 made a publisher's QoS travel; a check
+    /// reading only `sub_endpoints` is issue 1084's defect one map over.
+    #[test]
+    fn an_unknown_qos_spelling_on_a_publisher_is_rejected_too() {
+        let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(
+            r#"
+meta: { version: 1 }
+structure:
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      pub: [/talker/chatter]
+contracts:
+  pub_endpoints:
+    /talker/chatter:
+      qos: { durability: transient-local }
+"#,
+        )
+        .expect("model fixture parses");
+        let err = reject_unknown_qos_values(&model).unwrap_err().to_string();
+        assert!(err.contains("/talker/chatter"), "{err}");
+        assert!(err.contains("publisher"), "names which side: {err}");
+    }
+
+    /// ...and the VERB reaches that check, not just the function.
+    ///
+    /// The two tests above call `reject_unknown_qos_values` directly, which
+    /// proves the rule and says nothing about whether anything runs it -- the
+    /// exact shape issue 1226 names ("a gate that WORKS is not a gate that
+    /// RUNS"). This one drives [`run`] end to end over a real metadata file and
+    /// a real model, so deleting the call site is a red rather than a silent
+    /// return to the drop this wave fixed.
+    #[test]
+    fn the_verb_itself_refuses_an_unreadable_qos_value() {
+        let dir = scratch_dir("qos-verb");
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let metadata = dir.join("nros-metadata.json");
+        std::fs::write(
+            &metadata,
+            r#"{"components": [
+                 {"name": "listener", "pkg": "demo", "class": "demo::Listener",
+                  "entities": ["sub:std_msgs/msg/Int32:/chatter"]}
+               ]}"#,
+        )
+        .expect("write metadata");
+        let model = dir.join("system_model.yaml");
+        std::fs::write(
+            &model,
+            r#"
+meta: { version: 1 }
+structure:
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      sub: [/listener/chatter]
+contracts:
+  sub_endpoints:
+    /listener/chatter:
+      qos: { reliability: best-effort }
+"#,
+        )
+        .expect("write model");
+
+        let args = |model: Option<&std::path::Path>| EntityInventoryArgs {
+            metadata: Some(metadata.clone()),
+            model: model.map(|p| p.to_path_buf()),
+            output_json: None,
+            output_cmake: None,
+            output_dir: None,
+            output_header: None,
+            output_params_header: None,
+            component: None,
+            require_derived: false,
+        };
+        // The whole CHAIN: the verb wraps the check's message in "model
+        // `<path>`", so the outermost `to_string()` alone would pass on any
+        // model-shaped failure at all.
+        let err =
+            run(args(Some(&model))).expect_err("the verb must refuse a QoS value it cannot read");
+        let chain: String = err
+            .chain()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            chain.contains("best-effort"),
+            "the verb's error must carry the check's message: {chain}"
+        );
+        assert!(chain.contains("/listener/chatter"), "{chain}");
+
+        // The control: the SAME image with no model at all is fine, so the
+        // failure above is the check firing and not the fixture being broken.
+        run(args(None)).expect("a metadata-only run has no contract to check");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Unique scratch dir under the repo's gitignored `tmp/` (repo rule: temp
+    /// files live in `$project/tmp/`, not the system temp dir).
+    fn scratch_dir(name: &str) -> PathBuf {
+        let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("repo root");
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        repo.join("tmp")
+            .join(format!("{name}-{}-{stamp}", std::process::id()))
+    }
+
+    /// ...and every spelling this build DOES model passes, including the one
+    /// that will make a size consumer refuse.
+    ///
+    /// `keep_all` is legal to WRITE. It refuses the depth-derived facts
+    /// (RFC-0100 D6) and it is not a contract error, which is the distinction
+    /// this test pins: a build that rejected it outright would be telling
+    /// authors they may not ask for an unbounded queue.
+    #[test]
+    fn every_modelled_qos_spelling_is_accepted_keep_all_included() {
+        let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(
+            r#"
+meta: { version: 1 }
+structure:
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      pub: [/talker/chatter]
+      sub: [/listener/chatter]
+contracts:
+  pub_endpoints:
+    /talker/chatter:
+      qos: { reliability: reliable, durability: transient_local, history: keep_last }
+  sub_endpoints:
+    /listener/chatter:
+      qos: { reliability: best_effort, durability: volatile, history: keep_all }
+"#,
+        )
+        .expect("model fixture parses");
+        reject_unknown_qos_values(&model).expect("every spelling here is one this build models");
     }
 
     /// The committed C++ compile fixture is exactly what this emitter renders.

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -110,6 +110,14 @@
 
 use std::collections::BTreeMap;
 
+// phase-454 W3 -- the QoS VALUE vocabulary, taken from the module that already
+// owned it for `qos_overrides.*`. Parsing `best_effort` a second time here is
+// how a second vocabulary starts; see that module's header.
+use nros_orchestration_ir::qos_override::{
+    QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy, durability_spelling,
+    history_spelling, parse_durability, parse_history, parse_reliability, reliability_spelling,
+};
+
 /// Bumped when the shape of the emitted inventory changes incompatibly.
 /// A consumer that does not recognise the version must refuse, never guess.
 ///
@@ -140,7 +148,20 @@ use std::collections::BTreeMap;
 /// depth-carrying kind, and while no in-tree producer ever put a non-
 /// subscription row in one, the variable's DEFINITION changed and a reader
 /// cannot tell which definition it is holding without the version.
-pub const ENTITY_INVENTORY_SCHEMA_VERSION: u32 = 4;
+///
+/// **5** (phase-454 W3, issue 1256): the OTHER THREE QoS policies. The contract
+/// has been able to state `reliability`, `durability` and `history` per endpoint
+/// for four phases; `depth_of` read the depth and dropped them. They now travel
+/// as `NROS_ENTITY_DECLARED_{RELIABILITY,DURABILITY,HISTORY}[_PUBLISHER]` with
+/// per-kind undeclared counts and their own `_QOS_POLICY_STATUS`. Bumps for the
+/// familiar reason -- absence of a list in a version-4 fragment is an older
+/// CLI's silence, not "no endpoint declared" -- and for a second one that is
+/// NOT merely additive: `NROS_ENTITY_DECLARED_DEPTH_STATUS` can now read
+/// `refused` for a reason a version-4 reader has never seen, `history =
+/// keep_all` on some endpoint. A KEEP_ALL queue has no static bound, so a depth
+/// stated beside it prices nothing (RFC-0100 D6), and a reader that kept using
+/// the old list would size from a number that has stopped meaning what it said.
+pub const ENTITY_INVENTORY_SCHEMA_VERSION: u32 = 5;
 
 /// Canonical artifact name.
 pub const ENTITY_INVENTORY_JSON_NAME: &str = "nros_entity_inventory.json";
@@ -336,15 +357,57 @@ impl EntityKind {
 /// default 10 inflates an image that states 1 tenfold, and assuming 1
 /// UNDER-sizes one that took the default. `None` means NOBODY SAID, and a
 /// consumer that needs a depth must refuse on it. It must never read as 0.
+///
+/// # The other three policies (phase-454 W3, issue 1256)
+///
+/// `reliability`, `durability` and `history` ride here for the same reason and
+/// under the same rule. Each is `Option` and `None` means NOBODY SAID: an
+/// undeclared `reliability` is NOT `best_effort`, and a consumer that needs one
+/// -- XRCE's two 64 KiB `*_reliable_buf` are the first -- must refuse rather
+/// than assume, on the safe side of its own question.
+///
+/// They were stated, resolved and dropped for four phases: the contract schema
+/// has carried all four since `QosDecl` existed, `effective_qos` resolves them
+/// per endpoint into the SystemModel, and `from_model` read `qos.depth` and
+/// nothing else. The one with a live defect behind it is `history`: a
+/// `keep_all` endpoint was priced at whatever `depth` said, which is a silent
+/// UNDER-size (RFC-0100 D6) -- see [`EntityInventory::declared_depths`], which
+/// refuses on it now.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EntityDecl {
     pub kind: EntityKind,
     pub type_name: Option<String>,
     pub name: Option<String>,
     pub depth: Option<u32>,
+    /// phase-454 W3 -- `reliable` / `best_effort`, or `None` for "nobody said".
+    pub reliability: Option<QoSReliabilityPolicy>,
+    /// phase-454 W3 -- `volatile` / `transient_local`, or `None`.
+    pub durability: Option<QoSDurabilityPolicy>,
+    /// phase-454 W3 -- `keep_last` / `keep_all`, or `None`.
+    pub history: Option<QoSHistoryPolicy>,
 }
 
 impl EntityDecl {
+    /// A row that states no QoS policy at all.
+    ///
+    /// Every producer but `from_model` builds one of these -- the `ENTITIES`
+    /// grammar models only `@depth=`, and the timer/service rows carry no QoS
+    /// by construction. Spelled once so that adding a fifth policy is one
+    /// signature change rather than a sweep over thirteen struct literals, and
+    /// so that a site which MEANT to state one is the site that does not call
+    /// this.
+    pub fn bare(kind: EntityKind, type_name: Option<String>, name: Option<String>) -> Self {
+        Self {
+            kind,
+            type_name,
+            name,
+            depth: None,
+            reliability: None,
+            durability: None,
+            history: None,
+        }
+    }
+
     /// Parse the declaration spelling:
     /// `<kind>[:<type>[:<name>]][@<attr>=<value>...]`.
     ///
@@ -458,10 +521,17 @@ impl EntityDecl {
         }
         Ok((0..repeat)
             .map(|_| EntityDecl {
-                kind,
-                type_name: type_name.map(str::to_string),
-                name: name.map(str::to_string),
+                // phase-454 W3 -- the other three policies stay `None` on this
+                // road. The grammar models `@depth=` and nothing else, and the
+                // contract is the surface that carries the rest (RFC-0100 D3);
+                // inventing `@reliability=` here would add a second producer to
+                // a grammar phase-454 W9 retires.
                 depth,
+                ..EntityDecl::bare(
+                    kind,
+                    type_name.map(str::to_string),
+                    name.map(str::to_string),
+                )
             })
             .collect())
     }
@@ -997,6 +1067,149 @@ impl DeclaredDepths {
     }
 }
 
+/// The three QoS policies that are NOT a depth -- phase-454 W3, issue 1256.
+///
+/// One enumerated once, so a consumer that prices only one of them still reads
+/// a table with the join key ([`DeclaredDepth`]'s `(kind, type, topic)`) and
+/// still has to answer "did every endpoint state it?" for its own policy. The
+/// three are separate questions and the counts below are kept separately for
+/// exactly that reason: an image where every subscription states `reliability`
+/// and none states `durability` can size XRCE's reliable buffers and must
+/// refuse a transient-local retention budget, and one count over "any policy"
+/// would answer neither.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QosPolicyKind {
+    Reliability,
+    Durability,
+    History,
+}
+
+/// Every policy in [`QosPolicyKind`], for a consumer that walks them.
+pub const ALL_QOS_POLICY_KINDS: &[QosPolicyKind] = &[
+    QosPolicyKind::Reliability,
+    QosPolicyKind::Durability,
+    QosPolicyKind::History,
+];
+
+impl QosPolicyKind {
+    /// The lower-case name, as it is written in a contract and in the JSON.
+    pub fn tag(self) -> &'static str {
+        match self {
+            QosPolicyKind::Reliability => "reliability",
+            QosPolicyKind::Durability => "durability",
+            QosPolicyKind::History => "history",
+        }
+    }
+
+    /// The CMake variable INFIX -- `NROS_ENTITY_DECLARED_<INFIX>` and
+    /// `NROS_ENTITY_UNDECLARED_<INFIX>_COUNT_<KIND>`.
+    pub fn cmake_infix(self) -> &'static str {
+        match self {
+            QosPolicyKind::Reliability => "RELIABILITY",
+            QosPolicyKind::Durability => "DURABILITY",
+            QosPolicyKind::History => "HISTORY",
+        }
+    }
+}
+
+/// One endpoint's stated QoS policies, other than the depth.
+///
+/// Keyed exactly as [`DeclaredDepth`] is, so the two tables join without a
+/// second naming convention -- and an endpoint appears here whenever it states
+/// ANY of the three, which is not the same set as the endpoints that state a
+/// depth. A field is `None` when that policy was not stated; that is the
+/// `undeclared` half of the view, per policy and per kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredQosPolicies {
+    pub kind: EntityKind,
+    pub type_name: String,
+    pub topic: String,
+    pub reliability: Option<QoSReliabilityPolicy>,
+    pub durability: Option<QoSDurabilityPolicy>,
+    pub history: Option<QoSHistoryPolicy>,
+}
+
+impl DeclaredQosPolicies {
+    /// The stated value of one policy, in the contract's own spelling.
+    pub fn spelling(&self, policy: QosPolicyKind) -> Option<&'static str> {
+        match policy {
+            QosPolicyKind::Reliability => self.reliability.map(reliability_spelling),
+            QosPolicyKind::Durability => self.durability.map(durability_spelling),
+            QosPolicyKind::History => self.history.map(history_spelling),
+        }
+    }
+}
+
+/// Every stated non-depth QoS policy in an image, plus what stayed silent.
+///
+/// Same three-state discipline as [`DeclaredDepths`], and refused for the same
+/// one reason: the inventory itself did not compose, so whole components are
+/// missing and a missing row reads as "nobody declared this endpoint".
+///
+/// It does NOT refuse on `history = keep_all`. That refusal is per-FACT
+/// (RFC-0100 D6) and the fact it kills is the DEPTH-derived one: a KEEP_ALL
+/// queue has no static bound, so a depth beside it prices nothing. The
+/// statement "this endpoint asked for KEEP_ALL" is itself perfectly well
+/// declared, and a consumer -- an XRCE `STREAM_HISTORY`, a Cyclone resource
+/// limit -- must be able to read it. Degrading it would be the global refusal
+/// D6 exists to forbid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeclaredQos {
+    Resolved {
+        /// Sorted by `(kind, type_name, topic)`, like the depth table.
+        rows: Vec<DeclaredQosPolicies>,
+        /// Per policy, per kind: endpoints of that kind that COULD have stated
+        /// the policy and did not. `[(policy, kind) -> count]`, flattened into
+        /// two small maps so the render stays a loop rather than nine fields.
+        undeclared_subscriptions: [usize; 3],
+        undeclared_publishers: [usize; 3],
+    },
+    Refused {
+        reason: String,
+    },
+}
+
+impl DeclaredQos {
+    pub fn tag(&self) -> &'static str {
+        match self {
+            DeclaredQos::Resolved { .. } => "resolved",
+            DeclaredQos::Refused { .. } => "refused",
+        }
+    }
+
+    pub fn rows(&self) -> Option<&[DeclaredQosPolicies]> {
+        match self {
+            DeclaredQos::Resolved { rows, .. } => Some(rows),
+            DeclaredQos::Refused { .. } => None,
+        }
+    }
+
+    /// How many endpoints of `kind` did NOT state `policy`.
+    ///
+    /// `None` on a refusal, and that is the point: zero and "no answer" are the
+    /// two things this view exists to keep apart.
+    pub fn undeclared(&self, policy: QosPolicyKind, kind: EntityKind) -> Option<usize> {
+        let DeclaredQos::Resolved {
+            undeclared_subscriptions,
+            undeclared_publishers,
+            ..
+        } = self
+        else {
+            return None;
+        };
+        let i = ALL_QOS_POLICY_KINDS.iter().position(|p| *p == policy)?;
+        match kind {
+            EntityKind::Subscription => Some(undeclared_subscriptions[i]),
+            EntityKind::Publisher => Some(undeclared_publishers[i]),
+            // Only the two topic kinds are counted. A service server states no
+            // `reliability:` in any contract schema, so a count over it would
+            // be a number nothing can ever move off its maximum -- issue 1227's
+            // finding, which is why the depth counts are per kind too.
+            _ => None,
+        }
+    }
+}
+
 /// phase-446 W4 -- the parameter every node carries without declaring it.
 ///
 /// `Executor::seed_use_sim_time_default` declares `use_sim_time` on EVERY node
@@ -1497,21 +1710,83 @@ impl EntityInventory {
                 .and_then(|q| q.depth)
         };
 
+        // phase-454 W3 (issue 1256) -- the OTHER THREE policies, from whichever
+        // endpoint map the kind lives in.
+        //
+        // `Qos` in the model carries `reliability`, `durability` and `history`
+        // beside `depth`; this function read the fourth and dropped the other
+        // three, which is the whole of issue 1256. They arrive as free-form
+        // strings, so each is parsed through the ONE vocabulary
+        // (`nros_orchestration_ir::qos_override`) the `qos_overrides.*` lowering
+        // already uses.
+        //
+        // An UNRECOGNISED spelling parses to `None` here, which reads as "not
+        // declared" -- and that would be the silent drop this module exists to
+        // refuse. It cannot happen on the road a build takes: `nros ws
+        // entity-inventory` runs `reject_unknown_qos_values` over the same model
+        // BEFORE this, and that is where the error channel is (`from_model`
+        // returns `Option` to say "no wiring described", which has no room for
+        // "what you wrote is wrong" -- the same split issue 1084 made for
+        // `depth: 0`). The refusal is checked, not assumed:
+        // `an_unknown_qos_spelling_is_rejected_before_it_can_be_dropped` is the
+        // test that binds the two halves.
+        let sub_qos = |ep: &str| -> Option<&ros_launch_manifest_model::Qos> {
+            model
+                .contracts
+                .sub_endpoints
+                .get(ep)
+                .and_then(|c| c.qos.as_ref())
+        };
+        let pub_qos = |ep: &str| -> Option<&ros_launch_manifest_model::Qos> {
+            model
+                .contracts
+                .pub_endpoints
+                .get(ep)
+                .and_then(|c| c.qos.as_ref())
+        };
+        fn policies(
+            q: Option<&ros_launch_manifest_model::Qos>,
+        ) -> (
+            Option<QoSReliabilityPolicy>,
+            Option<QoSDurabilityPolicy>,
+            Option<QoSHistoryPolicy>,
+        ) {
+            (
+                q.and_then(|q| q.reliability.as_deref())
+                    .and_then(parse_reliability),
+                q.and_then(|q| q.durability.as_deref())
+                    .and_then(parse_durability),
+                q.and_then(|q| q.history.as_deref()).and_then(parse_history),
+            )
+        }
+
         for (topic, wiring) in &model.structure.topics {
             for ep in &wiring.subscribers {
+                let (reliability, durability, history) = policies(sub_qos(ep));
                 per_node.entry(node_of(ep)).or_default().push(EntityDecl {
-                    kind: EntityKind::Subscription,
-                    type_name: Some(wiring.msg_type.clone()),
-                    name: Some(topic.clone()),
                     depth: sub_depth_of(ep),
+                    reliability,
+                    durability,
+                    history,
+                    ..EntityDecl::bare(
+                        EntityKind::Subscription,
+                        Some(wiring.msg_type.clone()),
+                        Some(topic.clone()),
+                    )
                 });
             }
             for ep in &wiring.publishers {
+                let (reliability, durability, history) = policies(pub_qos(ep));
                 per_node.entry(node_of(ep)).or_default().push(EntityDecl {
-                    kind: EntityKind::Publisher,
-                    type_name: Some(wiring.msg_type.clone()),
-                    name: Some(topic.clone()),
                     depth: pub_depth_of(ep),
+                    reliability,
+                    durability,
+                    history,
+                    ..EntityDecl::bare(
+                        EntityKind::Publisher,
+                        Some(wiring.msg_type.clone()),
+                        Some(topic.clone()),
+                    )
                 });
             }
         }
@@ -1534,15 +1809,17 @@ impl EntityInventory {
             for (service, wiring) in wirings {
                 for (kind, eps) in [(server_kind, &wiring.server), (client_kind, &wiring.client)] {
                     for ep in eps {
-                        per_node.entry(node_of(ep)).or_default().push(EntityDecl {
-                            kind,
-                            type_name: Some(wiring.srv_type.clone()),
-                            // The SERVICE / ACTION name, for the same reason
-                            // the topic is used above: it is the string the
-                            // call site writes.
-                            name: Some(service.clone()),
-                            depth: None,
-                        });
+                        per_node
+                            .entry(node_of(ep))
+                            .or_default()
+                            .push(EntityDecl::bare(
+                                kind,
+                                Some(wiring.srv_type.clone()),
+                                // The SERVICE / ACTION name, for the same reason
+                                // the topic is used above: it is the string the
+                                // call site writes.
+                                Some(service.clone()),
+                            ));
                     }
                 }
             }
@@ -1563,12 +1840,11 @@ impl EntityInventory {
             per_node
                 .entry(node_of(path_key))
                 .or_default()
-                .push(EntityDecl {
-                    kind: EntityKind::Timer,
-                    type_name: None,
-                    name: Some(path_key.clone()),
-                    depth: None,
-                });
+                .push(EntityDecl::bare(
+                    EntityKind::Timer,
+                    None,
+                    Some(path_key.clone()),
+                ));
         }
 
         let mut inv = Self::new(source);
@@ -2012,6 +2288,37 @@ impl EntityInventory {
     /// has not opted in, which is not an error. The arena (step 3) refuses on a
     /// non-zero `undeclared` the way W8 refuses on an unbounded type; the
     /// compile-time check sees no row and asserts nothing.
+    ///
+    /// # …and it DOES refuse on `history = keep_all` (phase-454 W3, RFC-0100 D6)
+    ///
+    /// This is the one live defect behind that wave, and it is the only trigger
+    /// in the whole sizing model that could ship a buffer that is too SMALL
+    /// rather than too large.
+    ///
+    /// `KEEP_LAST(n)` bounds a queue at `n` samples. `KEEP_ALL` bounds it at
+    /// nothing -- DDS keeps every sample the resource limits allow, and no
+    /// number in a contract says how many that is. A `keep_all` endpoint that
+    /// also states `depth: 1` was priced at 1 here: the depth reached the table,
+    /// the history did not, and the arena budgeted one sample for a queue with
+    /// no bound. That is a silent UNDER-size, and it lands as
+    /// `NodeError::BufferTooSmall` at a registration the arena oracle passed.
+    ///
+    /// So the DEPTH-derived facts refuse, and they refuse whether or not a depth
+    /// was stated beside the `keep_all` -- a stated depth is not a cap on a
+    /// KEEP_ALL queue, it is a number that has stopped meaning what it says.
+    ///
+    /// The refusal is PER FACT and stops here. A `keep_all` subscription says
+    /// nothing about Cyclone's type table, about the entity counts, or about the
+    /// parameter store, and D6 forbids degrading them: *"a `keep_all`
+    /// subscription says nothing about Cyclone's type table, and a global
+    /// refusal would degrade it anyway."* [`EntityInventory::declared_qos`] keeps
+    /// resolving too, including the `keep_all` row itself -- the statement is
+    /// well declared, it is only the DEPTH arithmetic that has no answer.
+    ///
+    /// And it does not fall back to a number. RFC-0100 D6: a refused fact never
+    /// silently widens its basis, because *"that publishes the wrong row while
+    /// every status still reads 'derived', which is the shape that looks like it
+    /// worked."*
     pub fn declared_depths(&self) -> DeclaredDepths {
         if let Derivation::Refused { reason } = self.derive() {
             return DeclaredDepths::Refused {
@@ -2020,6 +2327,48 @@ impl EntityInventory {
                      would be missing whole components -- and a missing row reads as \"nobody \
                      declared this endpoint\", which is the one thing the table must never \
                      say wrongly:\n{reason}"
+                ),
+            };
+        }
+
+        // phase-454 W3 -- KEEP_ALL first, because every number below it would be
+        // an answer to a question that has none. Named endpoints, not a count: a
+        // refusal a user cannot act on is a refusal they work around.
+        let keep_all: Vec<String> = self
+            .components()
+            .iter()
+            .flat_map(|c| {
+                c.declaration
+                    .entities()
+                    .iter()
+                    .filter(|e| e.history == Some(QoSHistoryPolicy::KeepAll))
+                    .map(move |e| {
+                        format!(
+                            "    {}::{} declares a `{}` on `{}`{}",
+                            c.pkg,
+                            c.component,
+                            e.kind.tag(),
+                            e.name.as_deref().unwrap_or("<unnamed>"),
+                            match e.depth {
+                                Some(d) => format!(" with `depth: {d}` beside it"),
+                                None => String::new(),
+                            }
+                        )
+                    })
+            })
+            .collect();
+        if !keep_all.is_empty() {
+            return DeclaredDepths::Refused {
+                reason: format!(
+                    "{} endpoint(s) declare `history: keep_all`, which has NO STATIC BOUND -- \
+                     KEEP_ALL keeps every sample the resource limits allow, and no number in a \
+                     contract says how many that is:\n{}\nA depth stated beside KEEP_ALL is not \
+                     a cap on the queue, so pricing from it would UNDER-size the buffer and ship \
+                     `BufferTooSmall` at a registration this table had passed. Declare \
+                     `history: keep_last` with the `depth:` you mean, which is the pair every \
+                     size consumer here can derive from.",
+                    keep_all.len(),
+                    keep_all.join("\n")
                 ),
             };
         }
@@ -2068,6 +2417,98 @@ impl EntityInventory {
         DeclaredDepths::Resolved {
             rows,
             undeclared,
+            undeclared_subscriptions,
+            undeclared_publishers,
+        }
+    }
+
+    /// The other three QoS policies -- phase-454 W3, issue 1256.
+    ///
+    /// Sibling of [`Self::declared_depths`], and deliberately a SEPARATE view
+    /// rather than three more columns on that one. Two reasons:
+    ///
+    /// 1. **Its population differs.** A depth row exists only where a depth was
+    ///    stated; an endpoint can state `reliability: best_effort` and no depth
+    ///    at all, and it has to appear somewhere.
+    /// 2. **Its status differs, and that is the whole of RFC-0100 D6.** A
+    ///    `keep_all` endpoint makes the depth table REFUSE and leaves this one
+    ///    resolved, because the policy is well declared and only the depth
+    ///    arithmetic has no answer. Folding them into one view would make the
+    ///    per-fact refusal impossible to express.
+    ///
+    /// Refuses on exactly the one condition the depth table refuses on and no
+    /// other: the inventory itself did not compose, so whole components are
+    /// missing and an absent row would read as "nobody declared this endpoint".
+    pub fn declared_qos(&self) -> DeclaredQos {
+        if let Derivation::Refused { reason } = self.derive() {
+            return DeclaredQos::Refused {
+                reason: format!(
+                    "the entity inventory itself did not compose, so the declared-QoS table \
+                     would be missing whole components -- and a missing row reads as \"nobody \
+                     declared this endpoint\", which is the one thing the table must never \
+                     say wrongly:\n{reason}"
+                ),
+            };
+        }
+
+        let mut rows: Vec<DeclaredQosPolicies> = Vec::new();
+        let mut undeclared_subscriptions = [0usize; 3];
+        let mut undeclared_publishers = [0usize; 3];
+        for c in self.components() {
+            for e in c.declaration.entities() {
+                // The same population the depth view walks: a timer and a guard
+                // condition carry no QoS at all, so counting them as "did not
+                // state a reliability" would pin every consumer on its worst
+                // case for endpoints that cannot ever state one.
+                if !e.kind.carries_qos_depth() {
+                    continue;
+                }
+                let counts = match e.kind {
+                    EntityKind::Subscription => Some(&mut undeclared_subscriptions),
+                    EntityKind::Publisher => Some(&mut undeclared_publishers),
+                    // Services and actions carry QoS in ROS, but no contract
+                    // schema states one for them and `from_model` has no map to
+                    // read it from. Counting them would make every count
+                    // permanently non-zero -- issue 1227's defect exactly.
+                    _ => None,
+                };
+                if let Some(counts) = counts {
+                    for (i, policy) in ALL_QOS_POLICY_KINDS.iter().enumerate() {
+                        let stated = match policy {
+                            QosPolicyKind::Reliability => e.reliability.is_some(),
+                            QosPolicyKind::Durability => e.durability.is_some(),
+                            QosPolicyKind::History => e.history.is_some(),
+                        };
+                        // A policy stated on an endpoint with no type or no
+                        // topic cannot be JOINED to anything, so it counts as
+                        // undeclared rather than being dropped -- the rule the
+                        // depth view applies to the same shape.
+                        if !stated || e.type_name.is_none() || e.name.is_none() {
+                            counts[i] += 1;
+                        }
+                    }
+                }
+                let (Some(t), Some(n)) = (&e.type_name, &e.name) else {
+                    continue;
+                };
+                if e.reliability.is_none() && e.durability.is_none() && e.history.is_none() {
+                    continue;
+                }
+                rows.push(DeclaredQosPolicies {
+                    kind: e.kind,
+                    type_name: t.clone(),
+                    topic: n.clone(),
+                    reliability: e.reliability,
+                    durability: e.durability,
+                    history: e.history,
+                });
+            }
+        }
+        rows.sort_by(|a, b| {
+            (a.kind.tag(), &a.type_name, &a.topic).cmp(&(b.kind.tag(), &b.type_name, &b.topic))
+        });
+        DeclaredQos::Resolved {
+            rows,
             undeclared_subscriptions,
             undeclared_publishers,
         }
@@ -2359,6 +2800,69 @@ impl EntityInventory {
             }
             doc.insert("declared_depths".into(), serde_json::Value::Object(m));
         }
+        // phase-454 W3 (issue 1256) -- the OTHER THREE policies, as their own
+        // view with its own status. Its own, and not three more columns on the
+        // block above, because the two statuses genuinely differ: `history:
+        // keep_all` REFUSES the depth table and leaves this one resolved
+        // (RFC-0100 D6 -- refusal is per fact), and a reader that found the
+        // policies inside a refused `declared_depths` would lose the only
+        // statement that explains the refusal.
+        {
+            let qos = self.declared_qos();
+            let mut m = serde_json::Map::new();
+            m.insert("status".into(), qos.tag().into());
+            match &qos {
+                DeclaredQos::Refused { reason } => {
+                    m.insert("reason".into(), reason.clone().into());
+                }
+                DeclaredQos::Resolved { rows, .. } => {
+                    // Per policy AND per kind. One "undeclared" number over
+                    // three independent questions would answer none of them:
+                    // an image can state `reliability` on every subscription
+                    // and `durability` on none, which lets XRCE size its
+                    // reliable buffers and must still refuse a transient-local
+                    // retention budget.
+                    for policy in ALL_QOS_POLICY_KINDS {
+                        for (kind, suffix) in [
+                            (EntityKind::Subscription, "subscriptions"),
+                            (EntityKind::Publisher, "publishers"),
+                        ] {
+                            if let Some(n) = qos.undeclared(*policy, kind) {
+                                m.insert(format!("undeclared_{}_{suffix}", policy.tag()), n.into());
+                            }
+                        }
+                    }
+                    m.insert(
+                        "endpoints".into(),
+                        rows.iter()
+                            .map(|r| {
+                                let mut o = serde_json::Map::new();
+                                o.insert("kind".into(), r.kind.tag().into());
+                                o.insert("type_name".into(), r.type_name.clone().into());
+                                o.insert(
+                                    "dds_type_name".into(),
+                                    dds_type_name(&r.type_name).into(),
+                                );
+                                o.insert("name".into(), r.topic.clone().into());
+                                // A policy this endpoint did not state is
+                                // ABSENT from its object, never `null` and
+                                // never a default: "nobody said" is the claim,
+                                // and a defaulted `"volatile"` here would be
+                                // the silent drop this wave exists to end.
+                                for policy in ALL_QOS_POLICY_KINDS {
+                                    if let Some(v) = r.spelling(*policy) {
+                                        o.insert(policy.tag().into(), v.into());
+                                    }
+                                }
+                                serde_json::Value::Object(o)
+                            })
+                            .collect::<Vec<_>>()
+                            .into(),
+                    );
+                }
+            }
+            doc.insert("declared_qos".into(), serde_json::Value::Object(m));
+        }
         // phase-446 W4 -- the parameter store, same three-state shape: a
         // `status` always, the numbers only when every node declared.
         {
@@ -2643,6 +3147,11 @@ impl EntityInventory {
         // without it. Emitted in both branches for the same reason they are: an
         // absent variable would read as "every endpoint is depth 0".
         s.push_str(&render_declared_depths(&self.declared_depths()));
+        // phase-454 W3 -- the other three QoS policies. Rendered in both
+        // branches for the same reason every view above is: an absent list
+        // would read as "no endpoint stated a reliability", which is the claim
+        // a refusal must never make on an image's behalf.
+        s.push_str(&render_declared_qos(&self.declared_qos()));
         // phase-446 W4 -- the PARAMETER STORE. Independent of the entity
         // derivation above, so it renders in either branch.
         s.push_str(&render_param_store(&self.params));
@@ -2835,6 +3344,113 @@ fn render_declared_depths(d: &DeclaredDepths) -> String {
             s.push_str(&format!(
                 "set(NROS_ENTITY_UNDECLARED_DEPTH_COUNT_PUBLISHER {undeclared_publishers})\n"
             ));
+        }
+    }
+    s
+}
+
+/// The other three QoS policies, as CMake -- phase-454 W3, issue 1256.
+///
+/// Publishes, per policy P in {RELIABILITY, DURABILITY, HISTORY}:
+///
+///   `NROS_ENTITY_DECLARED_QOS_STATUS`            resolved | refused
+///   `NROS_ENTITY_DECLARED_QOS_REASON`            prose, when refused
+///   `NROS_ENTITY_DECLARED_<P>`                   SUBSCRIPTION `type|topic=value`
+///   `NROS_ENTITY_DECLARED_<P>_PUBLISHER`         the publisher list
+///   `NROS_ENTITY_UNDECLARED_<P>_COUNT_SUBSCRIPTION`
+///   `NROS_ENTITY_UNDECLARED_<P>_COUNT_PUBLISHER`
+///
+/// # Why one list per policy, and per kind
+///
+/// The grammar is `type|topic=value`, the SAME one the depth lists use, so a
+/// consumer already has the parse. Packing three policies into one row would
+/// need a second separator inside a field whose separator is already `|`, and
+/// a cmake list whose elements contain the list separator is the class of bug
+/// that reads as working until one topic is unusual.
+///
+/// Per KIND for the reason phase-454 W2 split the depth lists and issue 1227
+/// split the counts before it: a consumer prices ONE kind, and a count over
+/// both means one unannotated endpoint of the other kind pins it on its worst
+/// case forever. The first consumer here will be XRCE's, whose two 64 KiB
+/// `*_reliable_buf` are a per-SESSION cost gated on whether anything in the
+/// image asked for `reliable` -- and that is a question about this image's
+/// endpoints, not about a default.
+///
+/// Nothing reads these yet. They are wave W6's inputs, and W3's job is that the
+/// fact stated in the contract reaches the build at all; see the module header
+/// on why a declaration that is legal to write and silently dropped is the
+/// worst of the three possible outcomes.
+fn render_declared_qos(q: &DeclaredQos) -> String {
+    let mut s = String::from(
+        "# phase-454 W3 (issue 1256) -- the DECLARED QoS policies other than the depth.\n\
+         # A contract has been able to state `reliability`, `durability` and `history`\n\
+         # per endpoint since the schema had a `qos:` key; nano-ros read `depth` and\n\
+         # dropped the rest, so `reliability: best_effort` was legal to write, legal to\n\
+         # resolve, and read by nobody.\n\
+         #\n\
+         # ABSENCE IS NOT A VALUE. An endpoint missing from a list did not state that\n\
+         # policy; it did not state `volatile`. A consumer that sizes from one must\n\
+         # read the UNDECLARED count for ITS OWN policy and ITS OWN kind, and refuse on\n\
+         # the safe side of its own question -- for XRCE's two 64 KiB reliable buffers\n\
+         # the safe side is to assume RELIABLE and pay them (RFC-0100 D6).\n\
+         #\n\
+         # `history: keep_all` is NOT refused here. It refuses the DEPTH table above,\n\
+         # because a KEEP_ALL queue has no static bound and a depth stated beside it\n\
+         # prices nothing. The statement itself is well declared and a consumer that\n\
+         # reads history (an XRCE STREAM_HISTORY, a Cyclone resource limit) must see\n\
+         # it -- refusal is per fact, never global.\n",
+    );
+    s.push_str(&format!(
+        "set(NROS_ENTITY_DECLARED_QOS_STATUS \"{}\")\n",
+        q.tag()
+    ));
+    match q {
+        DeclaredQos::Refused { reason } => {
+            s.push_str(&format!(
+                "set(NROS_ENTITY_DECLARED_QOS_REASON \"{}\")\n",
+                cmake_escape(reason)
+            ));
+            s.push_str(
+                "# No policy table. A consumer that needs one must REFUSE -- a partial table\n\
+                 # is indistinguishable from an image whose endpoints all took the default.\n",
+            );
+        }
+        DeclaredQos::Resolved { rows, .. } => {
+            for policy in ALL_QOS_POLICY_KINDS {
+                let infix = policy.cmake_infix();
+                for (kind, suffix) in [
+                    (EntityKind::Subscription, ""),
+                    (EntityKind::Publisher, "_PUBLISHER"),
+                ] {
+                    let triples: Vec<String> = rows
+                        .iter()
+                        .filter(|r| r.kind == kind)
+                        .filter_map(|r| {
+                            r.spelling(*policy)
+                                .map(|v| format!("{}|{}={v}", r.type_name, r.topic))
+                        })
+                        .collect();
+                    s.push_str(&format!(
+                        "set(NROS_ENTITY_DECLARED_{infix}{suffix} \"{}\")\n",
+                        triples.join(";")
+                    ));
+                }
+                for (kind, suffix) in [
+                    (EntityKind::Subscription, "SUBSCRIPTION"),
+                    (EntityKind::Publisher, "PUBLISHER"),
+                ] {
+                    // `undeclared` returns `None` only on a refusal, and this
+                    // arm is the resolved one -- so the `unwrap_or` never fires
+                    // and a 0 it wrote would be a lie. Spelled as a match so a
+                    // future kind cannot silently become "0 undeclared".
+                    let n = q
+                        .undeclared(*policy, kind)
+                        .expect("a resolved table counts both topic kinds");
+                    s.push_str(&format!(
+                        "set(NROS_ENTITY_UNDECLARED_{infix}_COUNT_{suffix} {n})\n"
+                    ));
+                }
+            }
         }
     }
     s
@@ -4426,12 +5042,11 @@ structure:
             pkg: "p".into(),
             component: "talker".into(),
             class: "Talker".into(),
-            declaration: Declaration::Stated(vec![EntityDecl {
-                kind: EntityKind::Publisher,
-                type_name: Some("std_msgs/msg/String".into()),
-                name: Some("/chatter".into()),
-                depth: None,
-            }]),
+            declaration: Declaration::Stated(vec![EntityDecl::bare(
+                EntityKind::Publisher,
+                Some("std_msgs/msg/String".into()),
+                Some("/chatter".into()),
+            )]),
         });
         let d = inv.derive();
         let k = d.knobs().expect("a stated declaration derives");
@@ -4462,18 +5077,12 @@ structure:
             component: "mrm_handler".into(),
             class: "MrmHandler".into(),
             declaration: Declaration::Stated(vec![
-                EntityDecl {
-                    kind: EntityKind::Subscription,
-                    type_name: Some("a/msg/A".into()),
-                    name: Some("/one".into()),
-                    depth: None,
-                },
-                EntityDecl {
-                    kind: EntityKind::Timer,
-                    type_name: None,
-                    name: None,
-                    depth: None,
-                },
+                EntityDecl::bare(
+                    EntityKind::Subscription,
+                    Some("a/msg/A".into()),
+                    Some("/one".into()),
+                ),
+                EntityDecl::bare(EntityKind::Timer, None, None),
             ]),
         });
 
@@ -4483,18 +5092,16 @@ structure:
             component: "mrm_handler".into(),
             class: String::new(),
             declaration: Declaration::Stated(vec![
-                EntityDecl {
-                    kind: EntityKind::Subscription,
-                    type_name: Some("a/msg/A".into()),
-                    name: Some("/one".into()),
-                    depth: None,
-                },
-                EntityDecl {
-                    kind: EntityKind::Subscription,
-                    type_name: Some("b/msg/B".into()),
-                    name: Some("/two".into()),
-                    depth: None,
-                },
+                EntityDecl::bare(
+                    EntityKind::Subscription,
+                    Some("a/msg/A".into()),
+                    Some("/one".into()),
+                ),
+                EntityDecl::bare(
+                    EntityKind::Subscription,
+                    Some("b/msg/B".into()),
+                    Some("/two".into()),
+                ),
             ]),
         });
 
@@ -4956,6 +5563,634 @@ contracts:
         );
     }
 
+    // -----------------------------------------------------------------
+    // phase-454 W3 (issue 1256) -- the other three QoS policies.
+    // -----------------------------------------------------------------
+
+    /// One topic, both sides stating all four policies, and a silent pair
+    /// beside it.
+    fn model_with_four_policies() -> ros_launch_manifest_model::SystemModel {
+        model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /talker:
+      { scope: s.launch.xml, pkg: talker_pkg, exec: talker, node_name: talker }
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      pub: [/talker/chatter]
+      sub: [/listener/chatter]
+    /quiet:
+      type: std_msgs/msg/Int32
+      pub: [/talker/quiet]
+      sub: [/listener/quiet]
+contracts:
+  pub_endpoints:
+    /talker/chatter:
+      qos:
+        depth: 8
+        reliability: reliable
+        durability: transient_local
+        history: keep_last
+  sub_endpoints:
+    /listener/chatter:
+      qos:
+        depth: 3
+        reliability: best_effort
+        durability: volatile
+        history: keep_last
+"#,
+        )
+    }
+
+    /// One entity row as the acceptance below reads it: `(kind, topic, depth,
+    /// reliability, durability, history)` -- the FOUR policies plus what
+    /// identifies the endpoint. Every field is `Option` because "nobody said"
+    /// is the claim this whole module exists to keep distinguishable from a
+    /// value.
+    type DeclaredRow = (
+        &'static str,
+        Option<String>,
+        Option<u32>,
+        Option<QoSReliabilityPolicy>,
+        Option<QoSDurabilityPolicy>,
+        Option<QoSHistoryPolicy>,
+    );
+
+    /// phase-454 W3 -- all four policies reach the entity rows, and the two
+    /// sides keep their OWN profiles.
+    ///
+    /// `from_model` read `qos.depth` and dropped the other three, so a contract
+    /// saying `reliability: best_effort` parsed, resolved, and was read by
+    /// nobody -- issue 1256. The two endpoints state different profiles on
+    /// purpose: a reader that looked in the wrong endpoint map would pass a
+    /// fixture where both sides agree.
+    #[test]
+    fn all_four_declared_policies_reach_the_inventory() {
+        let inv = EntityInventory::from_model("test", &model_with_four_policies())
+            .expect("model describes wiring");
+        let mut rows: Vec<DeclaredRow> = inv
+            .components()
+            .iter()
+            .flat_map(|c| c.declaration.entities())
+            .filter(|e| e.kind == EntityKind::Publisher || e.kind == EntityKind::Subscription)
+            .map(|e| {
+                (
+                    e.kind.tag(),
+                    e.name.clone(),
+                    e.depth,
+                    e.reliability,
+                    e.durability,
+                    e.history,
+                )
+            })
+            .collect();
+        rows.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "publisher",
+                    Some("/chatter".to_string()),
+                    Some(8),
+                    Some(QoSReliabilityPolicy::Reliable),
+                    Some(QoSDurabilityPolicy::TransientLocal),
+                    Some(QoSHistoryPolicy::KeepLast),
+                ),
+                // ABSENCE IS NOT A VALUE. The silent publisher is `None` on
+                // every policy, never `Volatile` and never `Reliable`: those
+                // are ROS's defaults for an endpoint that did not choose, and
+                // recording one here would make "took the default" and "asked
+                // for it" the same row.
+                (
+                    "publisher",
+                    Some("/quiet".to_string()),
+                    None,
+                    None,
+                    None,
+                    None
+                ),
+                (
+                    "subscription",
+                    Some("/chatter".to_string()),
+                    Some(3),
+                    Some(QoSReliabilityPolicy::BestEffort),
+                    Some(QoSDurabilityPolicy::Volatile),
+                    Some(QoSHistoryPolicy::KeepLast),
+                ),
+                (
+                    "subscription",
+                    Some("/quiet".to_string()),
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ]
+        );
+    }
+
+    /// phase-454 W3 -- and into the policy VIEW, with a per-policy, per-kind
+    /// count of what stayed silent.
+    ///
+    /// Three counts and not one, for the reason issue 1227 gave the depth
+    /// counts one per kind: an image can state `reliability` on every
+    /// subscription and `durability` on none, and a single "some policy is
+    /// missing" number would pin the reliability consumer on its worst case for
+    /// a gap that is not its own.
+    #[test]
+    fn the_policy_view_counts_what_stayed_silent_per_policy_and_per_kind() {
+        let inv = EntityInventory::from_model("test", &model_with_four_policies())
+            .expect("model describes wiring");
+        let qos = inv.declared_qos();
+        let rows = qos.rows().expect("a composed inventory resolves");
+        assert_eq!(
+            rows.iter()
+                .map(|r| (
+                    r.kind.tag(),
+                    r.topic.as_str(),
+                    r.spelling(QosPolicyKind::Reliability)
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("publisher", "/chatter", Some("reliable")),
+                ("subscription", "/chatter", Some("best_effort")),
+            ],
+            "only the endpoints that stated SOMETHING get a row"
+        );
+        for policy in ALL_QOS_POLICY_KINDS {
+            assert_eq!(
+                qos.undeclared(*policy, EntityKind::Subscription),
+                Some(1),
+                "{}",
+                policy.tag()
+            );
+            assert_eq!(
+                qos.undeclared(*policy, EntityKind::Publisher),
+                Some(1),
+                "{}",
+                policy.tag()
+            );
+        }
+    }
+
+    /// phase-454 W3 -- a policy declared on only ONE of the three axes leaves
+    /// the other two counted as silent.
+    ///
+    /// The case the three-counts-in-one shape would get wrong, isolated: an
+    /// image that states `reliability` everywhere and nothing else can size
+    /// XRCE's reliable buffers and must still refuse a transient-local
+    /// retention budget.
+    #[test]
+    fn one_stated_policy_does_not_answer_for_the_other_two() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      sub: [/listener/chatter]
+contracts:
+  sub_endpoints:
+    /listener/chatter:
+      qos: { reliability: best_effort }
+"#,
+        );
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        let qos = inv.declared_qos();
+        assert_eq!(
+            qos.undeclared(QosPolicyKind::Reliability, EntityKind::Subscription),
+            Some(0),
+            "every subscription stated one, so a reliability consumer may size"
+        );
+        assert_eq!(
+            qos.undeclared(QosPolicyKind::Durability, EntityKind::Subscription),
+            Some(1)
+        );
+        assert_eq!(
+            qos.undeclared(QosPolicyKind::History, EntityKind::Subscription),
+            Some(1)
+        );
+        // The row exists because SOMETHING was stated, and it carries only what
+        // was: the two absent policies are absent from it, never defaulted.
+        let row = &qos.rows().expect("resolved")[0];
+        assert_eq!(
+            row.spelling(QosPolicyKind::Reliability),
+            Some("best_effort")
+        );
+        assert_eq!(row.spelling(QosPolicyKind::Durability), None);
+        assert_eq!(row.spelling(QosPolicyKind::History), None);
+        // ...and no depth was stated either, so the depth table still refuses
+        // through its own count. Two views, two independent answers.
+        let DeclaredDepths::Resolved {
+            undeclared_subscriptions,
+            ..
+        } = inv.declared_depths()
+        else {
+            panic!("no keep_all here");
+        };
+        assert_eq!(undeclared_subscriptions, 1);
+    }
+
+    /// phase-454 W3 -- `history: keep_all` REFUSES the depth-derived facts, and
+    /// the refusal names the endpoint.
+    ///
+    /// THE defect of this wave. A KEEP_ALL queue has no static bound; the depth
+    /// stated beside it was read and the history was not, so the arena budgeted
+    /// one sample for a queue DDS will let grow to the resource limits. That is
+    /// an UNDER-size, the direction that ships `NodeError::BufferTooSmall` at a
+    /// registration the sizing model had passed -- and RFC-0100 D6's only
+    /// trigger that can.
+    #[test]
+    fn a_keep_all_endpoint_refuses_the_depth_table_by_name() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      sub: [/listener/chatter]
+    /quiet:
+      type: std_msgs/msg/Int32
+      sub: [/listener/quiet]
+contracts:
+  sub_endpoints:
+    /listener/chatter:
+      qos: { depth: 1, history: keep_all }
+    /listener/quiet:
+      qos: { depth: 5, history: keep_last }
+"#,
+        );
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        let DeclaredDepths::Refused { reason } = inv.declared_depths() else {
+            panic!("keep_all has no static bound, so the depth table must refuse");
+        };
+        assert!(reason.contains("/chatter"), "names the endpoint: {reason}");
+        assert!(reason.contains("keep_all"), "{reason}");
+        assert!(
+            reason.contains("depth: 1"),
+            "and quotes the number that would have been believed: {reason}"
+        );
+        assert!(
+            reason.contains("keep_last"),
+            "and names the remedy (RFC-0065 D2): {reason}"
+        );
+
+        // No fallback and no partial table. The OTHER subscription's `depth: 5`
+        // is a real declaration and it must not survive alone: a table over the
+        // endpoints that happen to be priceable sizes an image from a subset of
+        // itself, which is the under-report this module exists to prevent.
+        let cmake = inv.to_cmake();
+        assert!(
+            cmake.contains("set(NROS_ENTITY_DECLARED_DEPTH_STATUS \"refused\")\n"),
+            "{cmake}"
+        );
+        assert!(
+            !cmake.contains("set(NROS_ENTITY_DECLARED_DEPTHS "),
+            "not even an empty list, which reads as \"nobody declared\": {cmake}"
+        );
+    }
+
+    /// phase-454 W3 -- a `keep_all` with NO depth beside it refuses just the
+    /// same.
+    ///
+    /// The refusal is a property of KEEP_ALL, not of the pair. Without this the
+    /// obvious implementation -- "refuse when a depth is stated beside a
+    /// keep_all" -- would pass every other test here while leaving the arena to
+    /// fall back to the ROS default 10 for an unbounded queue, which is the
+    /// same under-size one rung quieter.
+    #[test]
+    fn a_keep_all_with_no_depth_beside_it_refuses_too() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      sub: [/listener/chatter]
+contracts:
+  sub_endpoints:
+    /listener/chatter:
+      qos: { history: keep_all }
+"#,
+        );
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        assert!(
+            matches!(inv.declared_depths(), DeclaredDepths::Refused { .. }),
+            "KEEP_ALL has no bound whether or not a depth was written beside it"
+        );
+    }
+
+    /// phase-454 W3 -- and a PUBLISHER's `keep_all` refuses too.
+    ///
+    /// Publisher-side history is a real queue with a real cost (it is what
+    /// `transient_local` retention is sized from), and W2 made a publisher's
+    /// depth travel. A refusal that read only `sub_endpoints` would be issue
+    /// 1084's defect one map over, for the third time.
+    #[test]
+    fn a_publisher_keep_all_refuses_the_depth_table_too() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /talker:
+      { scope: s.launch.xml, pkg: talker_pkg, exec: talker, node_name: talker }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      pub: [/talker/chatter]
+contracts:
+  pub_endpoints:
+    /talker/chatter:
+      qos: { depth: 4, history: keep_all }
+"#,
+        );
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        let DeclaredDepths::Refused { reason } = inv.declared_depths() else {
+            panic!("a publisher's keep_all queue has no bound either");
+        };
+        assert!(reason.contains("publisher"), "{reason}");
+        assert!(reason.contains("/chatter"), "{reason}");
+    }
+
+    /// phase-454 W3 -- the refusal is PER FACT (RFC-0100 D6) and reaches
+    /// nothing else.
+    ///
+    /// D6's own words: *"a `keep_all` subscription says nothing about Cyclone's
+    /// type table, and a global refusal would degrade it anyway."* The entity
+    /// counts, the subscribed-type set and the POLICY table all keep resolving
+    /// -- including the `keep_all` row itself, because the statement is well
+    /// declared and a consumer that reads history (an XRCE `STREAM_HISTORY`, a
+    /// Cyclone resource limit) must be able to see it. Only the DEPTH
+    /// arithmetic has no answer.
+    #[test]
+    fn the_keep_all_refusal_is_per_fact_and_degrades_nothing_else() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      sub: [/listener/chatter]
+contracts:
+  sub_endpoints:
+    /listener/chatter:
+      qos: { depth: 1, history: keep_all, reliability: best_effort }
+"#,
+        );
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        assert!(
+            matches!(inv.declared_depths(), DeclaredDepths::Refused { .. }),
+            "the depth-derived fact refuses"
+        );
+        assert!(
+            inv.derive().knobs().is_some(),
+            "an entity COUNT does not depend on a queue depth"
+        );
+        assert!(
+            inv.subscribed_types().types().is_some(),
+            "a payload class is a property of the TYPE"
+        );
+        let qos = inv.declared_qos();
+        let row = &qos.rows().expect("the policy table resolves")[0];
+        assert_eq!(row.spelling(QosPolicyKind::History), Some("keep_all"));
+        assert_eq!(
+            row.spelling(QosPolicyKind::Reliability),
+            Some("best_effort")
+        );
+        let cmake = inv.to_cmake();
+        assert!(
+            cmake.contains("set(NROS_ENTITY_DECLARED_QOS_STATUS \"resolved\")\n"),
+            "{cmake}"
+        );
+        assert!(
+            cmake.contains(
+                "set(NROS_ENTITY_DECLARED_HISTORY \
+                            \"std_msgs/msg/Int32|/chatter=keep_all\")\n"
+            ),
+            "{cmake}"
+        );
+    }
+
+    /// phase-454 W3 -- THE ARENA IS UNCHANGED for an image that declares only
+    /// depths.
+    ///
+    /// The same acceptance W2 measured, against this wave's addition: take one
+    /// image, read every input `nros-node/build.rs::subs_arena` and
+    /// `_nros_qos_depth_env` use to size the subscription arena, then add the
+    /// three policies to the SAME image and read them again. Every line must be
+    /// byte-identical.
+    ///
+    /// Byte-identical is the right bar rather than "the number is the same",
+    /// because the two consumers PARSE those lines: `subs_arena` splits the
+    /// list on `;`/`,` and takes the depth after the last `=`, and its whole
+    /// guard is `declared.len() == subs`. A policy value that leaked into that
+    /// list would not change any number here and would silently break the
+    /// equality, dropping every declaring image back to
+    /// `subs * pubsub_entry_at_default` -- 207,096 bytes of arena against
+    /// 71,664 on the reference island.
+    ///
+    /// The read set below is W2's, unchanged, and deliberately does NOT include
+    /// the broad `NROS_ENTITY_UNDECLARED_DEPTH_COUNT`: that is the coupling W2
+    /// removed, and re-asserting it here would re-create it.
+    #[test]
+    fn a_policy_declaration_moves_no_input_the_subscription_arena_reads() {
+        fn arena_inputs(model: &ros_launch_manifest_model::SystemModel) -> Vec<String> {
+            let cmake = EntityInventory::from_model("test", model)
+                .expect("model describes wiring")
+                .to_cmake();
+            cmake
+                .lines()
+                .filter(|l| {
+                    l.starts_with("set(NROS_ENTITY_DECLARED_DEPTHS ")
+                        || l.starts_with("set(NROS_ENTITY_DECLARED_DEPTH_COUNT ")
+                        || l.starts_with("set(NROS_ENTITY_UNDECLARED_DEPTH_COUNT_SUBSCRIPTION ")
+                        || l.starts_with("set(NROS_ENTITY_DECLARED_DEPTH_STATUS ")
+                })
+                .map(str::to_string)
+                .collect()
+        }
+
+        let depths_only = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /talker:
+      { scope: s.launch.xml, pkg: talker_pkg, exec: talker, node_name: talker }
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      pub: [/talker/chatter]
+      sub: [/listener/chatter]
+contracts:
+  pub_endpoints:
+    /talker/chatter:
+      qos: { depth: 8 }
+  sub_endpoints:
+    /listener/chatter:
+      qos: { depth: 3 }
+"#,
+        );
+        let with_policies = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /talker:
+      { scope: s.launch.xml, pkg: talker_pkg, exec: talker, node_name: talker }
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      pub: [/talker/chatter]
+      sub: [/listener/chatter]
+contracts:
+  pub_endpoints:
+    /talker/chatter:
+      qos:
+        depth: 8
+        reliability: reliable
+        durability: transient_local
+        history: keep_last
+  sub_endpoints:
+    /listener/chatter:
+      qos:
+        depth: 3
+        reliability: best_effort
+        durability: volatile
+        history: keep_last
+"#,
+        );
+        let before = arena_inputs(&depths_only);
+        let after = arena_inputs(&with_policies);
+        assert_eq!(
+            before, after,
+            "stating reliability/durability/history must not move any value a \
+             subscription depth term reads"
+        );
+
+        // ...and `subs_arena`'s own parse still finds exactly one triple for
+        // the one subscription, which is the guard those inputs feed. Its
+        // reader, transcribed: split on `;`/`,`, depth after the LAST `=`.
+        let depths = after
+            .iter()
+            .find_map(|l| l.strip_prefix("set(NROS_ENTITY_DECLARED_DEPTHS \""))
+            .and_then(|l| l.strip_suffix("\")"))
+            .expect("the subscription list is published");
+        let declared: Vec<(&str, usize)> = depths
+            .split([';', ','])
+            .filter_map(|t| t.rsplit_once('='))
+            .filter_map(|(head, d)| {
+                let ty = head.split_once('|').map_or(head, |(ty, _topic)| ty).trim();
+                d.trim().parse::<usize>().ok().map(|d| (ty, d))
+            })
+            .collect();
+        assert_eq!(
+            declared,
+            vec![("std_msgs/msg/Int32", 3)],
+            "`declared.len() == subs` is subs_arena's whole guard, and a policy \
+             value in this list would break it without moving a number"
+        );
+    }
+
+    /// phase-454 W3 -- and the image that declares NOTHING new is byte-identical
+    /// in the WHOLE fragment except for what W3 added.
+    ///
+    /// The stronger half of the arena acceptance: not "the depth lines agree"
+    /// but "nothing else moved either". Every line an existing image's fragment
+    /// carried before this wave must still be there, verbatim -- so a build that
+    /// reads any of them reads the same bytes, and the only difference is the
+    /// new block.
+    #[test]
+    fn an_image_that_declares_no_policy_gains_only_the_new_block() {
+        let m = model_with_publisher_depths();
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        let cmake = inv.to_cmake();
+        let new_block: Vec<&str> = cmake
+            .lines()
+            .filter(|l| {
+                l.contains("DECLARED_QOS_")
+                    || l.contains("DECLARED_RELIABILITY")
+                    || l.contains("DECLARED_DURABILITY")
+                    || l.contains("DECLARED_HISTORY")
+                    || l.contains("UNDECLARED_RELIABILITY")
+                    || l.contains("UNDECLARED_DURABILITY")
+                    || l.contains("UNDECLARED_HISTORY")
+            })
+            .collect();
+        // Six lists and six counts and one status, all of them EMPTY or the
+        // full endpoint count: this image states no policy at all.
+        assert_eq!(
+            new_block,
+            vec![
+                "set(NROS_ENTITY_DECLARED_QOS_STATUS \"resolved\")",
+                "set(NROS_ENTITY_DECLARED_RELIABILITY \"\")",
+                "set(NROS_ENTITY_DECLARED_RELIABILITY_PUBLISHER \"\")",
+                "set(NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_SUBSCRIPTION 2)",
+                "set(NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_PUBLISHER 2)",
+                "set(NROS_ENTITY_DECLARED_DURABILITY \"\")",
+                "set(NROS_ENTITY_DECLARED_DURABILITY_PUBLISHER \"\")",
+                "set(NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_SUBSCRIPTION 2)",
+                "set(NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_PUBLISHER 2)",
+                "set(NROS_ENTITY_DECLARED_HISTORY \"\")",
+                "set(NROS_ENTITY_DECLARED_HISTORY_PUBLISHER \"\")",
+                "set(NROS_ENTITY_UNDECLARED_HISTORY_COUNT_SUBSCRIPTION 2)",
+                "set(NROS_ENTITY_UNDECLARED_HISTORY_COUNT_PUBLISHER 2)",
+            ],
+            "an empty list is NOT the same claim as a missing one -- it says \
+             \"this image stated none\", which is exactly what the counts beside \
+             it quantify"
+        );
+        // And every `set(` line that is NOT in the new block is one the schema
+        // version aside, a version-4 fragment carried too.
+        let carried: Vec<&str> = cmake
+            .lines()
+            .filter(|l| l.starts_with("set(") && !new_block.contains(l))
+            .collect();
+        assert!(
+            carried.contains(&"set(NROS_ENTITY_DECLARED_DEPTHS \"std_msgs/msg/Int32|/chatter=3\")"),
+            "{carried:?}"
+        );
+        assert!(
+            carried.contains(
+                &"set(NROS_ENTITY_DECLARED_DEPTHS_PUBLISHER \"std_msgs/msg/Int32|/chatter=8\")"
+            ),
+            "{carried:?}"
+        );
+    }
+
     /// issue 1084 -- the depth table a contract produces is keyed on the string
     /// a `NROS_SUBSCRIBE` call site writes, all the way through the renderer.
     ///
@@ -5008,12 +6243,7 @@ contracts:
             pkg: "p".into(),
             component: "only_declared".into(),
             class: "C".into(),
-            declaration: Declaration::Stated(vec![EntityDecl {
-                kind: EntityKind::Timer,
-                type_name: None,
-                name: None,
-                depth: None,
-            }]),
+            declaration: Declaration::Stated(vec![EntityDecl::bare(EntityKind::Timer, None, None)]),
         });
         let merged = decl.merged_per_kind_max(&EntityInventory::new("model"));
         assert_eq!(merged.len(), 1);

--- a/packages/cli/nros-cli-core/src/leaf_entity_env.rs
+++ b/packages/cli/nros-cli-core/src/leaf_entity_env.rs
@@ -130,12 +130,15 @@ pub fn declaration_from_probe(doc_json: &str) -> Result<(String, String, Declara
                         ));
                     }
                 };
-                decls.push(EntityDecl {
-                    kind: *kind,
-                    type_name: ent.interface.as_ref().and_then(qualified_type),
-                    name: ent.id,
-                    depth: None,
-                });
+                // No QoS at all on this road: the leaf probe reports what the
+                // code CREATES, and a `create_subscription(qos)` argument is a
+                // runtime value this metadata never carried. The contract file
+                // is the QoS surface (RFC-0100 D3).
+                decls.push(EntityDecl::bare(
+                    *kind,
+                    ent.interface.as_ref().and_then(qualified_type),
+                    ent.id,
+                ));
             }
         }
     }

--- a/packages/cli/nros-cli-core/tests/contract_qos_policies_resolve.rs
+++ b/packages/cli/nros-cli-core/tests/contract_qos_policies_resolve.rs
@@ -1,0 +1,317 @@
+//! phase-454 W3 (issue 1256) -- all four QoS policies survive resolution.
+//!
+//! The unit tests in `entity_inventory.rs` feed `EntityInventory::from_model` a
+//! hand-written model. This one produces the model the way a build does: the
+//! pinned `nros-launch-resolve` over a launch file and its contract sidecar,
+//! exactly as `nros sync` would. Both halves have to work for a declaration to
+//! reach the build, and as with the publisher depth in W2, only one of them was
+//! ever broken -- `QosDecl` has carried `reliability`, `durability` and
+//! `history` all along and `from_model` read `depth` and dropped the rest.
+//!
+//! Two fixtures, because the two outcomes are different facts:
+//!
+//! * `policies` -- a four-policy endpoint on each side of a topic, and a silent
+//!   pair beside it. The round trip.
+//! * `keep_all` -- `history: keep_all` with a `depth: 1` beside it, which is
+//!   the shape that was priced at 1 for a queue with no bound. The refusal.
+//!
+//! Run with:
+//! `cargo test --manifest-path packages/cli/Cargo.toml --test contract_qos_policies_resolve`
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use nros_cli_core::entity_inventory::{
+    ALL_QOS_POLICY_KINDS, DeclaredDepths, EntityInventory, EntityKind, QosPolicyKind,
+};
+use ros_launch_manifest_model::SystemModel;
+
+/// One endpoint's row as an assertion reads it: `(kind, topic, reliability,
+/// durability, history)`, each policy in the CONTRACT's own spelling and
+/// `None` where the endpoint stated nothing.
+type PolicyRow<'a> = (
+    &'a str,
+    &'a str,
+    Option<&'a str>,
+    Option<&'a str>,
+    Option<&'a str>,
+);
+
+/// The resolver carries all four policies into the model -- the half that was
+/// never broken, asserted anyway so a failure here cannot be misread as ours.
+#[test]
+fn the_resolver_carries_every_stated_policy_into_the_model() {
+    let m = resolve("policies");
+    let p = m
+        .contracts
+        .pub_endpoints
+        .get("/talker/chatter")
+        .and_then(|c| c.qos.as_ref())
+        .expect("the publisher states a qos block");
+    assert_eq!(p.depth, Some(8));
+    assert_eq!(p.reliability.as_deref(), Some("reliable"));
+    assert_eq!(p.durability.as_deref(), Some("transient_local"));
+    assert_eq!(p.history.as_deref(), Some("keep_last"));
+
+    let s = m
+        .contracts
+        .sub_endpoints
+        .get("/listener/chatter")
+        .and_then(|c| c.qos.as_ref())
+        .expect("the subscriber states a qos block");
+    assert_eq!(s.depth, Some(3));
+    assert_eq!(s.reliability.as_deref(), Some("best_effort"));
+    assert_eq!(s.durability.as_deref(), Some("volatile"));
+    assert_eq!(s.history.as_deref(), Some("keep_last"));
+}
+
+/// THE ACCEPTANCE: a contract stating all four policies round-trips -- parsed,
+/// carried, and readable by a consumer.
+///
+/// "Readable by a consumer" is asserted against the two surfaces a consumer
+/// actually reads: the typed view (`declared_qos`) and the CMake projection the
+/// build includes.
+#[test]
+fn a_four_policy_contract_reaches_the_inventory_and_both_projections() {
+    let inv = EntityInventory::from_model("fixture", &resolve("policies"))
+        .expect("the model describes wiring");
+
+    // 1. The typed view.
+    let rows = inv.declared_qos();
+    let rows = rows.rows().expect("a composed inventory resolves");
+    let seen: Vec<PolicyRow<'_>> = rows
+        .iter()
+        .map(|r| {
+            (
+                r.kind.tag(),
+                r.topic.as_str(),
+                r.spelling(QosPolicyKind::Reliability),
+                r.spelling(QosPolicyKind::Durability),
+                r.spelling(QosPolicyKind::History),
+            )
+        })
+        .collect();
+    assert_eq!(
+        seen,
+        vec![
+            (
+                "publisher",
+                "/chatter",
+                Some("reliable"),
+                Some("transient_local"),
+                Some("keep_last"),
+            ),
+            (
+                "subscription",
+                "/chatter",
+                Some("best_effort"),
+                Some("volatile"),
+                Some("keep_last"),
+            ),
+        ],
+        "the two sides state different profiles, and each must land on its own row"
+    );
+    // `/quiet` said nothing, on both sides, for all three policies. It is not
+    // a row and it IS a count -- the distinction the whole view exists for.
+    for policy in ALL_QOS_POLICY_KINDS {
+        for kind in [EntityKind::Subscription, EntityKind::Publisher] {
+            assert_eq!(
+                inv.declared_qos().undeclared(*policy, kind),
+                Some(1),
+                "one silent {} for {}",
+                kind.tag(),
+                policy.tag()
+            );
+        }
+    }
+
+    // 2. The depth is still there and still split by kind (W2's invariant).
+    let DeclaredDepths::Resolved { rows, .. } = inv.declared_depths() else {
+        panic!("no endpoint here says keep_all, so the depth table resolves");
+    };
+    assert_eq!(
+        rows.iter()
+            .map(|r| (r.kind.tag(), r.topic.as_str(), r.depth))
+            .collect::<Vec<_>>(),
+        vec![
+            ("publisher", "/chatter", 8),
+            ("subscription", "/chatter", 3),
+        ]
+    );
+
+    // 3. The CMake projection -- the transport a build actually includes.
+    let cmake = inv.to_cmake();
+    for want in [
+        "set(NROS_ENTITY_DECLARED_QOS_STATUS \"resolved\")\n",
+        "set(NROS_ENTITY_DECLARED_RELIABILITY \"std_msgs/msg/Int32|/chatter=best_effort\")\n",
+        "set(NROS_ENTITY_DECLARED_RELIABILITY_PUBLISHER \
+         \"std_msgs/msg/Int32|/chatter=reliable\")\n",
+        "set(NROS_ENTITY_DECLARED_DURABILITY \"std_msgs/msg/Int32|/chatter=volatile\")\n",
+        "set(NROS_ENTITY_DECLARED_DURABILITY_PUBLISHER \
+         \"std_msgs/msg/Int32|/chatter=transient_local\")\n",
+        "set(NROS_ENTITY_DECLARED_HISTORY \"std_msgs/msg/Int32|/chatter=keep_last\")\n",
+        "set(NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_SUBSCRIPTION 1)\n",
+        "set(NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_PUBLISHER 1)\n",
+    ] {
+        assert!(cmake.contains(want), "missing `{want}` in:\n{cmake}");
+    }
+}
+
+/// THE ACCEPTANCE for the defect: `history: keep_all` REFUSES, and the refusal
+/// names the endpoint.
+///
+/// The fixture states `depth: 1` beside the `keep_all`, which is the pair that
+/// was silently priced at 1. A KEEP_ALL queue has no static bound, so pricing
+/// from that 1 budgets one sample for a queue DDS will let grow -- an UNDER-size,
+/// which lands as `NodeError::BufferTooSmall` at a registration this table had
+/// passed. There is no number to fall back to, so there is no fallback.
+#[test]
+fn a_keep_all_endpoint_refuses_the_depth_table_and_names_itself() {
+    let inv = EntityInventory::from_model("fixture", &resolve("keep_all"))
+        .expect("the model describes wiring");
+
+    let DeclaredDepths::Refused { reason } = inv.declared_depths() else {
+        panic!("a keep_all endpoint has no static bound, so the depth table must refuse");
+    };
+    assert!(
+        reason.contains("/chatter"),
+        "the refusal must NAME the endpoint, or nobody can act on it: {reason}"
+    );
+    assert!(reason.contains("keep_all"), "{reason}");
+    assert!(
+        reason.contains("NO STATIC BOUND"),
+        "it must say WHY, not just that it refused: {reason}"
+    );
+    assert!(
+        reason.contains("keep_last"),
+        "and name the remedy (RFC-0065 D2): {reason}"
+    );
+
+    // And NO number survives. The `depth: 5` on the other subscription is a
+    // real declaration, and publishing it here would be the partial table that
+    // sizes an image from a subset of itself.
+    let cmake = inv.to_cmake();
+    assert!(
+        cmake.contains("set(NROS_ENTITY_DECLARED_DEPTH_STATUS \"refused\")\n"),
+        "{cmake}"
+    );
+    assert!(
+        !cmake.contains("set(NROS_ENTITY_DECLARED_DEPTHS "),
+        "a refused table publishes no list -- not even an empty one, which reads as \
+         \"nobody declared\": {cmake}"
+    );
+    assert!(
+        !cmake.contains("=5"),
+        "the sibling endpoint's depth must not leak out of a refused table: {cmake}"
+    );
+}
+
+/// ...and the refusal is PER FACT (RFC-0100 D6): it kills the depth-derived
+/// numbers and NOTHING else.
+///
+/// This is the half that is easy to get wrong, and D6 says so outright: *"a
+/// `keep_all` subscription says nothing about Cyclone's type table, and a global
+/// refusal would degrade it anyway."* The entity counts, the subscribed-type
+/// set and the policy table itself all stay resolved -- including the `keep_all`
+/// row, because the statement is perfectly well declared and a consumer that
+/// reads history (an XRCE `STREAM_HISTORY`, a Cyclone resource limit) needs it.
+#[test]
+fn the_keep_all_refusal_degrades_no_fact_it_says_nothing_about() {
+    let inv = EntityInventory::from_model("fixture", &resolve("keep_all"))
+        .expect("the model describes wiring");
+
+    assert!(
+        inv.derive().knobs().is_some(),
+        "an entity COUNT does not depend on any queue depth"
+    );
+    assert!(
+        inv.subscribed_types().types().is_some(),
+        "a payload class is a property of the TYPE, not of the history policy"
+    );
+
+    let qos = inv.declared_qos();
+    let rows = qos
+        .rows()
+        .expect("the policy table resolves -- keep_all is a statement, not a gap");
+    assert_eq!(
+        rows.iter()
+            .map(|r| (r.topic.as_str(), r.spelling(QosPolicyKind::History)))
+            .collect::<Vec<_>>(),
+        vec![
+            ("/chatter", Some("keep_all")),
+            ("/quiet", Some("keep_last")),
+        ],
+        "the keep_all row must SURVIVE; refusing it would be the global refusal D6 forbids"
+    );
+
+    let cmake = inv.to_cmake();
+    assert!(
+        cmake.contains("set(NROS_ENTITY_DECLARED_QOS_STATUS \"resolved\")\n"),
+        "{cmake}"
+    );
+    assert!(
+        cmake.contains(
+            "set(NROS_ENTITY_DECLARED_HISTORY \
+             \"std_msgs/msg/Int32|/chatter=keep_all;std_msgs/msg/Int32|/quiet=keep_last\")\n"
+        ),
+        "{cmake}"
+    );
+    assert!(
+        cmake.contains("set(NROS_DERIVED_EXECUTOR_MAX_CBS "),
+        "the slot count is unaffected: {cmake}"
+    );
+}
+
+/// Resolve `launch/<stem>.launch.xml` (with its `<stem>.contract.yaml`
+/// sidecar) through the pinned resolver, by ABSOLUTE path (issue 0285).
+fn resolve(stem: &str) -> SystemModel {
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("repo root");
+    let resolver = repo.join("packages/cli/nros-launch-resolve/target/release/nros-launch-resolve");
+    assert!(
+        resolver.is_file(),
+        "nros-launch-resolve not built at {} -- run `just setup-launch-resolve`",
+        resolver.display()
+    );
+    let bringup = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/qos_policies");
+    let out = temp_output(repo, stem);
+    fs::create_dir_all(&out).expect("create model out dir");
+    let model = out.join("system_model.yaml");
+    let output = std::process::Command::new(&resolver)
+        .arg(bringup.join(format!("launch/{stem}.launch.xml")))
+        .arg("--bringup-root")
+        .arg(&bringup)
+        .arg("-o")
+        .arg(&model)
+        .output()
+        .expect("spawn nros-launch-resolve");
+    assert!(
+        output.status.success(),
+        "nros-launch-resolve failed for {stem}:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = fs::read_to_string(&model).expect("read the resolved model");
+    let _ = fs::remove_dir_all(&out);
+    SystemModel::from_yaml_str(&text).expect("the resolved model parses")
+}
+
+/// Unique scratch dir under the repo's gitignored `tmp/` (repo rule: temp
+/// files live in `$project/tmp/`, not the system temp dir).
+fn temp_output(repo: &Path, name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = repo.join("tmp").join(format!(
+        "qos-policies-{name}-{}-{stamp}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    dir
+}

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/keep_all.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/keep_all.contract.yaml
@@ -1,0 +1,42 @@
+# phase-454 W3 (issue 1256) -- the live defect, as a fixture.
+#
+# `/listener/chatter` asks for `history: keep_all` AND states `depth: 1`. That
+# pair is exactly the shape that was priced wrongly: the depth reached the
+# arena and the history did not, so the build budgeted ONE sample for a queue
+# DDS will let grow to the resource limits. Too small, not too large -- the
+# direction that ships `NodeError::BufferTooSmall` at a registration the sizing
+# model had passed.
+#
+# The other subscription declares an ordinary `keep_last` depth, so the fixture
+# also shows that the refusal is about the IMAGE's depth table and not about
+# one row: a table missing the keep_all endpoint would read as "nobody declared
+# it" and the remaining rows would size the arena from a subset of the image.
+
+version: 1
+
+nodes:
+  talker:
+    pub:
+      chatter: {}
+      quiet: {}
+
+  listener:
+    sub:
+      chatter:
+        qos:
+          depth: 1
+          history: keep_all
+      quiet:
+        qos:
+          depth: 5
+          history: keep_last
+
+topics:
+  /chatter:
+    type: std_msgs/msg/Int32
+    pub: [talker/chatter]
+    sub: [listener/chatter]
+  /quiet:
+    type: std_msgs/msg/Int32
+    pub: [talker/quiet]
+    sub: [listener/quiet]

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/keep_all.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/keep_all.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+  <!-- phase-454 W3 (issue 1256): the same two nodes, with keep_all.contract.yaml
+       declaring `history: keep_all` on ONE subscription. That endpoint's queue
+       has no static bound, so the depth table must REFUSE and name it rather
+       than price it at the `depth: 1` stated beside it. -->
+  <node pkg="demo_pkg" exec="talker" name="talker" />
+  <node pkg="demo_pkg" exec="listener" name="listener" />
+</launch>

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/policies.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/policies.contract.yaml
@@ -1,0 +1,53 @@
+# phase-454 W3 (issue 1256) -- an endpoint states ALL FOUR QoS policies.
+#
+# Before this wave `EntityInventory::from_model` read `qos.depth` and nothing
+# else, so `reliability`, `durability` and `history` parsed into the SystemModel
+# and were read by nobody: a declaration that is legal to write, legal to
+# resolve and silently dropped.
+#
+# The two sides state DIFFERENT policies on purpose. The publisher's
+# `transient_local` is the retention case (publisher-side memory, which is why
+# W2 had to make the publisher's depth travel first); the subscriber's
+# `best_effort` is the one that gates XRCE's two 64 KiB reliable buffers. A
+# fixture stating the same profile on both sides could not catch a reader that
+# looked in the wrong endpoint map.
+#
+# `/quiet` states nothing on either side, because "nobody said" and "said a
+# value" license opposite actions and only a fixture carrying both can tell a
+# dropped declaration from a silent one.
+#
+# No endpoint here says `keep_all` -- that one REFUSES the depth table, and its
+# fixture is `qos_keep_all` beside this one.
+
+version: 1
+
+nodes:
+  talker:
+    pub:
+      chatter:
+        qos:
+          depth: 8
+          reliability: reliable
+          durability: transient_local
+          history: keep_last
+      quiet: {}
+
+  listener:
+    sub:
+      chatter:
+        qos:
+          depth: 3
+          reliability: best_effort
+          durability: volatile
+          history: keep_last
+      quiet: {}
+
+topics:
+  /chatter:
+    type: std_msgs/msg/Int32
+    pub: [talker/chatter]
+    sub: [listener/chatter]
+  /quiet:
+    type: std_msgs/msg/Int32
+    pub: [talker/quiet]
+    sub: [listener/quiet]

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/policies.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_policies/launch/policies.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+  <!-- phase-454 W3 (issue 1256): `talker` publishes /chatter and /quiet,
+       `listener` subscribes to both. policies.contract.yaml states all FOUR
+       QoS policies on one pair and leaves the other pair silent, so the
+       fixture carries "said everything" and "said nothing" side by side. -->
+  <node pkg="demo_pkg" exec="talker" name="talker" />
+  <node pkg="demo_pkg" exec="listener" name="listener" />
+</launch>

--- a/packages/core/nros-orchestration-ir/src/qos_override.rs
+++ b/packages/core/nros-orchestration-ir/src/qos_override.rs
@@ -108,6 +108,104 @@ impl std::error::Error for QoSOverrideError {}
 const POLICY_NAMES: &str = "reliability, durability, history, depth, deadline, lifespan, \
                             liveliness, liveliness_lease_duration";
 
+// ---------------------------------------------------------------------------
+// The VALUE vocabulary -- phase-454 W3.
+// ---------------------------------------------------------------------------
+//
+// `best_effort` / `transient_local` / `keep_all` are ROS 2's own spellings, and
+// until W3 they were read in exactly one place: [`lower`] below, against
+// `qos_overrides.*` parameters. The launch CONTRACT states the same three
+// policies in the same three vocabularies (`QosDecl::{reliability, durability,
+// history}` in the pinned `ros-launch-manifest`), and nano-ros dropped them at
+// `depth_of` -- issue 1256.
+//
+// W3 makes them travel, which means a SECOND reader of the same spellings. A
+// second reader is a second vocabulary unless it is the same function, and this
+// module's own header says what that costs: the four copies of the DECODER
+// drifted, and "whatever the macro and the CLI must agree on lives here".
+//
+// So the parse is here, once, and it returns `nros-rmw`'s enums -- the types
+// the runtime already folds an override into (`QoSProfile::apply_override_value`)
+// -- rather than a fresh set. Re-exported below so a caller need not dep
+// `nros-rmw`, exactly as the role/policy codes already are.
+//
+// `SystemDefault` is deliberately NOT a spelling either surface accepts. It is
+// a real upstream policy value, but "the author wrote `system_default`" and
+// "the author said nothing" are different claims that every consumer here would
+// have to distinguish, and no producer in this tree states it. Absence is the
+// spelling for absence.
+
+// Re-exported for the same reason the code constants are: a consumer of the
+// vocabulary should not have to dep `nros-rmw` to name what it parsed.
+pub use nros_rmw::{QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy};
+
+/// The accepted `reliability` spellings, for a diagnostic.
+pub const RELIABILITY_VALUES: &str = "`best_effort` or `reliable`";
+/// The accepted `durability` spellings, for a diagnostic.
+pub const DURABILITY_VALUES: &str = "`volatile` or `transient_local`";
+/// The accepted `history` spellings, for a diagnostic.
+pub const HISTORY_VALUES: &str = "`keep_last` or `keep_all`";
+
+/// Parse a `reliability` value. `None` for a spelling this build does not
+/// model -- an ERROR for every caller, never a skip.
+pub fn parse_reliability(value: &str) -> Option<QoSReliabilityPolicy> {
+    match value.trim() {
+        "best_effort" => Some(QoSReliabilityPolicy::BestEffort),
+        "reliable" => Some(QoSReliabilityPolicy::Reliable),
+        _ => None,
+    }
+}
+
+/// Parse a `durability` value. `None` for a spelling this build does not model.
+pub fn parse_durability(value: &str) -> Option<QoSDurabilityPolicy> {
+    match value.trim() {
+        "volatile" => Some(QoSDurabilityPolicy::Volatile),
+        "transient_local" => Some(QoSDurabilityPolicy::TransientLocal),
+        _ => None,
+    }
+}
+
+/// Parse a `history` value. `None` for a spelling this build does not model.
+pub fn parse_history(value: &str) -> Option<QoSHistoryPolicy> {
+    match value.trim() {
+        "keep_last" => Some(QoSHistoryPolicy::KeepLast),
+        "keep_all" => Some(QoSHistoryPolicy::KeepAll),
+        _ => None,
+    }
+}
+
+/// The canonical spelling of a parsed `reliability`, for rendering it back out.
+///
+/// `SystemDefault` renders as `system_default` even though no surface PARSES
+/// it: a renderer that had to return `Option` would make every call site
+/// decide what an unrenderable policy means, and this way the round trip is
+/// total in one direction and documented in the other.
+pub fn reliability_spelling(p: QoSReliabilityPolicy) -> &'static str {
+    match p {
+        QoSReliabilityPolicy::SystemDefault => "system_default",
+        QoSReliabilityPolicy::Reliable => "reliable",
+        QoSReliabilityPolicy::BestEffort => "best_effort",
+    }
+}
+
+/// The canonical spelling of a parsed `durability`. See [`reliability_spelling`].
+pub fn durability_spelling(p: QoSDurabilityPolicy) -> &'static str {
+    match p {
+        QoSDurabilityPolicy::SystemDefault => "system_default",
+        QoSDurabilityPolicy::Volatile => "volatile",
+        QoSDurabilityPolicy::TransientLocal => "transient_local",
+    }
+}
+
+/// The canonical spelling of a parsed `history`. See [`reliability_spelling`].
+pub fn history_spelling(p: QoSHistoryPolicy) -> &'static str {
+    match p {
+        QoSHistoryPolicy::SystemDefault => "system_default",
+        QoSHistoryPolicy::KeepLast => "keep_last",
+        QoSHistoryPolicy::KeepAll => "keep_all",
+    }
+}
+
 /// Is this parameter name a QoS override?
 pub fn is_qos_override(name: &str) -> bool {
     name.starts_with(QOS_OVERRIDE_PREFIX)
@@ -156,28 +254,44 @@ pub fn lower(name: &str, value: &str) -> Result<Option<LoweredOverride>, QoSOver
     let ms = |expected| v.parse::<u32>().map_err(|_| bad(expected));
 
     let (policy, value) = match policy_s {
+        // phase-454 W3 -- the SPELLINGS come from `parse_*` above, which the
+        // contract reader also calls; the 0/1 here is this WIRE's own encoding
+        // and not the enum's discriminant (`decode_qos_override_value` is the
+        // other end of it). Keeping the two apart is deliberate: the wire codes
+        // are an ABI, the enum's numbering is not, and phase-376 W5/B2 already
+        // renumbered the liveliness enum under a literal that kept compiling.
+        // Matching on the VARIANT is what makes a renumbering a compile error
+        // here instead of a silent policy swap.
         "reliability" => (
             qos_override_policy::RELIABILITY,
-            match v {
-                "best_effort" => 0,
-                "reliable" => 1,
-                _ => return Err(bad("`best_effort` or `reliable`")),
+            match parse_reliability(v) {
+                Some(QoSReliabilityPolicy::BestEffort) => 0,
+                Some(QoSReliabilityPolicy::Reliable) => 1,
+                // Unreachable while `parse_reliability` refuses the spelling;
+                // written out rather than `_` so adding one is a decision here.
+                Some(QoSReliabilityPolicy::SystemDefault) | None => {
+                    return Err(bad(RELIABILITY_VALUES));
+                }
             },
         ),
         "durability" => (
             qos_override_policy::DURABILITY,
-            match v {
-                "volatile" => 0,
-                "transient_local" => 1,
-                _ => return Err(bad("`volatile` or `transient_local`")),
+            match parse_durability(v) {
+                Some(QoSDurabilityPolicy::Volatile) => 0,
+                Some(QoSDurabilityPolicy::TransientLocal) => 1,
+                Some(QoSDurabilityPolicy::SystemDefault) | None => {
+                    return Err(bad(DURABILITY_VALUES));
+                }
             },
         ),
         "history" => (
             qos_override_policy::HISTORY,
-            match v {
-                "keep_last" => 0,
-                "keep_all" => 1,
-                _ => return Err(bad("`keep_last` or `keep_all`")),
+            match parse_history(v) {
+                Some(QoSHistoryPolicy::KeepLast) => 0,
+                Some(QoSHistoryPolicy::KeepAll) => 1,
+                Some(QoSHistoryPolicy::SystemDefault) | None => {
+                    return Err(bad(HISTORY_VALUES));
+                }
             },
         ),
         "depth" => (qos_override_policy::DEPTH, ms("a non-negative integer")?),
@@ -342,6 +456,69 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(got.topic, "/ns/a.b");
+    }
+
+    /// phase-454 W3 -- every spelling round-trips through parse and back.
+    ///
+    /// The contract reader (`nros_cli_core::entity_inventory`) PARSES with
+    /// these and RENDERS with `*_spelling`, so a round trip that lost a value
+    /// would publish a policy nobody wrote. Both directions, and every variant
+    /// including the `SystemDefault` no surface parses -- a renderer that
+    /// panicked or emptied on it would be a hole a future producer falls into.
+    #[test]
+    fn every_policy_spelling_round_trips() {
+        for (s, p) in [
+            ("best_effort", QoSReliabilityPolicy::BestEffort),
+            ("reliable", QoSReliabilityPolicy::Reliable),
+        ] {
+            assert_eq!(parse_reliability(s), Some(p), "{s}");
+            assert_eq!(reliability_spelling(p), s);
+        }
+        for (s, p) in [
+            ("volatile", QoSDurabilityPolicy::Volatile),
+            ("transient_local", QoSDurabilityPolicy::TransientLocal),
+        ] {
+            assert_eq!(parse_durability(s), Some(p), "{s}");
+            assert_eq!(durability_spelling(p), s);
+        }
+        for (s, p) in [
+            ("keep_last", QoSHistoryPolicy::KeepLast),
+            ("keep_all", QoSHistoryPolicy::KeepAll),
+        ] {
+            assert_eq!(parse_history(s), Some(p), "{s}");
+            assert_eq!(history_spelling(p), s);
+        }
+        // `system_default` renders and does NOT parse: an author who writes it
+        // gets a refusal naming the two spellings, rather than an endpoint that
+        // silently means "the backend picks". See the module note above.
+        assert_eq!(
+            reliability_spelling(QoSReliabilityPolicy::SystemDefault),
+            "system_default"
+        );
+        assert_eq!(parse_reliability("system_default"), None);
+        assert_eq!(parse_durability("system_default"), None);
+        assert_eq!(parse_history("system_default"), None);
+    }
+
+    /// phase-454 W3 -- a spelling neither surface models is `None`, and
+    /// `lower` turns that `None` into an error rather than a value.
+    ///
+    /// The binding between the two halves: the contract road refuses on the
+    /// `None`, and this road refuses on the same `None`. One vocabulary means a
+    /// spelling cannot be legal on one surface and silently dropped on the
+    /// other -- which is what a second `match v { "best_effort" => .. }` here
+    /// would eventually become.
+    #[test]
+    fn a_spelling_neither_surface_models_is_refused_on_both() {
+        for bad in ["best-effort", "BestEffort", "BEST_EFFORT", "", "reliabel"] {
+            assert_eq!(parse_reliability(bad), None, "{bad}");
+            let e = lower("qos_overrides./t.publisher.reliability", bad).unwrap_err();
+            assert!(
+                matches!(e, QoSOverrideError::BadValue { .. }),
+                "{bad}: {e:?}"
+            );
+            assert!(e.to_string().contains("best_effort"), "{e}");
+        }
     }
 
     /// The whole point of issue 0303: every rejection is an ERROR naming the

--- a/tests/cmake-entity-inventory-tests.sh
+++ b/tests/cmake-entity-inventory-tests.sh
@@ -141,7 +141,7 @@ chmod +x "$STUB"
 
 DERIVED_BODY="$TEST_TMPDIR/derived.cmake"
 cat > "$DERIVED_BODY" <<'EOF'
-set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 4)
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)
 # No NROS_ENTITY_INVENTORY_SOURCE: `to_cmake` stopped emitting it (issue 1228 --
 # it is composer-dependent content in a file whose bytes decide whether cmake
 # runs again), and this fixture mirrors what the producer writes.
@@ -178,6 +178,23 @@ set(NROS_ENTITY_UNDECLARED_DEPTH_COUNT_SUBSCRIPTION 0)
 set(NROS_ENTITY_DECLARED_DEPTHS_PUBLISHER "std_msgs/msg/Int32|/chatter=8")
 set(NROS_ENTITY_DECLARED_DEPTH_COUNT_PUBLISHER 1)
 set(NROS_ENTITY_UNDECLARED_DEPTH_COUNT_PUBLISHER 3)
+# phase-454 W3 (issue 1256) -- the other three QoS policies. `history` is
+# deliberately resolved here WITH a keep_last on the subscription side: the
+# depth table above is what `keep_all` refuses, and this block keeps resolving
+# either way (RFC-0100 D6 -- refusal is per fact, never global).
+set(NROS_ENTITY_DECLARED_QOS_STATUS "resolved")
+set(NROS_ENTITY_DECLARED_RELIABILITY "std_msgs/msg/Int32|/chatter=best_effort")
+set(NROS_ENTITY_DECLARED_RELIABILITY_PUBLISHER "std_msgs/msg/Int32|/chatter=reliable")
+set(NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_SUBSCRIPTION 10)
+set(NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_PUBLISHER 13)
+set(NROS_ENTITY_DECLARED_DURABILITY "")
+set(NROS_ENTITY_DECLARED_DURABILITY_PUBLISHER "std_msgs/msg/Int32|/chatter=transient_local")
+set(NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_SUBSCRIPTION 11)
+set(NROS_ENTITY_UNDECLARED_DURABILITY_COUNT_PUBLISHER 13)
+set(NROS_ENTITY_DECLARED_HISTORY "std_msgs/msg/Int32|/chatter=keep_last")
+set(NROS_ENTITY_DECLARED_HISTORY_PUBLISHER "")
+set(NROS_ENTITY_UNDECLARED_HISTORY_COUNT_SUBSCRIPTION 10)
+set(NROS_ENTITY_UNDECLARED_HISTORY_COUNT_PUBLISHER 14)
 set(NROS_PARAM_DECLARATION_STATUS "declared")
 set(NROS_PARAM_DECLARED_COUNT 21)
 set(NROS_DERIVED_MAX_PARAMETERS 25)
@@ -190,7 +207,7 @@ EOF
 
 REFUSED_BODY="$TEST_TMPDIR/refused.cmake"
 cat > "$REFUSED_BODY" <<'EOF'
-set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 4)
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)
 set(NROS_ENTITY_INVENTORY_STATUS "refused")
 set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 4)
 set(NROS_ENTITY_INVENTORY_REASON "1 of 4 components in this image declare no entities:\n    demo::legacy (demo::Legacy)")
@@ -200,15 +217,18 @@ set(NROS_ENTITY_RECEIVED_TYPES_STATUS "refused")
 set(NROS_ENTITY_RECEIVED_TYPES_REASON "the entity inventory itself did not compose")
 set(NROS_ENTITY_DECLARED_DEPTH_STATUS "refused")
 set(NROS_ENTITY_DECLARED_DEPTH_REASON "the entity inventory itself did not compose")
+set(NROS_ENTITY_DECLARED_QOS_STATUS "refused")
+set(NROS_ENTITY_DECLARED_QOS_REASON "the entity inventory itself did not compose")
 EOF
 
 # A schema this reader does NOT understand. Written as "one past supported"
 # rather than a literal, because the literal was `2` until phase-403 step 1
 # made 2 the supported version -- at which point the case silently stopped
-# testing anything it claimed to. Step 2 moved it to 3/4 and phase-454 W2, which
-# split the depth table by kind, to 4/5.
+# testing anything it claimed to. Step 2 moved it to 3/4, phase-454 W2, which
+# split the depth table by kind, to 4/5, and phase-454 W3, which added the
+# other three QoS policies, to 5/6.
 BAD_SCHEMA_BODY="$TEST_TMPDIR/bad-schema.cmake"
-sed 's/SCHEMA_VERSION 4/SCHEMA_VERSION 5/' "$DERIVED_BODY" > "$BAD_SCHEMA_BODY"
+sed 's/SCHEMA_VERSION 5/SCHEMA_VERSION 6/' "$DERIVED_BODY" > "$BAD_SCHEMA_BODY"
 
 NO_SCHEMA_BODY="$TEST_TMPDIR/no-schema.cmake"
 grep -v SCHEMA_VERSION "$DERIVED_BODY" > "$NO_SCHEMA_BODY"
@@ -324,6 +344,60 @@ if nros_grep_q "NROS_ENTITY_DECLARED_DEPTHS=.*=8" <<<"$OUT"; then
     fail "A: a publisher depth reached the SUBSCRIPTION sizing list -- $OUT"
 fi
 
+# phase-454 W3 (issue 1256). The other three policies cross the same boundary,
+# in the same per-kind shape and with the same per-POLICY undeclared counts.
+# Losing one at the function boundary is the drift this module's own comment
+# lists four instances of ("the symbol loaded here, died at the function
+# boundary, and the consumer fell back to a default that looked deliberate") --
+# and here the default a consumer would fall back to is RELIABLE, which is two
+# 64 KiB buffers per XRCE session that the image said it did not want.
+check
+if ! nros_grep_q "NROS_ENTITY_DECLARED_QOS_STATUS=resolved" <<<"$OUT"; then
+    fail "A: the declared-QoS status did not reach the caller's scope -- $OUT"
+fi
+check
+if ! nros_grep_q "NROS_ENTITY_DECLARED_RELIABILITY=std_msgs/msg/Int32|/chatter=best_effort" <<<"$OUT"; then
+    fail "A: the declared reliability did not reach the caller's scope -- $OUT"
+fi
+check
+if ! nros_grep_q "NROS_ENTITY_DECLARED_RELIABILITY_PUBLISHER=std_msgs/msg/Int32|/chatter=reliable" <<<"$OUT"; then
+    fail "A: the PUBLISHER reliability did not reach the caller's scope -- $OUT"
+fi
+check
+if ! nros_grep_q "NROS_ENTITY_DECLARED_DURABILITY_PUBLISHER=std_msgs/msg/Int32|/chatter=transient_local" <<<"$OUT"; then
+    fail "A: the declared durability did not reach the caller's scope -- $OUT"
+fi
+check
+if ! nros_grep_q "NROS_ENTITY_DECLARED_HISTORY=std_msgs/msg/Int32|/chatter=keep_last" <<<"$OUT"; then
+    fail "A: the declared history did not reach the caller's scope -- $OUT"
+fi
+# An EMPTY list is a published fact and must survive the boundary too: it says
+# "this image stated none of this policy", which is different from the variable
+# being absent, and the count beside it is what quantifies the gap.
+check
+if ! nros_grep_q "NROS_ENTITY_DECLARED_DURABILITY=$" <<<"$OUT"; then
+    fail "A: an EMPTY policy list did not reach the caller's scope. Absent and \
+empty are different claims and only one of them is this image's -- $OUT"
+fi
+# Per POLICY, not one count for all three. An image can state reliability on
+# every endpoint and durability on none; one number would pin the reliability
+# consumer on its worst case for a gap that is not its own.
+check
+if ! nros_grep_q "NROS_ENTITY_UNDECLARED_RELIABILITY_COUNT_SUBSCRIPTION=10" <<<"$OUT"; then
+    fail "A: the per-policy UNDECLARED count did not reach the caller's scope -- $OUT"
+fi
+check
+if ! nros_grep_q "NROS_ENTITY_UNDECLARED_HISTORY_COUNT_PUBLISHER=14" <<<"$OUT"; then
+    fail "A: the per-policy, per-kind UNDECLARED count did not reach the \
+caller's scope -- $OUT"
+fi
+# And no policy value leaks into the DEPTH list, which is the list whose length
+# is `subs_arena`'s guard.
+check
+if nros_grep_q "NROS_ENTITY_DECLARED_DEPTHS=.*best_effort" <<<"$OUT"; then
+    fail "A: a QoS policy value reached the SUBSCRIPTION depth list -- $OUT"
+fi
+
 # phase-446 W4. The parameter store's numbers cross the same function boundary,
 # and so does the NEEDS fact: a capacity a declared type uses carries the name
 # of the parameter instead of a number, and nros-params' build script refuses
@@ -374,6 +448,17 @@ fi
 check
 if nros_grep_q "NROS_DERIVED_RUNTIME_MAX_CELL_ENTITIES=" <<<"$OUT"; then
     fail "B: a refusal published a cell-registry bound -- $OUT"
+fi
+# phase-454 W3 -- and no policy list. A partial one reads as "these are the
+# only endpoints that asked for best_effort", which is how an XRCE image stops
+# paying for buffers endpoints nobody enumerated still need.
+check
+if nros_grep_q "NROS_ENTITY_DECLARED_RELIABILITY=" <<<"$OUT"; then
+    fail "B: a refusal published a reliability list -- $OUT"
+fi
+check
+if ! nros_grep_q "NROS_ENTITY_DECLARED_QOS_STATUS=refused" <<<"$OUT"; then
+    fail "B: the declared-QoS refusal did not reach the caller -- $OUT"
 fi
 check
 if ! nros_grep_q "declare no entities" <<<"$OUT"; then
@@ -436,7 +521,7 @@ log_info "D. an unrecognised schema refuses to be read"
 flat() { tr '\n' ' ' | tr -s ' '; }
 OUT="$(derive "$BAD_SCHEMA_BODY" 0 "$META" "$TEST_TMPDIR/d1.cmake" | flat)"
 check
-if ! nros_grep_q "states entity-inventory schema version 5" <<<"$OUT"; then
+if ! nros_grep_q "states entity-inventory schema version 6" <<<"$OUT"; then
     fail "D: a future schema was read rather than refused -- $OUT"
 fi
 check

--- a/tests/cmake-message-bounds-tests.sh
+++ b/tests/cmake-message-bounds-tests.sh
@@ -182,7 +182,7 @@ derive() {
 entity_frag() {
     local path="$1" inv_status="$2" sub_status="$3"; shift 3
     {
-        echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 4)"
+        echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)"
         echo "set(NROS_ENTITY_INVENTORY_STATUS \"$inv_status\")"
         echo "set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 1)"
         echo "set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS \"$sub_status\")"
@@ -761,7 +761,7 @@ fi
 
 log_header "M -- a current schema that states no subscribed set REFUSES"
 {
-    echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 4)"
+    echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)"
     echo "set(NROS_ENTITY_INVENTORY_STATUS \"derived\")"
 } > "$T/m3-ents.cmake"
 OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/m3-ents.cmake")"
@@ -877,7 +877,7 @@ EOF
 # for the wrong reason. It did, on the first run of this test.
 _o_frag() {
     {
-        printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 4)\n'
+        printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)\n'
         printf 'set(NROS_ENTITY_INVENTORY_STATUS "derived")\n'
         printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved")\n'
         printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES "%s")\n' "$1"
@@ -956,7 +956,7 @@ set(NROS_MESSAGE_BOUND_demo_msg_Open_REASON "unbounded member: data (string)")
 EOF
 # Subscribes to the BOUNDED type only. The unbounded one is linked, never received.
 {
-    printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 4)\n'
+    printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)\n'
     printf 'set(NROS_ENTITY_INVENTORY_STATUS "derived")\n'
     printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved")\n'
     printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES "std_msgs/msg/Int32")\n'


### PR DESCRIPTION
phase-454 W3. Carries W1 (#966) and W2 (#967), already on `main` — the queue drops
them by patch-id.

## The defect

A `*.contract.yaml` endpoint could state four QoS policies. Three of them —
`reliability`, `durability`, `history` — parsed, resolved into the `SystemModel`,
and were dropped at `depth_of`. Issue 1256.

The dangerous one is `history`. A `keep_all` endpoint was priced at whatever
`depth` sat beside it, which is a **silent UNDER-size** — the direction that
ships `NodeError::BufferTooSmall` rather than wasted bytes. `KEEP_ALL` has no
static bound; there is no number to fall back to.

## How `keep_all` refuses

`declared_depths()` returns `Refused`, naming every offending endpoint, quoting
the depth that would have been believed, and naming the remedy:

```
/listener::listener declares a subscription on /chatter with depth: 1 beside it
  ... NO STATIC BOUND ...
  Declare history: keep_last with the depth: you mean
```

It refuses **with or without** a depth beside it — stronger than 1256 asked, and
`a_keep_all_with_no_depth_beside_it_refuses_too` forbids the narrower
implementation. No fallback number, and **no list published, not even an empty
one**.

Refusal is **per fact** (RFC-0100 D6): `derive()`, `subscribed_types()` and
`declared_qos()` all keep resolving, including the `keep_all` row itself.

## Shape

- The QoS *value* vocabulary moved into `nros-orchestration-ir::qos_override` as
  `parse_reliability` / `parse_durability` / `parse_history`, returning
  `nros-rmw`'s enums. `lower()` now matches on the **variant** rather than a
  literal when mapping to the wire code — the same shape phase-376 W5/B2's
  renumbering broke in the liveliness arm. `system_default` is deliberately
  parsed by neither surface.
- `EntityDecl` gained the three policies beside `depth`, plus an
  `EntityDecl::bare` constructor so the 13 sites that state no QoS say so once.
- `declared_qos()` is a new view (rows + per-policy, per-kind undeclared counts),
  rendered to JSON and 13 new CMake variables. Schema 4 → 5, both halves in
  lockstep.
- `reject_unknown_qos_values` — an unreadable spelling is an error naming the
  endpoint, the side, what was written and what is accepted. Wired on **both**
  roads a model reaches `from_model`.

## Arena-unchanged proof

`a_policy_declaration_moves_no_input_the_subscription_arena_reads` reads one
image's full `subs_arena` / `_nros_qos_depth_env` line set, adds the three
policies to the same image, asserts byte-identity, then re-parses the list the
way `subs_arena` does and asserts `declared.len() == subs`. Sibling
`an_image_that_declares_no_policy_gains_only_the_new_block` asserts nothing else
in the fragment moved.

**Mutation-checked five ways**: delete the `keep_all` refusal → 5 red; couple a
stated `reliability` into the depth view → 2 red incl. the arena proof; drop the
policies at `from_model` → 7 red; leak a policy triple into
`NROS_ENTITY_DECLARED_DEPTHS` → 3 red; delete the verb's call site → 1 red (which
is why an end-to-end `run()` test exists — the function's own tests stay green).

## Issue 1256 stays OPEN, deliberately

Four of its five acceptance bullets are met and now marked DONE in the issue file
with the wave that did them. The fifth — "the declared-QoS header and boot check
cover reliability and durability" — is **W10**'s surface, since widening
`NROS_ASSERT_DECLARED_DEPTH` past depth is the same edit as widening it to
Rust/C. It blocks no derivation: a reliability disagreement is an interop
failure, not a sizing one. The issue says so in place rather than being closed
over.

## Testing

`just ci gate` **green in one run**: `cli-fresh`, `fast` (307, 1 skipped),
`build` (21/21), `api-parity`, `test-unit` (1432 passed; 2 `[SKIPPED]`
preconditions), `test-lane-contracts` (17/17). Plus `check cli-tests` and both
cmake suites (64 + 103 assertions). fmt and clippy clean on both workspaces.

## Three worktree findings, none about this diff

Recorded in the commit. The one worth chasing: **`nros-cli-core/build.rs`'s
`rerun-if-changed=<root>/.git/index` never registers in a linked worktree**
(`.git` is a file there), so the CLI source stamp does not re-bake on a commit.
Every agent worktree has this, and it reads as a stale CLI rather than a missing
dependency edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1