### PR TITLE
feat(phase-442 W8, RFC-0096 D9 rev 3): the Rust arena already owns the dispatch entities

### DIFF
--- a/docs/design/0096-cpp-freestanding-core-and-porting-layer.md
+++ b/docs/design/0096-cpp-freestanding-core-and-porting-layer.md
@@ -346,6 +346,14 @@ an edit, and every one is a compile error naming the exact site:
    the bulk of any port, is what must be drop-in and is.
 3. **A lambda capture larger than the declared budget**, which is a
    `static_assert` naming the knob.
+4. **Copying a PUBLISHER handle** (phase-442 W8). A dispatch entity's
+   `X::SharedPtr` is `nros::Handle`, which copies like upstream's. A publisher
+   has no arena slot, so its handle is `nros::Owned<T>` and is MOVE-ONLY; a copy
+   is a compile error at the call site. The W0 census found no entity handle
+   copied anywhere in this tree or in the porting corpus — handles are stored as
+   members, and the one by-value pass is a NODE handle, which is
+   `nros::Handle<Node>` and copyable — so this is on the list because it is a
+   difference, not because it has cost anything measured.
 
 What this does not promise: an arbitrary third-party ROS 2 package that uses
 `std::string` internally will not become freestanding because our API is. The
@@ -561,6 +569,88 @@ answer belongs and it is larger than phase-442.**
    executor storage size. Keeps the user's spelling identical to upstream's and
    costs them nothing to write; the heaviest of the three, and the closest to
    the primary candidate without the ABI change.
+
+#### RESOLVED (revision 3, 2026-09-12): the Rust arena already owns the dispatch entities
+
+The question was *where does a returned `X::SharedPtr` handle's entity live*, and
+two revisions of this section looked for somewhere in C++ to put it — a pool,
+then a Rust arena to be built. Both were the wrong question. The C/C++ API is a
+thin wrapper over the Rust API, entity lifetime is a Rust data structure's, and
+**for the rclcpp dispatch model the Rust side already owns the entity.** The
+tree documents this at `packages/api/nros-cpp/src/subscription.rs`:
+
+> arena (rclcpp dispatch model), as opposed to the poll-style
+> `nros_cpp_subscription_create` above. **The arena owns the subscriber**; spin …
+
+There are two ABI paths per entity, and only one of them is caller-storage:
+
+| path | entry point | owner |
+| --- | --- | --- |
+| poll-style | `nros_cpp_subscription_create(…, void *storage)` | the caller |
+| **rclcpp dispatch** | `nros_cpp_subscription_register(…, out_handle_id)` | **the arena** |
+
+and the arena's C-facing entry already holds everything:
+
+```rust
+pub(crate) struct SubBufferedRawCEntry {
+    pub(crate) handle: session::RmwSubscriber,      // the subscriber
+    pub(crate) buffer: BufferStrategy,              // the rx buffer
+    pub(crate) callback: RawSubscriptionCallback,
+    pub(crate) context: *mut core::ffi::c_void,
+}
+```
+
+**So `X::SharedPtr` for a dispatch entity is `nros::Handle` over
+`{executor, handle_id}`** — exactly what `Timer` is today, and exactly what W3
+already built. The C++ `Subscription<M>`'s 888 bytes of `storage_`, and the
+heap `detail::SubscriptionCallback<M>` cell that today holds a `std::function`,
+are a second copy of state the arena already keeps. They accumulated; they were
+not decided.
+
+Four things follow, and every one of them is a simplification:
+
+* **No ABI addition, no new arena, no pool, no node template parameter.** The
+  entry point exists and returns a handle id.
+* **`X::SharedPtr` is COPYABLE**, because a handle is. That removes the
+  move-only difference from D5 rather than adding one.
+* **The "must not move after register" hazard loses its subject.**
+  `service.hpp`'s warning — *"the arena holds `this` as the trampoline context…
+  the move only transfers bookkeeping and leaves that pointer stale, so don't"*
+  — is about a C++ object that, under this shape, does not exist.
+* **`sizeof` stops being a design input.** The 4 672-byte `Client<int>` that made
+  every pooling answer look unaffordable was the C++ object holding the reply
+  buffer; as a handle it is two words.
+
+**The one genuinely new piece.** `context` is a single pointer. That carries a
+`[this]` capture — 7 of the 11 capture sites the W0 census found — and does not
+carry `[obj, method]`, which is three pointers. So a capturing lambda needs
+somewhere for its bytes, and by the same principle that somewhere is the
+registration, in Rust. The mechanism is already there: the arena allocates
+trailing bytes today for the rx buffer
+(`arena_alloc_with_trailing::<SubBufferedRawCEntry>(trailing_bytes)`), so the
+capture is the same allocation with a larger tail and `InplaceFn`'s invoker
+becomes the `callback` field. That is the only Rust-side work this design needs.
+
+**What `nros::Owned<T>` is for, then.** The entities with NO dispatch, where no
+arena slot exists and the C++ object genuinely is the entity: publishers, and
+the poll-style forms. It is a fallback for one kind, not the shape of the API,
+and `nros/owned.hpp` says so at the top. Whether publishers should get an arena
+slot too, for uniformity, is open and small.
+
+**What remains per entity kind.** `nros_cpp_service_server_register` already
+returns a handle id, so the slot exists — but it is handed `&out`, the C++
+object, as its context. Moving that state into the arena entry the way
+subscriptions would removes the back-reference. Same audit for the action forms.
+
+Issue **1335** narrows accordingly: not "where should entity storage live", but
+"the C++ API uses the poll path where it means the dispatch path, and carries
+storage for both".
+
+#### What the alternatives above are now for
+
+They are the record of two wrong framings, kept because the question that
+retired them — *why is the C++ API inventing storage when it is a thin wrapper
+over a Rust API that already has it?* — is the one worth asking first next time.
 
 #### W8 does not start until this is answered
 

--- a/docs/issues/1335-entity-storage-split-timer-arena-vs-caller-buffer.md
+++ b/docs/issues/1335-entity-storage-split-timer-arena-vs-caller-buffer.md
@@ -1,8 +1,8 @@
 ---
 id: 1335
-title: "One entity concept, three storage shapes: the C++ timer lives in the
-  Rust arena, the other seven C++ entities live in a caller buffer, and the C
-  API puts all of them in caller structs — no recorded decision says why"
+title: "The C++ API uses the POLL path where it means the DISPATCH path, and
+  carries entity storage for both — an 888-byte `Subscription<M>` beside an
+  arena entry that already holds the subscriber"
 status: open
 type: question
 area: [api, api-c, core, docs]
@@ -11,33 +11,72 @@ related: [rfc-0022, rfc-0054, rfc-0096, phase-409, phase-412, phase-442]
 
 ## The question
 
-Where an entity's memory lives is answered three different ways in this tree for
-one concept, and the difference is not recorded anywhere as a decision.
+The C++ API reaches the runtime by two paths for the same entity, and carries
+storage for both.
 
-Measured on `nros_cpp_ffi.h` — every `create` entry point, classified by whether
-it returns an arena index or writes into a caller buffer:
+**Correction to this issue's first version, which is also the point.** The table
+originally here was built from the generated `nros_cpp_ffi.h` and listed only the
+`*_create` family, concluding that the timer was the sole arena-shaped entity.
+That reach was too narrow: the DISPATCH entry points are hand-declared
+`extern "C"` in the entity headers, not in the generated header, so the scan
+never saw them. They exist:
 
-| entry point | shape |
-| --- | --- |
-| `nros_cpp_timer_create` | **arena** — `size_t *out_handle_id` |
-| `nros_cpp_timer_create_on_clock` | **arena** |
-| `nros_cpp_timer_create_oneshot` | **arena** |
-| `nros_cpp_timer_create_in_group` | **arena** |
-| `nros_cpp_publisher_create` | caller storage — `void *storage` |
-| `nros_cpp_subscription_create` | caller storage |
-| `nros_cpp_service_server_create` | caller storage |
-| `nros_cpp_service_client_create` | caller storage |
-| `nros_cpp_action_server_create` | caller storage |
-| `nros_cpp_action_client_create` | caller storage |
-| `nros_cpp_guard_condition_create` | caller storage |
+```c
+/* subscription.hpp */
+nros_cpp_ret_t nros_cpp_subscription_register(const nros_cpp_node_t* node, const char* topic,
+                                              const char* type_name, const char* type_hash,
+                                              nros_cpp_qos_t qos,
+                                              nros_cpp_subscription_message_callback_t callback,
+                                              void* context, size_t* out_handle_id,
+                                              const nros_cpp_subscription_options_t* options);
+```
 
-And the C API is a third shape again: `nros_publisher_init_with_qos` and
-`nros_timer_init` both take a pointer to a caller-declared
-`struct nros_publisher_t` / `struct nros_timer_t`, so there the TIMER is
-caller-storage too.
+and `subscription.rs` states what they mean:
 
-So: C++ timer in the Rust arena, C++ everything-else in a C++ buffer, C timer
-and C publisher in a C struct. Three answers, one concept.
+> arena (rclcpp dispatch model), as opposed to the poll-style
+> `nros_cpp_subscription_create` above. **The arena owns the subscriber**; spin …
+
+So per entity there are two paths, and the C++ API uses both at once:
+
+| path | entry point | owner |
+| --- | --- | --- |
+| poll-style | `nros_cpp_subscription_create(…, void *storage)` | the caller |
+| dispatch | `nros_cpp_subscription_register(…, out_handle_id)` | the arena |
+
+The arena's C-facing entry already holds everything a dispatch subscription
+needs:
+
+```rust
+pub(crate) struct SubBufferedRawCEntry {
+    pub(crate) handle: session::RmwSubscriber,
+    pub(crate) buffer: BufferStrategy,
+    pub(crate) callback: RawSubscriptionCallback,
+    pub(crate) context: *mut core::ffi::c_void,
+}
+```
+
+**And yet the C++ object still carries its own.** `Subscription<M>` is 888 bytes,
+of which `alignas(8) uint8_t storage_[NROS_SUBSCRIBER_SIZE]` is unused on the
+dispatch path. The returning `create_subscription` in `nros.hpp` adds a third
+copy: a heap `detail::SubscriptionCallback<M>` cell whose only job is to hold a
+`std::function` that the arena entry's own `callback` + `context` fields already
+model.
+
+`component.hpp` shows the shape the rest of the API could have had — its own
+comment calls it a *"Thin wrapper over `nros_cpp_subscription_register`"* — and
+it keeps nothing.
+
+Services are the same one step less far along: `nros_cpp_service_server_register`
+returns a handle id, so the slot exists, but it is handed `&out` — the C++
+object — as its trampoline context. That back-reference is exactly what
+`service.hpp`'s move constructor warns about:
+
+> A callback-style service must NOT be moved after register — the arena holds
+> `this` as the trampoline context (Phase 189.M3.3.e); the move only transfers
+> bookkeeping and leaves that pointer stale, so don't.
+
+A hazard that exists only because the C++ side kept an object the arena did not
+need.
 
 ## Why it matters, in numbers
 
@@ -96,16 +135,60 @@ which side holds the bytes.
 
 So this may be accreted rather than decided. That is what the issue asks.
 
-## What it blocks
+## RE-SCOPED 2026-09-12 — it does not block phase-442, and the question is sharper
 
-phase-442 W8, directly. RFC-0096 D9 has to say where a returned
-`X::SharedPtr` handle's entity lives, and the answer is different depending on
-this: if entity storage moves into a Rust-side arena the way the timer's
-already has, every C++ entity becomes handle-shaped, `nros::Handle<T>` is
-trivially correct because C++ owns nothing, and D9 dissolves instead of being
-answered. If caller storage is the deliberate design, D9 has to pick among
-pools, node template parameters, or derived counts — all of which are heavier
-and none of which delete the 4 672.
+The first filing asked "where should entity storage live". That was the wrong
+question, and RFC-0096 D9 revision 3 answers it: for the rclcpp DISPATCH model
+the Rust arena already owns the entity, and `subscription.rs` says so —
+
+> arena (rclcpp dispatch model), as opposed to the poll-style
+> `nros_cpp_subscription_create` above. **The arena owns the subscriber**; spin …
+
+So there are TWO ABI paths per entity, not one shape to choose:
+
+| path | entry point | owner |
+| --- | --- | --- |
+| poll-style | `nros_cpp_subscription_create(…, void *storage)` | the caller |
+| dispatch | `nros_cpp_subscription_register(…, out_handle_id)` | the arena |
+
+and the arena's C-facing entry already holds everything a dispatch subscription
+needs:
+
+```rust
+pub(crate) struct SubBufferedRawCEntry {
+    pub(crate) handle: session::RmwSubscriber,
+    pub(crate) buffer: BufferStrategy,
+    pub(crate) callback: RawSubscriptionCallback,
+    pub(crate) context: *mut core::ffi::c_void,
+}
+```
+
+**The real defect is that the C++ API does not pick one.** `create_subscription`
+registers through the arena path AND keeps an 888-byte `Subscription<M>` whose
+`storage_` is unused there, AND heap-allocates a `detail::SubscriptionCallback<M>`
+cell to hold a `std::function` that duplicates the entry's own `callback` +
+`context`. Three copies of one subscription's identity.
+
+The same shape, one step less advanced, in services:
+`nros_cpp_service_server_register` returns a handle id — so the arena slot
+exists — but is handed `&out`, the C++ object, as its trampoline context. That
+back-reference is what `service.hpp`'s move constructor warns about:
+
+> A callback-style service must NOT be moved after register — the arena holds
+> `this` as the trampoline context (Phase 189.M3.3.e); the move only transfers
+> bookkeeping and leaves that pointer stale, so don't.
+
+A hazard that exists only because the C++ side kept an object the arena did not
+need.
+
+**So the question is now:** per entity kind, should the C++ dispatch path carry
+any storage of its own at all, and where a capture does not fit the single
+`context` pointer, should its bytes live in the arena's trailing allocation
+(which already exists for the rx buffer, `arena_alloc_with_trailing`)?
+
+phase-442 W8 does not wait on this. It can take the handle shape for
+subscriptions with the entry point that already exists. What this issue governs
+is the remaining kinds and whether the poll-path storage stays where it is.
 
 ## What would answer it
 

--- a/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
+++ b/docs/roadmap/phase-442-one-freestanding-rclcpp-api.md
@@ -286,6 +286,42 @@ the rest and do not depend on each other.
   `NROS_CPP_NODE_HOSTED` in the tree; the per-header parse loop at `fail=0` on
   every toolchain; the FreeRTOS, Zephyr, NuttX and ThreadX C++ builds green.
 
+* **W8's blocker is RESOLVED (2026-09-12), and the answer was already in the
+  tree.** RFC-0096 D9 revision 3: the C/C++ API is a thin wrapper over the Rust
+  API, and for the rclcpp dispatch model **the Rust arena already owns the
+  entity**. `subscription.rs` says so — *"arena (rclcpp dispatch model), as
+  opposed to the poll-style `nros_cpp_subscription_create` above. The arena owns
+  the subscriber."* Two ABI paths exist per entity;
+  `nros_cpp_subscription_register(..., out_handle_id)` is the dispatch one and
+  returns a handle id, exactly as `nros_cpp_timer_create` does.
+
+  So **`X::SharedPtr` for a dispatch entity is `nros::Handle` over
+  `{executor, handle_id}`** — what `Timer` already is, and what W3 already
+  built. The C++ `Subscription<M>`'s 888 bytes of `storage_` and the heap
+  `detail::SubscriptionCallback<M>` cell are a second copy of state
+  `SubBufferedRawCEntry` already holds (the `RmwSubscriber`, the rx buffer, the
+  callback, its context). No ABI addition, no pool, no node template parameter;
+  `X::SharedPtr` becomes COPYABLE again, and `service.hpp`'s "must not move
+  after register" hazard loses its subject because there is no C++ object to
+  move.
+
+  *The one new piece:* `context` is a single pointer, which carries `[this]` (7
+  of the 11 census sites) and not `[obj, method]` (three pointers). Capture bytes
+  belong with the registration, in Rust, and the arena already allocates
+  trailing bytes for the rx buffer — `arena_alloc_with_trailing` — so this is
+  the same allocation with a larger tail, `InplaceFn`'s invoker in the
+  `callback` field. That is the only Rust-side work the design needs.
+
+  *`nros::Owned<T>` is the exception, not the shape:* publishers and the
+  poll-style forms, where no arena slot exists and the C++ object genuinely is
+  the entity. `nros/owned.hpp` says so at the top.
+
+  *Per entity kind, what remains:* `nros_cpp_service_server_register` already
+  returns a handle id, but is handed `&out` — the C++ object — as its context;
+  moving that state into the arena entry removes the back-reference. Same audit
+  for the action forms. Issue 1335 narrows to "the C++ API uses the poll path
+  where it means the dispatch path, and carries storage for both".
+
 * **W9 [examples] — examples and fixtures follow.** The explicit
   `std::shared_ptr<rclcpp::X>` members in our own porting templates become the
   nested alias. DELIBERATELY LAST: this corpus is what made RFC-0096's first

--- a/packages/api/nros-cpp/include/nros/owned.hpp
+++ b/packages/api/nros-cpp/include/nros/owned.hpp
@@ -1,0 +1,175 @@
+// nros-cpp: the owning entity holder
+// Freestanding C++ — no exceptions, no STL required
+
+/**
+ * @file owned.hpp
+ * @ingroup grp_support
+ * @brief `nros::Owned<T>` — what an entity's `X::SharedPtr` is on every target.
+ */
+
+#ifndef NROS_CPP_OWNED_HPP
+#define NROS_CPP_OWNED_HPP
+
+#include "nros/traits.hpp"
+
+namespace nros {
+
+/// Owns an entity BY VALUE and speaks pointer — phase-442 W8.
+///
+/// THIS IS THE EXCEPTION, NOT THE RULE. READ THIS FIRST.
+///
+/// An entity that the executor DISPATCHES to — a subscription, a service, an
+/// action, a timer — is owned by the Rust arena, not by C++, and its
+/// `X::SharedPtr` is a `nros::Handle` over `{executor, handle_id}`. That is
+/// what `Timer` already is, and the ABI has the entry point for it:
+/// `nros_cpp_subscription_register(..., out_handle_id)`, whose own doc says
+/// "arena (rclcpp dispatch model), as opposed to the poll-style
+/// `nros_cpp_subscription_create` above. The arena owns the subscriber."
+///
+/// `Owned<T>` is for the entities with NO dispatch, where no arena slot exists
+/// and the C++ object genuinely is the entity: **publishers**, and the
+/// poll-style forms of the others. It is one kind and a fallback, not the
+/// shape of the API.
+///
+/// WHY THAT DISTINCTION IS THE DESIGN AND NOT AN IMPLEMENTATION DETAIL
+///
+/// The C/C++ API is a thin wrapper over the Rust API; entity lifetime is a Rust
+/// data structure's. Where that holds, C++ should hold a handle and nothing
+/// else — anything more is a second copy of state the arena already keeps.
+/// `SubBufferedRawCEntry` holds the `RmwSubscriber`, the rx buffer, the
+/// callback and its context, all of it; a C++ `Subscription<M>` carrying 888
+/// bytes of its own storage on that path is duplication that accumulated, not
+/// a decision.
+///
+/// WHY AN OWNING VALUE, WHERE IT DOES APPLY
+///
+/// `X::SharedPtr` is the name a ported file writes for an entity it keeps as a
+/// member. Upstream's is a `std::shared_ptr`, which needs an allocator and a
+/// control block. For a publisher there is no arena slot to point at, so the
+/// entity has to live somewhere C++ can name — and it can live in the member
+/// the ported file already declares, because the RMW handle RELOCATES. Every
+/// caller-storage entity has a `relocate` entry point, and the ABI states the
+/// contract:
+///
+///     Subscriptions are pull-based (`take_serialized`) and register nothing
+///     externally that references the storage address -- relocation is a
+///     straight `ptr::read` + `ptr::write`.
+///
+/// ```cpp
+/// class MinimalPublisher : public rclcpp::Node {
+///     rclcpp::Publisher<Msg>::SharedPtr pub_;   // no dispatch, so the entity IS here
+///   public:
+///     MinimalPublisher() { pub_ = this->create_publisher<Msg>("chatter", 10); }
+///     void tick() { pub_->publish(msg); }
+/// };
+/// ```
+///
+/// THE LIMIT, AND WHY IT IS NOT A GAP
+///
+/// Relocatability belongs to the RMW handle, not to the C++ object. Where the
+/// runtime has been handed a pointer to the OBJECT, moving it leaves that
+/// pointer stale, and the tree says so in the move constructor of the type it
+/// applies to (`service.hpp`):
+///
+///     A callback-style service must NOT be moved after register -- the arena
+///     holds `this` as the trampoline context (Phase 189.M3.3.e); the move only
+///     transfers bookkeeping and leaves that pointer stale, so don't.
+///
+/// That is not a hole in `Owned<T>`; it is the boundary of where `Owned<T>`
+/// belongs. An entity the runtime knows by address is a DISPATCH entity, and a
+/// dispatch entity takes the handle shape above, at which point there is no C++
+/// object to move and the hazard has no subject.
+///
+/// WHAT IT COSTS, MEASURED
+///
+/// Two relocations per creation on C++14 and C++17 alike — the temporary into
+/// the holder, the holder into the member. Elision does not remove the second,
+/// which is an assignment rather than an initialisation. Each is the
+/// `ptr::read` + `ptr::write` the ABI documents, at construction time only;
+/// nothing on the publish path moves.
+///
+/// HOW IT DIFFERS FROM `std::shared_ptr`, STATED
+///
+/// It is MOVE-ONLY, because a publisher is. Upstream's handle copies. The W0
+/// census found no entity handle copied anywhere in this tree or the porting
+/// corpus, so this costs nothing measured — and it applies only to the kinds
+/// listed above, because a dispatch entity's handle is `nros::Handle`, which
+/// copies.
+///
+/// There is also no `use_count()`, no `weak_ptr`, and no custom deleter. The
+/// entity's destructor runs when the holder does, which for the ported pattern
+/// is when the node does — the same observable lifetime upstream gives it.
+template <typename T> class Owned {
+  public:
+    using element_type = T;
+
+    Owned() : value_(), live_(false) {}
+    /// Null, spelled the way a ported file spells it (`X::SharedPtr p = nullptr`).
+    Owned(decltype(nullptr)) : value_(), live_(false) {}
+
+    /// Take ownership of `v`. Explicit so an entity does not silently become a
+    /// handle at a call site that meant to keep the value.
+    explicit Owned(T&& v) : value_(static_cast<T&&>(v)), live_(true) {}
+
+    Owned(Owned&& other) : value_(static_cast<T&&>(other.value_)), live_(other.live_) {
+        other.live_ = false;
+    }
+
+    Owned& operator=(Owned&& other) {
+        if (this != &other) {
+            value_ = static_cast<T&&>(other.value_);
+            live_ = other.live_;
+            other.live_ = false;
+        }
+        return *this;
+    }
+
+    Owned(const Owned&) = delete;
+    Owned& operator=(const Owned&) = delete;
+
+    T* operator->() { return &value_; }
+    const T* operator->() const { return &value_; }
+    T& operator*() { return value_; }
+    const T& operator*() const { return value_; }
+
+    /// The entity's address, or null when empty. Valid until this holder is
+    /// moved from or destroyed — which is the one thing a caller must not
+    /// assume about `std::shared_ptr`'s `get()`, so it is said here.
+    T* get() { return live_ ? &value_ : nullptr; }
+    const T* get() const { return live_ ? &value_ : nullptr; }
+
+    /// `if (pub)` / `if (!pub)`.
+    explicit operator bool() const { return live_; }
+
+    /// Destroy the entity now rather than at scope end. `X::SharedPtr::reset()`
+    /// in ported code means "drop my reference"; here there is only one
+    /// reference, so dropping it destroys, which is what upstream does when it
+    /// was the last one.
+    void reset() {
+        if (live_) {
+            value_ = T();
+            live_ = false;
+        }
+    }
+
+  private:
+    T value_;
+    bool live_;
+};
+
+template <typename T> bool operator==(const Owned<T>& a, decltype(nullptr)) {
+    return !static_cast<bool>(a);
+}
+template <typename T> bool operator!=(const Owned<T>& a, decltype(nullptr)) {
+    return static_cast<bool>(a);
+}
+template <typename T> bool operator==(decltype(nullptr), const Owned<T>& a) {
+    return !static_cast<bool>(a);
+}
+template <typename T> bool operator!=(decltype(nullptr), const Owned<T>& a) {
+    return static_cast<bool>(a);
+}
+
+} // namespace nros
+
+#endif // NROS_CPP_OWNED_HPP

--- a/packages/api/nros-cpp/tests/compile/freestanding_mechanisms.cpp
+++ b/packages/api/nros-cpp/tests/compile/freestanding_mechanisms.cpp
@@ -13,6 +13,7 @@
 #include "nros/traits.hpp"
 #include "nros/handle.hpp"
 #include "nros/inplace_fn.hpp"
+#include "nros/owned.hpp"
 
 namespace tr = nros::tr;
 static_assert(tr::is_same<tr::decay<const int&>::type, int>::value, "decay cv-ref");
@@ -71,4 +72,80 @@ extern "C" int nros_w3_probe(const Msg& m) {
     }
     moved.clear();
     return g_sub.n + static_cast<int>(moved.valid());
+}
+
+// --- Owned<T>: an entity kept BY VALUE, spoken to as a pointer (W8) ---------
+//
+// The stand-in carries the same move contract the real entities do: a
+// relocation that the C ABI documents as `ptr::read` + `ptr::write`, counted
+// here so the probe measures the move rather than assuming it.
+static int g_relocations = 0;
+
+class FakePublisher {
+  public:
+    FakePublisher() : initialized_(false) { storage_[0] = 0; }
+    FakePublisher(FakePublisher&& o) : initialized_(o.initialized_) {
+        if (o.initialized_) {
+            ++g_relocations;
+            storage_[0] = o.storage_[0];
+            o.initialized_ = false;
+        }
+    }
+    FakePublisher& operator=(FakePublisher&& o) {
+        if (this != &o) {
+            initialized_ = o.initialized_;
+            if (o.initialized_) {
+                ++g_relocations;
+                storage_[0] = o.storage_[0];
+                o.initialized_ = false;
+            }
+        }
+        return *this;
+    }
+    FakePublisher(const FakePublisher&) = delete;
+    FakePublisher& operator=(const FakePublisher&) = delete;
+
+    void publish(const Msg&) {}
+    void mark_live() { initialized_ = true; }
+
+    using SharedPtr = nros::Owned<FakePublisher>;
+
+  private:
+    alignas(8) unsigned char storage_[64];
+    bool initialized_;
+};
+
+// The ported shape: a member holds the entity, and the factory returns it.
+class PortedNode {
+  public:
+    PortedNode() { pub_ = make(); }
+    void tick() {
+        Msg m{1};
+        pub_->publish(m);
+        if (pub_) {
+            (*pub_).publish(m);
+        }
+    }
+
+  private:
+    static FakePublisher::SharedPtr make() {
+        FakePublisher p;
+        p.mark_live();
+        return FakePublisher::SharedPtr(static_cast<FakePublisher&&>(p));
+    }
+    FakePublisher::SharedPtr pub_;
+};
+
+static_assert(!nros::tr::is_same<FakePublisher::SharedPtr, FakePublisher*>::value,
+              "Owned is not a raw pointer");
+
+extern "C" int nros_w8_owned_probe() {
+    PortedNode n;
+    n.tick();
+    nros::Owned<FakePublisher> empty;
+    if (empty != nullptr) {
+        return -1;
+    }
+    empty.reset();
+    return g_relocations;
 }

--- a/scripts/check-cpp-freestanding-mechanisms.py
+++ b/scripts/check-cpp-freestanding-mechanisms.py
@@ -4,8 +4,10 @@
 WHAT IS BEING MEASURED
 
 RFC-0096's claim is that one API can be freestanding AND be the rclcpp API, and
-it rests on two mechanisms: a copyable non-owning handle behind `X::SharedPtr`,
-and a fixed-capacity inplace callable behind a capturing-lambda callback. A
+it rests on three mechanisms: a copyable non-owning handle behind
+`Node::SharedPtr`, an OWNING value holder behind an entity's `X::SharedPtr`
+(phase-442 W8), and a fixed-capacity inplace callable behind a capturing-lambda
+callback. A
 claim like that is worth exactly the compile that backs it, on the toolchains
 that actually differ.
 
@@ -150,7 +152,8 @@ def main():
               % (PROBE, OVERBUDGET), file=sys.stderr)
         return 1
 
-    print("check-cpp-freestanding-mechanisms: OK -- the handle and the inplace callable compile "
+    print("check-cpp-freestanding-mechanisms: OK -- the handle, the owning holder and the "
+          "inplace callable compile "
           "on %d toolchain configuration(s), and an over-budget capture fails on each with a "
           "diagnostic naming %s" % (ran, KNOB))
     return 0


### PR DESCRIPTION
D9 asked where a returned `X::SharedPtr` handle's entity lives and blocked W8 on
the answer. Two revisions looked for somewhere in C++ to put it — a pool, then a
Rust arena to be built. Both were the wrong question. The C/C++ API is a thin
wrapper over the Rust API, entity lifetime is a Rust data structure's, and for
the rclcpp dispatch model the Rust side ALREADY owns the entity.

`packages/api/nros-cpp/src/subscription.rs` says so:

    arena (rclcpp dispatch model), as opposed to the poll-style
    `nros_cpp_subscription_create` above. The arena owns the subscriber; spin ...

TWO PATHS PER ENTITY, AND THE C++ API USES BOTH AT ONCE

    poll-style   nros_cpp_subscription_create(..., void *storage)    caller owns
    dispatch     nros_cpp_subscription_register(..., out_handle_id)  arena owns

The arena's C-facing entry already holds everything the dispatch path needs —
`SubBufferedRawCEntry { handle: RmwSubscriber, buffer, callback, context }` —
and yet `Subscription<M>` still carries 888 bytes of its own `storage_`, unused
there, and `nros.hpp`'s returning `create_subscription` adds a third copy: a
heap `detail::SubscriptionCallback<M>` cell holding a `std::function` that the
entry's own `callback` + `context` already model.

`component.hpp` shows what the rest could have looked like. Its own comment
calls it a "Thin wrapper over `nros_cpp_subscription_register`", and it keeps
nothing.

SO `X::SharedPtr` FOR A DISPATCH ENTITY IS A HANDLE

`nros::Handle` over `{executor, handle_id}` — what `Timer` already is, and what
W3 already built. Four consequences, every one a simplification:

  * no ABI addition, no pool, no node template parameter: the entry point exists
    and returns a handle id;
  * `X::SharedPtr` is COPYABLE, which REMOVES a difference from D5 instead of
    adding one;
  * `service.hpp`'s "must not move after register" hazard loses its subject —
    there is no C++ object to move;
  * `sizeof` stops being a design input. The 4 672-byte `Client<int>` that made
    every pooling answer look unaffordable was the C++ object holding the reply
    buffer.

THE ONE GENUINELY NEW PIECE

`context` is a single pointer. It carries `[this]` — 7 of the 11 capture sites
the W0 census found — and not `[obj, method]`, which is three pointers. Capture
bytes belong with the registration, in Rust, and the arena already allocates
trailing bytes for the rx buffer (`arena_alloc_with_trailing`), so this is the
same allocation with a larger tail and `InplaceFn`'s invoker in the `callback`
field. That is the only Rust-side work the design needs.

WHAT `nros::Owned<T>` IS FOR

The entities with NO dispatch, where no arena slot exists and the C++ object
genuinely is the entity: publishers, and the poll-style forms. It is a fallback
for one kind, not the shape of the API, and `owned.hpp` says so in its first
paragraph. Where it does apply it is sound: the RMW handle relocates, per the
ABI's own contract, so the entity can live in the member the ported file already
declares — two relocations per creation, construction time only.

ISSUE 1335 IS RE-SCOPED, AND ITS OWN EVIDENCE IS CORRECTED

It asked "where should entity storage live" and answered with a table showing
the timer as the only arena-shaped entity. That table was built from the
generated `nros_cpp_ffi.h`, which does not contain the dispatch entry points —
they are hand-declared `extern "C"` in the entity headers. Reach narrower than
the rule, in the issue written about reach. The question is now the sharper one:
the C++ API uses the poll path where it means the dispatch path and carries
storage for both.

It no longer blocks W8: subscriptions can take the handle shape with the entry
point that already exists.

## Verification

`just check fast` — 312 gates green, 1 skipped. `check-cpp-freestanding-mechanisms`
green on all three arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A4bG1pAtNwG5BDJBFBtfb