### PR TITLE
fix(ci, #1338): `arm-auto-merge` printed `armed #N` on every run and had never armed one

### DIFF
--- a/.github/workflows/arm-auto-merge.yml
+++ b/.github/workflows/arm-auto-merge.yml
@@ -173,7 +173,32 @@ jobs:
           #
           # Already-armed is also not an error, and `synchronize` will re-run
           # this on every push, so the common case is a no-op.
-          if gh pr merge "$NUMBER" --auto --rebase 2>&1 | tee /tmp/arm.log; then
+          # issue 1338 — TWO faults lived in the single line this replaces, and
+          # they compounded in the worst direction: one made it always fail,
+          # the other made it always report success.
+          #
+          #   * No `--repo`. This job checks out NOTHING, on purpose (see the
+          #     `pull_request_target` note above — do not add a checkout to fix
+          #     this). `gh pr merge` resolves the repository from the local git
+          #     remote, so with no local git it died on EVERY run with
+          #     `failed to run git: fatal: not a git repository`.
+          #   * `if cmd | tee ...` tests the PIPELINE's status, which is
+          #     `tee`'s and is 0 either way. The `else` below was unreachable,
+          #     so the `::warning::` had never once been emitted and the run
+          #     printed `armed #N` three lines under the git error.
+          #
+          # So the workflow written to fix "16 of 23 PRs are not armed" had
+          # never armed one, and the only visible evidence was a green check
+          # saying it had. Issue 1226's shape with the sign flipped.
+          #
+          # `rc=0; cmd || rc=$?` is this repo's ONE spelling for a status you
+          # mean to INSPECT under `set -e` (issue 1249) — and a pipe destroys
+          # it, which is why the redirect replaces the `tee`.
+          rc=0
+          gh pr merge "$NUMBER" --repo "$GITHUB_REPOSITORY" --auto --rebase \
+            > /tmp/arm.log 2>&1 || rc=$?
+          sed 's/^/  /' /tmp/arm.log
+          if [ "$rc" -eq 0 ]; then
             echo "armed #$NUMBER"
           else
             # Never fail the workflow for this. A PR that cannot be armed yet
@@ -181,5 +206,4 @@ jobs:
             # on someone's pull request -- and a red check here would be a
             # second, confusing signal beside the real `CI` one.
             echo "::warning::could not arm auto-merge on #$NUMBER"
-            sed 's/^/  /' /tmp/arm.log
           fi

--- a/docs/issues/1338-arm-auto-merge-reports-armed-and-never-arms.md
+++ b/docs/issues/1338-arm-auto-merge-reports-armed-and-never-arms.md
@@ -1,0 +1,86 @@
+---
+id: 1338
+title: "`arm-auto-merge` prints `armed #N` on every run and has never armed
+  anything: no `--repo` with no checkout, and an `if` that tests `tee`"
+status: open
+type: bug
+area: ci
+severity: high
+related: [issue-1040, issue-1226, issue-1249, issue-0952]
+---
+
+## Symptom
+
+Pull request #947, 2026-09-11: every required check green, `mergeStateStatus`
+`CLEAN`, the `arm auto-merge` check **SUCCESS** — and `autoMergeRequest` is
+`null`. The PR is not armed, so it never enters the merge queue and never
+lands, while the check that exists to say so is green.
+
+## The two faults, in one line
+
+`.github/workflows/arm-auto-merge.yml:176`:
+
+```bash
+if gh pr merge "$NUMBER" --auto --rebase 2>&1 | tee /tmp/arm.log; then
+  echo "armed #$NUMBER"
+else
+  echo "::warning::could not arm auto-merge on #$NUMBER"
+```
+
+1. **No `--repo`, and the workflow checks out nothing.** That is deliberate and
+   correct — it is `pull_request_target`, and its own header says *"Do not add
+   `actions/checkout` here"*, because checking out PR code under that trigger
+   hands a writable token to untrusted code. But `gh pr merge` resolves the
+   repository from the local git remote, and there is no local git:
+
+       failed to run git: fatal: not a git repository (or any of the parent
+       directories): .git
+
+   The command fails on **every** invocation. It has never armed a pull request.
+
+2. **The `if` tests the wrong exit status, so the failure branch is
+   unreachable.** A pipeline's status is its LAST command's, i.e. `tee`'s, which
+   is 0 whether `gh` succeeded or died. So the `else` can never run, the
+   `::warning::` has never been emitted, and the run prints `armed #947`
+   immediately after the git error — both lines are in the log of run
+   34653777221, three lines apart.
+
+The two compound in the worst direction: fault 1 makes it always fail, fault 2
+makes it always report success.
+
+## Why it stayed invisible
+
+The workflow was written to fix a measured throughput problem — *"of 23 open
+pull requests, 16 were not armed"* — and its header reasons carefully about the
+re-arming loop (*"a force-push CANCELS auto-merge... `synchronize` is what
+closes it"*). That reasoning is right. The loop simply never ran.
+
+Nothing contradicted it, because the only evidence anyone sees is a green check
+named `arm auto-merge` and a log line saying `armed #N`. A human arming a PR by
+hand (as happened on #947 at 19:58Z) looks exactly like the workflow working.
+
+This is issue 1226's shape — *a gate that WORKS is not a gate that RUNS* — with
+the sign flipped: a job that runs, cannot work, and reports that it did. It is
+also issue 0952's withdrawal class and issue 1249's exit-status class in one
+line.
+
+## Fix
+
+```bash
+rc=0
+gh pr merge "$NUMBER" --repo "$GITHUB_REPOSITORY" --auto --rebase \
+  > /tmp/arm.log 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+```
+
+`--repo` because there is no checkout and there must not be one; `rc=0; cmd ||
+rc=$?` because that is this repo's one spelling for a status you mean to
+INSPECT under `set -e` (issue 1249), and because a pipe destroys it.
+
+## Acceptance
+
+- A pull request whose checks are green and whose `mergeStateStatus` is `CLEAN`
+  reports non-null `autoMergeRequest` after the workflow runs.
+- Negative control: with a deliberately bad `--repo`, the run emits the
+  `::warning::` and the captured `gh` output, rather than `armed #N`.
+- The `armed #N` line is only printed when the API call actually succeeded.


### PR DESCRIPTION
`arm-auto-merge` has never armed a pull request, and its check is green every time.

## The evidence

PR #947, 2026-09-11: every required check green, `mergeStateStatus` **CLEAN**, the `arm auto-merge` check **SUCCESS** — and `autoMergeRequest: null`.

Run 34653777221's log, three lines apart:

    failed to run git: fatal: not a git repository (or any of the parent directories): .git

    armed #947

## Two faults in one line, compounding in the worst direction

`.github/workflows/arm-auto-merge.yml:176`

```bash
if gh pr merge "$NUMBER" --auto --rebase 2>&1 | tee /tmp/arm.log; then
```

1. **No `--repo`, and this job checks out nothing.** That is deliberate and right — it is `pull_request_target`, and the file's own header says *"Do not add `actions/checkout` here"*, because checking out PR code under that trigger hands a writable token to untrusted code. But `gh pr merge` resolves the repository from the local git remote, so with no local git it fails on **every** invocation.
2. **The `if` tests `tee`.** A pipeline's exit status is its last command's, which is 0 whether `gh` succeeded or died. The `else` is unreachable: the `::warning::` it exists to print has never once been emitted.

One makes it always fail; the other makes it always report success.

## Why nobody noticed

The workflow was written against a measured problem — *"of 23 open pull requests, 16 were not armed"* — and its header reasons carefully about the loop it closes: *a force-push CANCELS auto-merge, so `synchronize` is what re-arms.* That reasoning is correct. It has simply never run.

Nothing contradicted it, because the only visible evidence is a green check named `arm auto-merge` and a log line saying `armed #N` — and a human arming a PR by hand looks identical. That is what happened on #947: armed at 19:58Z by a person, disarmed by the next force-push, and never re-armed.

This is **issue 1226's shape with the sign flipped** — *a gate that WORKS is not a gate that RUNS*; here it runs, cannot work, and reports that it did. It is also issue 0952's withdrawal class and issue 1249's exit-status class in the same line.

## The fix

```bash
rc=0
gh pr merge "$NUMBER" --repo "$GITHUB_REPOSITORY" --auto --rebase \
  > /tmp/arm.log 2>&1 || rc=$?
sed 's/^/  /' /tmp/arm.log
if [ "$rc" -eq 0 ]; then
```

`--repo` because there is no checkout and there must not be one. `rc=0; cmd || rc=$?` because that is this repo's one spelling for a status you mean to INSPECT under `set -e` (issue 1249) — and a pipe is precisely what destroyed it. The captured output now prints unconditionally, so a successful arm is legible too, and the failure branch no longer prints it twice.

`check-set-e-bare-assignment` is green over this line both before and after — it reads assignments, and this was a pipeline. Worth knowing where that gate's reach ends.

## Verification

`just check fast` green. The real acceptance is behavioural and is stated in issue 1338: a green, CLEAN pull request must show non-null `autoMergeRequest` after this runs, and a deliberately bad `--repo` must produce the `::warning::` rather than `armed #N`. Both are observable on this PR's own `arm auto-merge` run.

Found while pushing #947, whose subject is gates whose reach is narrower than the rule they enforce. Filed as issue 1338 and split onto its own branch off `main` rather than carried there — #947 was already in the merge queue, and this is unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkfB3GGnzUvL9aXhL4qyf8
