### PR TITLE
feat(phase-454 W8, #1339): a queue endpoint's depth is derivable from rates the contract already carries — and the model drops them

### DIFF
--- a/cmake/NanoRosEntityInventory.cmake
+++ b/cmake/NanoRosEntityInventory.cmake
@@ -241,7 +241,19 @@ include_guard(GLOBAL)
 # can now say `refused` because an endpoint declared `history: keep_all`, and a
 # version-4 reader that had never seen that reason would keep sizing from a
 # depth that has stopped bounding anything.
-set(NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED 5 CACHE INTERNAL
+# **6** (phase-454 W8, RFC-0100 D9) gave the depth rows a PROVENANCE.
+# `NROS_ENTITY_DERIVED_DEPTHS` and `NROS_ENTITY_DERIVED_DEPTH_COUNT` name the
+# subset of `NROS_ENTITY_DECLARED_DEPTHS` that this CLI DERIVED, from a
+# `buffer: queue` endpoint's publish and drain rates, rather than read off a
+# contract. Bumps for the usual reason -- an absent list in a version-5 fragment
+# is an older CLI's silence, not "nothing was derived" -- and for one that is
+# not additive: `NROS_ENTITY_DECLARED_DEPTHS`' own DEFINITION widened, from "the
+# numbers an author wrote" to "the numbers this image will size from, however
+# they were arrived at". A consumer that SIZES from the list is unaffected and
+# is the reason the derived rows are in it at all; a consumer that ASSERTS
+# against it must subtract the derived subset, or it turns a default into a
+# requirement every call site has to match.
+set(NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED 6 CACHE INTERNAL
     "phase-403 W9: the nros_entity_inventory fragment schema this tree reads")
 
 # nros_entity_inventory_knobs_file(<out_var>)

--- a/docs/design/0100-rmw-agnostic-sizing-model.md
+++ b/docs/design/0100-rmw-agnostic-sizing-model.md
@@ -402,6 +402,59 @@ A derived default under the ladder — a stated `depth` still wins — for exact
 the endpoints where a hand-typed depth is most likely wrong, using keys already
 in the schema.
 
+### The margin is ONE slot, and the argument is the phase relationship
+
+`ceil(publish / drain)` is the number of samples emitted during one drain
+period, and it is the right answer only for a queue whose drain instants are
+ALIGNED with its arrivals. They are not: a `queue` subscription and the timer
+that drains it are two independent periodic streams with no phase relationship
+the contract states, and for an unaligned window of length `T` the arrivals of a
+`p`-periodic stream are bounded by `floor(p·T) + 1`. One slot is exactly that
+straggler — the sample that landed just after a drain instant and is still
+queued when the next period's own samples arrive.
+
+Not two, and not a percentage. Every extra slot is a whole message: the arena
+charges `(depth + 1) * bound + (depth + 1) * pointer` per subscription, so
+inflating a DEFAULT is the over-size direction the table above keeps measuring.
+And the things a larger margin would absorb — timer jitter, drain overrun, a
+burst above the declared rate — are bounded by no number that reaches the
+derivation, so a margin covering them would be a guess wearing arithmetic's
+clothes, which is precisely what this decision refuses to let `buffer:` itself
+be. The contract does carry `paths.<p>.max_jitter` and `paths.<p>.miss`; when
+those travel, a jitter-aware margin can be DERIVED and the constant retired.
+
+### MEASURED: two of the three inputs do not reach the build (issue 1339)
+
+phase-454 W8 implemented this and measured what a contract actually delivers,
+resolving `packages/cli/nros-cli-core/tests/fixtures/queue_buffer/` through the
+pinned `nros-launch-resolve`. The retraction above was about what `buffer:`
+MEANS; this is about where it GOES, and it is the more immediate constraint:
+
+| fact | contract key | in the SystemModel? |
+| --- | --- | --- |
+| publish rate | `topics.<t>.rate_hz` | yes — `TopicContract::rate_hz` |
+| publish rate | `<n>.pub.<ep>.min_rate_hz` | yes — `PubContract::min_rate_hz` |
+| drain rate | `<n>.paths.<p>.trigger.timer.rate_hz` | **no** — `PathContract` has no trigger |
+| discipline | `<n>.sub.<ep>.buffer` | **no** — `SubContract` has no `buffer` |
+
+Both gaps are the MODEL SCHEMA's, not nano-ros's. The resolver parses both,
+validates `buffer` (outside `state: true` it is a parse-time error), and
+performs this decision's own division to emit a `[queue-drain-rate]` warning —
+then writes a `sub_endpoints` entry with no discipline and a `node_paths` entry
+carrying `output` alone. So the derivation ships ARMED and inert: no contract in
+this tree can produce a `queue` endpoint, and therefore no image's sizing moves.
+
+Two consequences this RFC should be read with. First, the drain rate nano-ros
+can see is a SUBSTITUTE — the `min_rate_hz` of what a node's timer paths
+publish, the convention `mapper_input::pub_rate_hz` already uses — absent for a
+drain timer that publishes nothing, and the resolver's own `[derivable-min-rate]`
+advice is to delete it. Second, a derived depth is not interchangeable with a
+stated one: `DeclaredDepth` carries a `DepthSource`, the arena reads both and the
+compile-time `NROS_ASSERT_DECLARED_DEPTH` table reads only `Stated`. A default
+that became a `static_assert` would oblige every call site to spell this CLI's
+arithmetic, and moving the margin by one slot would break every image at once —
+the ladder inverted.
+
 ## D10 — single-source the ROS QoS defaults first
 
 ROS defaults are literals in four places (`nros-node/build.rs:27`, the

--- a/docs/issues/1339-queue-buffer-and-path-trigger-dropped-by-system-model.md
+++ b/docs/issues/1339-queue-buffer-and-path-trigger-dropped-by-system-model.md
@@ -1,0 +1,115 @@
+---
+id: 1339
+title: "`buffer:` and a path's `trigger:` are stated, validated, reasoned about — and dropped by the SystemModel schema"
+status: open
+area: cli, launch, contract
+severity: medium
+found: 2026-09-12
+related: [1256, 0760, phase-454, RFC-0100]
+---
+
+# What is wrong
+
+The launch contract states three facts the RFC-0100 D9 queue-depth default is
+built from. Two of them do not reach nano-ros, because the **SystemModel schema
+has no field for them** — not because nano-ros fails to read them.
+
+| fact | contract key | manifest type | SystemModel type | arrives? |
+| --- | --- | --- | --- | --- |
+| publish rate | `topics.<t>.rate_hz` | `TopicDecl` | `TopicContract::rate_hz` | **yes** |
+| publish rate | `<n>.pub.<ep>.min_rate_hz` | `EndpointProps` | `PubContract::min_rate_hz` | **yes** |
+| drain rate | `<n>.paths.<p>.trigger.timer.rate_hz` | `Trigger::Timer` | — `PathContract` has no `trigger` | **no** |
+| discipline | `<n>.sub.<ep>.buffer` | `EndpointProps::buffer` | — `SubContract` has no `buffer` | **no** |
+
+Measured on `ros-launch-manifest` **v0.1.35** (the pin across every nano-ros
+crate; it is also the newest tag) with the pinned `nros-launch-resolve`, over
+`packages/cli/nros-cli-core/tests/fixtures/queue_buffer/`. The contract states
+`buffer: queue` on a `state: true` subscription and
+`trigger: { timer: { rate_hz: 10 } }` on the path that drains it; the resolved
+model carries:
+
+```yaml
+contracts:
+  sub_endpoints:
+    /listener/chatter:
+      state: true            # the sibling key on the SAME endpoint DID travel
+      qos: { history: keep_last }
+  node_paths:
+    /listener/drain:
+      output: [/listener/status]   # and nothing else
+```
+
+# Why this is not "an unused key"
+
+The resolver does not ignore these. It **parses** them, **validates** them
+(`buffer` outside `state: true` is a parse-time error) and **reasons** about
+them — on this very fixture it emits
+
+> `[queue-drain-rate] warning: node 'listener' timer path 'drain' rate_hz (10)
+> is less than the sum of its 'buffer: queue' subscriptions' producer rates
+> (50, from ["chatter"]) — the queue will accumulate backlog every period`
+
+which is the publish rate divided by the drain rate, joined per node, with the
+discipline selecting the population. Every input RFC-0100 D9's default needs is
+already computed at layer 2 and then discarded at the model boundary. Nothing
+needs inventing upstream; it needs **carrying**.
+
+This is issue 1256's shape one layer further out. 1256 was "the contract states
+four QoS policies and `from_model` reads one"; this is "the contract states a
+fact, the resolver acts on it, and the artifact nano-ros reads has no field for
+it". A declaration that is legal to write, legal to resolve, acted upon, and
+then dropped is one the author believes they made.
+
+Compare issue 0760, which is the same boundary from the other side: a schema
+that belongs to `ros-launch-manifest` rather than to nano-ros.
+
+# Consequence
+
+phase-454 W8 lands the whole derivation — the ladder, the arithmetic, both
+diagnostics — and it is **inert on every image in this tree**, because no
+contract can produce a `queue` endpoint in a SystemModel. The wave ships the two
+rates wired (`EntityDecl::{publish_rate, drain_rate}`, read from
+`contracts.topics.<t>.rate_hz` and from the `min_rate_hz` of what a node's timer
+paths publish) and `EntityDecl::buffer` permanently `None`, so
+`queue_depth_defaults()` reports `NoDefault::NotAQueue` for every endpoint.
+
+The cost is not only the missing default. The drain rate nano-ros *can* see is a
+**substitute**: the `min_rate_hz` promise made by whatever the timer publishes,
+which is the convention `nros_orchestration_ir::mapper_input::pub_rate_hz`
+already uses for a periodic path's fire rate. It is not the authored timer rate,
+it is absent for a drain timer that publishes nothing, and the resolver itself
+calls such a `min_rate_hz` *"redundant and can be deleted"* — advice that, taken,
+removes the only spelling of the drain rate that survives.
+
+# What would fix it
+
+In `ros-launch-manifest` (and the resolver that writes the model):
+
+1. `SubContract` gains `buffer: Option<Buffer>`, emitted where the endpoint
+   states one.
+2. `PathContract` gains the effective trigger — at minimum the timer rate.
+   `PathDecl::effective_trigger()` already computes it; today the model keeps
+   only the `input`-empty/non-empty distinction that falls out of it, which is
+   also why `from_model` counts `once` and `spontaneous` paths as timers
+   (documented there, over-counting in the safe direction).
+
+Then in nano-ros, both edits are one line each, and both are marked:
+
+* `EntityInventory::from_model`'s `buffer: None`, with this issue number beside
+  it, becomes a read of the new field.
+* the `drain_rate_by_node` derivation reads the path's own rate instead of its
+  output's promise.
+
+# Acceptance
+
+`packages/cli/nros-cli-core/tests/contract_queue_buffer_reaches_the_model.rs`
+holds two tripwires that go **red** the day this closes, each naming what to
+wire:
+
+* `the_model_does_not_carry_the_buffer_discipline_yet`
+* `the_model_does_not_carry_a_paths_trigger_rate_yet`
+
+Closing the issue means: those two are deleted, the two reads above are live,
+and a contract stating `buffer: queue` with both rates derives a depth end to
+end — the case phase-454 W8's unit tests currently exercise over hand-built
+rows because no contract can reach them.

--- a/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
+++ b/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
@@ -306,12 +306,43 @@ cause.
 Acceptance: a divergent pair fails the build naming both; an agreeing pair
 builds; a params-only policy fails naming the contract.
 
-### W8 — `buffer:` earns its keep
+### W8 — `buffer:` earns its keep — LANDED, and ARMED rather than firing
 
-Two diagnostics (`queue` at `depth = 1`; `latest` at a large depth), and the
-rate-derived depth default for `queue` endpoints from `topics.<t>.rate_hz` and
-`paths.<p>.trigger.timer.rate_hz` — both keys already in the schema. A stated
-`depth` still wins, per the ladder.
+Two diagnostics (`queue` at `depth = 1`; `latest` at a depth of 2 or more — the
+arena's own break point, where an endpoint stops being a read-latest triple
+buffer and starts paying by the message), and the rate-derived depth default for
+`queue` endpoints. A stated `depth` still wins, per the ladder; the margin is
+**one slot**, from the unaligned-window bound, argued in RFC-0100 D9.
+
+`packages/cli/nros-cli-core/src/queue_depth.rs` is the whole vocabulary and the
+whole arithmetic; `EntityInventory::{queue_depth_defaults, buffer_diagnostics}`
+are the views, and `declared_depths()` is where the ladder runs. `DeclaredDepth`
+gained a `DepthSource`, because the depth table has two consumers that want
+opposite things from a default: `subs_arena` SIZES from it (a default is the
+point) and `to_declared_qos_header` ASSERTS from it (a default there is a
+requirement every call site must match). Schema 5 → 6, with
+`NROS_ENTITY_DERIVED_DEPTHS` publishing the provenance.
+
+**What the wave measured, and it is the finding rather than a caveat.** Of the
+three contract facts the derivation needs, ONE reaches the SystemModel. The
+resolver parses, validates and reasons about the other two — it emits a
+`[queue-drain-rate]` warning performing exactly this division — and the model
+schema has no field for either, so it writes neither. Issue **1339**; RFC-0100 D9
+carries the table. Consequences:
+
+* No contract in this tree can produce a `queue` endpoint, so **no image's
+  sizing moves**, which is acceptance 5 satisfied structurally rather than by
+  luck. The targeted controls are asserted anyway (rates present + no
+  discipline, and `buffer: latest`, both byte-identical).
+* The drain rate that does arrive is a SUBSTITUTE: the `min_rate_hz` of what a
+  node's timer paths publish (`mapper_input::pub_rate_hz`'s convention). Absent
+  for a drain timer that publishes nothing.
+* Acceptances 1, 2 and 4 are asserted over hand-built inventory rows, which is
+  the only road that can reach a `queue` endpoint today; acceptance 3 is
+  asserted end to end from a real contract through the real resolver, where the
+  reported reason is `NotAQueue` precisely because both rates DID arrive.
+* `tests/contract_queue_buffer_reaches_the_model.rs` holds two tripwires that go
+  red the day 1339 closes, each naming the one line to wire.
 
 ### W9 — retirement
 

--- a/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
@@ -299,6 +299,38 @@ pub fn run(args: EntityInventoryArgs) -> Result<()> {
     // build script stays on its own default.
     print!("{}", inv.to_env());
 
+    // phase-454 W8 (RFC-0100 D9) -- the two `buffer:` diagnostics.
+    //
+    // WARNINGS, on stderr, and deliberately not gated behind `--require-derived`
+    // or anything else: both shapes are legal, so there is no flag under which
+    // they should become fatal. Stderr and not stdout because stdout is this
+    // verb's ENV TRANSPORT -- a line printed there lands in a
+    // `corrosion_set_env_vars` call site and would be parsed as a variable.
+    for d in inv.buffer_diagnostics() {
+        eprintln!("nros: warning: {}", d.message());
+    }
+
+    // ...and the visible REASON an endpoint that asked for the derivation did
+    // not get one (RFC-0100 D9, acceptance 3).
+    //
+    // Narrowed to endpoints that declared `buffer: queue`, which is the whole
+    // population that asked. A line per subscription would be noise on every
+    // build; a silent decline for an author who wrote `buffer: queue` and got
+    // no default is the failure this campaign keeps paying for -- a derivation
+    // that declines quietly is indistinguishable from one that never ran.
+    for row in inv.queue_depth_defaults() {
+        if row.buffer != Some(crate::queue_depth::BufferDiscipline::Queue) {
+            continue;
+        }
+        if let Err(reason) = &row.outcome {
+            // A stated depth is not a failure -- it is the rung above working.
+            if matches!(reason, crate::queue_depth::NoDefault::DepthStated(_)) {
+                continue;
+            }
+            eprintln!("nros: {}", row.line());
+        }
+    }
+
     let derivation = inv.derive();
     if let crate::entity_inventory::Derivation::Refused { reason } = &derivation {
         if args.require_derived {

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -118,6 +118,13 @@ use nros_orchestration_ir::qos_override::{
     history_spelling, parse_durability, parse_history, parse_reliability, reliability_spelling,
 };
 
+// phase-454 W8 -- `buffer:` and the derivation it selects. NOT in the module
+// above: `buffer` never reaches a `qos_overrides.*` parameter, no runtime folds
+// it into a `QoSProfile`, and it is not a QoS policy at all (RFC-0100 D9).
+use crate::queue_depth::{
+    BufferDiagnostic, BufferDiscipline, NoDefault, RateMilliHz, depth_default, diagnose,
+};
+
 /// Bumped when the shape of the emitted inventory changes incompatibly.
 /// A consumer that does not recognise the version must refuse, never guess.
 ///
@@ -161,7 +168,24 @@ use nros_orchestration_ir::qos_override::{
 /// keep_all` on some endpoint. A KEEP_ALL queue has no static bound, so a depth
 /// stated beside it prices nothing (RFC-0100 D6), and a reader that kept using
 /// the old list would size from a number that has stopped meaning what it said.
-pub const ENTITY_INVENTORY_SCHEMA_VERSION: u32 = 5;
+///
+/// **6** (phase-454 W8, RFC-0100 D9): the depth table's rows now have a
+/// PROVENANCE, and `NROS_ENTITY_DERIVED_DEPTHS` / `_COUNT` publish it. Bumps for
+/// the familiar reason and for one that is, again, not additive.
+///
+/// The familiar half: an absent `NROS_ENTITY_DERIVED_DEPTHS` in a version-5
+/// fragment is an older CLI's silence, not "this image derived no depth", and a
+/// reader that took it for the second would report a derived number as stated.
+///
+/// The half that is not additive: `NROS_ENTITY_DECLARED_DEPTHS`'s DEFINITION
+/// moved again. In version 5 every entry in it was a number a contract author
+/// wrote; from version 6 an entry may be one this CLI derived from a
+/// `buffer: queue` endpoint's publish and drain rates. Same variable, same
+/// shape, different warrant -- and a consumer that asserts against the list
+/// (rather than sizing from it) must now read the derived subset and exclude
+/// it. The in-tree asserting consumer already does, one function over: see
+/// [`EntityInventory::to_declared_qos_header`] and [`DepthSource`].
+pub const ENTITY_INVENTORY_SCHEMA_VERSION: u32 = 6;
 
 /// Canonical artifact name.
 pub const ENTITY_INVENTORY_JSON_NAME: &str = "nros_entity_inventory.json";
@@ -385,6 +409,27 @@ pub struct EntityDecl {
     pub durability: Option<QoSDurabilityPolicy>,
     /// phase-454 W3 -- `keep_last` / `keep_all`, or `None`.
     pub history: Option<QoSHistoryPolicy>,
+    /// phase-454 W8 -- `latest` / `queue`, or `None` for "nobody said".
+    ///
+    /// NOT a QoS policy and not a size (RFC-0100 D9): it is the FAULT MODE the
+    /// author declared for a `state: true` subscription. `None` must never read
+    /// as `Latest` even though `latest` is the schema's default when the key is
+    /// absent -- see [`crate::queue_depth::BufferDiscipline`].
+    pub buffer: Option<BufferDiscipline>,
+    /// phase-454 W8 -- how fast this endpoint's topic is published.
+    ///
+    /// The numerator of the queue-depth derivation. Read from the model's
+    /// `contracts.topics.<topic>.rate_hz`, or failing that from the
+    /// `min_rate_hz` the topic's publishers promise.
+    pub publish_rate: Option<RateMilliHz>,
+    /// phase-454 W8 -- how fast the consuming timer drains it.
+    ///
+    /// The denominator. Authored as `paths.<p>.trigger: { timer: { rate_hz } }`
+    /// and NOT carried by the SystemModel (issue 1339); what reaches this
+    /// reader today is the `min_rate_hz` of what the node's timer paths
+    /// publish, which is the model's own convention for a periodic path's rate
+    /// (`nros_orchestration_ir::mapper_input::pub_rate_hz`).
+    pub drain_rate: Option<RateMilliHz>,
 }
 
 impl EntityDecl {
@@ -405,6 +450,9 @@ impl EntityDecl {
             reliability: None,
             durability: None,
             history: None,
+            buffer: None,
+            publish_rate: None,
+            drain_rate: None,
         }
     }
 
@@ -1002,6 +1050,89 @@ pub struct DeclaredDepth {
     pub type_name: String,
     pub topic: String,
     pub depth: u32,
+    /// Where this number came from -- phase-454 W8.
+    pub source: DepthSource,
+}
+
+/// Which rung of RFC-0049's ladder a depth row came from -- phase-454 W8.
+///
+/// # Why a row has to carry this, and what breaks without it
+///
+/// The depth table has two consumers and they want OPPOSITE things from a
+/// derived default:
+///
+/// * `nros-node/build.rs::subs_arena` SIZES from it. A default is exactly what
+///   it wants -- that is the point of deriving one.
+/// * [`EntityInventory::to_declared_qos_header`] ASSERTS from it. Every row it
+///   emits becomes a `static_assert` that `NROS_SUBSCRIBE`'s own QoS must match,
+///   and a row that disagrees fails the BUILD naming the topic and both numbers.
+///
+/// A derived default reaching the second consumer would turn a default into a
+/// REQUIREMENT: an image that never stated a depth would suddenly have to spell
+/// this module's arithmetic at every call site or not compile, and raising the
+/// margin by one would break every such image. That is the ladder inverted --
+/// the derived rung dictating to the code instead of filling in behind it.
+///
+/// So the header filters to [`DepthSource::Stated`] and the arena does not.
+/// One column, two consumers, and the difference is stated rather than implied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthSource {
+    /// The contract stated `qos: { depth: N }` on this endpoint.
+    Stated,
+    /// Nobody stated one, and it was derived from the endpoint's publish and
+    /// drain rates because it declared `buffer: queue` (RFC-0100 D9).
+    DerivedFromRates,
+}
+
+impl DepthSource {
+    pub fn tag(self) -> &'static str {
+        match self {
+            DepthSource::Stated => "stated",
+            DepthSource::DerivedFromRates => "derived_from_rates",
+        }
+    }
+}
+
+/// One subscription's queue-depth default and what decided it -- phase-454 W8.
+///
+/// Carries the INPUTS beside the outcome on purpose. A row saying only "no
+/// default" sends an author to read the contract and guess which of three facts
+/// was missing; a row that also shows which rates arrived answers it. This is
+/// the same rule the `keep_all` refusal follows one view over -- name the
+/// endpoints, not the count.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueDepthDefault {
+    pub topic: String,
+    pub type_name: Option<String>,
+    pub buffer: Option<BufferDiscipline>,
+    pub stated_depth: Option<u32>,
+    pub publish_rate: Option<RateMilliHz>,
+    pub drain_rate: Option<RateMilliHz>,
+    /// `Ok(depth)` when a default was derived; `Err` naming which rung stopped
+    /// it -- a stated depth above, a discipline that is not `queue`, or a rate
+    /// that never arrived.
+    pub outcome: Result<u32, NoDefault>,
+}
+
+impl QueueDepthDefault {
+    /// One line an author can act on. Names the topic, the outcome and, on a
+    /// refusal, the reason [`NoDefault`] gives for it.
+    pub fn line(&self) -> String {
+        match &self.outcome {
+            Ok(depth) => format!(
+                "{}: depth {depth} derived from {} in / {} drained ({})",
+                self.topic,
+                self.publish_rate
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "?".into()),
+                self.drain_rate
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "?".into()),
+                DepthSource::DerivedFromRates.tag(),
+            ),
+            Err(reason) => format!("{}: no derived depth -- {}", self.topic, reason.reason()),
+        }
+    }
 }
 
 /// Every declared depth in an image, plus how many endpoints did NOT state one.
@@ -1760,7 +1891,89 @@ impl EntityInventory {
             )
         }
 
+        // phase-454 W8 (RFC-0100 D9) -- the two RATES the queue-depth default
+        // divides, read from the model's own conventions.
+        //
+        // PUBLISH rate: the channel's negotiated rate first
+        // (`contracts.topics.<t>.rate_hz`), and the strongest promise its
+        // publishers make second (`min_rate_hz`). The topic rate leads because
+        // it is the CHANNEL's fact -- a topic with three publishers has one
+        // arrival rate at the subscriber and three promises upstream -- and
+        // `max` over the promises is the safe direction when there is no
+        // channel rate: over-stating the arrival rate over-sizes the queue,
+        // and under-stating it is the direction that ships a backlog.
+        //
+        // DRAIN rate: see `drain_rate_of` below. The model does not carry a
+        // path's trigger (issue 1339), so this is a derivation from what the
+        // node's timer paths PUBLISH, which is the same convention
+        // `nros_orchestration_ir::mapper_input::pub_rate_hz` already uses to
+        // give a periodic path its fire rate.
+        let min_rate_of = |ep: &str| -> Option<f64> {
+            model
+                .contracts
+                .pub_endpoints
+                .get(ep)
+                .and_then(|c| c.min_rate_hz)
+        };
+        let publish_rate_of =
+            |topic: &str, wiring: &ros_launch_manifest_model::TopicWiring| -> Option<RateMilliHz> {
+                if let Some(r) = model
+                    .contracts
+                    .topics
+                    .get(topic)
+                    .and_then(|t| t.rate_hz)
+                    .and_then(RateMilliHz::from_hz)
+                {
+                    return Some(r);
+                }
+                wiring
+                    .publishers
+                    .iter()
+                    .filter_map(|ep| min_rate_of(ep))
+                    .filter_map(RateMilliHz::from_hz)
+                    .max()
+            };
+        // A node's DRAIN rate: the rate of the timer paths it runs.
+        //
+        // A `node_paths` entry with an EMPTY `input` IS the periodic callback
+        // -- the model's own definition, and the same test `from_model` already
+        // uses to count a timer entity. Its RATE is not carried, so it is taken
+        // from what the path publishes, exactly as `mapper_input` takes it.
+        //
+        // `min` over a node's timer paths, and the direction is the opposite of
+        // the one above for the same reason: the SLOWEST drain is the one that
+        // lets the most backlog accumulate, so it is the conservative
+        // denominator. A node with one timer -- which is the shape the contract
+        // describes when it says "drained batch-wise by the consuming timer" --
+        // has one answer either way.
+        //
+        // Pairing a node's timer with a node's queue subscription is the layer
+        // 2 rule, not an invention here: the resolver's own `queue-drain-rate`
+        // check reads "node 'listener' timer path 'drain' rate_hz ... its
+        // 'buffer: queue' subscriptions' producer rates".
+        let mut drain_rate_by_node: std::collections::BTreeMap<String, RateMilliHz> =
+            std::collections::BTreeMap::new();
+        for (path_key, path) in &model.contracts.node_paths {
+            if !path.input.is_empty() {
+                continue;
+            }
+            let Some(rate) = path
+                .output
+                .iter()
+                .filter_map(|ep| min_rate_of(ep))
+                .filter_map(RateMilliHz::from_hz)
+                .min()
+            else {
+                continue;
+            };
+            drain_rate_by_node
+                .entry(node_of(path_key))
+                .and_modify(|r| *r = (*r).min(rate))
+                .or_insert(rate);
+        }
+
         for (topic, wiring) in &model.structure.topics {
+            let publish_rate = publish_rate_of(topic, wiring);
             for ep in &wiring.subscribers {
                 let (reliability, durability, history) = policies(sub_qos(ep));
                 per_node.entry(node_of(ep)).or_default().push(EntityDecl {
@@ -1768,6 +1981,26 @@ impl EntityInventory {
                     reliability,
                     durability,
                     history,
+                    // phase-454 W8 -- `buffer:` is NOT read here, because there
+                    // is nothing to read. `SubContract` in the pinned
+                    // `ros-launch-manifest` (v0.1.35) has no `buffer` field:
+                    // the contract states it, the parser validates it, the
+                    // resolver REASONS about it -- it emits a
+                    // `[queue-drain-rate]` warning comparing exactly the two
+                    // rates above -- and then writes a `sub_endpoints` entry
+                    // without it. Issue 1339; the tripwire that goes red the
+                    // day it lands is
+                    // `tests/contract_queue_buffer_reaches_the_model.rs`.
+                    //
+                    // Left explicitly `None` and NOT defaulted to `Latest`
+                    // even though `latest` is the schema's default for an
+                    // absent key: "the author wrote latest" and "this reader
+                    // cannot see what the author wrote" are different claims,
+                    // and defaulting here would make the second one silently
+                    // print as the first in every diagnostic below.
+                    buffer: None,
+                    publish_rate,
+                    drain_rate: drain_rate_by_node.get(&node_of(ep)).copied(),
                     ..EntityDecl::bare(
                         EntityKind::Subscription,
                         Some(wiring.msg_type.clone()),
@@ -2382,12 +2615,34 @@ impl EntityInventory {
                 if !e.kind.carries_qos_depth() {
                     continue;
                 }
-                match (e.depth, &e.type_name, &e.name) {
-                    (Some(depth), Some(t), Some(n)) => rows.push(DeclaredDepth {
+                // phase-454 W8 -- RFC-0049's ladder, in order. A STATED depth
+                // is taken first and nothing below it runs; only where nobody
+                // stated one does the rate derivation get a turn, and only for
+                // an endpoint that declared `buffer: queue`. Every other
+                // endpoint takes the `None` arm exactly as it did before this
+                // wave, which is what makes an image with no queue endpoint
+                // byte-identical (`depth_default` returns `NotAQueue` for a
+                // `latest` endpoint and for one that stated no discipline).
+                //
+                // `keep_all` never reaches here: the refusal above returns
+                // first, for the whole table. That ordering is the W3 contract
+                // this wave has to honour -- a KEEP_ALL queue has no static
+                // bound, and deriving a number for one would be the same
+                // UNDER-size W3 refuses, arrived at by arithmetic instead of by
+                // believing a stated depth.
+                let resolved = match e.depth {
+                    Some(depth) => Some((depth, DepthSource::Stated)),
+                    None => depth_default(e.buffer, None, e.publish_rate, e.drain_rate)
+                        .ok()
+                        .map(|depth| (depth, DepthSource::DerivedFromRates)),
+                };
+                match (resolved, &e.type_name, &e.name) {
+                    (Some((depth, source)), Some(t), Some(n)) => rows.push(DeclaredDepth {
                         kind: e.kind,
                         type_name: t.clone(),
                         topic: n.clone(),
                         depth,
+                        source,
                     }),
                     // A depth with no type or no topic cannot be JOINED to
                     // anything -- the table is keyed `(type, topic)` and the
@@ -2420,6 +2675,77 @@ impl EntityInventory {
             undeclared_subscriptions,
             undeclared_publishers,
         }
+    }
+
+    /// Every endpoint's queue-depth default, DERIVED OR NOT -- phase-454 W8.
+    ///
+    /// Sibling of [`Self::declared_depths`] and deliberately not folded into
+    /// it, for the reason [`Self::declared_qos`] is separate: this view's
+    /// population is different. The depth table carries the endpoints that HAVE
+    /// a depth; this one carries the endpoints that could have been defaulted
+    /// and says, for each, what happened -- which is the only place an author
+    /// can read WHY an endpoint got no default.
+    ///
+    /// That "why" is the whole of RFC-0100 D9's acceptance 3. Where either rate
+    /// is absent there is no default, and the absence has to be VISIBLE: a
+    /// derivation that silently declines is indistinguishable from one that was
+    /// never asked, which is the shape this campaign keeps paying for.
+    ///
+    /// Restricted to SUBSCRIPTIONS. `buffer:` is defined only on a subscriber
+    /// endpoint (`parse_buffer` in the manifest is a parse-time error anywhere
+    /// else), and a publisher has no queue a timer drains.
+    pub fn queue_depth_defaults(&self) -> Vec<QueueDepthDefault> {
+        let mut out = Vec::new();
+        for c in self.components() {
+            for e in c.declaration.entities() {
+                if e.kind != EntityKind::Subscription {
+                    continue;
+                }
+                let Some(topic) = e.name.as_deref() else {
+                    continue;
+                };
+                out.push(QueueDepthDefault {
+                    topic: topic.to_string(),
+                    type_name: e.type_name.clone(),
+                    buffer: e.buffer,
+                    stated_depth: e.depth,
+                    publish_rate: e.publish_rate,
+                    drain_rate: e.drain_rate,
+                    outcome: depth_default(e.buffer, e.depth, e.publish_rate, e.drain_rate),
+                });
+            }
+        }
+        out.sort_by(|a, b| a.topic.cmp(&b.topic));
+        out
+    }
+
+    /// The two `buffer:` diagnostics -- phase-454 W8, RFC-0100 D9.
+    ///
+    /// WARNINGS, never errors. See [`BufferDiagnostic`]: both shapes are legal
+    /// and a legitimate image can want either, so this returns prose for a
+    /// caller to print and has no error channel at all. Making either fatal
+    /// would be the build deciding an application question.
+    ///
+    /// Empty for every image that states no `buffer:` -- which is every image
+    /// in this tree today, because the SystemModel does not carry the key
+    /// (issue 1339). That is why nothing in the warning stream moves and why
+    /// the byte-identical proof holds.
+    pub fn buffer_diagnostics(&self) -> Vec<BufferDiagnostic> {
+        let mut out = Vec::new();
+        for c in self.components() {
+            for e in c.declaration.entities() {
+                if !e.kind.carries_qos_depth() {
+                    continue;
+                }
+                let Some(topic) = e.name.as_deref() else {
+                    continue;
+                };
+                if let Some(d) = diagnose(e.kind.tag(), topic, e.buffer, e.depth) {
+                    out.push(d);
+                }
+            }
+        }
+        out
     }
 
     /// The other three QoS policies -- phase-454 W3, issue 1256.
@@ -2581,9 +2907,16 @@ impl EntityInventory {
             DeclaredDepths::Resolved {
                 rows, undeclared, ..
             } => {
+                // phase-454 W8 -- STATED rows only. A derived default sizes the
+                // arena and must never become a `static_assert`: an image that
+                // declared no depth would then have to spell this CLI's
+                // arithmetic at every `NROS_SUBSCRIBE` or fail to compile, and
+                // moving the margin by one slot would break every such image.
+                // See [`DepthSource`], which exists for exactly this split.
                 let subs: Vec<&DeclaredDepth> = rows
                     .iter()
                     .filter(|r| r.kind == EntityKind::Subscription)
+                    .filter(|r| r.source == DepthSource::Stated)
                     .collect();
                 s.push_str("#define NROS_DECLARED_QOS_STATUS \"resolved\"\n");
                 s.push_str(&format!(
@@ -2675,6 +3008,24 @@ impl EntityInventory {
                             // is built to avoid.
                             if let Some(d) = e.depth {
                                 r.insert("depth".into(), d.into());
+                            }
+                            // phase-454 W8 -- present ONLY when the endpoint
+                            // carries them, for the reason `depth` is: a
+                            // `"buffer": null` on every row would make "nobody
+                            // said" and "said latest" the same JSON, and
+                            // `latest` is the schema's DEFAULT, so that
+                            // collapse would read as a statement.
+                            if let Some(b) = e.buffer {
+                                r.insert(
+                                    "buffer".into(),
+                                    crate::queue_depth::buffer_spelling(b).into(),
+                                );
+                            }
+                            if let Some(p) = e.publish_rate {
+                                r.insert("publish_rate_hz".into(), p.hz().into());
+                            }
+                            if let Some(d) = e.drain_rate {
+                                r.insert("drain_rate_hz".into(), d.hz().into());
                             }
                             serde_json::Value::Object(r)
                         })
@@ -3309,6 +3660,17 @@ fn render_declared_depths(d: &DeclaredDepths) -> String {
                     .collect()
             };
             let subs = triples(EntityKind::Subscription);
+            // phase-454 W8 -- which of those rows were DERIVED rather than
+            // stated. The main list keeps carrying both, because its one
+            // consumer (`subs_arena`) wants the size and a default is exactly
+            // what a default is for. This is the provenance beside it, so a
+            // reader that needs to distinguish them can, and nobody has to
+            // recover it by diffing against the contract.
+            let derived: Vec<String> = rows
+                .iter()
+                .filter(|r| r.source == DepthSource::DerivedFromRates)
+                .map(|r| format!("{}|{}={}", r.type_name, r.topic, r.depth))
+                .collect();
             s.push_str(&format!(
                 "set(NROS_ENTITY_DECLARED_DEPTHS \"{}\")\n",
                 subs.join(";")
@@ -3343,6 +3705,28 @@ fn render_declared_depths(d: &DeclaredDepths) -> String {
             ));
             s.push_str(&format!(
                 "set(NROS_ENTITY_UNDECLARED_DEPTH_COUNT_PUBLISHER {undeclared_publishers})\n"
+            ));
+            // phase-454 W8 (RFC-0100 D9) -- the DERIVED subset, always emitted.
+            //
+            // Emitted even when empty, which is every image today: an empty
+            // list is the published fact "this image derived none", and leaving
+            // the variable out would make it indistinguishable from an older
+            // CLI that could not derive any. That distinction is the whole
+            // reason the schema version below bumps.
+            s.push_str(
+                "# phase-454 W8 -- which rows above were DERIVED from a `buffer: queue`\n\
+                 # endpoint's publish and drain rates rather than STATED by the contract\n\
+                 # (RFC-0100 D9). They are in the list above because a default is what the\n\
+                 # arena wants; they are NOT in the declared-QoS header, because a default\n\
+                 # must never become a `static_assert` a call site has to match.\n",
+            );
+            s.push_str(&format!(
+                "set(NROS_ENTITY_DERIVED_DEPTHS \"{}\")\n",
+                derived.join(";")
+            ));
+            s.push_str(&format!(
+                "set(NROS_ENTITY_DERIVED_DEPTH_COUNT {})\n",
+                derived.len()
             ));
         }
     }
@@ -6272,5 +6656,450 @@ structure:
             EntityInventory::from_model("test", &m).is_none(),
             "no contract authored means unanswered, not zero"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // phase-454 W8 (RFC-0100 D9) -- `buffer:` earns its keep.
+    // -----------------------------------------------------------------------
+
+    /// An image of one subscription, stated field by field.
+    ///
+    /// Built by hand rather than resolved, and that is a STATEMENT about what
+    /// can be resolved: `SubContract` in the pinned `ros-launch-manifest` has no
+    /// `buffer` field, so no contract on earth produces a `queue` endpoint in a
+    /// SystemModel today (issue 1339, and
+    /// `tests/contract_queue_buffer_reaches_the_model.rs` measures it against
+    /// the real resolver). These tests exercise the ladder, the arithmetic and
+    /// both diagnostics over the rows the reader WILL build the day the field
+    /// travels; the rate halves of the same rows are resolved for real, from a
+    /// contract, in `the_model_supplies_both_rates_a_queue_default_would_divide`
+    /// below.
+    fn queue_image(
+        buffer: Option<BufferDiscipline>,
+        depth: Option<u32>,
+        publish_hz: Option<f64>,
+        drain_hz: Option<f64>,
+    ) -> EntityInventory {
+        queue_image_with_history(
+            buffer,
+            depth,
+            publish_hz,
+            drain_hz,
+            QoSHistoryPolicy::KeepLast,
+        )
+    }
+
+    fn queue_image_with_history(
+        buffer: Option<BufferDiscipline>,
+        depth: Option<u32>,
+        publish_hz: Option<f64>,
+        drain_hz: Option<f64>,
+        history: QoSHistoryPolicy,
+    ) -> EntityInventory {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(ComponentEntities {
+            pkg: "listener_pkg".into(),
+            component: "listener".into(),
+            class: String::new(),
+            declaration: Declaration::Stated(vec![EntityDecl {
+                depth,
+                history: Some(history),
+                buffer,
+                publish_rate: publish_hz.and_then(RateMilliHz::from_hz),
+                drain_rate: drain_hz.and_then(RateMilliHz::from_hz),
+                ..EntityDecl::bare(
+                    EntityKind::Subscription,
+                    Some("std_msgs/msg/Int32".into()),
+                    Some("/chatter".into()),
+                )
+            }]),
+        });
+        inv
+    }
+
+    fn only_row(inv: &EntityInventory) -> DeclaredDepth {
+        inv.declared_depths()
+            .rows()
+            .expect("the table resolves")
+            .first()
+            .expect("the image has one depth-carrying row")
+            .clone()
+    }
+
+    /// Every `set(` line of an image's fragment, for a byte comparison.
+    fn set_lines(inv: &EntityInventory) -> Vec<String> {
+        inv.to_cmake()
+            .lines()
+            .filter(|l| l.starts_with("set("))
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// ACCEPTANCE 1 -- a `queue` endpoint with both rates and no stated depth
+    /// gets the derived default, and it reaches the DEPTH TABLE the arena
+    /// sizes from.
+    ///
+    /// 50 Hz in, 10 Hz drained: five arrivals a period plus the straggler slot
+    /// the unaligned-window bound forces, so 6. The arithmetic is asserted on
+    /// the ROW rather than on `derive_queue_depth` alone, because a correct
+    /// function nothing calls is the vacuous shape this campaign keeps finding.
+    #[test]
+    fn a_queue_endpoint_with_both_rates_gets_the_derived_default() {
+        let inv = queue_image(Some(BufferDiscipline::Queue), None, Some(50.0), Some(10.0));
+        let row = only_row(&inv);
+        assert_eq!(row.depth, 6, "ceil(50 / 10) + 1");
+        assert_eq!(
+            row.source,
+            DepthSource::DerivedFromRates,
+            "the row must say it was derived, or a consumer that asserts will assert on it"
+        );
+        // ...and it is NOT counted as undeclared any more: the endpoint has a
+        // depth now, which is the point of a default.
+        let DeclaredDepths::Resolved {
+            undeclared_subscriptions,
+            ..
+        } = inv.declared_depths()
+        else {
+            panic!("the table resolves");
+        };
+        assert_eq!(undeclared_subscriptions, 0);
+        let cmake = inv.to_cmake();
+        assert!(
+            cmake.contains("set(NROS_ENTITY_DECLARED_DEPTHS \"std_msgs/msg/Int32|/chatter=6\")\n"),
+            "{cmake}"
+        );
+        assert!(
+            cmake.contains("set(NROS_ENTITY_DERIVED_DEPTHS \"std_msgs/msg/Int32|/chatter=6\")\n"),
+            "the provenance is published beside it: {cmake}"
+        );
+    }
+
+    /// ACCEPTANCE 2 -- a stated depth beats the derived default, ALL THE WAY
+    /// THROUGH.
+    ///
+    /// The unit test in `queue_depth` proves the ladder at the arithmetic; this
+    /// one proves nothing downstream undoes it. The rates are the same pair
+    /// that derives 6, so a reader that consulted them at all would be visible.
+    #[test]
+    fn a_stated_depth_beats_the_derived_default_in_the_table() {
+        let inv = queue_image(
+            Some(BufferDiscipline::Queue),
+            Some(3),
+            Some(50.0),
+            Some(10.0),
+        );
+        let row = only_row(&inv);
+        assert_eq!(row.depth, 3, "the stated 3, not the derived 6");
+        assert_eq!(row.source, DepthSource::Stated);
+    }
+
+    /// ACCEPTANCE 3 -- either rate absent means NO default, and the reason is
+    /// VISIBLE rather than merely true.
+    ///
+    /// "Visible" is the bar this campaign sets: a derivation that declines
+    /// quietly is indistinguishable from one that never ran, which is how a
+    /// green vacuous check survives. So the assertion is on the prose a user
+    /// reads, not only on the absence of a row.
+    #[test]
+    fn a_missing_rate_leaves_the_endpoint_undeclared_with_a_readable_reason() {
+        for (publish, drain, want) in [
+            (None, Some(10.0), NoDefault::NoPublishRate),
+            (Some(50.0), None, NoDefault::NoDrainRate),
+        ] {
+            let inv = queue_image(Some(BufferDiscipline::Queue), None, publish, drain);
+            let DeclaredDepths::Resolved {
+                rows,
+                undeclared_subscriptions,
+                ..
+            } = inv.declared_depths()
+            else {
+                panic!("the table resolves");
+            };
+            assert!(rows.is_empty(), "no default may be invented: {rows:?}");
+            assert_eq!(
+                undeclared_subscriptions, 1,
+                "the endpoint stays counted as undeclared, so a size consumer still refuses"
+            );
+
+            let report = inv.queue_depth_defaults();
+            let row = report.first().expect("the endpoint is reported");
+            assert_eq!(row.outcome, Err(want.clone()));
+            let line = row.line();
+            assert!(line.contains("/chatter"), "{line}");
+            assert!(
+                line.contains("no derived depth"),
+                "the line must say a default was not produced: {line}"
+            );
+            assert!(
+                line.contains("rate_hz"),
+                "and name the contract key that would produce one: {line}"
+            );
+        }
+    }
+
+    /// ACCEPTANCE 4 -- both diagnostics fire on their shapes, and both are
+    /// WARNINGS: `buffer_diagnostics` has no error channel, and neither shape
+    /// changes any number the image sizes from.
+    #[test]
+    fn both_buffer_diagnostics_fire_and_neither_is_an_error() {
+        let queue_at_one = queue_image(Some(BufferDiscipline::Queue), Some(1), None, None);
+        let d = queue_at_one.buffer_diagnostics();
+        assert_eq!(d.len(), 1, "{d:?}");
+        assert!(d[0].message().contains("buffer: queue"), "{:?}", d[0]);
+        assert!(d[0].message().contains("Not an error"), "{:?}", d[0]);
+        // The stated 1 still sizes the image -- a diagnostic is not a refusal.
+        assert_eq!(only_row(&queue_at_one).depth, 1);
+        assert_eq!(queue_at_one.declared_depths().tag(), "resolved");
+
+        let latest_at_ten = queue_image(Some(BufferDiscipline::Latest), Some(10), None, None);
+        let d = latest_at_ten.buffer_diagnostics();
+        assert_eq!(d.len(), 1, "{d:?}");
+        assert!(d[0].message().contains("buffer: latest"), "{:?}", d[0]);
+        assert!(d[0].message().contains("Not an error"), "{:?}", d[0]);
+        assert_eq!(only_row(&latest_at_ten).depth, 10);
+        assert_eq!(latest_at_ten.declared_depths().tag(), "resolved");
+
+        // The agreeing shapes are silent, which is what keeps the warning
+        // stream worth reading.
+        for (buffer, depth) in [(BufferDiscipline::Queue, 6), (BufferDiscipline::Latest, 1)] {
+            assert!(
+                queue_image(Some(buffer), Some(depth), None, None)
+                    .buffer_diagnostics()
+                    .is_empty(),
+                "{buffer:?} at depth {depth} is not a contradiction"
+            );
+        }
+    }
+
+    /// A `keep_all` endpoint gets NO derived depth -- the W3 refusal comes
+    /// first, for the whole table.
+    ///
+    /// The one case where this wave could have re-created the defect W3 fixed,
+    /// by a different route. W3 refuses a depth STATED beside `keep_all`
+    /// because a KEEP_ALL queue has no static bound; a depth this CLI DERIVED
+    /// for one would be the same under-size arrived at by arithmetic, and it
+    /// would carry more authority, not less.
+    #[test]
+    fn a_keep_all_queue_endpoint_is_refused_and_never_derived() {
+        let inv = queue_image_with_history(
+            Some(BufferDiscipline::Queue),
+            None,
+            Some(50.0),
+            Some(10.0),
+            QoSHistoryPolicy::KeepAll,
+        );
+        let d = inv.declared_depths();
+        assert_eq!(d.tag(), "refused", "keep_all refuses the whole depth table");
+        assert!(d.rows().is_none(), "and publishes no rows at all");
+        let DeclaredDepths::Refused { reason } = d else {
+            panic!("refused above");
+        };
+        assert!(
+            reason.contains("keep_all") && reason.contains("NO STATIC BOUND"),
+            "the W3 reason, not a W8 one: {reason}"
+        );
+        // The control: the identical image with `keep_last` DOES derive, so the
+        // refusal above is the history and not a missing input.
+        assert_eq!(
+            only_row(&queue_image(
+                Some(BufferDiscipline::Queue),
+                None,
+                Some(50.0),
+                Some(10.0)
+            ))
+            .depth,
+            6
+        );
+    }
+
+    /// ACCEPTANCE 5 -- an image with NO `queue` endpoint is byte-identical.
+    ///
+    /// The strong form, on the whole fragment rather than on the depth lines:
+    /// every `set(` line the image emitted must agree, and the only variables
+    /// that may differ are the two W8 adds. This is W3's own proof shape, which
+    /// caught the coupling it existed to rule out.
+    ///
+    /// The CONTROLS matter more than the base case. An image with no rates is
+    /// trivially unchanged; the ones that could regress are the image that HAS
+    /// both rates and no `buffer:` -- which is every image in this tree today,
+    /// since the model drops the key -- and the image that declared
+    /// `buffer: latest`. Both must emit the same bytes as the image with no
+    /// rates at all, or a default is leaking into endpoints that never asked.
+    #[test]
+    fn an_image_with_no_queue_endpoint_is_byte_identical() {
+        let base = set_lines(&queue_image(None, Some(3), None, None));
+        for (label, inv) in [
+            (
+                "rates, no discipline",
+                queue_image(None, Some(3), Some(50.0), Some(10.0)),
+            ),
+            (
+                "buffer: latest with rates",
+                queue_image(
+                    Some(BufferDiscipline::Latest),
+                    Some(3),
+                    Some(50.0),
+                    Some(10.0),
+                ),
+            ),
+            (
+                "no depth and no discipline, rates present",
+                queue_image(None, None, Some(50.0), Some(10.0)),
+            ),
+        ] {
+            if label.starts_with("no depth") {
+                // This one legitimately differs from `base` (no depth stated),
+                // so it is compared against its own pre-W8 shape instead: the
+                // endpoint must stay UNDECLARED, with no row and no derived
+                // entry.
+                let DeclaredDepths::Resolved {
+                    rows,
+                    undeclared_subscriptions,
+                    ..
+                } = inv.declared_depths()
+                else {
+                    panic!("the table resolves");
+                };
+                assert!(rows.is_empty(), "{label}: {rows:?}");
+                assert_eq!(undeclared_subscriptions, 1, "{label}");
+                continue;
+            }
+            assert_eq!(
+                set_lines(&inv),
+                base,
+                "{label}: an image with no `buffer: queue` endpoint must emit the same bytes"
+            );
+        }
+
+        // And the new variables are PRESENT and EMPTY on such an image rather
+        // than absent: an absent list would be indistinguishable from an older
+        // CLI's silence, which is exactly why the schema version bumped.
+        assert!(
+            base.iter()
+                .any(|l| l == "set(NROS_ENTITY_DERIVED_DEPTHS \"\")"),
+            "{base:?}"
+        );
+        assert!(
+            base.iter()
+                .any(|l| l == "set(NROS_ENTITY_DERIVED_DEPTH_COUNT 0)"),
+            "{base:?}"
+        );
+    }
+
+    /// A DERIVED depth sizes the arena and never reaches the compile-time
+    /// assertion table.
+    ///
+    /// The hazard this wave had to avoid, and it is not hypothetical: every row
+    /// `to_declared_qos_header` emits becomes a `static_assert` that
+    /// `NROS_SUBSCRIBE`'s own QoS must match. A derived default landing there
+    /// would turn a DEFAULT into a REQUIREMENT -- an image that stated no depth
+    /// would have to spell this CLI's arithmetic at every call site or fail to
+    /// compile, and moving `QUEUE_DEPTH_MARGIN` by one slot would break every
+    /// such image at once. The ladder inverted.
+    #[test]
+    fn a_derived_depth_sizes_but_never_asserts() {
+        let derived = queue_image(Some(BufferDiscipline::Queue), None, Some(50.0), Some(10.0));
+        assert_eq!(only_row(&derived).depth, 6, "it DID size");
+        let h = derived.to_declared_qos_header();
+        // `#define`, not the bare name: the "no table" branch's own prose says
+        // "NROS_DECLARED_QOS_ROWS stays undefined", and matching that sentence
+        // would make this assertion pass on a header that DID define the macro.
+        assert!(
+            !h.contains("#define NROS_DECLARED_QOS_ROWS"),
+            "a derived depth must emit NO assertion row: {h}"
+        );
+        assert!(
+            h.contains("stays undefined"),
+            "and it takes the no-table branch, which says so: {h}"
+        );
+        assert!(
+            h.contains("NROS_DECLARED_QOS_STATUS \"resolved\""),
+            "the table still resolved -- it is the ROWS that are withheld: {h}"
+        );
+        // The control: the same image with the depth STATED does emit one, so
+        // the assertion above cannot pass merely because the header is broken.
+        let h = queue_image(Some(BufferDiscipline::Queue), Some(6), None, None)
+            .to_declared_qos_header();
+        assert!(h.contains("#define NROS_DECLARED_QOS_ROWS"), "{h}");
+        assert!(h.contains(", 6)"), "{h}");
+    }
+
+    /// The two rates the MODEL does carry reach the endpoint row.
+    ///
+    /// Not the whole derivation -- `buffer` cannot arrive (issue 1339) -- but
+    /// the two halves that can, read by the model's own conventions: the
+    /// channel's `contracts.topics.<t>.rate_hz` for the publish rate, and the
+    /// `min_rate_hz` of what the node's timer path publishes for the drain
+    /// rate. Without this, every `NoDefault` in this wave would read
+    /// `NoPublishRate` forever -- a reason that is true and useless.
+    #[test]
+    fn the_model_supplies_both_rates_a_queue_default_would_divide() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /talker:
+      { scope: s.launch.xml, pkg: talker_pkg, exec: talker, node_name: talker }
+    /listener:
+      { scope: s.launch.xml, pkg: listener_pkg, exec: listener,
+        node_name: listener }
+  topics:
+    /chatter:
+      type: std_msgs/msg/Int32
+      pub: [/talker/chatter]
+      sub: [/listener/chatter]
+    /status:
+      type: std_msgs/msg/Int32
+      pub: [/listener/status]
+      sub: []
+contracts:
+  pub_endpoints:
+    /listener/status:
+      min_rate_hz: 10.0
+  sub_endpoints:
+    /listener/chatter:
+      state: true
+  node_paths:
+    /listener/drain:
+      output: [/listener/status]
+  topics:
+    /chatter:
+      rate_hz: 50.0
+"#,
+        );
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        let sub = inv
+            .components()
+            .iter()
+            .flat_map(|c| c.declaration.entities())
+            .find(|e| e.kind == EntityKind::Subscription)
+            .expect("the listener subscribes")
+            .clone();
+        assert_eq!(
+            sub.publish_rate,
+            RateMilliHz::from_hz(50.0),
+            "the channel rate is the publish rate"
+        );
+        assert_eq!(
+            sub.drain_rate,
+            RateMilliHz::from_hz(10.0),
+            "the node's timer path publishes at 10 Hz, so that is its drain rate"
+        );
+        // And the discipline is the half that did NOT arrive, which is the
+        // whole of issue 1339. Asserted here so that the day it does arrive,
+        // this test says where to wire it.
+        assert_eq!(
+            sub.buffer, None,
+            "SubContract carries no `buffer` -- see issue 1339"
+        );
+        // So there is no default, and the REASON names the discipline rather
+        // than a rate, because both rates are present.
+        let row = inv
+            .queue_depth_defaults()
+            .into_iter()
+            .find(|r| r.topic == "/chatter")
+            .expect("the subscription is reported");
+        assert_eq!(row.outcome, Err(NoDefault::NotAQueue));
     }
 }

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -45,6 +45,13 @@ pub mod leaf_payload_classes;
 /// `NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE` half of
 /// `cmake/NanoRosMessageBounds.cmake`.
 pub mod leaf_take_buffer;
+/// phase-454 W8 (RFC-0100 D9) — `buffer: latest | queue`, the two diagnostics
+/// it earns and the rate-derived depth default it selects.
+///
+/// Deliberately NOT a sizing input in its own right: D9 retracts the earlier
+/// draft that made it the `SLOTS` source. What it does is choose a derivation,
+/// from the two rates the contract already carries.
+pub mod queue_depth;
 /// phase-439 W2 (RFC-0094 D1/D2) — stage 3.5, the resolve phase: the one place
 /// that decides an image's declared counts, run BEFORE any configure so a
 /// reader early in one sees the final answer on its first pass.

--- a/packages/cli/nros-cli-core/src/queue_depth.rs
+++ b/packages/cli/nros-cli-core/src/queue_depth.rs
@@ -1,0 +1,653 @@
+//! `buffer:` — the fault-analysis discipline, two diagnostics, and the one
+//! derivation it selects. **phase-454 W8, RFC-0100 D9.**
+//!
+//! # What `buffer:` is, and what it is not
+//!
+//! `buffer: latest | queue` has been in the contract schema since Vocabulary
+//! v2, on `EndpointProps::buffer` in the pinned `ros-launch-manifest`:
+//!
+//! > *"buffering discipline for a `state: true` subscription. `latest`
+//! > (default) — staleness is the failure mode; `queue` — backlog is the
+//! > failure mode, drained batch-wise by the consuming timer. Only meaningful
+//! > alongside `state: true`; parse-time error otherwise."*
+//!
+//! That is FAULT-ANALYSIS vocabulary. An earlier draft of RFC-0100 proposed it
+//! as the `SLOTS` source and D9 retracts that, because it is deterministic in
+//! neither direction: `queue` states no depth, `latest` does not forbid a depth
+//! above one, and the key is only defined for `state: true` endpoints, which
+//! are a minority. A sizing input that answers "some number" for one value and
+//! "not necessarily one" for the other is not a sizing input.
+//!
+//! So it earns its keep twice over instead.
+//!
+//! # 1. Two diagnostics ([`BufferDiagnostic`])
+//!
+//! Each is one author statement contradicting another one beside it, and
+//! NEITHER IS AN ERROR — a legitimate image can want either, and this module
+//! refuses to decide that for it. They name the endpoint and both values.
+//!
+//! # 2. The derivation ([`derive_queue_depth`])
+//!
+//! `queue` is *"drained batch-wise by the consuming timer"*, so the depth such
+//! an endpoint needs is a function of how fast it fills and how fast it drains,
+//! and the contract already carries both rates. This is a DEFAULT under the
+//! RFC-0049 ladder — a stated `depth` still wins — for exactly the endpoints
+//! where a hand-typed depth is most likely to be wrong.
+//!
+//! # What the SystemModel actually carries today (MEASURED, issue 1339)
+//!
+//! The three facts this module needs are authored in the contract and reach
+//! nano-ros unevenly, and the measurement is the reason this wave lands armed
+//! rather than firing. Resolved with the pinned `nros-launch-resolve` over a
+//! contract stating all three (`tests/fixtures/queue_buffer/`):
+//!
+//! | fact | contract key | in the SystemModel? |
+//! | --- | --- | --- |
+//! | publish rate | `topics.<t>.rate_hz` | **yes** — `TopicContract::rate_hz` |
+//! | publish rate | `<node>.pub.<ep>.min_rate_hz` | **yes** — `PubContract::min_rate_hz` |
+//! | drain rate | `<node>.paths.<p>.trigger.timer.rate_hz` | **NO** — `PathContract` has no trigger |
+//! | discipline | `<node>.sub.<ep>.buffer` | **NO** — `SubContract` has no `buffer` |
+//!
+//! Both missing halves are dropped by the MODEL SCHEMA, not by nano-ros: the
+//! resolver reads them, reasons about them, and emits neither. It emits a
+//! diagnostic proving it computed exactly the division below —
+//!
+//! > `[queue-drain-rate] warning: node 'listener' timer path 'drain' rate_hz
+//! > (10) is less than the sum of its 'buffer: queue' subscriptions' producer
+//! > rates (50, from ["chatter"]) — the queue will accumulate backlog every
+//! > period`
+//!
+//! — and then writes a `node_paths` entry carrying `output` alone. That is
+//! issue 1256's shape one layer upstream of where W3 found it: a declaration
+//! legal to write, legal to resolve, and dropped before any consumer can read
+//! it. Issue 1339 carries it; `contract_queue_buffer_reaches_the_model.rs` is
+//! the tripwire that goes red the day it closes.
+//!
+//! Which is why nothing here guesses. An endpoint whose discipline or whose
+//! rates did not arrive gets NO DEFAULT and a reason saying which one is
+//! missing ([`NoDefault`]), because RFC-0100 D6's rule holds here as everywhere
+//! else: *"a refused fact never silently widens its basis."*
+
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// The vocabulary. ONE spelling, for `qos_override`'s reason.
+// ---------------------------------------------------------------------------
+//
+// `nros_orchestration_ir::qos_override` holds the four QoS policy vocabularies
+// because "whatever the macro and the CLI must agree on lives here", and the
+// four copies of the decoder that preceded it had drifted. `buffer` is NOT one
+// of those: it never reaches a `qos_overrides.*` parameter, it is not a QoS
+// policy, and no runtime folds it into a `QoSProfile`. It is a contract-side
+// analysis fact with exactly one reader, which is this file — so it lives here,
+// beside the derivation it selects, rather than in a module about QoS.
+
+/// The buffering discipline a `state: true` subscription declared.
+///
+/// `None` on an [`crate::entity_inventory::EntityDecl`] means NOBODY SAID, and
+/// it must never read as `Latest`: `latest` IS the schema's default, but "the
+/// author wrote `latest`" and "the author wrote nothing" license different
+/// actions here. The first is a statement this module diagnoses against a large
+/// depth; the second is silence, which it says nothing about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferDiscipline {
+    /// Read-latest; STALENESS is the failure mode.
+    Latest,
+    /// Bounded queue drained batch-wise by the consuming timer; BACKLOG is the
+    /// failure mode.
+    Queue,
+}
+
+/// The accepted `buffer` spellings, for a diagnostic.
+pub const BUFFER_VALUES: &str = "`latest` or `queue`";
+
+/// Parse a `buffer` value. `None` for a spelling the schema does not model —
+/// an ERROR for every caller, never a skip.
+pub fn parse_buffer(value: &str) -> Option<BufferDiscipline> {
+    match value.trim() {
+        "latest" => Some(BufferDiscipline::Latest),
+        "queue" => Some(BufferDiscipline::Queue),
+        _ => None,
+    }
+}
+
+/// The canonical spelling, for rendering one back out.
+pub fn buffer_spelling(b: BufferDiscipline) -> &'static str {
+    match b {
+        BufferDiscipline::Latest => "latest",
+        BufferDiscipline::Queue => "queue",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rates, as exact integers.
+// ---------------------------------------------------------------------------
+
+/// A rate in MILLIHERTZ.
+///
+/// The contract authors a rate as a decimal and the model carries it as `f64`,
+/// and this type is the boundary where that stops. Two reasons, and the second
+/// is the load-bearing one:
+///
+/// * [`crate::entity_inventory::EntityDecl`] derives `Eq`, which an `f64` field
+///   would forbid — and a derived `PartialEq` over floats is a hazard in its own
+///   right, since two rates that differ in the last bit would make two otherwise
+///   identical inventories unequal and two `NaN`s make one unequal to itself.
+/// * The derivation is a CEILING DIVISION. In integers it is exact;
+///   `(p / d).ceil()` in floating point is not — `(0.3f64 / 0.1).ceil()` is 3
+///   on some inputs and 4 on others, and a depth that depends on which is a
+///   size that depends on the decimal spelling of a rate.
+///
+/// Millihertz rather than hertz because a contract may legitimately author a
+/// sub-hertz rate (a 0.5 Hz health beat), and rounding that to an integer hertz
+/// would be a divide-by-zero. Three decimal places is where the schema's own
+/// examples stop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RateMilliHz(u64);
+
+impl RateMilliHz {
+    /// Build one from a contract's `f64`. `None` for anything that is not a
+    /// rate: a negative, a zero, a `NaN`, an infinity, or a value so small it
+    /// rounds to zero millihertz.
+    ///
+    /// Zero is refused rather than carried, for [`EntityDecl::depth`]'s reason
+    /// one field over: a zero rate is a typo for "I did not want to say", and
+    /// the two license opposite actions — a rate DIVIDES, and a zero drain rate
+    /// would either panic or produce a depth of infinity.
+    ///
+    /// [`EntityDecl::depth`]: crate::entity_inventory::EntityDecl::depth
+    pub fn from_hz(hz: f64) -> Option<Self> {
+        if !hz.is_finite() || hz <= 0.0 {
+            return None;
+        }
+        let milli = (hz * 1000.0).round();
+        if milli < 1.0 || milli > u64::MAX as f64 {
+            return None;
+        }
+        Some(Self(milli as u64))
+    }
+
+    /// The rate in millihertz.
+    pub fn milli_hz(self) -> u64 {
+        self.0
+    }
+
+    /// The rate in hertz, for a message a human reads.
+    pub fn hz(self) -> f64 {
+        self.0 as f64 / 1000.0
+    }
+}
+
+impl fmt::Display for RateMilliHz {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Trailing zeroes trimmed so `50` prints as `50 Hz`, not `50.000 Hz`,
+        // while `0.5` keeps the digit that distinguishes it from `0`.
+        let hz = self.hz();
+        if (hz.fract()).abs() < f64::EPSILON {
+            write!(f, "{} Hz", hz as u64)
+        } else {
+            write!(f, "{hz} Hz")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The derivation.
+// ---------------------------------------------------------------------------
+
+/// The margin added to the arrivals-per-drain-period count. **One slot.**
+///
+/// # Why there is a margin at all
+///
+/// `ceil(publish / drain)` is the number of samples the producer emits during
+/// one drain period, and it is the right answer only for a queue whose drain
+/// instants are ALIGNED with its arrivals. They are not: a `queue` subscription
+/// and the timer that drains it are two independent periodic streams with no
+/// phase relationship the contract states. For an unaligned window of length
+/// `T`, the number of arrivals of a `p`-periodic stream is bounded by
+/// `floor(p·T) + 1`, not `p·T` — a sample that arrives just after one drain
+/// instant waits a full period, and is still in the queue when the next
+/// period's own samples land. One slot is exactly that straggler.
+///
+/// # Why it is not two, and not a percentage
+///
+/// Because every extra slot is a whole message. The arena charges
+/// `(depth + 1) * bound + (depth + 1) * pointer` per subscription, so a margin
+/// is priced in bytes at the image's largest type, and inflating a DEFAULT is
+/// the over-size direction this RFC keeps measuring (the island arena, 207,096
+/// bytes against 71,664, is the same mistake made by a different default).
+///
+/// And because the things a bigger margin would absorb — timer jitter, drain
+/// overrun, a burst above the declared rate — are bounded by NO number in the
+/// contract that reaches here. A margin chosen to cover them would be a guess
+/// wearing arithmetic's clothes, which is precisely what D9 refuses to let
+/// `buffer:` itself be. The contract does carry `paths.<p>.max_jitter` and
+/// `paths.<p>.miss`; when those reach the model (issue 1339 is the same gap),
+/// a jitter-aware margin can be DERIVED here and this constant retired. Until
+/// then the honest margin is the one the phase relationship alone forces.
+pub const QUEUE_DEPTH_MARGIN: u32 = 1;
+
+/// The depth at which a `buffer: latest` endpoint stops being read-latest.
+///
+/// Not a taste threshold: it is the arena's own break point. The descriptor
+/// writer prices `depth <= 1` as a triple buffer (`TripleBuffer::SLOT_COUNT`)
+/// and everything above it as `(depth + 1)` full slots, so depth 2 is the first
+/// depth at which an endpoint that declared staleness as its failure mode
+/// starts paying for history by the message.
+pub const LATEST_DEPTH_DIAGNOSTIC_FLOOR: u32 = 2;
+
+/// Why an endpoint got no derived default.
+///
+/// Every variant is a REASON A USER CAN ACT ON, not a silent skip. This is the
+/// whole of acceptance 3: where either rate is absent there is no default, and
+/// the absence is visible rather than filled in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NoDefault {
+    /// The endpoint declared no `buffer:` at all, or declared `latest`. Only a
+    /// `queue` endpoint is drained batch-wise, and the derivation is a
+    /// statement about draining.
+    NotAQueue,
+    /// A depth was STATED. The ladder ends here and nothing below it runs —
+    /// this is not a failure, it is the rung above working.
+    DepthStated(u32),
+    /// No publish rate reached this endpoint.
+    NoPublishRate,
+    /// No drain rate reached this endpoint.
+    NoDrainRate,
+}
+
+impl NoDefault {
+    /// The prose a consumer shows. Names the contract key that would supply the
+    /// missing fact, because a refusal a user cannot act on is a refusal they
+    /// work around.
+    pub fn reason(&self) -> String {
+        match self {
+            NoDefault::NotAQueue => "the endpoint declares no `buffer: queue`, and only a queue \
+                                     is drained batch-wise by a timer -- a `latest` subscription \
+                                     keeps the newest sample and has no backlog to size"
+                .to_string(),
+            NoDefault::DepthStated(d) => format!(
+                "the endpoint states `depth: {d}`, which WINS -- RFC-0049's ladder puts a \
+                 stated value above every derived one, and this derivation only fills in \
+                 where nobody stated"
+            ),
+            NoDefault::NoPublishRate => "no publish rate reached this endpoint. State \
+                                         `topics.<topic>.rate_hz`, or `min_rate_hz` on the \
+                                         publishing endpoint; without it the number of samples \
+                                         arriving in a drain period is unknown and a guessed \
+                                         depth is a guessed buffer size"
+                .to_string(),
+            NoDefault::NoDrainRate => "no drain rate reached this endpoint. It is authored as \
+                                       `paths.<path>.trigger: { timer: { rate_hz: N } }` on the \
+                                       consuming node, and the SystemModel does not carry a \
+                                       path's trigger today (issue 1339) -- the resolver reads \
+                                       it, warns on it, and emits only the path's `output`. \
+                                       Until it travels, state `min_rate_hz` on what that timer \
+                                       publishes, which is the rate this reader can see"
+                .to_string(),
+        }
+    }
+}
+
+/// The arithmetic, over nothing but two rates.
+///
+/// ```text
+/// depth = ceil(publish_rate / drain_rate) + QUEUE_DEPTH_MARGIN
+/// ```
+///
+/// Exact: both rates are integer millihertz, so the ceiling division is integer
+/// division and carries no floating-point tie to break. See
+/// [`QUEUE_DEPTH_MARGIN`] for the margin's argument.
+///
+/// A queue drained FASTER than it fills still gets `1 + margin = 2`: the
+/// ceiling never falls below one, because at least one sample arrives per
+/// period the producer is live, and the straggler slot is a property of the
+/// phase relationship rather than of the ratio.
+///
+/// Saturates at [`u32::MAX`] rather than wrapping, which is unreachable for any
+/// rate pair a contract can state (it would need a ratio above four billion)
+/// and is spelled anyway so that the one arithmetic in this module has no
+/// panicking path at all.
+pub fn derive_queue_depth(publish: RateMilliHz, drain: RateMilliHz) -> u32 {
+    let p = publish.milli_hz();
+    let d = drain.milli_hz();
+    // Both are non-zero by construction -- `RateMilliHz::from_hz` refuses a
+    // zero -- so this division cannot trap.
+    let per_period = p.div_ceil(d);
+    let depth = per_period.saturating_add(QUEUE_DEPTH_MARGIN as u64);
+    u32::try_from(depth).unwrap_or(u32::MAX)
+}
+
+/// Resolve one endpoint's depth default, ladder and all.
+///
+/// The ORDER is the ladder, and it is asserted rather than implied: a stated
+/// depth is checked FIRST, so no combination of rates can ever displace one.
+pub fn depth_default(
+    buffer: Option<BufferDiscipline>,
+    stated_depth: Option<u32>,
+    publish: Option<RateMilliHz>,
+    drain: Option<RateMilliHz>,
+) -> Result<u32, NoDefault> {
+    if let Some(d) = stated_depth {
+        return Err(NoDefault::DepthStated(d));
+    }
+    if buffer != Some(BufferDiscipline::Queue) {
+        return Err(NoDefault::NotAQueue);
+    }
+    let publish = publish.ok_or(NoDefault::NoPublishRate)?;
+    let drain = drain.ok_or(NoDefault::NoDrainRate)?;
+    Ok(derive_queue_depth(publish, drain))
+}
+
+// ---------------------------------------------------------------------------
+// The diagnostics.
+// ---------------------------------------------------------------------------
+
+/// One author statement contradicting another one beside it.
+///
+/// **A warning, never an error.** Both shapes are legal and a legitimate image
+/// can want either: a `queue` at depth 1 is a deliberate drop-oldest-immediately
+/// channel, and a `latest` at depth 10 may be a subscription whose QoS has to
+/// match a publisher it does not own. This module reports what the author wrote
+/// on both lines and lets them decide; making either fatal would be this
+/// module deciding an application question from a build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BufferDiagnostic {
+    /// `buffer: queue` with `depth: 1` — backlog declared as the failure mode,
+    /// then sized for no backlog at all.
+    QueueSizedForNoBacklog {
+        kind: &'static str,
+        topic: String,
+        depth: u32,
+    },
+    /// `buffer: latest` with a depth at or above
+    /// [`LATEST_DEPTH_DIAGNOSTIC_FLOOR`] — paying by the message for history
+    /// the author declared they do not read.
+    LatestPaysForHistory {
+        kind: &'static str,
+        topic: String,
+        depth: u32,
+    },
+}
+
+impl BufferDiagnostic {
+    /// The prose. Names the endpoint and BOTH values, because the point of
+    /// either diagnostic is that two lines of one endpoint disagree and the
+    /// author has to see both to pick which one to change.
+    pub fn message(&self) -> String {
+        match self {
+            BufferDiagnostic::QueueSizedForNoBacklog { kind, topic, depth } => format!(
+                "{kind} `{topic}` declares `buffer: queue` -- backlog is its failure mode -- \
+                 and `depth: {depth}` beside it, which holds no backlog. A KEEP_LAST(1) queue \
+                 drops every sample but the newest between drains, which is `buffer: latest` \
+                 behaviour under a `queue` declaration. Not an error: a deliberate \
+                 drop-oldest channel is a legitimate design. Raise the depth, or say \
+                 `buffer: latest` and mean it."
+            ),
+            BufferDiagnostic::LatestPaysForHistory { kind, topic, depth } => format!(
+                "{kind} `{topic}` declares `buffer: latest` -- staleness is its failure mode, \
+                 so it reads only the newest sample -- and `depth: {depth}` beside it. Every \
+                 slot above one is a whole message of receive region the endpoint has \
+                 declared it will not read. Not an error: a depth can be there to match a \
+                 publisher this node does not own. Drop it to 1, or say `buffer: queue` if \
+                 the backlog is real."
+            ),
+        }
+    }
+}
+
+/// Diagnose one endpoint. `None` when the two lines agree, or when either is
+/// missing — silence is not a contradiction.
+pub fn diagnose(
+    kind: &'static str,
+    topic: &str,
+    buffer: Option<BufferDiscipline>,
+    depth: Option<u32>,
+) -> Option<BufferDiagnostic> {
+    let (buffer, depth) = (buffer?, depth?);
+    match buffer {
+        BufferDiscipline::Queue if depth <= 1 => Some(BufferDiagnostic::QueueSizedForNoBacklog {
+            kind,
+            topic: topic.to_string(),
+            depth,
+        }),
+        BufferDiscipline::Latest if depth >= LATEST_DEPTH_DIAGNOSTIC_FLOOR => {
+            Some(BufferDiagnostic::LatestPaysForHistory {
+                kind,
+                topic: topic.to_string(),
+                depth,
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hz(v: f64) -> RateMilliHz {
+        RateMilliHz::from_hz(v).expect("a positive finite rate")
+    }
+
+    /// ACCEPTANCE 1, the arithmetic itself: `ceil(pub / drain) + 1`.
+    ///
+    /// The table carries the three cases that are structurally different, not
+    /// three samples of one: an exact multiple (where the ceiling is a no-op
+    /// and the margin is the ONLY thing separating the answer from a naive
+    /// division), a non-multiple (where the ceiling is what stops a truncation
+    /// from under-sizing), and a queue drained faster than it fills.
+    #[test]
+    fn the_derived_depth_is_arrivals_per_drain_period_plus_one() {
+        // Exact multiple: 50 Hz in, 10 Hz out -> 5 arrivals a period, +1.
+        assert_eq!(derive_queue_depth(hz(50.0), hz(10.0)), 6);
+        // Not a multiple: 50/12 = 4.16.. -> the CEILING is 5, +1. A truncating
+        // division would say 4+1 = 5 and under-size by a slot every period.
+        assert_eq!(derive_queue_depth(hz(50.0), hz(12.0)), 6);
+        assert_eq!(derive_queue_depth(hz(100.0), hz(30.0)), 5);
+        // Drained faster than filled: one arrival, plus the straggler.
+        assert_eq!(derive_queue_depth(hz(1.0), hz(10.0)), 2);
+        // Sub-hertz, which is why the unit is millihertz: 0.5 Hz in, 0.1 Hz
+        // out is 5 a period. Rounded to integer hertz the drain rate would be
+        // zero and this would divide by it.
+        assert_eq!(derive_queue_depth(hz(0.5), hz(0.1)), 6);
+    }
+
+    /// The ceiling is EXACT, which floating point would not be.
+    ///
+    /// `0.3 / 0.1` is `2.9999999999999996` in IEEE 754 and its ceiling is 3;
+    /// the true ratio is 3 and the true answer is 3 + 1. A float implementation
+    /// gets this one right by luck and `0.7 / 0.1` (`6.999...` -> 7) wrong in
+    /// the other direction. Integer millihertz has no such cases, and this test
+    /// is the one that fails if someone moves the arithmetic back to `f64`.
+    #[test]
+    fn the_ceiling_does_not_depend_on_a_floating_point_tie() {
+        assert_eq!(derive_queue_depth(hz(0.3), hz(0.1)), 4);
+        assert_eq!(derive_queue_depth(hz(0.7), hz(0.1)), 8);
+        assert_eq!(derive_queue_depth(hz(0.1), hz(0.3)), 2);
+    }
+
+    /// ACCEPTANCE 2: a stated depth beats the derived default, and it does so
+    /// FIRST -- before the discipline and before either rate is looked at.
+    ///
+    /// Asserted with rates that WOULD derive a different number, because a
+    /// ladder that only holds when the lower rung has nothing to say is not a
+    /// ladder.
+    #[test]
+    fn a_stated_depth_beats_the_derived_default() {
+        let derived = derive_queue_depth(hz(50.0), hz(10.0));
+        assert_eq!(derived, 6, "the rung below would have said 6");
+        assert_eq!(
+            depth_default(
+                Some(BufferDiscipline::Queue),
+                Some(3),
+                Some(hz(50.0)),
+                Some(hz(10.0))
+            ),
+            Err(NoDefault::DepthStated(3)),
+            "a stated 3 must win over a derived 6"
+        );
+        // And with no depth stated, the same endpoint DOES get the 6 -- the
+        // control that keeps the assertion above from passing vacuously.
+        assert_eq!(
+            depth_default(
+                Some(BufferDiscipline::Queue),
+                None,
+                Some(hz(50.0)),
+                Some(hz(10.0))
+            ),
+            Ok(6)
+        );
+    }
+
+    /// ACCEPTANCE 3: either rate absent means NO default, and the reason names
+    /// the contract key that would supply it.
+    #[test]
+    fn a_missing_rate_yields_no_default_and_a_reason_that_names_the_key() {
+        let no_pub = depth_default(Some(BufferDiscipline::Queue), None, None, Some(hz(10.0)))
+            .expect_err("no publish rate means no default");
+        assert_eq!(no_pub, NoDefault::NoPublishRate);
+        assert!(
+            no_pub.reason().contains("rate_hz") && no_pub.reason().contains("min_rate_hz"),
+            "the reason must name the keys that would fix it: {}",
+            no_pub.reason()
+        );
+
+        let no_drain = depth_default(Some(BufferDiscipline::Queue), None, Some(hz(50.0)), None)
+            .expect_err("no drain rate means no default");
+        assert_eq!(no_drain, NoDefault::NoDrainRate);
+        assert!(
+            no_drain.reason().contains("trigger") && no_drain.reason().contains("1339"),
+            "the reason must name the key AND the issue that keeps it from arriving: {}",
+            no_drain.reason()
+        );
+
+        // Neither rate: the PUBLISH one is reported, because it is the fact
+        // that is actually reachable today and therefore the one an author can
+        // act on first.
+        assert_eq!(
+            depth_default(Some(BufferDiscipline::Queue), None, None, None),
+            Err(NoDefault::NoPublishRate)
+        );
+    }
+
+    /// A `latest` endpoint -- and an endpoint that stated no discipline at all
+    /// -- gets no default however complete its rates are. This is the half of
+    /// the no-op proof that lives at the arithmetic.
+    #[test]
+    fn only_a_queue_endpoint_is_ever_defaulted() {
+        for buffer in [None, Some(BufferDiscipline::Latest)] {
+            assert_eq!(
+                depth_default(buffer, None, Some(hz(50.0)), Some(hz(10.0))),
+                Err(NoDefault::NotAQueue),
+                "{buffer:?} must not be sized from a drain rate"
+            );
+        }
+    }
+
+    /// ACCEPTANCE 4, first shape: `queue` at depth 1.
+    #[test]
+    fn a_queue_sized_for_no_backlog_is_diagnosed() {
+        let d = diagnose(
+            "subscription",
+            "/image",
+            Some(BufferDiscipline::Queue),
+            Some(1),
+        )
+        .expect("queue at depth 1 is the diagnosed shape");
+        let m = d.message();
+        assert!(m.contains("/image"), "{m}");
+        assert!(m.contains("queue") && m.contains("depth: 1"), "{m}");
+        assert!(
+            m.contains("Not an error"),
+            "the diagnostic must say it is not fatal: {m}"
+        );
+        // Depth 2 is the first depth that holds a backlog, so it is silent.
+        assert_eq!(
+            diagnose(
+                "subscription",
+                "/image",
+                Some(BufferDiscipline::Queue),
+                Some(2)
+            ),
+            None
+        );
+    }
+
+    /// ACCEPTANCE 4, second shape: `latest` at a depth above the read-latest
+    /// break point.
+    #[test]
+    fn a_latest_paying_for_history_is_diagnosed() {
+        let d = diagnose(
+            "subscription",
+            "/odom",
+            Some(BufferDiscipline::Latest),
+            Some(10),
+        )
+        .expect("latest at depth 10 is the diagnosed shape");
+        let m = d.message();
+        assert!(m.contains("/odom") && m.contains("depth: 10"), "{m}");
+        assert!(m.contains("Not an error"), "{m}");
+        // Depth 1 IS read-latest, so it agrees with the declaration.
+        assert_eq!(
+            diagnose(
+                "subscription",
+                "/odom",
+                Some(BufferDiscipline::Latest),
+                Some(1)
+            ),
+            None
+        );
+    }
+
+    /// Silence is not a contradiction. An endpoint missing either line is not
+    /// diagnosed -- which is what keeps every image that states no `buffer:`
+    /// (all of them today) out of the warning stream entirely.
+    #[test]
+    fn a_missing_line_is_never_a_contradiction() {
+        assert_eq!(diagnose("subscription", "/t", None, Some(10)), None);
+        assert_eq!(
+            diagnose("subscription", "/t", Some(BufferDiscipline::Queue), None),
+            None
+        );
+        assert_eq!(diagnose("subscription", "/t", None, None), None);
+    }
+
+    /// The vocabulary round-trips, and a spelling the schema does not model is
+    /// `None` rather than a silently defaulted `latest`.
+    ///
+    /// `latest` IS the schema's default when the key is absent, which is
+    /// exactly why a MISSPELLING must not resolve to it: an author who writes
+    /// `buffer: qeue` would otherwise get read-latest semantics and a green
+    /// build, having declared the opposite.
+    #[test]
+    fn the_buffer_vocabulary_round_trips_and_refuses_everything_else() {
+        for (s, b) in [
+            ("latest", BufferDiscipline::Latest),
+            ("queue", BufferDiscipline::Queue),
+        ] {
+            assert_eq!(parse_buffer(s), Some(b), "{s}");
+            assert_eq!(buffer_spelling(b), s);
+        }
+        for bad in ["", "Queue", "QUEUE", "qeue", "ring", "keep_all", "latest "] {
+            if bad.trim() == "latest" {
+                continue;
+            }
+            assert_eq!(parse_buffer(bad), None, "{bad:?} must not parse");
+        }
+    }
+
+    /// A rate that is not a rate does not become one.
+    #[test]
+    fn a_zero_or_nonfinite_rate_is_not_a_rate() {
+        for bad in [0.0, -1.0, -0.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(RateMilliHz::from_hz(bad), None, "{bad}");
+        }
+        // Below one millihertz rounds to zero, which would divide by zero.
+        assert_eq!(RateMilliHz::from_hz(0.0004), None);
+        assert_eq!(
+            RateMilliHz::from_hz(0.001).map(RateMilliHz::milli_hz),
+            Some(1)
+        );
+    }
+}

--- a/packages/cli/nros-cli-core/tests/contract_queue_buffer_reaches_the_model.rs
+++ b/packages/cli/nros-cli-core/tests/contract_queue_buffer_reaches_the_model.rs
@@ -1,0 +1,286 @@
+//! phase-454 W8 (RFC-0100 D9) — what `buffer:` and the two rates SURVIVE.
+//!
+//! The unit tests in `entity_inventory.rs` and `queue_depth.rs` prove the
+//! ladder, the arithmetic and both diagnostics over rows built by hand. This
+//! one asks the question those cannot: does a contract stating all three facts
+//! deliver all three to the build? It produces the model the way a build does —
+//! the pinned `nros-launch-resolve` over a launch file and its contract
+//! sidecar, exactly as `nros sync` would.
+//!
+//! The answer is NO, and it is the wave's central finding rather than a
+//! footnote, so it is measured here rather than asserted in prose:
+//!
+//! | fact | contract key | in the SystemModel? |
+//! | --- | --- | --- |
+//! | publish rate | `topics.<t>.rate_hz` | yes |
+//! | publish rate | `<node>.pub.<ep>.min_rate_hz` | yes |
+//! | drain rate | `<node>.paths.<p>.trigger.timer.rate_hz` | **no** |
+//! | discipline | `<node>.sub.<ep>.buffer` | **no** |
+//!
+//! Both missing halves are dropped by the MODEL SCHEMA, not by nano-ros. The
+//! resolver PARSES them, VALIDATES them (`buffer` outside `state: true` is a
+//! parse-time error) and REASONS about them — it emits a `[queue-drain-rate]`
+//! warning that divides exactly the two rates this wave's default divides — and
+//! then writes a `sub_endpoints` entry with no discipline and a `node_paths`
+//! entry with nothing but `output`. That is issue 1256's shape one layer
+//! upstream of where W3 found it: a declaration legal to write, legal to
+//! resolve, and dropped before any consumer can read it. Issue 1339.
+//!
+//! These are therefore TRIPWIRES, in the deliberate sense: two of them go RED
+//! the day the model carries the field, and the red is the instruction to wire
+//! `from_model` up. A test that only asserted the half that works would leave
+//! the gap to be rediscovered.
+//!
+//! Run with:
+//! `cargo test --manifest-path packages/cli/Cargo.toml --test contract_queue_buffer_reaches_the_model`
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use nros_cli_core::{
+    entity_inventory::{EntityInventory, EntityKind},
+    queue_depth::{NoDefault, RateMilliHz},
+};
+use ros_launch_manifest_model::SystemModel;
+
+/// The resolver ACCEPTS all three facts — so the gap below is not a contract
+/// that failed to parse.
+///
+/// The control for every assertion in this file. Without it, "the model does
+/// not carry `buffer`" would be equally explained by a fixture the resolver
+/// rejected, and the two have opposite remedies.
+#[test]
+fn the_resolver_accepts_a_contract_stating_buffer_and_both_rates() {
+    let (_text, model) = resolve("queue");
+    assert_eq!(
+        model.structure.topics.len(),
+        2,
+        "the fixture's two topics resolved, so the file was read in full"
+    );
+    assert!(
+        model.contracts.node_paths.contains_key("/listener/drain"),
+        "the timer path resolved: {:?}",
+        model.contracts.node_paths.keys().collect::<Vec<_>>()
+    );
+}
+
+/// THE MEASUREMENT: layer 2 has BOTH rates and the discipline, and proves it by
+/// performing this wave's own division.
+///
+/// The resolver's `queue-drain-rate` check reads the `buffer: queue`
+/// subscriptions of a node, sums their producers' rates, and compares against
+/// the node's timer path rate. That is `publish / drain` with a different
+/// comparison on the end — so the facts are not merely present upstream, they
+/// are already joined. Nothing about this wave needs inventing at layer 2; it
+/// needs CARRYING.
+#[test]
+fn the_resolver_already_computes_the_division_this_wave_derives_from() {
+    let (_text, model) = resolve("queue");
+    let drain = model
+        .meta
+        .diagnostics
+        .iter()
+        .find(|d| d.contains("[queue-drain-rate]"))
+        .unwrap_or_else(|| {
+            panic!(
+                "the resolver must reason about the queue's drain rate; it emitted:\n{}",
+                model.meta.diagnostics.join("\n")
+            )
+        });
+    // Both rates, named, in one upstream diagnostic.
+    assert!(drain.contains("rate_hz (10)"), "{drain}");
+    assert!(drain.contains("(50,"), "{drain}");
+    assert!(drain.contains("buffer: queue"), "{drain}");
+}
+
+/// TRIPWIRE 1 — `SubContract` carries no `buffer`, so nano-ros cannot see the
+/// discipline.
+///
+/// Asserted against the model's own YAML rather than against the typed struct,
+/// because the typed struct HAS NO SUCH FIELD: there is nothing to call. When
+/// `ros-launch-manifest` grows one and the resolver emits it, this key appears
+/// and this test goes red — which is the moment `from_model`'s `buffer: None`
+/// must become a read. Issue 1339.
+#[test]
+fn the_model_does_not_carry_the_buffer_discipline_yet() {
+    let (text, _model) = resolve("queue");
+    let raw: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&text).expect("the resolved model parses as YAML");
+    let sub = raw
+        .get("contracts")
+        .and_then(|c| c.get("sub_endpoints"))
+        .and_then(|s| s.get("/listener/chatter"))
+        .expect("the subscriber endpoint has a contract entry");
+    // The control: the entry is REAL and carries what the schema does model, so
+    // an absent `buffer` is a missing FIELD rather than a missing entry.
+    assert_eq!(
+        sub.get("state").and_then(serde_yaml_ng::Value::as_bool),
+        Some(true),
+        "the same endpoint's `state: true` DID travel: {sub:?}"
+    );
+    assert!(
+        sub.get("buffer").is_none(),
+        "issue 1339 has closed -- `buffer` now reaches the SystemModel. Wire it into \
+         `EntityInventory::from_model` (the `buffer: None` with this issue number beside \
+         it) and delete this tripwire: {sub:?}"
+    );
+}
+
+/// TRIPWIRE 2 — `PathContract` carries no trigger, so the DRAIN RATE is not in
+/// the model either.
+///
+/// The fixture's drain path states `trigger: { timer: { rate_hz: 10 } }`. What
+/// survives is a `node_paths` entry with `output` alone — which is why
+/// `from_model` recovers the rate from what the timer PUBLISHES instead, the
+/// same convention `mapper_input::pub_rate_hz` uses.
+#[test]
+fn the_model_does_not_carry_a_paths_trigger_rate_yet() {
+    let (text, _model) = resolve("queue");
+    let raw: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&text).expect("the resolved model parses as YAML");
+    let path = raw
+        .get("contracts")
+        .and_then(|c| c.get("node_paths"))
+        .and_then(|p| p.get("/listener/drain"))
+        .expect("the drain path has an entry");
+    assert!(
+        path.get("output").is_some(),
+        "the control: the path entry is real and carries its output: {path:?}"
+    );
+    assert!(
+        path.get("trigger").is_none() && path.get("rate_hz").is_none(),
+        "issue 1339 has closed -- a path's trigger now reaches the SystemModel. Read the \
+         drain rate from it in `EntityInventory::from_model` instead of from the timer's \
+         output promise, and delete this tripwire: {path:?}"
+    );
+}
+
+/// THE ACCEPTANCE that does hold end to end: both rates reach the endpoint row,
+/// from a real contract through the real resolver.
+///
+/// This is the half of the derivation that is live today, and it is what makes
+/// the `NoDefault` this fixture produces INFORMATIVE. Without it every endpoint
+/// in every image would report `NoPublishRate` — a reason that is true and
+/// says nothing.
+#[test]
+fn both_rates_reach_the_endpoint_row_through_the_real_resolver() {
+    let (_text, model) = resolve("queue");
+    let inv = EntityInventory::from_model("fixture", &model).expect("the model describes wiring");
+    let sub = inv
+        .components()
+        .iter()
+        .flat_map(|c| c.declaration.entities())
+        .find(|e| e.kind == EntityKind::Subscription)
+        .expect("the listener subscribes to /chatter")
+        .clone();
+    assert_eq!(sub.name.as_deref(), Some("/chatter"));
+    assert_eq!(
+        sub.publish_rate,
+        RateMilliHz::from_hz(50.0),
+        "`topics./chatter.rate_hz: 50` is the channel's arrival rate"
+    );
+    assert_eq!(
+        sub.drain_rate,
+        RateMilliHz::from_hz(10.0),
+        "the node's timer path publishes /status at min_rate_hz 10, so 10 Hz is the \
+         drain rate this reader can see"
+    );
+}
+
+/// ...and therefore the endpoint reports NO DEFAULT for the one fact that is
+/// missing, naming it — RFC-0100 D9, acceptance 3.
+///
+/// The outcome is `NotAQueue` and NOT `NoPublishRate` or `NoDrainRate`, which
+/// is the whole value of the test: with both rates live, the reason an author
+/// reads points at the ONE thing that did not arrive rather than at a rate they
+/// already stated. It also pins the derivation's inertness on today's toolchain
+/// — a `queue` endpoint cannot exist, so no image's sizing can move.
+#[test]
+fn the_reason_names_the_discipline_because_both_rates_did_arrive() {
+    let (_text, model) = resolve("queue");
+    let inv = EntityInventory::from_model("fixture", &model).expect("the model describes wiring");
+    let row = inv
+        .queue_depth_defaults()
+        .into_iter()
+        .find(|r| r.topic == "/chatter")
+        .expect("the subscription is reported");
+    assert_eq!(
+        row.outcome,
+        Err(NoDefault::NotAQueue),
+        "both rates arrived, so the missing fact is the discipline: {}",
+        row.line()
+    );
+    assert!(row.publish_rate.is_some() && row.drain_rate.is_some());
+
+    // No derived depth reaches the fragment, so no image's sizing moves.
+    let cmake = inv.to_cmake();
+    assert!(
+        cmake.contains("set(NROS_ENTITY_DERIVED_DEPTHS \"\")\n"),
+        "the derived list is published and EMPTY: {cmake}"
+    );
+    assert!(
+        cmake.contains("set(NROS_ENTITY_DERIVED_DEPTH_COUNT 0)\n"),
+        "{cmake}"
+    );
+    // ...and the diagnostics are silent, because no endpoint states a
+    // discipline to contradict.
+    assert!(inv.buffer_diagnostics().is_empty());
+}
+
+/// Resolve `launch/<stem>.launch.xml` (with its `<stem>.contract.yaml`
+/// sidecar) through the pinned resolver, by ABSOLUTE path (issue 0285).
+///
+/// Returns the model's raw TEXT beside the parsed value, because two of the
+/// assertions here are about keys the typed model has no field for.
+fn resolve(stem: &str) -> (String, SystemModel) {
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("repo root");
+    let resolver = repo.join("packages/cli/nros-launch-resolve/target/release/nros-launch-resolve");
+    assert!(
+        resolver.is_file(),
+        "nros-launch-resolve not built at {} -- run `just setup-launch-resolve`",
+        resolver.display()
+    );
+    let bringup = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/queue_buffer");
+    let out = temp_output(repo, stem);
+    fs::create_dir_all(&out).expect("create model out dir");
+    let model = out.join("system_model.yaml");
+    let output = std::process::Command::new(&resolver)
+        .arg(bringup.join(format!("launch/{stem}.launch.xml")))
+        .arg("--bringup-root")
+        .arg(&bringup)
+        .arg("-o")
+        .arg(&model)
+        .output()
+        .expect("spawn nros-launch-resolve");
+    assert!(
+        output.status.success(),
+        "nros-launch-resolve failed for {stem}:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = fs::read_to_string(&model).expect("read the resolved model");
+    let _ = fs::remove_dir_all(&out);
+    let parsed = SystemModel::from_yaml_str(&text).expect("the resolved model parses");
+    (text, parsed)
+}
+
+/// Unique scratch dir under the repo's gitignored `tmp/` (repo rule: temp
+/// files live in `$project/tmp/`, not the system temp dir).
+fn temp_output(repo: &Path, name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = repo.join("tmp").join(format!(
+        "queue-buffer-{name}-{}-{stamp}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    dir
+}

--- a/packages/cli/nros-cli-core/tests/fixtures/queue_buffer/launch/queue.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/queue_buffer/launch/queue.contract.yaml
@@ -1,0 +1,63 @@
+# phase-454 W8 (RFC-0100 D9) -- the shape the rate-derived depth default is FOR.
+#
+# `/chatter` is published at 50 Hz and consumed by a subscription that declares
+# `buffer: queue` -- backlog is its failure mode -- drained batch-wise by a
+# 10 Hz timer path on the same node. Five arrivals a drain period plus the
+# straggler slot the unaligned-window bound forces is a depth of 6, and no line
+# of this file says 6: that is the whole point of deriving it.
+#
+# The fixture exists to MEASURE what survives resolution, not only to assert
+# what an author may write. Of the three facts the derivation needs:
+#
+#   * `topics./chatter.rate_hz`            -> reaches the model
+#   * `listener.paths.drain.trigger.timer` -> DOES NOT (PathContract has no
+#                                             trigger; only `output` survives)
+#   * `listener.sub.chatter.buffer`        -> DOES NOT (SubContract has no
+#                                             `buffer` field at all)
+#
+# The resolver reads both missing halves and reasons about them -- it emits a
+# `[queue-drain-rate]` warning comparing exactly the two rates below -- and then
+# writes neither. Issue 1339; `contract_queue_buffer_reaches_the_model.rs` is
+# the tripwire.
+#
+# `min_rate_hz` on `/listener/status` is not decoration. A periodic path's rate
+# is not carried either, so the drain rate this reader can see is the promise
+# the timer's OUTPUT makes -- the same convention
+# `nros_orchestration_ir::mapper_input::pub_rate_hz` already uses.
+
+version: 1
+
+nodes:
+  talker:
+    pub:
+      chatter: {}
+    paths:
+      tick:
+        output: [chatter]
+        trigger: { timer: { rate_hz: 50 } }
+
+  listener:
+    sub:
+      chatter:
+        state: true
+        buffer: queue
+        qos:
+          history: keep_last
+    pub:
+      status:
+        min_rate_hz: 10
+    paths:
+      drain:
+        output: [status]
+        trigger: { timer: { rate_hz: 10 } }
+
+topics:
+  /chatter:
+    type: std_msgs/msg/Int32
+    rate_hz: 50
+    pub: [talker/chatter]
+    sub: [listener/chatter]
+  /status:
+    type: std_msgs/msg/Int32
+    pub: [listener/status]
+    sub: []

--- a/packages/cli/nros-cli-core/tests/fixtures/queue_buffer/launch/queue.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/queue_buffer/launch/queue.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+  <!-- phase-454 W8 (RFC-0100 D9): `talker` publishes /chatter at 50 Hz and
+       `listener` subscribes with `buffer: queue`, draining it from a 10 Hz
+       timer path that publishes /status. Three facts the contract states and
+       the SystemModel carries unevenly; see queue.contract.yaml. -->
+  <node pkg="demo_pkg" exec="talker" name="talker" />
+  <node pkg="demo_pkg" exec="listener" name="listener" />
+</launch>

--- a/tests/cmake-entity-inventory-tests.sh
+++ b/tests/cmake-entity-inventory-tests.sh
@@ -141,7 +141,7 @@ chmod +x "$STUB"
 
 DERIVED_BODY="$TEST_TMPDIR/derived.cmake"
 cat > "$DERIVED_BODY" <<'EOF'
-set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 6)
 # No NROS_ENTITY_INVENTORY_SOURCE: `to_cmake` stopped emitting it (issue 1228 --
 # it is composer-dependent content in a file whose bytes decide whether cmake
 # runs again), and this fixture mirrors what the producer writes.
@@ -207,7 +207,7 @@ EOF
 
 REFUSED_BODY="$TEST_TMPDIR/refused.cmake"
 cat > "$REFUSED_BODY" <<'EOF'
-set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 6)
 set(NROS_ENTITY_INVENTORY_STATUS "refused")
 set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 4)
 set(NROS_ENTITY_INVENTORY_REASON "1 of 4 components in this image declare no entities:\n    demo::legacy (demo::Legacy)")
@@ -225,10 +225,11 @@ EOF
 # rather than a literal, because the literal was `2` until phase-403 step 1
 # made 2 the supported version -- at which point the case silently stopped
 # testing anything it claimed to. Step 2 moved it to 3/4, phase-454 W2, which
-# split the depth table by kind, to 4/5, and phase-454 W3, which added the
-# other three QoS policies, to 5/6.
+# split the depth table by kind, to 4/5, phase-454 W3, which added the
+# other three QoS policies, to 5/6, and phase-454 W8, which gave the depth rows
+# a provenance, to 6/7.
 BAD_SCHEMA_BODY="$TEST_TMPDIR/bad-schema.cmake"
-sed 's/SCHEMA_VERSION 5/SCHEMA_VERSION 6/' "$DERIVED_BODY" > "$BAD_SCHEMA_BODY"
+sed 's/SCHEMA_VERSION 6/SCHEMA_VERSION 7/' "$DERIVED_BODY" > "$BAD_SCHEMA_BODY"
 
 NO_SCHEMA_BODY="$TEST_TMPDIR/no-schema.cmake"
 grep -v SCHEMA_VERSION "$DERIVED_BODY" > "$NO_SCHEMA_BODY"
@@ -521,7 +522,7 @@ log_info "D. an unrecognised schema refuses to be read"
 flat() { tr '\n' ' ' | tr -s ' '; }
 OUT="$(derive "$BAD_SCHEMA_BODY" 0 "$META" "$TEST_TMPDIR/d1.cmake" | flat)"
 check
-if ! nros_grep_q "states entity-inventory schema version 6" <<<"$OUT"; then
+if ! nros_grep_q "states entity-inventory schema version 7" <<<"$OUT"; then
     fail "D: a future schema was read rather than refused -- $OUT"
 fi
 check

--- a/tests/cmake-message-bounds-tests.sh
+++ b/tests/cmake-message-bounds-tests.sh
@@ -182,7 +182,7 @@ derive() {
 entity_frag() {
     local path="$1" inv_status="$2" sub_status="$3"; shift 3
     {
-        echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)"
+        echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 6)"
         echo "set(NROS_ENTITY_INVENTORY_STATUS \"$inv_status\")"
         echo "set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 1)"
         echo "set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS \"$sub_status\")"
@@ -761,7 +761,7 @@ fi
 
 log_header "M -- a current schema that states no subscribed set REFUSES"
 {
-    echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)"
+    echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 6)"
     echo "set(NROS_ENTITY_INVENTORY_STATUS \"derived\")"
 } > "$T/m3-ents.cmake"
 OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/m3-ents.cmake")"
@@ -877,7 +877,7 @@ EOF
 # for the wrong reason. It did, on the first run of this test.
 _o_frag() {
     {
-        printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)\n'
+        printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 6)\n'
         printf 'set(NROS_ENTITY_INVENTORY_STATUS "derived")\n'
         printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved")\n'
         printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES "%s")\n' "$1"
@@ -956,7 +956,7 @@ set(NROS_MESSAGE_BOUND_demo_msg_Open_REASON "unbounded member: data (string)")
 EOF
 # Subscribes to the BOUNDED type only. The unbounded one is linked, never received.
 {
-    printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 5)\n'
+    printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 6)\n'
     printf 'set(NROS_ENTITY_INVENTORY_STATUS "derived")\n'
     printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved")\n'
     printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES "std_msgs/msg/Int32")\n'


### PR DESCRIPTION
phase-454 W8. Carries W3 (#984) and W4 (#993); the queue drops them by patch-id.

## What `buffer:` is, and is not

RFC-0100 **D9** records a retraction: an earlier draft proposed `buffer:` as the
`SLOTS` source, and that was wrong. Its spec meaning is fault-analysis
vocabulary — `latest` means staleness is the failure mode, `queue` means backlog
is — and it is deterministic in neither direction. So this wave does **not** size
from it. It earns its keep as two diagnostics plus one derivation.

## The margin is one slot, and the reasoning is the deliverable

`ceil(publish/drain)` is only right for a queue whose drain instants are
**aligned** with its arrivals. They are not: the subscription and the timer that
drains it are independent periodic streams with no phase relationship the
contract states, and over an unaligned window of length `T` a `p`-periodic
stream's arrivals are bounded by `floor(p·T) + 1`. **One slot is exactly that
straggler.**

Not two, and not a percentage: each extra slot is a whole message in the arena
(`(depth+1)·bound + (depth+1)·pointer`), and the things a larger margin would
absorb — jitter, drain overrun, bursts — are bounded by no number that reaches
the derivation.

The arithmetic is **integer millihertz** (`u64::div_ceil`), not `f64`:
`(0.3/0.1).ceil()` is 3 from a value that is really `2.9999999999999996`, so a
float depth would depend on the decimal *spelling* of a rate.

## The finding that reshaped the wave — issue #1339

The brief said the contract carries both rates. **The contract does; the
SystemModel does not.**

Measured with the pinned resolver over a new fixture:

| fact | reaches the model? |
| --- | --- |
| `topics.<t>.rate_hz`, `min_rate_hz` | yes |
| `sub.<ep>.buffer` | **no** — `SubContract` has no such field |
| `paths.<p>.trigger.timer.rate_hz` | **no** — `PathContract` has no trigger |

v0.1.35 is the newest tag, so this is not a stale pin. And the resolver does not
merely ignore them — it **parses them, validates them, and performs this wave's
own division**, emitting

```
[queue-drain-rate] warning: … rate_hz (10) is less than the sum of its
'buffer: queue' subscriptions' producer rates (50, …)
```

— and then writes neither to the model. **That is issue 1256's shape one layer
upstream**: stated, resolved, dropped.

Filed as **#1339**, with two tripwire tests that go red the day it closes, each
naming the one line to wire.

So the derivation ships **armed and inert**. That makes acceptance 5 (an image
with no `queue` endpoint is byte-identical) structural rather than lucky, and it
is stated plainly rather than presented as a passing result.

## The hazard I had to design around

The depth table has two consumers that want **opposite** things from a default:

- `subs_arena` sizes from it — a derived default is good
- `to_declared_qos_header` turns each row into a `static_assert` — a derived
  default is **fatal**

A default in the shared table would make every call site spell the CLI's
arithmetic or fail to compile, and moving the margin by one slot would break
every such image. Hence `DepthSource`: the header filters to `Stated`, the arena
does not.

## Byte-identical proof

The real `nros ws entity-inventory` binary, built from this commit **and** from
the base, over four models resolved from real in-tree contracts
(`workspaces/{cpp,managed,realtime-cpp-subnode-portable}` plus cpp's
`action_server`).

Every `set(` line identical except `SCHEMA_VERSION 5→6` and two new empty
variables (`NROS_ENTITY_DERIVED_DEPTHS ""`, `_COUNT 0`). The declared-QoS header
is byte-for-byte identical; the env transport on stdout is byte-for-byte
identical; JSON differs only in `schema_version`.

## Testing

Green: `nros-cli-core --lib` 1239/0, the new integration test 6/6,
`cmake-entity-inventory-tests.sh` 64, `cmake-message-bounds-tests.sh` 103,
`cargo +nightly fmt --check` clean.

`ci gate` lanes were run under heavy contention — three concurrent `just ci gate`
runs from other sessions — and `/home` hit **0 bytes free** mid-task (`git
status` itself failed with `index.lock … Out of diskspace`). The byte-identical
proof was obtained by building both CLIs onto `/` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1