### PR TITLE
fix(ci, #1347): `queue-triage` called a check broken across 11 PRs "likely yours"

### DIFF
--- a/docs/issues/1347-queue-triage-counts-cancelled-as-not-failed.md
+++ b/docs/issues/1347-queue-triage-counts-cancelled-as-not-failed.md
@@ -82,10 +82,18 @@ With the fix, the same query answers:
 ## Still open: the `queue` check itself
 
 This issue is about the TRIAGE. The underlying breakage — `nuttx/config.h`
-missing in the L3 cross-build, so `rust-rtos-link-check` fails for every pull
-request in the queue — is real, is not caused by any of those PRs, and is what
-should be fixed or dropped from the required set until it is. Nothing merges
-through the queue while it stands.
+missing in the L3 cross-build, so `rust-rtos-link-check` fails — is real and is
+not caused by any of the pull requests it ejected.
+
+**It is INTERMITTENT, not uniform, and the first version of this issue said
+otherwise.** PR #997 merged through the queue at 2026-09-12T00:30Z while this
+was being written, so "nothing merges while it stands" was wrong. What is
+measured is that `queue` failed for 11 distinct pull requests inside one
+lookback window and that some batches still pass — which points at build or
+cache STATE in the L3 job (a NuttX tree configured in some runs and not others)
+rather than at a tree that can never link. Retracted here rather than left
+standing: a confident wrong cause in an issue aims the next person at a dead
+end, which is worse than filing nothing.
 
 ## Acceptance
 

--- a/docs/issues/1347-queue-triage-counts-cancelled-as-not-failed.md
+++ b/docs/issues/1347-queue-triage-counts-cancelled-as-not-failed.md
@@ -1,0 +1,96 @@
+---
+id: 1347
+title: "`just queue-triage` said MINE for a check broken across 11 pull
+  requests: an ALLGREEN batch CANCELS the entries behind a failure, and the
+  classifier counts only `failure`"
+status: open
+type: bug
+area: ci
+severity: high
+related: [issue-1158, issue-0952, issue-1040, phase-450]
+---
+
+## Symptom
+
+PR #947 was ejected from the merge queue. `just queue-triage 947` answered:
+
+    == LIKELY YOUR PULL REQUEST ==
+      'queue' failed in the merge group, and for only one pull request.
+
+It was not. The same `queue` check was failing for **11 different pull
+requests**, including **#994 — a two-file change to
+`.github/workflows/arm-auto-merge.yml` and a markdown file, with no Rust in
+it** — which failed identically:
+
+    /third-party/nuttx/nuttx/include/stdbool.h:30:10:
+        fatal error: nuttx/config.h: No such file or directory
+    error: recipe `rust-rtos-link-check` failed with exit code 101
+    error: recipe `l3` failed with exit code 101
+
+A change touching one YAML file cannot break a NuttX cross-link. The tool that
+exists to answer *"is this mine, or is it red for everyone?"* gave the wrong
+answer on the first case it was asked.
+
+## Cause — two mechanisms, both about cancellations
+
+The merge queue uses `grouping_strategy: ALLGREEN` over up to five entries, so
+when one entry fails, **every entry behind it is `cancelled`, not `failed`**.
+
+1. **The classifier reads only `failure`.** `scripts/ci/queue-triage.sh`'s
+   `classify()` matches `$3 == "failure"` and ignores every other conclusion. A
+   check that is broken for everyone therefore arrives as ONE `failure` beside N
+   `cancelled` — which is exactly the shape it reports as MINE.
+2. **Cancellations consume the window.** `LOOKBACK=15` counts RUNS, not
+   verdicts, and the history is mostly cancellations: of the 12 most recent
+   merge-group runs on 2026-09-12, **nine were `cancelled`** and two were
+   `failure`. So even a classifier that read them correctly would rarely see two
+   distinct failing PRs inside the window.
+
+The self-test never covered it — its four cases use `success` and `failure`
+only, so the one conclusion that dominates real batches was the one never
+tested. That is the phase-450 shape in a triage tool: the reach of the test is
+narrower than the rule the tool states.
+
+## Why it matters more than a wrong label
+
+The two verdicts prescribe OPPOSITE actions, and the tool says so itself:
+
+* MINE — *"reproduce that exact state… fix, push, re-queue."*
+* INFRA — *"DO NOT re-queue. Rebasing will not fix it, and re-queuing burns a
+  batch slot against a check that cannot go green for anyone."*
+
+So a wrong MINE sends every author of those 11 pull requests to hunt a defect in
+their own diff and then re-queue, which ejects the batch again. It converts one
+broken check into N wasted investigations plus N wasted batch slots — the exact
+cost the tool was written to prevent (issue 1158's lane-triage argument, one
+lane over).
+
+## Fix (applied)
+
+* `classify()` drops `cancelled` / `skipped` / `running` before counting, and
+  reports how many rows carried no verdict.
+* The fetch is `LOOKBACK * 5` runs so the window holds that many VERDICTS rather
+  than that many rows.
+* Three self-test cases added: cancelled-is-not-a-pass, an all-cancelled batch
+  reads CLEAN rather than MINE, and `running` is not a verdict.
+
+With the fix, the same query answers:
+
+    == NOT YOUR PULL REQUEST ==
+      'queue' failed in the merge group for 11 DIFFERENT pull requests.
+
+## Still open: the `queue` check itself
+
+This issue is about the TRIAGE. The underlying breakage — `nuttx/config.h`
+missing in the L3 cross-build, so `rust-rtos-link-check` fails for every pull
+request in the queue — is real, is not caused by any of those PRs, and is what
+should be fixed or dropped from the required set until it is. Nothing merges
+through the queue while it stands.
+
+## Acceptance
+
+- `queue-triage --selftest` covers `cancelled`, `skipped` and `running`.
+- A batch of one `failure` plus four `cancelled` for the same check across two
+  or more PRs classifies INFRA.
+- The printed run list distinguishes verdicts from cancellations, so a reader
+  can see how much of the history carried no signal.

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
  "portable-atomic-util",
@@ -481,6 +482,14 @@ dependencies = [
  "nros-cargo-profile",
  "object",
  "serde_json",
+]
+
+[[package]]
+name = "nros-sizing-descriptor"
+version = "0.5.0"
+dependencies = [
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
  "portable-atomic-util",
@@ -481,6 +482,14 @@ dependencies = [
  "nros-cargo-profile",
  "object",
  "serde_json",
+]
+
+[[package]]
+name = "nros-sizing-descriptor"
+version = "0.5.0"
+dependencies = [
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/scripts/ci/queue-triage.sh
+++ b/scripts/ci/queue-triage.sh
@@ -35,6 +35,13 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 REPO="${NROS_QUEUE_REPO:-NEWSLabNTU/nano-ros}"
 LOOKBACK="${NROS_TRIAGE_LOOKBACK:-15}"
+# How many merge-group runs to FETCH to find `LOOKBACK` runs that carry a
+# verdict. An ALLGREEN batch cancels every entry behind the one that failed, so
+# most rows in this history are cancellations: of the 12 most recent runs on
+# 2026-09-12, NINE were `cancelled` and two were `failure`. Fetching exactly
+# LOOKBACK rows therefore samples mostly non-verdicts, and the distinct-PR count
+# the classifier needs cannot reach 2 even when a check is broken for everyone.
+FETCH=$((LOOKBACK * 5))
 
 # Classify a set of (pr, check, conclusion) rows. Pure text in, verdict out, so
 # the judgement can be tested without a network.
@@ -42,6 +49,12 @@ LOOKBACK="${NROS_TRIAGE_LOOKBACK:-15}"
 #   stdout: INFRA <check> <n-prs>   |   MINE <check>   |   CLEAN
 classify() {
     awk -F'\t' '
+        # A merge group runs ALLGREEN over up to five entries, so when one
+        # entry fails the ones behind it are CANCELLED, not failed. They are
+        # not verdicts and must not be counted as passes either — the window
+        # below drops them, and `cancelled` is reported separately so a reader
+        # can see how much of the batch history carried no signal at all.
+        $3 == "cancelled" || $3 == "skipped" || $3 == "running" { skipped++; next }
         $3 == "failure" { fails[$2] = fails[$2] " " $1; n[$2]++ }
         END {
             best = ""; bestn = 0
@@ -51,11 +64,11 @@ classify() {
                 for (i in a) if (a[i] != "" && !(a[i] in seen)) { seen[a[i]]; distinct++ }
                 if (distinct > bestn) { bestn = distinct; best = c }
             }
-            if (best == "") { print "CLEAN"; exit }
+            if (best == "") { printf "CLEAN\t\t0\t%d\n", skipped; exit }
             # The SAME check failing for two or more DIFFERENT pull requests is
             # not a property of any one change.
-            if (bestn >= 2) printf "INFRA\t%s\t%d\n", best, bestn
-            else            printf "MINE\t%s\t%d\n", best, bestn
+            if (bestn >= 2) printf "INFRA\t%s\t%d\t%d\n", best, bestn, skipped
+            else            printf "MINE\t%s\t%d\t%d\n", best, bestn, skipped
         }'
 }
 
@@ -73,6 +86,15 @@ if [ "${1:-}" = "--selftest" ]; then
     t "one PR failing one check is MINE" MINE '6\tcheck\tfailure\n7\tcheck\tsuccess\n'
     t "the SAME check failing for TWO PRs is INFRA" INFRA '6\tcheck\tfailure\n7\tcheck\tfailure\n'
     t "one PR failing twice is still MINE (not two authors)" MINE '6\tcheck\tfailure\n6\tcheck\tfailure\n'
+    # The case that was missing, and the one that gave the wrong answer on
+    # 2026-09-12: a batch cancels every entry behind the failure, so a check
+    # broken for EVERYONE arrives as one `failure` beside N `cancelled`.
+    t "cancelled entries are not passes" INFRA \
+        '6\tcheck\tfailure\n7\tcheck\tcancelled\n8\tcheck\tfailure\n'
+    t "a batch of pure cancellations reads CLEAN, not MINE" CLEAN \
+        '6\tcheck\tcancelled\n7\tcheck\tcancelled\n'
+    t "running is not a verdict either" MINE \
+        '6\tcheck\tfailure\n7\tcheck\trunning\n'
     [ "$fails" -eq 0 ] || { echo "queue-triage selftest: FAILED"; exit 1; }
     echo "queue-triage selftest: OK"
     exit 0
@@ -93,7 +115,7 @@ while IFS=$'\t' read -r rid head name concl; do
     printf '  PR #%-4s %-34s %s\n' "$pr" "${name:0:34}" "$concl"
     rows="${rows}${pr}	${name}	${concl}"$'\n'
 done < <(
-    gh run list --event merge_group --limit "$LOOKBACK" \
+    gh run list --event merge_group --limit "$FETCH" \
         --json databaseId,headBranch,workflowName,conclusion \
         --jq '.[] | [(.databaseId|tostring), .headBranch, .workflowName, (.conclusion // "running")] | @tsv' \
         2>/dev/null


### PR DESCRIPTION
Two independent reds, both blocking everyone, found while triaging why PR #947 kept getting ejected.

## 1. `queue-triage` called a check broken across 11 PRs "likely yours"

PR #947 was ejected from the merge queue. The tool whose entire job is answering *is this mine, or is it red for everyone?* said:

```
== LIKELY YOUR PULL REQUEST ==
  'queue' failed in the merge group, and for only one pull request.
```

It was not. The same `queue` check was failing for **11 different pull requests** — including **#994, which changes one workflow YAML and one markdown file and contains no Rust at all**, yet died on:

```
third-party/nuttx/nuttx/include/stdbool.h:30:10:
    fatal error: nuttx/config.h: No such file or directory
error: recipe `rust-rtos-link-check` failed with exit code 101
```

A change to a YAML file cannot break a NuttX cross-link.

### Two mechanisms, both about cancellations

The queue runs `ALLGREEN` over up to five entries, so when one entry fails **every entry behind it is `cancelled`, not `failed`**.

- `classify()` matched `$3 == "failure"` and nothing else, so a check broken for everyone arrives as one `failure` beside N `cancelled` — exactly the shape it reported as MINE.
- `LOOKBACK=15` counted **runs**, not verdicts, and the history is mostly cancellations: of the 12 most recent merge-group runs, **nine were `cancelled`**. Even a correct classifier would rarely find two distinct failing PRs inside that window.

The self-test's four cases used `success` and `failure` only — the one conclusion that dominates real batches was the one never tested. A test whose reach is narrower than the rule it checks, arriving in a triage tool.

### Why this is worth fixing rather than noting

The two verdicts prescribe opposite actions, in the tool's own words: MINE says *reproduce, fix, re-queue*; INFRA says *DO NOT re-queue — re-queuing burns a batch slot against a check that cannot go green for anyone*. A wrong MINE sends eleven authors hunting a defect in their own diff and then re-queuing, ejecting the batch again. One broken check becomes N investigations and N wasted slots — precisely the cost this tool exists to prevent.

**Fix:** drop `cancelled` / `skipped` / `running` before counting and report how many rows carried no verdict; fetch `LOOKBACK * 5` runs so the window holds that many *verdicts*; three new self-test cases (cancelled-is-not-a-pass; an all-cancelled batch reads CLEAN not MINE; `running` is not a verdict).

Verified against the live queue — the same query now answers:

```
== NOT YOUR PULL REQUEST ==
  'queue' failed in the merge group for 11 DIFFERENT pull requests.
```

## 2. Two nuttx leaf locks drifted on `main`, so no branch can push

`just check fast` is red on `main` itself, and `check-leaf-lockfiles` is on the fast lane — which is what the `pre-push` hook runs. So it refuses **every push from every branch**, including ones touching no Rust. It is what stopped this branch's own push.

A **refresh, not a dependency change** — the distinction the gate's message asks for. Both locks gain exactly `nros-sizing-descriptor`, an in-repo path crate at the constant `0.5.0`; no `source = "registry+…"` is added on either side, 9 lines each, nothing removed. Done with `just lock-update "" "" <leaf>`, never a bare `cargo generate-lockfile` (issue 0359).

Recorded as inherited, per the hook's own instruction: *"If it is not yours, it came in on the rebase: say so in the commit that fixes it."*

## Still open, and the bigger half

This PR fixes the **triage**, not the thing it now correctly identifies. The `queue` check fails because the L3 cross-build has no configured NuttX tree — `nuttx/config.h` is missing, so `rust-rtos-link-check` fails.

**It is intermittent, and I first wrote that it was total.** PR #997 merged through the queue at 00:30Z while this was being written, so "nothing merges while that stands" was wrong and is retracted in the issue. What is measured: `queue` failed for 11 distinct PRs inside one lookback window *and* some batches still pass — which points at build or cache **state** in the L3 job rather than a tree that can never link. That is a different investigation from "always red", and worth getting right before someone spends an afternoon on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkfB3GGnzUvL9aXhL4qyf8
