### PR TITLE
feat(phase-454 W6.d+e): uORB and cffi size from the descriptor — and a pool the floor gate could not see

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -892,8 +892,14 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   1015's floor — landed in the derivation a day before 1033's fix — silently defeated
   it, and every knob gate stayed green because the number was derived correctly and
   delivered faithfully. Floor at the pool (`c_array_pool_floor` /
-  `_nros_c_array_pool_floor`), keep `#if X < 1 / #error` beside the array as the
+  `_nros_c_array_pool_floor`, the latter now in `cmake/NanoRosPoolFloor.cmake`
+  because phase-454 W6.d gave it a second backend — uORB's two C++ pools, whose
+  build cannot include a Zephyr module file), keep `#if X < 1 / #error` beside the
+  array as the
   backstop that binds a producer neither reaches. Gate: `check-c-array-pool-floors`
+  (its FLOORED knob set is PER PRODUCER since W6.d: a global list made the Zephyr
+  ZPICO bridge answerable for a pool in a PX4 module, and the only way to satisfy
+  that is a written abstention that says nothing true)
   (also refuses an unruled new one; the 1 still unruled is issue 1131 — the
   other 14 were ruled there, 10 guarded and 4 already covered). **Issue 1131
   has since ruled the last one too, so the table is EMPTY and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,6 +2059,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/cmake/NanoRosPoolFloor.cmake
+++ b/cmake/NanoRosPoolFloor.cmake
@@ -1,0 +1,60 @@
+# NanoRosPoolFloor.cmake — the C-array pool floor, in ONE place.
+#
+# Issues 1015 + 1033, and RFC-0100 D7:
+#
+#   > derivation publishes demand, unfloored; the floor lives at the consumer.
+#
+# A derived count is the image's DEMAND, and zero is a legitimate demand.
+# Whether zero is a legal SIZE is a property of the STORAGE, so it is decided at
+# each pool that names a knob — never in the shared derivation, which feeds
+# consumers whose right answers at zero disagree:
+#
+#   zenoh   `queryable_entry_t queryables[ZPICO_MAX_QUERYABLES]` is a fixed C
+#           array. A derived 0 gave a board that transmitted NOTHING in 15
+#           seconds — no panic, no log line, core in WFI, every gate green,
+#           because the number was derived correctly and delivered faithfully.
+#
+#   XRCE    the SAME derived numbers reach `NROS_XRCE_MAX_SUBSCRIBERS` and
+#           `NROS_XRCE_MAX_SERVICE_SERVERS`, where zero is the ANSWER and worth
+#           33,296 / 4,384 bytes of heap a slot.
+#
+#   uORB    `Slot g_pool[NROS_RMW_UORB_PX4_MAX_CALLBACKS]` and
+#           `Entry g_table[NROS_RMW_UORB_REGISTRY_CAPACITY]` are C++, and ISO
+#           C++ has no zero-size array at all — the TU is built `-Wpedantic`
+#           inside a `-Werror` PX4, so zero is not a saving the language will
+#           express (issue 1131).
+#
+# 1015's first fix floored the three zenoh pools in `EntityInventory::derive`.
+# That landed the day BEFORE 1033's fix and silently defeated it, with every
+# knob gate green. This file exists so the rule has one spelling on the CMake
+# side rather than one per backend — CLAUDE.md's "add ONE shared helper rather
+# than a second spelling". Its Rust sibling is
+# `nros_cli_core::entity_inventory::c_array_pool_floor`.
+#
+# `check-c-array-pool-floors` holds both ends: every producer of a GUARDED knob
+# calls this, and the derivation calls nothing.
+
+include_guard(GLOBAL)
+
+# _nros_c_array_pool_floor(<out_var> <value> <knob>)
+#
+# Raise a DERIVED demand to what a fixed C array can be sized to.
+#
+# EMPTY passes through untouched: empty means "nothing resolved", and turning
+# that into a 1 would state a number where the reading build script is supposed
+# to fall through to its own default.
+#
+# An explicit environment value is NOT floored — the callers apply this BEFORE
+# their own resolve step, so a person who states 0 gets the `#error` beside the
+# array that names the knob and its issue, rather than a number they did not ask
+# for.
+function(_nros_c_array_pool_floor out_var value knob)
+    set(_v "${value}")
+    if(_v MATCHES "^[0-9]+$" AND _v LESS 1)
+        message(STATUS
+            "nros: ${knob}=${_v} raised to 1 — it sizes a fixed C array, where "
+            "zero is not a smaller pool (issue 1015)")
+        set(_v 1)
+    endif()
+    set(${out_var} "${_v}" PARENT_SCOPE)
+endfunction()

--- a/docs/design/0100-rmw-agnostic-sizing-model.md
+++ b/docs/design/0100-rmw-agnostic-sizing-model.md
@@ -212,6 +212,11 @@ wire_bound_bytes = 4096
 depth = "history = keep_all on subscription /image: a KEEP_ALL queue has no static bound (RFC-0100 D6)"
 storage_bytes = "`depth` is refused (history = keep_all), and a receive region is sized from it"
 
+[image]
+node_count = 2
+backend_count = 1
+subscriber_count = 3
+
 # All four STATED since phase-454 W6.c. The three maxima come from codegen's own
 # per-type schema walk (the one that prices the bounds), taken per column: the
 # widest type and the deepest type need not be the same type. A type whose schema
@@ -248,6 +253,16 @@ means NOBODY SAID … It must never read as 0"* — and `Refused` is "I looked a
 there is no number, here is why". `Fact::stated()` is the only accessor that
 yields a value, so there is no spelling of "read it, and if that fails use 10"
 that does not go through a `match`.
+
+**`[image]` carries the counts no endpoint row can** (phase-454 W6.d/W6.e). Most
+of D1's "entity counts by kind" are read off the rows — a consumer wanting
+subscriptions counts `kind = "subscription"`. Three are not there to be counted:
+the NODE count, the BACKEND count, and the session's SUBSCRIBER count, which is
+declared subscriptions plus the feedback subscription each action client opens.
+The third is a fact rather than a row count on purpose: the multiplier that turns
+one declared action into several session slots lives beside the calls that make
+it (`check-infra-queryable-counts` holds it there), and a build script counting
+rows and multiplying would be a third mirror of it in a file no gate scans.
 
 **Three fields the sketch above did not have, and one it did.**
 `schema_version` and `[meta] entry` are new: the first because a reader that kept
@@ -293,8 +308,8 @@ maintainer of that backend reads it.
 | zenoh | counts; `depth`; small/large bounds; service req/resp bounds; `[policy]` | `ZPICO_MAX_*`, `SUBSCRIBER_RING_DEPTH`, payload pools, `SERVICE_BUFFERS` | counts and payload classes derived; ring depth DERIVED from the declared depths (phase-454 W6.a, −124,032 B measured); `SERVICE_BUFFERS`'s slot size takes the declared service bound as its default and carries a stated non-annotation — but **no service or action type has a bound row to read** (`record_message` runs for `.msg` only), so it refuses on every image today |
 | XRCE | counts (**zero legal**); per-family bounds; `depth`; MTU; `reliability` | `MAX_*`, per-family `BUFFER_SIZE`, ring depths, `STREAM_HISTORY` | two counts derivable via `-1`; one global `BUFFER_SIZE = 1024` serves three families; reliability unread |
 | Cyclone | `[types]`, `[target].heap_budget_bytes`. **Nothing else** | `MAX_TYPES`, `MAX_DESCRIPTOR_TYPES`, `MAX_FIELDS`, `MAX_KINDS`, heap assertion | **all derived, phase-454 W6.c** |
-| uORB | distinct topic count; subscription count | `REGISTRY_CAPACITY`, `PX4_MAX_CALLBACKS` | neither wired |
-| cffi | subscription count; node count; backend count | `RMW_SUBSCRIBER_SLOTS`, `MAX_NODES`, `MAX_BACKENDS` | slots derived; `max_nodes = components().len()` computed and discarded |
+| uORB | distinct topic count; subscription count | `REGISTRY_CAPACITY`, `PX4_MAX_CALLBACKS` | **both derived, phase-454 W6.d** |
+| cffi | subscription count; node count; backend count | `RMW_SUBSCRIBER_SLOTS`, `MAX_NODES`, `MAX_BACKENDS` | **all three derived, phase-454 W6.e** |
 
 **Not a derivation, and must not be modelled as one:** cffi's `SLOT_SIZE` is a
 hard 1024, and `insert::<T>()` returns `None` both when every slot is claimed and
@@ -341,7 +356,7 @@ build prints what declaring would save:
 | zenoh | ROS default depth, closure bound, `UNDECLARED_HEADROOM` queryables |
 | XRCE | **assume reliable** — pay both 64 KiB buffers |
 | Cyclone | `DEFAULT_MAX_TYPES = 32` floor |
-| uORB | current literals |
+| uORB | current literals — the `#ifndef … 64` in each source, so an image with no descriptor is byte-identical to every build before W6.d |
 
 ## D7 — derivation publishes demand, unfloored; the floor lives at the consumer
 

--- a/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
+++ b/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
@@ -220,8 +220,8 @@ One sub-wave per consumer; they are independent and can run in parallel.
 | W6.a | zenoh | `SUBSCRIBER_RING_DEPTH` from declared depth (authored today); `SERVICE_BUFFERS` derived from request/response bounds and given a `// nros-pool:` annotation or a stated reason — it is 144,128 B on a native talker and in neither |
 | W6.b | XRCE | `reliability` gates the two 64 KiB `*_reliable_buf`; one global `BUFFER_SIZE = 1024` splits into three per-family sizes; ring depths take declared depth as their default |
 | W6.c | Cyclone | **LANDED** — `MAX_DESCRIPTOR_TYPES` derived from the same count as `MAX_TYPES` (silent-drop overflow at ~86 types today); `MAX_FIELDS`/`MAX_KINDS`/`MAX_NESTED_DEPTH` from the schema walk codegen already does; heap budget asserted at boot (D11) |
-| W6.d | uORB | `REGISTRY_CAPACITY` and `PX4_MAX_CALLBACKS` — both trivially derivable, neither wired |
-| W6.e | cffi | `MAX_NODES` from `components().len()`, which is already computed and discarded |
+| W6.d | uORB | **LANDED.** `REGISTRY_CAPACITY` and `PX4_MAX_CALLBACKS` — both trivially derivable, neither wired |
+| W6.e | cffi | **LANDED.** `MAX_NODES` from `components().len()`, which is already computed and discarded |
 
 Each sub-wave keeps RFC-0100 D7: publish demand **unfloored**, floor at the pool.
 Issues 1015 and 1033 are the negative control — one derivation feeding two
@@ -332,6 +332,32 @@ by every image at its coordinate, so a `-D` there would be last-configure-wins
 across images. That road keeps the `#ifndef` fallbacks, which is exactly what it
 had before. Wiring it needs a per-entry OBJECT library or a runtime cap, and
 neither belongs in this wave.
+
+#### W6.d + W6.e — uORB and cffi — **LANDED**
+
+They land together: they share a shape — counts only, no payload bound, no
+depth, no MTU — and they share the schema change that makes them possible:
+`[image]` carries the node count, the backend count and the session's subscriber
+count, the three RFC-0100 D5 names that no endpoint row can be counted
+to get.
+
+Measured, on a linked artifact rather than by arithmetic:
+
+| image | pool | before | after | delta |
+| --- | --- | --- | --- | --- |
+| `examples/esp32-c3-baremetal/rust/listener` (1 component, 1 subscription) | uORB `g_table` (`nm` on `topic_registry.cpp.o`, host ABI) | 1,536 B (64 slots) | 24 B (1 slot) | **−1,512 B** |
+| `examples/native/rust/talker` (1 component, 1 publisher, `rmw = "zenoh"`) | cffi `REGISTRY` (`nm` on a linked binary) | 328 B (8 slots) | 48 B (1 slot) | **−280 B** |
+
+`NODE_TABLE` is `MAX_NODES` × a measured 144-byte `NodeSlot`, so the same
+declaration takes it from 576 B to 144 B on any image that registers a node; the
+probe binary above does not keep it live, so that one is arithmetic over two
+measured quantities rather than a symbol read, and is reported as such.
+
+And the direction the campaign cares about more: on the pub-only talker the
+subscriber demand is **0**, published unfloored, and the uORB consumer raises it
+to 1 with a line that says so — `NROS_RMW_UORB_PX4_MAX_CALLBACKS=0 raised to 1`.
+That is D7 working in both directions in one image: zero reaches cffi's `[T; 0]`
+untouched and is refused by the C++ array that cannot express it.
 
 ### W7 — contract and `qos_overrides` must agree
 

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -535,6 +535,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/cli/nros-cli-core/src/cmd/sizing_descriptor.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sizing_descriptor.rs
@@ -86,6 +86,10 @@ fn summary(desc: &nros_sizing_descriptor::SizingDescriptor) -> String {
         "    heap_budget_bytes {}",
         desc.target.heap_budget_bytes()
     );
+    let _ = writeln!(s, "  image:");
+    let _ = writeln!(s, "    node_count        {}", desc.image.node_count());
+    let _ = writeln!(s, "    backend_count     {}", desc.image.backend_count());
+    let _ = writeln!(s, "    subscriber_count  {}", desc.image.subscriber_count());
     let _ = writeln!(s, "  types:");
     let _ = writeln!(s, "    distinct_count    {}", desc.types.distinct_count());
     let _ = writeln!(s, "    max_fields        {}", desc.types.max_fields());

--- a/packages/cli/nros-cli-core/src/sizing_descriptor.rs
+++ b/packages/cli/nros-cli-core/src/sizing_descriptor.rs
@@ -162,6 +162,7 @@ pub fn build(inputs: &DescriptorInputs<'_>) -> SizingDescriptor {
         }
     }
 
+    desc.image = image_facts(inputs);
     desc.types = type_facts(inputs, &desc.endpoints);
     // `[policy]` stays empty. See the module docs: a policy fact is STATED, and
     // nothing states one yet.
@@ -528,6 +529,61 @@ fn registration_path_refusal(inputs: &DescriptorInputs<'_>) -> String {
          bound (issue 1319), so the path is refused rather than assumed",
         missing.join(" and ")
     )
+}
+
+/// `[image]` — the three counts no endpoint row carries (phase-454 W6.e).
+///
+/// Every number here is one the entity inventory ALREADY derived; nothing is
+/// re-computed, which is the same rule the rest of this module holds to. Two of
+/// them are simply thrown away today: `DerivedEntityKnobs::max_nodes` reaches the
+/// executor's node table and never the cffi shim's, and no producer of any kind
+/// states how many backends an image links.
+///
+/// UNFLOORED, D7. `max_subscribers` is zero for a pub-only image and that is the
+/// answer — 1 KiB a slot in the cffi pool (issue 1033's measurement, one backend
+/// over). Whether zero is a legal SIZE is decided at each pool that names a knob.
+fn image_facts(inputs: &DescriptorInputs<'_>) -> nros_sizing_descriptor::Image {
+    use crate::entity_inventory::Derivation;
+
+    let mut img = nros_sizing_descriptor::Image::default();
+
+    // The backend half is independent of the inventory: it comes from what the
+    // image DECLARES it links, not from what it declares it publishes.
+    match inputs.rmw.as_deref() {
+        // A leaf names exactly ONE backend (`LeafSystem::rmw` is a single
+        // value), and `nros build` generates exactly one `register()` call for
+        // it. A bridge binds several -- and a bridge leaf carries no
+        // `system.toml`, so no descriptor is written for one and this arm is
+        // never the answer for a multi-backend image.
+        Some(_) => {
+            img = nros_sizing_descriptor::Image::new(None, Some(1), None);
+        }
+        None => {
+            img.refuse(
+                "backend_count",
+                "the image names no rmw, so what it links is not known here -- a short backend \
+                 registry is a registration FAILURE, so it is refused rather than guessed",
+            );
+        }
+    }
+
+    match inputs.inventory.map(EntityInventory::derive) {
+        Some(Derivation::Derived(k)) => {
+            img.set_node_count(Some(k.max_nodes))
+                .set_subscriber_count(Some(k.max_subscribers));
+        }
+        Some(Derivation::Refused { reason }) => {
+            img.refuse("node_count", reason.clone())
+                .refuse("subscriber_count", reason);
+        }
+        None => {
+            let why = "the entity inventory did not compose for this entry, so the image's \
+                       node and subscriber counts are not known -- absence is not zero";
+            img.refuse("node_count", why)
+                .refuse("subscriber_count", why);
+        }
+    }
+    img
 }
 
 /// `[types]` — Cyclone's whole appetite (RFC-0100 D5).
@@ -904,6 +960,25 @@ pub fn to_cmake(desc: &SizingDescriptor) -> String {
         &mut out,
         "NROS_SIZING_TYPES_MAX_NESTED_DEPTH",
         &desc.types.max_nested_depth(),
+    );
+    // phase-454 W6 — the three image counts. uORB reads the subscriber one and
+    // the endpoint TOPIC column beside it; a C/C++ consumer of the cffi shim
+    // reads all three. Same D6 shape as every fact above: a refused one has no
+    // `set()` at all, so `if(DEFINED ...)` is the only road to a number.
+    emit_cmake_fact(
+        &mut out,
+        "NROS_SIZING_IMAGE_NODE_COUNT",
+        &desc.image.node_count(),
+    );
+    emit_cmake_fact(
+        &mut out,
+        "NROS_SIZING_IMAGE_BACKEND_COUNT",
+        &desc.image.backend_count(),
+    );
+    emit_cmake_fact(
+        &mut out,
+        "NROS_SIZING_IMAGE_SUBSCRIBER_COUNT",
+        &desc.image.subscriber_count(),
     );
     out.push_str(&format!(
         "set(NROS_SIZING_ENDPOINT_COUNT {})\n",
@@ -1305,5 +1380,99 @@ mod tests {
         let d = build(&base(&inv));
         assert_eq!(d.types.distinct_count().stated(), Some(&0));
         assert_eq!(d.meta.undeclared_endpoints().stated(), Some(&0));
+        // phase-454 W6.d/W6.e — and the same for the count uORB's push-wake
+        // pool and cffi's slot pool both read. Zero subscriptions IS zero
+        // demand; `_nros_c_array_pool_floor` raises it where the storage
+        // refuses zero, and `[T; 0]` keeps it where the storage does not.
+        assert_eq!(d.image.subscriber_count().stated(), Some(&0));
+    }
+
+    #[test]
+    fn the_image_counts_come_from_the_derivation_and_not_from_the_rows() {
+        // phase-454 W6.e. The subscriber count is `max_subscribers`, which is
+        // declared subscriptions PLUS the feedback subscription each action
+        // client opens -- so it is NOT the number of `kind = "subscription"`
+        // rows, and an image with an action client proves the difference.
+        let mut ac = EntityDecl::bare(
+            EntityKind::ActionClient,
+            Some("test_msgs/action/Fibonacci".into()),
+            Some("/fib".into()),
+        );
+        ac.history = Some(QoSHistoryPolicy::KeepLast);
+        let inv = inventory(vec![sub("std_msgs/msg/String", "/chatter", Some(10)), ac]);
+        let d = build(&base(&inv));
+        let subs = d
+            .endpoints
+            .iter()
+            .filter(|e| e.kind == EndpointKind::Subscription)
+            .count();
+        assert_eq!(subs, 1, "one row says `subscription`");
+        // ...and the session opens two slots. A consumer that counted rows and
+        // multiplied would need a third mirror of a multiplier that already has
+        // two, in a build script no gate scans.
+        assert_eq!(d.image.subscriber_count().stated(), Some(&2));
+        assert_eq!(d.image.node_count().stated(), Some(&1));
+    }
+
+    #[test]
+    fn an_image_that_names_no_backend_refuses_the_backend_count() {
+        // A short backend registry is a REGISTRATION FAILURE and not a
+        // truncation, so the safe direction is the builtin 8 and a guess is
+        // never it.
+        let inv = inventory(vec![sub("std_msgs/msg/String", "/chatter", Some(10))]);
+        let mut i = base(&inv);
+        i.rmw = None;
+        let d = build(&i);
+        let backends = d.image.backend_count();
+        let r = backends.refusal().unwrap();
+        assert!(r.contains("names no rmw"), "{r}");
+        // Degrades nothing else, D6.
+        assert_eq!(d.image.node_count().stated(), Some(&1));
+        assert_eq!(d.image.subscriber_count().stated(), Some(&1));
+    }
+
+    #[test]
+    fn a_refused_inventory_refuses_both_counts_rather_than_reporting_zero() {
+        let mut i = DescriptorInputs {
+            entry: "talker".into(),
+            ..Default::default()
+        };
+        i.host_build = true;
+        i.rmw = Some("zenoh".into());
+        let d = build(&i);
+        assert!(d.image.node_count().stated().is_none());
+        assert!(
+            d.image
+                .subscriber_count()
+                .refusal()
+                .unwrap()
+                .contains("absence is not zero")
+        );
+        // The backend half is independent of the inventory and survives.
+        assert_eq!(d.image.backend_count().stated(), Some(&1));
+    }
+
+    #[test]
+    fn the_cmake_projection_carries_the_image_counts() {
+        // uORB and every C/C++ consumer of the cffi shim read these through the
+        // projection; a refused one gets no `set()` at all, so `if(DEFINED ...)`
+        // stays the only road to a number.
+        let inv = inventory(vec![sub("std_msgs/msg/String", "/chatter", Some(10))]);
+        let mut i = base(&inv);
+        i.rmw = None;
+        let out = to_cmake(&build(&i));
+        assert!(out.contains("set(NROS_SIZING_IMAGE_NODE_COUNT 1)"), "{out}");
+        assert!(
+            out.contains("set(NROS_SIZING_IMAGE_SUBSCRIBER_COUNT 1)"),
+            "{out}"
+        );
+        assert!(
+            !out.contains("set(NROS_SIZING_IMAGE_BACKEND_COUNT "),
+            "{out}"
+        );
+        assert!(
+            out.contains("set(NROS_SIZING_IMAGE_BACKEND_COUNT_REFUSED "),
+            "{out}"
+        );
     }
 }

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/rmw/cffi/Cargo.toml
+++ b/packages/rmw/cffi/Cargo.toml
@@ -41,6 +41,12 @@ nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }
 nros-board-common = { path = "../../boards/nros-board-common", features = [
     "build-helpers",
 ], default-features = false }
+# phase-454 W6.e (RFC-0100 D4/D5) — the sizing descriptor `nros sync` writes per
+# entry, and the road three of this crate's four pools now take their DEFAULT
+# from. Read by PATH, never through a knob-per-fact environment: issues 0460 and
+# 0491 are what env transport cost here, and neither can carry a per-endpoint
+# table without encoding one in a string.
+nros-sizing-descriptor = { path = "../../tooling/nros-sizing-descriptor" }
 # Phase 115.G.4 — compiles the second-language smoke-test stubs in
 # `tests/c_stubs/*.c` into a small static lib that the integration
 # tests link against. Only used during `cargo build`/`cargo test`;

--- a/packages/rmw/cffi/build.rs
+++ b/packages/rmw/cffi/build.rs
@@ -1,4 +1,4 @@
-//! Build script. Two responsibilities:
+//! Build script. Three responsibilities:
 //!
 //! 1. Phase 104.B.1 — read `NROS_RMW_MAX_BACKENDS` (env var, default
 //!    8) and re-emit it as a `cargo:rustc-env` so the crate's source
@@ -8,13 +8,32 @@
 //!    companion-class hardware can bump to 16. Range [1, 64];
 //!    values outside the range fail the build.
 //!
-//! 2. Phase 115.G.4 — compile `tests/c_stubs/c_stub_transport.c`
+//! 2. phase-454 W6.e (RFC-0100 D5) — take the DEFAULT for three of those
+//!    pools from the image's sizing descriptor instead of from a literal.
+//!    RFC-0100 D5's cffi row is three counts and this is where they land:
+//!
+//!    ```text
+//!    NROS_RMW_MAX_BACKENDS      [image] backend_count
+//!    NROS_RMW_MAX_NODES         [image] node_count
+//!    NROS_RMW_SUBSCRIBER_SLOTS  [image] subscriber_count
+//!    ```
+//!
+//!    `NROS_RMW_MESSAGE_INFO_SLOTS` is NOT among them and must not be:
+//!    `MessageInfoSlot`'s width is cfg-dependent (`alloc` + `safety-e2e` add
+//!    three fields), which is why it carries a documented deliberate
+//!    non-annotation in `lib.rs` rather than a formula. Neither is
+//!    `SLOT_SIZE` — a hard 1024 where a size overflow and a full pool return
+//!    the same code (issue 1322), and D5 rules it out by name: no user fact
+//!    answers "how big is a backend's private state struct".
+//!
+//! 3. Phase 115.G.4 — compile `tests/c_stubs/c_stub_transport.c`
 //!    into a small static lib for the second-language smoke test.
 //!    Gated behind the `c-stub-test` Cargo feature so consumers of
 //!    `nros-rmw-cffi` that vendor it without a C toolchain on the
 //!    build host aren't forced through the cc invocation.
 
 use nros_board_common::platform_config::{BuildRungs, RmwKnobs};
+use nros_sizing_descriptor::{Fact, SizingDescriptor};
 
 fn main() {
     watch_declared_facts();
@@ -24,11 +43,64 @@ fn main() {
     let rungs = BuildRungs::from_build_env()
         .map(|r| r.rmw_rungs())
         .unwrap_or_default();
+    // phase-454 W6.e — what this IMAGE declares. `None` for a build nobody ran
+    // `nros sync` for, which is every plain `cargo build` here and every
+    // out-of-tree consumer; all three knobs below then size exactly as they did
+    // before this wave.
+    let sizing = sizing_descriptor();
 
-    emit_max_backends(&rungs);
-    emit_subscriber_slots();
+    emit_max_backends(&rungs, sizing.as_ref());
+    emit_subscriber_slots(sizing.as_ref());
     emit_message_info_slots(&rungs);
     maybe_build_c_stub();
+}
+
+/// The descriptor this build was pointed at, or `None`.
+///
+/// A parse or schema failure PANICS, which is a build error naming the file.
+/// That is the negative control for the whole transport: a descriptor EXISTS, so
+/// keeping our own literals here would size three static pools from numbers a
+/// user believes they supplied. Same three outcomes as `nros-node`'s reader —
+/// absent is silent, refused is loud, broken is fatal.
+fn sizing_descriptor() -> Option<SizingDescriptor> {
+    match nros_sizing_descriptor::from_build_env() {
+        // `Ok(None)` is the variable being UNSET, which is the ordinary case.
+        // `Err(Missing)` is a path that was NAMED and is not there, and that is
+        // an error for the same reason as the rest: somebody pointed this build
+        // at a descriptor.
+        Ok(d) => d,
+        Err(e) => panic!("{e}"),
+    }
+}
+
+/// A descriptor count, as the rung under an operator's stated value.
+///
+/// RFC-0049's ladder is unchanged and RFC-0100 D6 says where a derived number
+/// sits in it: *"a policy fact is stated, and a derived fact may supply its
+/// default"*. So an env var, a `CONFIG_*` symbol and a `[knobs.rmw]` rung all
+/// still win; this replaces the crate BUILTIN, which is a literal nobody chose
+/// for this image.
+///
+/// LOUD on a refusal, D6's second half — *"always the safe direction and always
+/// loud"*. The safe direction for all three of these pools is the larger
+/// builtin, so a refusal costs memory rather than correctness, and the warning
+/// says what declaring would have bought.
+fn derived_rung(fact: &Fact<usize>, what: &str, builtin: usize) -> Option<usize> {
+    match fact {
+        Fact::Stated(v) => Some(*v),
+        Fact::Refused(why) => {
+            println!(
+                "cargo::warning=nros-rmw-cffi: sizing descriptor refused `{what}`: {why}; the \
+                 pool keeps its builtin {builtin}, which over-states this image rather than \
+                 under-sizing it"
+            );
+            None
+        }
+        // ABSENT is not an event. A descriptor that states no count for a
+        // section nobody derived has nothing to report, and a warning on every
+        // such build is the guard that fires on every call.
+        Fact::Absent => None,
+    }
 }
 
 /// Resolve a sizing knob the way every Zephyr-aware build script here does.
@@ -69,8 +141,28 @@ fn declared_usize(name: &str) -> Option<usize> {
     std::env::var(name).ok().and_then(|v| v.trim().parse().ok())
 }
 
-fn emit_max_backends(rungs: &RmwKnobs) {
-    let parsed = knob("NROS_RMW_MAX_BACKENDS", rungs.max_backends, 8);
+/// phase-454 W6.e — `MAX_BACKENDS` and `MAX_NODES`, both derived.
+///
+/// **`MAX_BACKENDS`** is the count of distinct RMW backends the image links.
+/// Every leaf that gets a descriptor names exactly one (`LeafSystem::rmw` is a
+/// single value, and `nros build` generates one `register()` call for it); a
+/// bridge that binds several carries no `system.toml`, so no descriptor is
+/// written for one and it keeps the builtin 8. Under-sizing this registry is a
+/// REGISTRATION FAILURE and not a truncation — `nros_rmw_cffi_register` returns
+/// non-OK and `register()` returns `Err` — so the number is refused rather than
+/// guessed wherever the producer cannot name the backend.
+///
+/// **`MAX_NODES`** is `components().len()`, which the entity inventory has
+/// derived since phase-412 and handed only to `NROS_EXECUTOR_MAX_NODES`. The
+/// comment below has said "the default mirrors the executor's `MAX_NODES`" for
+/// four phases, and that was true of the two DEFAULTS and of nothing else: a
+/// declared image sized the executor's node table per image and left this one at
+/// 4. Now both read one count.
+fn emit_max_backends(rungs: &RmwKnobs, sizing: Option<&SizingDescriptor>) {
+    let backends = rungs.max_backends.or_else(|| {
+        sizing.and_then(|d| derived_rung(&d.image.backend_count(), "backend_count", 8))
+    });
+    let parsed = knob("NROS_RMW_MAX_BACKENDS", backends, 8);
 
     if !(1..=64).contains(&parsed) {
         panic!(
@@ -84,8 +176,12 @@ fn emit_max_backends(rungs: &RmwKnobs) {
 
     // Phase 376 W5/B1 — distinct `(name, namespace)` pairs one session hosts.
     // Default 4, matching `nros-node`'s `NROS_EXECUTOR_MAX_NODES`: the shim
-    // cannot see more nodes than the executor will register.
-    let nodes = knob("NROS_RMW_MAX_NODES", rungs.max_nodes, 4);
+    // cannot see more nodes than the executor will register. phase-454 W6.e —
+    // and now they read ONE count rather than two equal literals.
+    let node_rung = rungs
+        .max_nodes
+        .or_else(|| sizing.and_then(|d| derived_rung(&d.image.node_count(), "node_count", 4)));
+    let nodes = knob("NROS_RMW_MAX_NODES", node_rung, 4);
     if !(1..=64).contains(&nodes) {
         panic!(
             "NROS_RMW_MAX_NODES={nodes} out of range [1, 64]. Bump \
@@ -101,7 +197,7 @@ fn emit_max_backends(rungs: &RmwKnobs) {
 /// The old hardcoded 4 silently capped a session at four subscriptions:
 /// the fifth `create_subscription` returned BAD_ALLOC, which the
 /// executor then surfaced as an opaque `SubscriberCreationFailed`.
-fn emit_subscriber_slots() {
+fn emit_subscriber_slots(sizing: Option<&SizingDescriptor>) {
     // NO ladder rung, deliberately: phase-412 W1 derives this from the
     // entity inventory (`COUNT_SUBSCRIPTION`). Two campaigns resolving one
     // knob is the drift issue 0938 cost, so this one keeps env -> Kconfig ->
@@ -112,11 +208,25 @@ fn emit_subscriber_slots() {
     // that have no Kconfig. NOT floored: zero is legal here and measured --
     // `[T; 0]` is ordinary Rust, the only access is `for index in
     // 0..SLOT_COUNT`, and issue 1033 retracted the clamp that rounded it to 1.
-    let parsed = knob(
-        "NROS_RMW_SUBSCRIBER_SLOTS",
-        declared_usize("NROS_DECLARED_RMW_SUBSCRIBER_SLOTS"),
-        8,
-    );
+    //
+    // phase-454 W6.e — the DESCRIPTOR is now the first of those two roads, and
+    // the `NROS_DECLARED_*` carrier is the fallback rather than the answer.
+    // They cannot disagree today: both are `DerivedEntityKnobs::max_subscribers`
+    // from one `EntityInventory::derive`, which is the whole point of RFC-0100
+    // D4 — *"one artifact, one road"* — and the reason `[image] subscriber_count`
+    // carries the TOTAL rather than leaving a build script to count
+    // `kind = "action_client"` rows and multiply. That multiplier is one an
+    // action's creation calls own (`check-infra-queryable-counts` holds it
+    // there), and a third mirror of it, in a build script no gate scans, is how
+    // an image with an action gets sized short.
+    //
+    // The carrier stays because it is the road the C/C++ CMake lane takes and
+    // that lane has no descriptor yet; removing the read would take those images
+    // from a derived count back to the builtin 8. W9 is where it retires.
+    let declared = sizing
+        .and_then(|d| derived_rung(&d.image.subscriber_count(), "subscriber_count", 8))
+        .or_else(|| declared_usize("NROS_DECLARED_RMW_SUBSCRIBER_SLOTS"));
+    let parsed = knob("NROS_RMW_SUBSCRIBER_SLOTS", declared, 8);
 
     // issue 1033 — ZERO is in range. A pub-only image derives 0 subscriptions
     // from the entity inventory, and 0 slots is the honest answer: `[T; 0]` is

--- a/packages/rmw/uorb/nros-rmw-uorb/CMakeLists.txt
+++ b/packages/rmw/uorb/nros-rmw-uorb/CMakeLists.txt
@@ -147,6 +147,37 @@ target_compile_options(nros_rmw_uorb PRIVATE
     -fno-exceptions -fno-rtti
 )
 
+# ---- Derived pool sizes (phase-454 W6.d, RFC-0100 D5) ----------------------
+# The two size knobs this backend has, from what the IMAGE declares rather than
+# from the literals in the sources. `NrosRmwUorbSizing.cmake` carries the
+# arithmetic and the floors; this is only where the answer is applied.
+#
+# Reading the descriptor is OPTIONAL and its absence is the ordinary case: a
+# standalone `add_subdirectory` of this package, or a PX4 module shell, has no
+# `nros` CLI in scope and no contract to resolve. Then no `-D` is emitted and
+# each source's own `#ifndef ... 64` stands — byte-identical to every build
+# before this wave.
+set(NROS_RMW_UORB_SIZING_DESCRIPTOR "" CACHE PATH
+    "The image's `build/nros/sizing/<entry>.toml` (RFC-0100 D4). Empty: keep the built-in pool sizes.")
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/NrosRmwUorbSizing.cmake")
+if(NROS_RMW_UORB_SIZING_DESCRIPTOR AND COMMAND nros_sizing_descriptor_read)
+    nros_sizing_descriptor_read("${NROS_RMW_UORB_SIZING_DESCRIPTOR}")
+elseif(NROS_RMW_UORB_SIZING_DESCRIPTOR)
+    # A descriptor was NAMED and the reader is not here. Loud rather than
+    # silent: sizing from our own literals while a user believes they supplied
+    # numbers is exactly the silent default RFC-0100 D6 exists to remove.
+    message(FATAL_ERROR
+        "nros-rmw-uorb: NROS_RMW_UORB_SIZING_DESCRIPTOR names "
+        "${NROS_RMW_UORB_SIZING_DESCRIPTOR}, but `nros_sizing_descriptor_read` is not "
+        "available. Include cmake/NanoRosSizingDescriptor.cmake (and NanoRosCodegenCore.cmake "
+        "before it) in the consuming build, or unset the variable.")
+endif()
+nros_rmw_uorb_sizing_defines(_nros_rmw_uorb_pool_defs)
+if(_nros_rmw_uorb_pool_defs)
+    message(STATUS "nros-rmw-uorb: derived pool sizes ${_nros_rmw_uorb_pool_defs}")
+    target_compile_definitions(nros_rmw_uorb PRIVATE ${_nros_rmw_uorb_pool_defs})
+endif()
+
 set_target_properties(nros_rmw_uorb PROPERTIES
     POSITION_INDEPENDENT_CODE ON
     EXPORT_NAME NrosRmwUorb

--- a/packages/rmw/uorb/nros-rmw-uorb/cmake/NrosRmwUorbSizing.cmake
+++ b/packages/rmw/uorb/nros-rmw-uorb/cmake/NrosRmwUorbSizing.cmake
@@ -1,0 +1,130 @@
+# NrosRmwUorbSizing.cmake — phase-454 W6.d, RFC-0100 D5.
+#
+#   > Each backend's build reads the descriptor and computes its OWN knobs.
+#   > Adding a fifth backend touches no shared code, and each backend's
+#   > arithmetic stays where a maintainer of that backend reads it.
+#
+# uORB has exactly two size knobs and owns the sample storage itself, so there
+# is no payload bound, no QoS depth, no MTU and no reliability to consume here.
+# Counts only:
+#
+#   NROS_RMW_UORB_REGISTRY_CAPACITY   `Entry g_table[N]` in topic_registry.cpp,
+#                                     a topic name -> `orb_metadata *` map. The
+#                                     image's DISTINCT TOPIC count: its declared
+#                                     publishers and subscriptions, deduplicated
+#                                     BY TOPIC NAME, because two endpoints on one
+#                                     topic share one registry entry.
+#
+#   NROS_RMW_UORB_PX4_MAX_CALLBACKS   `Slot g_pool[N]` in px4_callback_glue.cpp,
+#                                     one per subscription wanting a push-wake
+#                                     callback. `[image] subscriber_count` is
+#                                     that count: the session's subscriber slots,
+#                                     which is what the vtable opens.
+#
+# THE FLOOR IS HERE, AND THE DEMAND IS NOT FLOORED (RFC-0100 D7, issues
+# 1015 + 1033). The descriptor publishes an image's demand unfloored — zero
+# publishers and zero subscriptions IS zero distinct topics — and whether zero
+# is a legal SIZE is a property of the storage. For these two it is not: both
+# arrays are C++, ISO C++ has no zero-size array, and both TUs are built
+# `-Wpedantic` inside a `-Werror` PX4 (issue 1131). So `_nros_c_array_pool_floor`
+# raises each to 1 at THIS consumer, and the `#if < 1 / #error` beside each array
+# is the backstop that binds a producer this file never reaches.
+#
+# NO DESCRIPTOR, NO DEFINES. An image nobody ran `nros sync` for gets an empty
+# list back, no `-D` reaches either TU, and the `#ifndef ... 64` in each source
+# stands — byte-identical to every uORB build before this wave.
+#
+# THE SECOND ROAD, AND WHY IT HAS NOTHING TO READ. `px4_add_module()` consumers
+# (`packages/testing/nros-px4-register-check`, `examples/px4/cpp/*`) list these
+# sources by path and pass defines through `COMPILE_FLAGS`, bypassing the
+# package's own `CMakeLists.txt` entirely. They may call this function too — it
+# emits a plain `<MACRO>=<value>` list, which is what both `COMPILE_FLAGS` and
+# `target_compile_definitions` take. None does today, because none of them has a
+# sizing descriptor: a PX4 firmware module is built inside a PX4 tree from
+# sources with no `system.toml`, so there is no contract for `nros sync` to
+# resolve. The abstention is written here rather than left to be rediscovered.
+
+include_guard(GLOBAL)
+
+# `_nros_c_array_pool_floor` — the ONE CMake spelling of the rule above, shared
+# with the Zephyr lane's three zenoh pools. Reached by a path relative to this
+# file, the same way the package's own `CMakeLists.txt` reaches the rmw-abi
+# headers, so a standalone `add_subdirectory` of this package resolves it.
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../cmake/NanoRosPoolFloor.cmake")
+
+# nros_rmw_uorb_sizing_defines(<out_var>)
+#
+# Compute the two `-D` rows from the `NROS_SIZING_*` variables a prior
+# `nros_sizing_descriptor_read()` defined, and return them as a
+# `<MACRO>=<value>` list. EMPTY when this image declared nothing.
+#
+# It reads the variables rather than the file: CMake does not parse TOML and
+# must not learn to (the schema has ONE reader), and the projection is already
+# the shape a `.cmake` consumer can use. A REFUSED fact has no value variable at
+# all — only a `_REFUSED` reason beside it — so `if(DEFINED ...)` below is the
+# only road to a number, which is RFC-0100 D6 in CMake's vocabulary.
+function(nros_rmw_uorb_sizing_defines out_var)
+    set(_defs "")
+
+    # --- the registry: distinct topics over publishers and subscriptions -----
+    #
+    # The endpoint table arrives as parallel lists of NROS_SIZING_ENDPOINT_COUNT
+    # elements. A cell that is the literal `REFUSED` or `ABSENT` is not a value;
+    # `kind` and `topic` are the descriptor's IDENTITY columns and are never
+    # either, which is what makes this count derivable from rows at all.
+    #
+    # `NROS_SIZING_UNDECLARED_ENDPOINTS` is the precondition, and it is not
+    # decoration. An `ENDPOINT_COUNT` of 0 has two causes that read identically
+    # here: an image that declares no endpoints, and an image whose entity
+    # inventory DID NOT COMPOSE. The descriptor keeps them apart -- the second
+    # refuses `undeclared_endpoints` with "absence is not zero" and so publishes
+    # no value for it -- and the difference is the whole ballgame, because a
+    # registry derived from rows nobody could see is SHORT, and a short registry
+    # is topics that fail to register at runtime. Unlike every other number in
+    # this file, that is the direction with no safe fallback, so the row-derived
+    # capacity is withheld rather than floored.
+    if(DEFINED NROS_SIZING_ENDPOINT_COUNT AND DEFINED NROS_SIZING_UNDECLARED_ENDPOINTS)
+        set(_topics "")
+        math(EXPR _last "${NROS_SIZING_ENDPOINT_COUNT} - 1")
+        if(_last GREATER_EQUAL 0)
+            foreach(_i RANGE ${_last})
+                list(GET NROS_SIZING_ENDPOINT_KIND ${_i} _kind)
+                list(GET NROS_SIZING_ENDPOINT_TOPIC ${_i} _topic)
+                if(_kind STREQUAL "publisher" OR _kind STREQUAL "subscription")
+                    list(APPEND _topics "${_topic}")
+                endif()
+            endforeach()
+        endif()
+        # Deduplicate BY TOPIC NAME: a publisher and a subscription on one topic
+        # are one registry entry, because the table is keyed by name.
+        if(_topics)
+            list(REMOVE_DUPLICATES _topics)
+        endif()
+        list(LENGTH _topics _capacity)
+        _nros_c_array_pool_floor(_capacity "${_capacity}"
+            NROS_RMW_UORB_REGISTRY_CAPACITY)
+        list(APPEND _defs "NROS_RMW_UORB_REGISTRY_CAPACITY=${_capacity}")
+    elseif(DEFINED NROS_SIZING_ENDPOINT_COUNT)
+        message(STATUS
+            "nano-ros: the sizing descriptor states no `undeclared_endpoints`, so its "
+            "endpoint rows are not a complete account of this image; "
+            "NROS_RMW_UORB_REGISTRY_CAPACITY keeps its built-in 64 rather than a count "
+            "that could be short")
+    endif()
+
+    # --- the push-wake pool: one slot per subscriber ------------------------
+    if(DEFINED NROS_SIZING_IMAGE_SUBSCRIBER_COUNT)
+        _nros_c_array_pool_floor(_callbacks "${NROS_SIZING_IMAGE_SUBSCRIBER_COUNT}"
+            NROS_RMW_UORB_PX4_MAX_CALLBACKS)
+        list(APPEND _defs "NROS_RMW_UORB_PX4_MAX_CALLBACKS=${_callbacks}")
+    elseif(DEFINED NROS_SIZING_IMAGE_SUBSCRIBER_COUNT_REFUSED)
+        # LOUD, and the safe direction (D6). The builtin 64 over-states this
+        # image; a derived number under it would be a pool that runs out.
+        message(STATUS
+            "nano-ros: sizing descriptor refused `subscriber_count` "
+            "(${NROS_SIZING_IMAGE_SUBSCRIBER_COUNT_REFUSED}); "
+            "NROS_RMW_UORB_PX4_MAX_CALLBACKS keeps its built-in 64")
+    endif()
+
+    set(${out_var} "${_defs}" PARENT_SCOPE)
+endfunction()

--- a/packages/rmw/uorb/nros-rmw-uorb/src/topic_registry.cpp
+++ b/packages/rmw/uorb/nros-rmw-uorb/src/topic_registry.cpp
@@ -10,7 +10,11 @@
 // Storage is a fixed-capacity array. uORB topic counts in
 // production PX4 modules are bounded (~30–60 distinct topics
 // per module); the 64 default cap is generous. Tunable via
-// `-DNROS_RMW_UORB_REGISTRY_CAPACITY=<N>` at compile time.
+// `-DNROS_RMW_UORB_REGISTRY_CAPACITY=<N>` at compile time, and
+// phase-454 W6.d DERIVES it: the image's distinct topic count,
+// over the publishers and subscriptions its contract declares,
+// deduplicated by topic name. `NrosRmwUorbSizing.cmake` is the
+// one producer; an image with no sizing descriptor keeps the 64.
 
 #include "nros_rmw_uorb_registry.h"
 
@@ -22,9 +26,26 @@
 #define NROS_RMW_UORB_REGISTRY_CAPACITY 64
 #endif
 
-namespace {
+/* issue 1131 / phase-454 W6.d — this knob sizes `Entry g_table[N]`, and 0 is
+ * not a legal size here for the same LANGUAGE reason as the `Slot g_pool[N]`
+ * next door: ISO C++ has no zero-size array, and this TU is built `-Wpedantic`
+ * inside a `-Werror` PX4. So the question "does the runtime survive an empty
+ * registry?" is not the whole question — the image does not COMPILE.
+ *
+ * It matters now because the capacity is derived. Before W6.d the only way to
+ * reach 0 was a person typing `-D...=0`; now an image whose contract declares
+ * no publishers and no subscriptions derives exactly 0 distinct topics, and
+ * that is a legitimate DEMAND (RFC-0100 D7) which `_nros_c_array_pool_floor`
+ * raises at the consumer. This is the backstop that binds a producer the floor
+ * never reached.
+ *
+ * Below the `#ifndef`, never above: an undefined identifier reads as 0 in
+ * `#if`, so a guard above its own default fires on every build (issue 1167). */
+#if NROS_RMW_UORB_REGISTRY_CAPACITY < 1
+#error "NROS_RMW_UORB_REGISTRY_CAPACITY must be >= 1: ISO C++ forbids a zero-size array (1131)"
+#endif
 
-constexpr size_t kCapacity = NROS_RMW_UORB_REGISTRY_CAPACITY;
+namespace {
 
 struct Entry {
     const char *topic_name;
@@ -34,7 +55,15 @@ struct Entry {
 
 // Static storage. Zero-initialised at program start; entries with
 // `meta == nullptr` are empty slots.
-Entry g_table[kCapacity];
+//
+// The extent is the MACRO and not a `constexpr` alias of it, deliberately.
+// `check-c-array-pool-floors` discovers a knob-sized array by intersecting the
+// `#ifndef` knobs with the ALL-CAPS array extents in the file, so the
+// `constexpr size_t kCapacity = ...` this line used to read through laundered
+// the macro straight past the gate: the audit reported 24 knob-sized arrays
+// over a tree that had 25, and this was the one it could not see.
+Entry g_table[NROS_RMW_UORB_REGISTRY_CAPACITY];
+constexpr size_t kCapacity = NROS_RMW_UORB_REGISTRY_CAPACITY;
 size_t g_count = 0;
 
 bool eq(const char *a, const char *b) {

--- a/packages/testing/nros-tests/bins/advertised-state-probe/Cargo.lock
+++ b/packages/testing/nros-tests/bins/advertised-state-probe/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]
@@ -236,6 +237,14 @@ name = "nros-serdes"
 version = "0.5.0"
 dependencies = [
  "heapless",
+]
+
+[[package]]
+name = "nros-sizing-descriptor"
+version = "0.5.0"
+dependencies = [
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/testing/nros-tests/bins/qos-event-probe/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-event-probe/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/testing/nros-tests/bins/sim-clock-listener/Cargo.lock
+++ b/packages/testing/nros-tests/bins/sim-clock-listener/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/testing/nros-tests/bins/sim-clock-publisher/Cargo.lock
+++ b/packages/testing/nros-tests/bins/sim-clock-publisher/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/tooling/nros-sizing-descriptor/src/lib.rs
+++ b/packages/tooling/nros-sizing-descriptor/src/lib.rs
@@ -64,7 +64,7 @@ use std::path::{Path, PathBuf};
 
 pub use fact::Fact;
 pub use render::{portability_violation, render};
-pub use schema::{Endpoint, Meta, Policy, SizingDescriptor, Target, Types};
+pub use schema::{Endpoint, Image, Meta, Policy, SizingDescriptor, Target, Types};
 pub use vocabulary::{
     Basis, Durability, EndpointKind, History, RegistrationPath, Reliability, Status,
 };
@@ -239,6 +239,7 @@ mod tests {
         d.endpoints.push(sub);
         d.types = Types::new(Some(7), Some(12), Some(48), Some(3));
         d.policy = Policy::new(Some(64), Some(4096), Some(1));
+        d.image = Image::new(Some(2), Some(1), Some(3));
         d
     }
 
@@ -327,6 +328,55 @@ mod tests {
         let back = parse(&render(&d), Path::new("e.toml")).unwrap();
         assert_eq!(back.types.distinct_count().stated(), Some(&0));
         assert_eq!(back.meta.undeclared_endpoints().stated(), Some(&0));
+    }
+
+    #[test]
+    fn the_image_counts_survive_a_round_trip_and_refuse_one_at_a_time() {
+        // phase-454 W6.e. The three counts feed three different cffi pools, and
+        // D6's rule is that a refusal degrades nothing else -- an image whose
+        // backend nobody named must still get its node table sized.
+        let mut d = island();
+        d.image = Image::new(Some(2), None, Some(3));
+        d.image.refuse(
+            "backend_count",
+            "the image names no rmw, so what it links \
+                    is not known here",
+        );
+        let back = parse(&render(&d), Path::new("t.toml")).unwrap();
+        assert_eq!(back.image.node_count().stated(), Some(&2));
+        assert_eq!(back.image.subscriber_count().stated(), Some(&3));
+        assert_eq!(back.image.backend_count().tag(), "refused");
+        assert!(
+            back.image
+                .backend_count()
+                .refusal()
+                .unwrap()
+                .contains("names no rmw")
+        );
+    }
+
+    #[test]
+    fn an_image_with_no_counts_reads_absent_not_zero() {
+        // The distinction the whole `Fact` type exists for, at the section a
+        // pool size is read from: a consumer that saw `0` here would build a
+        // zero-slot registry for an image nobody measured.
+        let d = SizingDescriptor::new("x", Status::Refused, Basis::Closure);
+        let back = parse(&render(&d), Path::new("x.toml")).unwrap();
+        assert_eq!(back.image.node_count().tag(), "absent");
+        assert_eq!(back.image.backend_count().tag(), "absent");
+        assert!(back.image.subscriber_count().stated().is_none());
+    }
+
+    #[test]
+    fn a_zero_subscriber_count_is_a_demand_and_reaches_the_consumer() {
+        // Issue 1033's half of D7: a pub-only image demands ZERO subscriber
+        // slots and that is the answer, worth 1 KiB a slot in the cffi pool.
+        // Nothing here floors it; whether zero is a legal SIZE is decided at
+        // the pool that names the knob.
+        let mut d = island();
+        d.image = Image::new(Some(1), Some(1), Some(0));
+        let back = parse(&render(&d), Path::new("p.toml")).unwrap();
+        assert_eq!(back.image.subscriber_count().stated(), Some(&0));
     }
 
     // --- negative controls: a reader that would default silently -------------

--- a/packages/tooling/nros-sizing-descriptor/src/render.rs
+++ b/packages/tooling/nros-sizing-descriptor/src/render.rs
@@ -25,7 +25,7 @@
 //! writes freely, and the one place an interpolated `Path::display()` would slip
 //! in. A refusal that names a file names it relative, or names the entry instead.
 
-use crate::schema::{Endpoint, Meta, Policy, SizingDescriptor, Target, Types};
+use crate::schema::{Endpoint, Image, Meta, Policy, SizingDescriptor, Target, Types};
 
 /// The header every descriptor carries.
 const HEADER: &str = "\
@@ -82,6 +82,10 @@ pub fn render(desc: &SizingDescriptor) -> String {
         emit_values(&mut out, Endpoint::FIELDS, |f| ep.raw_value(f));
         emit_refusals(&mut out, "endpoint.refused", ep.refusals());
     }
+
+    out.push_str("\n[image]\n");
+    emit_values(&mut out, Image::FIELDS, |f| desc.image.raw_value(f));
+    emit_refusals(&mut out, "image.refused", desc.image.refusals());
 
     out.push_str("\n[types]\n");
     emit_values(&mut out, Types::FIELDS, |f| desc.types.raw_value(f));

--- a/packages/tooling/nros-sizing-descriptor/src/schema.rs
+++ b/packages/tooling/nros-sizing-descriptor/src/schema.rs
@@ -427,6 +427,138 @@ impl Endpoint {
     }
 }
 
+/// `[image]` — the counts that are properties of the IMAGE and of no endpoint.
+///
+/// RFC-0100 D1 lists "entity counts by kind" as an image fact, and the endpoint
+/// rows carry most of them: a consumer that wants subscriptions counts rows with
+/// `kind = "subscription"`. Three counts have no row to be read off, and this is
+/// where they live.
+///
+/// D5's cffi row names all three:
+///
+/// > cffi | reads: subscription count; node count; backend count | computes:
+/// > `RMW_SUBSCRIBER_SLOTS`, `MAX_NODES`, `MAX_BACKENDS`
+///
+/// [`Self::subscriber_count`] is in here rather than left to a row count for a
+/// reason that is measured rather than stylistic — see its own doc. Nothing else
+/// a consumer can count itself belongs here; the rows are the surface, and a
+/// second spelling of a count the rows already carry is how two green tools come
+/// to disagree.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Image {
+    node_count: Option<usize>,
+    backend_count: Option<usize>,
+    subscriber_count: Option<usize>,
+    #[serde(default)]
+    refused: BTreeMap<String, String>,
+}
+
+impl Image {
+    pub(crate) const FIELDS: &'static [&'static str] =
+        &["node_count", "backend_count", "subscriber_count"];
+
+    /// Distinct `(name, namespace)` nodes the image registers — one per declared
+    /// component.
+    ///
+    /// Sizes the executor's node table and the cffi shim's, which are two tables
+    /// over one count. Exhaustion of either NAMES its knob
+    /// (`NodeError::NodeTableFull`), which is the property phase-412 required
+    /// before deriving a count at all.
+    pub fn node_count(&self) -> Fact<usize> {
+        fact(&self.node_count, "node_count", &self.refused)
+    }
+
+    /// Distinct RMW backends this image links and registers.
+    ///
+    /// Sizes `nros_rmw_cffi`'s backend registry. The registry is a fixed array
+    /// and a short one is a REGISTRATION FAILURE rather than a silent
+    /// truncation, so the number has to describe the image and not a guess.
+    pub fn backend_count(&self) -> Fact<usize> {
+        fact(&self.backend_count, "backend_count", &self.refused)
+    }
+
+    /// Subscriber slots one session opens: declared subscriptions PLUS the
+    /// feedback subscription each action client opens.
+    ///
+    /// **This is why it is a fact and not a row count.** An action is ONE
+    /// declared entity that costs SEVERAL session slots, and the multipliers
+    /// that say how many live beside the calls that make them
+    /// (`nros_node::executor::action`, held there by
+    /// `check-infra-queryable-counts`). A consumer counting
+    /// `kind = "action_client"` rows and multiplying would be a new mirror of a
+    /// number that already has two, in a build script no gate scans. So the
+    /// producer — which already owns a checked mirror — states the total.
+    pub fn subscriber_count(&self) -> Fact<usize> {
+        fact(&self.subscriber_count, "subscriber_count", &self.refused)
+    }
+
+    pub fn new(
+        node_count: Option<usize>,
+        backend_count: Option<usize>,
+        subscriber_count: Option<usize>,
+    ) -> Self {
+        Self {
+            node_count,
+            backend_count,
+            subscriber_count,
+            refused: BTreeMap::new(),
+        }
+    }
+
+    /// Builder setters. Each takes `Option` so a producer that has one count and
+    /// not another writes what it actually knows, leaving the rest ABSENT (or
+    /// refusing it with [`Self::refuse`], which is the louder and usually right
+    /// answer).
+    pub fn set_node_count(&mut self, v: Option<usize>) -> &mut Self {
+        self.node_count = v;
+        self
+    }
+    pub fn set_backend_count(&mut self, v: Option<usize>) -> &mut Self {
+        self.backend_count = v;
+        self
+    }
+    pub fn set_subscriber_count(&mut self, v: Option<usize>) -> &mut Self {
+        self.subscriber_count = v;
+        self
+    }
+
+    pub fn refuse(&mut self, field: &str, reason: impl Into<String>) -> &mut Self {
+        debug_assert!(
+            Self::FIELDS.contains(&field),
+            "unknown [image] field {field}"
+        );
+        self.refused.insert(field.to_string(), reason.into());
+        self
+    }
+
+    pub(crate) fn refusals(&self) -> &BTreeMap<String, String> {
+        &self.refused
+    }
+
+    pub(crate) fn raw_value(&self, field: &str) -> Option<String> {
+        Some(match field {
+            "node_count" => self.node_count?.to_string(),
+            "backend_count" => self.backend_count?.to_string(),
+            "subscriber_count" => self.subscriber_count?.to_string(),
+            _ => return None,
+        })
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        known_refusals(
+            "image",
+            &self.refused,
+            Self::FIELDS,
+            &[
+                ("node_count", self.node_count.is_some()),
+                ("backend_count", self.backend_count.is_some()),
+                ("subscriber_count", self.subscriber_count.is_some()),
+            ],
+        )
+    }
+}
+
 /// `[types]` — Cyclone's whole appetite (RFC-0100 D5).
 ///
 /// > Cyclone: reads `[types]`, `[target].heap_budget_bytes`. **Nothing else**.
@@ -619,6 +751,8 @@ pub struct SizingDescriptor {
     #[serde(default, rename = "endpoint")]
     pub endpoints: Vec<Endpoint>,
     #[serde(default)]
+    pub image: Image,
+    #[serde(default)]
     pub types: Types,
     #[serde(default)]
     pub policy: Policy,
@@ -638,6 +772,7 @@ impl SizingDescriptor {
             },
             target: Target::default(),
             endpoints: Vec::new(),
+            image: Image::default(),
             types: Types::default(),
             policy: Policy::default(),
         }
@@ -669,6 +804,7 @@ impl SizingDescriptor {
         for ep in &self.endpoints {
             ep.validate()?;
         }
+        self.image.validate()?;
         self.types.validate()?;
         self.policy.validate()?;
         Ok(())

--- a/scripts/check-c-array-guard-probe.py
+++ b/scripts/check-c-array-guard-probe.py
@@ -205,6 +205,27 @@ PROBE_CONTEXT = {
                      "preprocessing. Stated so a reviewer is not misled into "
                      "thinking this probe proves more than it does.",
     },
+    # phase-454 W6.d — the registry's capacity became a DERIVED number, so a
+    # contract declaring no publishers and no subscriptions can now reach it
+    # with 0, and `Entry g_table[0]` is a hard error in a `-Wpedantic -Werror`
+    # PX4 C++ build. The guard landed with the derivation; this is the probe
+    # that proves it fires.
+    #
+    # `compile`, not `preprocess`, and that is the whole difference from its
+    # neighbour above: this TU includes only the package's own registry header,
+    # `nros/rmw_ret.h` and `<cstring>` — no PX4 SDK, no per-build generated
+    # config — so the real translation unit builds from this checkout with two
+    # include paths and the probe asks the compiler the actual question.
+    "packages/rmw/uorb/nros-rmw-uorb/src/topic_registry.cpp": {
+        "mode": "compile",
+        "cc": "c++",
+        "std": "c++14",
+        "includes": [
+            "packages/rmw/uorb/nros-rmw-uorb/include",
+            "packages/core/nros-rmw-abi/include",
+        ],
+        "defines": [],
+    },
 }
 INCLUDE_LINE = re.compile(r"^\s*#\s*include\b")
 

--- a/scripts/check-c-array-pool-floors.py
+++ b/scripts/check-c-array-pool-floors.py
@@ -159,20 +159,45 @@ UNCLASSIFIED_CEILING = 0
 
 # --- the producer half -----------------------------------------------------
 
-# Every producer that hands a DERIVED number to a guarded knob, and the floor
-# call it must apply. Two lanes, because a Zephyr Rust image and a cargo leaf
-# reach the same pools by different paths (issue 0460).
-# A producer either FLOORS the knob or ABSTAINS from producing it at all, and
+# Every producer that hands a DERIVED number to a guarded knob, the floor call
+# it must apply, and THE KNOBS IT IS ANSWERABLE FOR.
+#
+# The knob set is per producer and not one global list. Until phase-454 W6.d
+# there was only one pool family with a derived count, so a global
+# `FLOORED_KNOBS` and a per-producer list were the same thing; the moment a
+# SECOND backend derived its own pools they stopped being. uORB's two C++ pools
+# are produced by uORB's own CMake helper and by nothing else — requiring the
+# Zephyr ZPICO bridge to floor `NROS_RMW_UORB_PX4_MAX_CALLBACKS` would be asking
+# a file that has never heard of uORB to state a number for it, and the only way
+# to satisfy that is a written abstention that says nothing true.
+#
+# A producer either FLOORS its knob or ABSTAINS from producing it at all, and
 # the abstention has to be written down: `ZPICO_MAX_QUERYABLES` is deliberately
 # not derived on the cargo lane (a leaf has no `NROS_DECLARED_INFRA_QUERYABLES`
 # channel, so a bare count would be SHORT for any image with param services),
 # and a rule with no spelling for that would push it into an unwanted floor.
+_ZPICO_POOLS = (
+    "ZPICO_MAX_LIVELINESS",  # phase-412 W2 -- derived since, same C-array rule
+    "ZPICO_MAX_PUBLISHERS",
+    "ZPICO_MAX_QUERYABLES",
+    "ZPICO_MAX_SUBSCRIBERS",
+)
+# phase-454 W6.d. Both are C++ arrays, so zero is refused by the LANGUAGE rather
+# than by the runtime: ISO C++ has no zero-size array and both TUs build
+# `-Wpedantic` inside a `-Werror` PX4 (issue 1131). The derivation publishes the
+# demand unfloored -- an image declaring no publishers and no subscriptions
+# derives exactly 0 distinct topics -- and this is where it is raised.
+_UORB_POOLS = (
+    "NROS_RMW_UORB_PX4_MAX_CALLBACKS",
+    "NROS_RMW_UORB_REGISTRY_CAPACITY",
+)
 FLOOR_PRODUCERS = [
     (
         "zephyr/cmake/nros_cargo_build.cmake",
         r"_nros_c_array_pool_floor\([^)]*\b{knob}\b",
         None,
         "the CMake ZPICO bridge",
+        _ZPICO_POOLS,
     ),
     (
         "packages/cli/nros-cli-core/src/leaf_entity_env.rs",
@@ -183,14 +208,20 @@ FLOOR_PRODUCERS = [
         # facts and the consumer floors the count itself, issue 0460).
         r'(?:NOT_DERIVED[A-Z_]*|[A-Z_]*DERIVED_BY_CONSUMER): &str = "{knob}"',
         "the cargo-leaf `[env]` sidecar",
+        _ZPICO_POOLS,
+    ),
+    (
+        "packages/rmw/uorb/nros-rmw-uorb/cmake/NrosRmwUorbSizing.cmake",
+        r"_nros_c_array_pool_floor\([^)]*\b{knob}\b",
+        None,
+        "the uORB sizing helper",
+        _UORB_POOLS,
     ),
 ]
-FLOORED_KNOBS = [
-    "ZPICO_MAX_LIVELINESS",  # phase-412 W2 -- derived since, same C-array rule
-    "ZPICO_MAX_PUBLISHERS",
-    "ZPICO_MAX_QUERYABLES",
-    "ZPICO_MAX_SUBSCRIBERS",
-]
+# Every knob any producer is answerable for — what `--audit` reports on, and
+# what the selftest mutates. Derived from the table above so the two cannot
+# drift.
+FLOORED_KNOBS = sorted({k for p in FLOOR_PRODUCERS for k in p[4]})
 
 # The shared derivation, and the slice of it that computes the pools. Nothing in
 # that slice may raise a count: it is the image's DEMAND, and two consumers read
@@ -364,14 +395,14 @@ def check_arrays(found: dict[str, dict]) -> list[str]:
 def check_producers(texts: dict[str, str]) -> list[str]:
     """Every producer floors the guarded knobs, and the derivation does not."""
     problems = []
-    for path, pattern, abstain, what in FLOOR_PRODUCERS:
+    for path, pattern, abstain, what, knobs in FLOOR_PRODUCERS:
         text = texts.get(path)
         if text is None:
             raise Failure(
                 f"{path}: missing. This gate names its producers explicitly, so a\n"
                 "renamed or deleted one is a failure rather than a silent pass."
             )
-        for knob in FLOORED_KNOBS:
+        for knob in knobs:
             if abstain and re.search(abstain.format(knob=knob), text):
                 continue
             if not re.search(pattern.format(knob=knob), text):
@@ -570,6 +601,13 @@ const NOT_DERIVED_LIVELINESS_NEEDS_INFRA_COUNT: &str = "ZPICO_MAX_LIVELINESS";
         ("ZPICO_MAX_SUBSCRIBERS", floor(knobs.max_subscribers)),
 """
 
+# phase-454 W6.d — the third producer, and the one that made the knob set
+# per-producer: it answers for uORB's two C++ pools and for nothing else.
+GOOD_UORB = """
+_nros_c_array_pool_floor(_capacity "${N}" NROS_RMW_UORB_REGISTRY_CAPACITY)
+_nros_c_array_pool_floor(_callbacks "${M}" NROS_RMW_UORB_PX4_MAX_CALLBACKS)
+"""
+
 GOOD_DERIVE = """
         let n = |tag: &str| per_kind.get(tag).copied().unwrap_or(0);
         let max_subscribers = n(sub) + n(ac) * ACTION_CLIENT_SUBSCRIPTIONS;
@@ -577,10 +615,11 @@ GOOD_DERIVE = """
 """
 
 
-def producer_texts(cmake=GOOD_CMAKE, rust=GOOD_RUST, derive=GOOD_DERIVE):
+def producer_texts(cmake=GOOD_CMAKE, rust=GOOD_RUST, derive=GOOD_DERIVE, uorb=GOOD_UORB):
     return {
         FLOOR_PRODUCERS[0][0]: cmake,
         FLOOR_PRODUCERS[1][0]: rust,
+        FLOOR_PRODUCERS[2][0]: uorb,
         DERIVATION: derive,
     }
 
@@ -717,6 +756,23 @@ def selftest() -> int:
         "ZPICO_MAX_LIVELINESS" in p
         for p in check_producers(producer_texts(rust=lvl_silent))
     )
+    # phase-454 W6.d -- the uORB producer, and the control that the knob set is
+    # really PER PRODUCER. Dropping uORB's floor must fail...
+    uorb_dropped = GOOD_UORB.replace(
+        '_nros_c_array_pool_floor(_callbacks "${M}" NROS_RMW_UORB_PX4_MAX_CALLBACKS)', ""
+    )
+    assert any(
+        "produces NROS_RMW_UORB_PX4_MAX_CALLBACKS without the C-array floor" in p
+        for p in check_producers(producer_texts(uorb=uorb_dropped))
+    )
+    # ...and the two lanes that have never heard of uORB must NOT be asked for
+    # it. Before the knob set was per producer, a global list made the Zephyr
+    # ZPICO bridge answerable for a pool in a PX4 module, and the only way to
+    # satisfy that is a written abstention that says nothing true.
+    for name in ("NROS_RMW_UORB_PX4_MAX_CALLBACKS", "NROS_RMW_UORB_REGISTRY_CAPACITY"):
+        for p in check_producers(producer_texts()):
+            assert name not in p, p
+
     # The regression this gate was written after: the floor back in the shared
     # derivation, where it also reaches the XRCE pools.
     floored = GOOD_DERIVE.replace(

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -33,6 +33,12 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosResolved.cmake")
 # them the right place to clear a date a previous pass armed. FILE scope, same
 # reason as the two above.
 include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosReconfigure.cmake")
+# Issues 1015 + 1033 / RFC-0100 D7 -- `_nros_c_array_pool_floor`, the ONE CMake
+# spelling of "raise a derived demand to what a fixed C array can be sized to".
+# It lives in `cmake/` rather than here because phase-454 W6.d gave it a second
+# backend: uORB's two C++ pools are floored by the same function, from a build
+# that cannot include a Zephyr module file. FILE scope, same reason as above.
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosPoolFloor.cmake")
 
 # =============================================================================
 # nros_detect_rust_target()
@@ -169,41 +175,11 @@ function(_nros_resolve_knob env_name kconfig_value)
         "every nros knob resolved during this configure")
 endfunction()
 
-# _nros_c_array_pool_floor(<out_var> <value> <knob>)
-#
-# Issue 1015 — raise a DERIVED demand to what a fixed C array can be sized to.
-#
-# The three zenoh pools reach `zpico.c` as the extents of real C arrays
-# (`queryable_entry_t queryables[ZPICO_MAX_QUERYABLES]` and its siblings). A
-# derived 0 is a legitimate demand — the reference island declares no service
-# servers — and it produced a board that transmitted NOTHING in 15 seconds: no
-# panic, no log line, core in WFI, every gate green, because the value was
-# derived correctly and delivered faithfully. The same image at 4 transmitted
-# 110 bytes, and at 1 it transmitted 110.
-#
-# The floor is applied HERE, at the consumer that names the knob, and NOT in
-# the derivation. The same `NROS_DERIVED_*` numbers reach
-# `NROS_XRCE_MAX_SUBSCRIBERS` / `NROS_XRCE_MAX_SERVICE_SERVERS` below, where a
-# zero is the ANSWER and worth 33,296 / 4,384 bytes of heap a slot (issue
-# 1033). One derivation, two consumers, two different legal minima.
-#
-# EMPTY passes through untouched: empty means "rung 4, nothing resolved", and
-# turning that into a 1 would state a number where the reading build script is
-# supposed to fall through to its own default.
-#
-# An explicit environment value is NOT floored — `_nros_resolve_knob` applies
-# it after this, so a person who states 0 gets the `#error` in `zpico.c` that
-# names the knob and this issue, rather than a number they did not ask for.
-function(_nros_c_array_pool_floor out_var value knob)
-    set(_v "${value}")
-    if(_v MATCHES "^[0-9]+$" AND _v LESS 1)
-        message(STATUS
-            "nros: ${knob}=${_v} raised to 1 — it sizes a fixed C array in "
-            "zpico.c, where zero is not a smaller pool (issue 1015)")
-        set(_v 1)
-    endif()
-    set(${out_var} "${_v}" PARENT_SCOPE)
-endfunction()
+# `_nros_c_array_pool_floor` — issue 1015, moved to `cmake/NanoRosPoolFloor.cmake`
+# by phase-454 W6.d, which gave it a SECOND backend (uORB's two C++ pools) whose
+# build cannot include this Zephyr file. Included at FILE scope with its
+# neighbours above, for the same reason: an `include()` inside a function frame
+# drops the file's vars when the frame pops. The call sites below are unchanged.
 
 # =============================================================================
 # The DERIVE sentinel (phase-403 W8, issue 0940)


### PR DESCRIPTION
phase-454 W6.d (uORB) + W6.e (cffi). Carries W3 (#984) and W4 (#993); the queue
drops them by patch-id.

## The descriptor gained an `[image]` section

Three counts **no endpoint row can be counted to get** — which is exactly
RFC-0100 D5's cffi row:

```toml
[image]
node_count = 2          # components().len() — derived since phase-412, handed only to the executor
backend_count = 1       # what the image links
subscriber_count = 3    # declared subs + each action client's feedback sub
```

`subscriber_count` is a **fact rather than a row count, on purpose**: an action is
one declared entity costing several session slots, so a build script counting
`action_client` rows and multiplying would be a **third** mirror of a multiplier
that already has two — in a file `check-infra-queryable-counts` does not scan. A
test pins the difference (1 row → 2 slots).

**No `schema_version` bump**, and the reasoning is measured rather than assumed:
the version guards meaning *moving*, and an added section moves nothing. An older
reader already refuses loudly via `deny_unknown_fields` — verified by feeding a
new descriptor to an older `nros-node` build script, which rejected it naming
`nros sync`.

## What derives

- **W6.d (uORB)** — `NrosRmwUorbSizing.cmake`, in the backend's own build, since
  uORB has no Rust crate at all. `REGISTRY_CAPACITY` = distinct topics over
  publisher + subscription rows, deduped by name; `PX4_MAX_CALLBACKS` =
  `subscriber_count`.
- **W6.e (cffi)** — `MAX_BACKENDS`, `MAX_NODES`, `SUBSCRIBER_SLOTS` take the
  descriptor as the rung **under** any stated value, replacing the crate builtin.
  RFC-0049's ladder unchanged. `MESSAGE_INFO_SLOTS` and `SLOT_SIZE` untouched
  (the latter is issue 1322, and D5 says it is not derivable).

## Measured

| image | pool | before | after | delta |
| --- | --- | --- | --- | --- |
| `esp32-c3-baremetal/rust/listener` | uORB `g_table` (`nm` on the `.o`) | 1,536 B | 24 B | **−1,512 B** |
| `native/rust/talker` | cffi `REGISTRY` (`nm` on a linked binary) | 328 B | 48 B | **−280 B** |

`NODE_TABLE` is `MAX_NODES` × a measured 144-byte `NodeSlot` → 576→144 on any
image registering a node. The probe binary does not keep it live, so that one is
**arithmetic over two measured quantities and is reported as such**, not as a
symbol read.

**No descriptor ⇒ byte-identical**, measured the same way: the same uORB configure
with no descriptor emits no `-D`, and `g_table` is 1,536 B.

**D7 in both directions in one image**: the pub-only talker demands 0
subscribers; cffi's `[T; 0]` takes it untouched, and uORB raises it out loud —
`NROS_RMW_UORB_PX4_MAX_CALLBACKS=0 raised to 1`.

## Two things found beyond the brief

**1. A gate whose reach was narrower than its rule.** `topic_registry.cpp` wrote
`Entry g_table[kCapacity]` through a `constexpr` alias, which **launders the
macro past `check-c-array-pool-floors`' discovery** — the audit reported 24
knob-sized arrays over a tree with 25, and the invisible one is a knob this wave
makes derivable. Extent is the macro now, with a `#if < 1 / #error` guard and a
`PROBE_CONTEXT` in **compile** mode against a real TU. Now 25 arrays / 22
guarded; 22 guards across 10 files fire at 0.

**2. A short-registry hole in my own first cut.** An `ENDPOINT_COUNT` of 0 has
two causes that read identically in cmake — no endpoints, or an inventory that
did not compose. The row-derived capacity is now gated on
`NROS_SIZING_UNDECLARED_ENDPOINTS` being *stated*, because **a short registry is
the one direction with no safe fallback**. Negative control run: a refused
descriptor keeps the builtin 64, loudly.

`_nros_c_array_pool_floor` moved to `cmake/NanoRosPoolFloor.cmake` — a PX4 module
build cannot include a Zephyr file, and one shared helper beats a third copy. The
gate's FLOORED knob set is **per producer** now; a global list made the Zephyr
ZPICO bridge answerable for a pool in a PX4 module.

## Gates

Green: `check fast` 314/315, `cli-tests`, `c-array-pool-floors`,
`c-array-guard-probe`, `pool-inventory --check` (regenerated),
`sizing-descriptor-reader`, `declared-fact-carriers`, `knob-single-reader`,
`knob-delivery`, `kconfig-knob-forwarding`, `config-knob-census`,
`cli-source-dirs`, `cli-fresh`. Tests: `nros-sizing-descriptor` 22/22,
`nros-cli-core` sizing 18/18, `nros-rmw-cffi` green, uORB builds `-Wpedantic`
clean + ctest passes. Clippy clean on all three touched crates.

**Environmental, none from this change:** `check::build` and
`test-lane-contracts` did not finish (~80 min, 24 sibling worktrees, `/home`
oscillating between 0 and ~1.4 GB free). `test-unit` fails on the unprovisioned
`cyclonedds` submodule — every touched crate was tested directly instead. `just
check rmw-uorb` fails with `does not match the source used to generate cache`,
which is **issue 1280's class** (fixed in #1004); the package was verified in a
private build dir — configure, parallel build, ctest, all clean. The remaining
`check fast` red is `xrce-vendored-versions`, needing `nros setup --source`
(issue #1345's class).

## Note for the sibling W6 waves

They will each want to extend the same `[image]`/schema surface, and
`deny_unknown_fields` means a **stale descriptor on disk is a hard error rather
than a silent default** — expect a re-sync, not a merge conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1