### PR TITLE
fix(ci): the link check built a NuttX leaf without provisioning NuttX

### DIFF
--- a/justfile
+++ b/justfile
@@ -2585,6 +2585,32 @@ rust-rtos-link-check: _codegen
         mapfile -t freertos_profile < <(nros_cargo_profile_args_for "$(nros_cargo_platform_profile freertos)")
         freertos_settings="$(leaf_cargo_config examples/mps2-an385-freertos/rust/talker)"
         ( cd examples/mps2-an385-freertos/rust/talker && cargo build "${freertos_profile[@]}" --config "$freertos_settings" --target-dir target-link-check ) >/dev/null
+        # issue 0551's error, from the one lane that never provisioned what it
+        # consumes. `just/nuttx.just` states the rule this violated:
+        #
+        #   "These are prerequisites the example/board build.rs *consume* —
+        #    neither build.rs nor the C/C++ cmake triggers the kernel build"
+        #
+        # So building the nuttx leaf without provisioning NuttX first compiles
+        # against a tree whose generated `include/nuttx/config.h` does not
+        # exist, and every C TU that reaches a NuttX header dies:
+        #
+        #   third-party/nuttx/nuttx/include/stdbool.h:30:10:
+        #       fatal error: nuttx/config.h: No such file or directory
+        #
+        # It passed for anyone whose checkout had been configured by an earlier
+        # `just nuttx build` — which is every developer host and no CI runner —
+        # so the lane was green locally and red in the merge group. `queue` has
+        # 0 successes in its last 40 runs.
+        #
+        # `build-nuttx.sh` is idempotent and self-guards on the NuttX HEAD plus
+        # THIS defconfig's hash, so a provisioned tree makes this a fast no-op
+        # and only the first run pays. Deliberately NOT a skip when the tree is
+        # absent: this lane's whole job is to LINK, and a nuttx talker that
+        # links without NuttX cannot exist — a skip here would be the vacuous
+        # green the lane exists to prevent.
+        echo "  nuttx kernel (prerequisite for the leaf below):"
+        scripts/nuttx/build-nuttx.sh >/dev/null
         echo "  nuttx talker ($(nros_cargo_platform_profile nuttx)):"
         mapfile -t nuttx_profile < <(nros_cargo_profile_args_for "$(nros_cargo_platform_profile nuttx)")
         nuttx_settings="$(leaf_cargo_config examples/qemu-armv7a-nuttx/rust/talker)"


### PR DESCRIPTION
The merge-queue `queue` lane has **0 successes in its last 40 runs** — 13 failures and 25 cancellations, the cancellations being the entries `ALLGREEN` ejected behind each failure. This is why.

## The lane built a NuttX leaf and never provisioned NuttX

`just/nuttx.just` states the rule, in the very recipe that exists to satisfy it:

> *"These are prerequisites the example/board build.rs **consume** — neither build.rs nor the C/C++ cmake triggers the kernel build; they silently no-op when the prebuilt NuttX is absent"*

`rust-rtos-link-check` builds `examples/qemu-armv7a-nuttx/rust/talker` and never runs that build. So every C translation unit reaching a NuttX header compiles against a tree whose **generated** `include/nuttx/config.h` does not exist:

```
third-party/nuttx/nuttx/include/stdbool.h:30:10:
    fatal error: nuttx/config.h: No such file or directory
error: failed to run custom build command for `zpico-sys`
error: recipe `rust-rtos-link-check` failed with exit code 101
```

## Why it looked like somebody's diff

That header is generated by `just nuttx build` — which **every developer host has run and no CI runner has**. So the lane is green locally and red in the merge group: the exact shape `queue-triage` exists to name, and which it named wrong (issue 1347, PR #1005). Ejected authors were told *"LIKELY YOUR PULL REQUEST"* while the same check was failing for 11 of them, one of which contains no Rust at all.

It is **not** intermittent, and I said it was earlier in this session before counting. The lane has been uniformly red. By this repo's own rule that means it has no signal capacity — a real regression landing in it would be indistinguishable from the standing failure. It is not a required check, so nothing was blocked; it simply stopped answering.

## The fix, and why not a skip

`scripts/nuttx/build-nuttx.sh` runs before the leaf, inside the existing `arm-none-eabi-gcc` guard. It is idempotent and self-guards on the NuttX HEAD plus *this* board's defconfig hash, so a provisioned tree makes it a fast no-op and only the first run pays.

Deliberately **not** a skip when the tree is unconfigured: this lane's entire job is to LINK, and a nuttx talker that links without NuttX cannot exist — `build.rs` no-ops into `undefined malloc/pthread_*` instead. A skip here would be the vacuous green the lane exists to prevent.

## Verified against CI's actual starting state

Not against a description of it. I moved `include/nuttx/config.h` aside to reproduce an unconfigured checkout, then ran the recipe:

- it provisioned the kernel (the `nuttx kernel (prerequisite for the leaf below):` line, which did not exist before),
- regenerated the header — **16,007 bytes**,
- and linked all three leaves, `rc=0`, producing a **682,504-byte** `armv7a-nuttx-eabihf` talker where the previous run produced none.

`just check fast` green, 314 gates.

## What this does not settle

The lane is not a required check, so it has been failing where nobody had to look. Whether it should become required — or be dropped — is a decision rather than a patch, and it is worth making now that it can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkfB3GGnzUvL9aXhL4qyf8
