### PR TITLE
feat(phase-454 W5, #1319, #1340): the executor prices each subscription at what its registration path claims — and 1319's table was wrong

### DIFF
--- a/docs/design/0100-rmw-agnostic-sizing-model.md
+++ b/docs/design/0100-rmw-agnostic-sizing-model.md
@@ -96,6 +96,31 @@ which it cannot see today"* — because the third (*"state the shortfall as a
 per-image margin"*) is explicitly *"the answer that goes stale next time a path
 changes"*, and the first is a narrower repair that leaves the build blind.
 
+**The path has FIVE rows, not four — phase-454 W5 measured the fifth.** Issue
+1319 read the four out of the source and assigned zenoh and XRCE to the
+`RX_BUF` row. Running it says otherwise: `register_subscription_buffered_on`
+asks `handle.supports_process_in_place()` **before** it computes a slot size,
+both schemaless backends answer an unconditional `true`, and the registration
+returns through `SubInplaceEntry` having allocated no receive region at all.
+Measured on `contract-monitor-sub` over zenoh, a `std_msgs/Header` subscription
+claims **672 bytes** of arena against the 9,768-byte region the model budgets it
+at `KEEP_LAST(10)`.
+
+So `rust_typed_in_place` is its own row, and the two directions are not
+symmetric:
+
+| direction | rows | what the model does |
+| --- | --- | --- |
+| UNDER — ships `BufferTooSmall` | `rust_typed_schemaless`, `c_raw_no_hint` | fixed in W5.b: each row is priced at what its path claims |
+| OVER — wastes RAM | `rust_typed_in_place` | left where it was, deliberately |
+
+The over-statement is left alone because the Rust **generic**
+(`.generic(ty, hash)`) registration on the same backend does NOT reach that
+capability test and does claim `RX_BUF` — and an endpoint row cannot say which
+of the two an image writes. Taking the ~9.7 KiB a subscription is a separate
+decision with its own evidence; the row exists so that decision has somewhere to
+land.
+
 Target facts are separate because **build scripts run for the host**
 (phase-118-E), so `DEP_NROS_NODE_*` carry host sizes on a cross build. Storage
 capacity is the target-ABI-dependent size; it cannot be inferred where it is

--- a/docs/issues/1340-arena-budgets-a-receive-region-an-in-place-backend-never-claims.md
+++ b/docs/issues/1340-arena-budgets-a-receive-region-an-in-place-backend-never-claims.md
@@ -1,0 +1,92 @@
+---
+id: 1340
+title: "The arena budgets a full receive region for every subscription, and a backend that dispatches IN PLACE claims none — 9,768 bytes per subscription on zenoh and XRCE"
+status: open
+type: tech-debt
+area: executor, build
+severity: medium
+found: 2026-09-12
+related: [issue-1319, issue-1255, issue-1190, phase-454, rfc-0100]
+---
+
+## What the model says and what the runtime does
+
+`Executor::register_subscription_buffered_on` asks the backend whether it can
+hand a sample to the callback out of its own ring:
+
+```rust
+if handle.supports_process_in_place() {
+    let entry_offset = self.arena_alloc::<SubInplaceEntry<M, F>>()?;
+    …
+    return Ok(HandleId(slot));
+}
+```
+
+That test runs **before** the slot size is computed, so the buffered region —
+`buffered_region_size(depth, slot)` — is never allocated. Both schemaless
+backends answer an unconditional `true`:
+
+* `nros-rmw-zenoh`'s `Subscription::supports_process_in_place` is
+  `fn(&self) -> bool { true }`;
+* XRCE's `xrce_subscription_supports_in_place` writes `true` and its
+  `process_raw_in_place` slot is non-NULL (the capability is the conjunction of
+  the two, per `rmw_vtable.h`);
+* Cyclone leaves both slots NULL, so its subscriptions do take the buffered
+  path.
+
+`nros-node/build.rs` budgets a full region for every subscription regardless.
+
+## Measured
+
+`packages/testing/nros-tests/bins/contract-monitor`, `contract-monitor-sub`: a
+Rust node on zenoh subscribing `std_msgs/Header` at the default `KEEP_LAST(10)`.
+A probe over `Executor::arena_used()` across the one registration:
+
+```
+arena used: open=0 node=0 sub=672
+SUB CLAIM   = 672
+```
+
+Against the model for the same image (`NROS_SUBSCRIBER_BUFFER_SIZE=880`,
+`NROS_SUBSCRIPTION_BUFFER_SIZE=1496`, one declared subscription):
+
+```
+ARENA_SIZE=12840  REQUIRED=12840  PUBSUB_REGION=9768
+```
+
+So the subscription is budgeted **9,768 + 1,024 = 10,792 bytes** and claims
+**672**. `mem-report` prices the linked image's executor backing at 27,152 bytes
+of `.bss`; an image whose subscriptions all dispatch in place could give most of
+the per-subscription half back.
+
+This is the OVER direction, so nothing fails — which is why it has sat.
+`report_arena_headroom` is the advisory that would say so at run time.
+
+## Why phase-454 W5 did not take the saving
+
+W5 recorded the fact (`RegistrationPath::RustTypedInPlace`, RFC-0100 D1) and
+left the PRICE where it was. Lowering it needs one thing the descriptor does not
+carry:
+
+**The Rust GENERIC registration path does not consult the capability.**
+`supports_process_in_place` has exactly one call site in `nros-node`, in
+`register_subscription_buffered_on`. `register_subscription_buffered_generic`
+— what `node_mut(id).subscription(t).generic(ty, hash)` lowers to, and what a
+bridge writes — allocates `buffered_region_size(depth, RX_BUF)` unconditionally
+on the same backend. An `[[endpoint]]` row carries `(kind, type, topic)` and
+says nothing about which of the two spellings the image's code uses, so pricing
+the in-place row at zero would under-size every generic subscription on zenoh
+and XRCE, which is the direction that ships `NodeError::BufferTooSmall`.
+
+## What a fix has to decide
+
+* whether a generic registration should ALSO take the in-place path when the
+  backend offers it — one call site moves, and the saving then needs no new
+  fact; or
+* whether the descriptor should distinguish a typed endpoint from a generic one,
+  which is a property of the CALL SITE rather than of the contract — the same
+  limit phase-454 W10 addresses for the C half's `rx_size_bound<M>`.
+
+The first is the smaller change and removes the reason for the second. Either
+way acceptance is a measured `mem-report --baseline` on an image with a GENERIC
+subscription, not only on a typed one.

--- a/docs/issues/archived/1319-arena-prices-a-subscription-below-what-a-schemaless-backend-allocates.md
+++ b/docs/issues/archived/1319-arena-prices-a-subscription-below-what-a-schemaless-backend-allocates.md
@@ -1,12 +1,79 @@
 ---
 id: 1319
 title: "The arena prices a subscription at the SUBSCRIBED payload class, and a backend without type descriptors allocates the CLOSURE buffer — the model is below the allocation on zenoh and XRCE"
-status: open
+status: resolved
 type: bug
 area: executor, build
 severity: medium
 found: 2026-09-11
-related: [issue-1255, issue-1190, phase-403, phase-448]
+resolved: 2026-09-12
+related: [issue-1255, issue-1190, issue-1340, phase-403, phase-448, phase-454]
+---
+
+## Resolution — phase-454 W5.b
+
+The arena derivation no longer prices every subscription at its type's bound.
+`nros-node/build.rs` reads the sizing descriptor's per-endpoint
+`registration_path` (RFC-0100 D1/D4, landed W4) and charges each row what THAT
+path claims: the type's own bound where the registration reaches it, and the
+closure buffer `RX_BUF` where it does not. A path the descriptor could not state
+is priced at the closure buffer and says so as a `cargo::warning` — the safe
+direction, loudly, per D6.
+
+That is this issue's SECOND candidate fix. The first leaves the build blind; the
+third is ruled out below as *"the answer that goes stale next time a path
+changes"*. It is explicitly **not** *"raise the term back to `RX_BUF`"*, which
+would give up issue 1255's saving on the two paths where the per-type bound IS
+what is allocated.
+
+Measured — derived arena for one `KEEP_LAST(1)` subscription at the reference
+island's numbers (`NROS_SUBSCRIBER_BUFFER_SIZE=880`,
+`NROS_SUBSCRIPTION_BUFFER_SIZE=1496`):
+
+| descriptor says | `arena_model::REQUIRED` | slot |
+| --- | --- | --- |
+| no descriptor | 5,712 | 880 |
+| `c_typed_hint` | 5,712 | 880 |
+| `rust_typed_descriptors` | 5,712 | 880 |
+| `rust_typed_in_place` | 5,712 | 880 |
+| `rust_typed_schemaless` | **7,560** | 1,496 |
+| `c_raw_no_hint` | **7,560** | 1,496 |
+| path REFUSED | 7,560, plus a warning naming the refusal | 1,496 |
+
+`7560 − 5712 = 1848` — this issue's own number, `3 × (1496 − 880)`. With no
+descriptor every emitted VALUE is byte-identical to the build before the wave
+(diffed against `bc7ae4617`; the only textual difference is the new
+`arena_model::PUBSUB_SLOT_BYTES` const, whose value is the number the derivation
+already used).
+
+## Reproduced — and the analysis needed one correction
+
+**Reproduced**, in
+`executor::tests::a_schemaless_subscription_outgrows_an_arena_priced_at_its_types_bound`.
+An arena sized at what the OLD model budgets for one subscription refuses the
+registration with `NodeError::BufferTooSmall`; the same registration fits the
+number W5.b derives, and the shortfall is the slot count times the difference in
+slot size, exactly as predicted here.
+
+**The correction, which the reproduction is what found.** The table below
+assigns zenoh and XRCE to the `RX_BUF` row.
+`register_subscription_buffered_on` asks `handle.supports_process_in_place()`
+**before** it computes a slot size; both schemaless backends answer an
+unconditional `true`, and the registration returns through `SubInplaceEntry`
+having allocated no receive region at all. Measured on `contract-monitor-sub`
+over zenoh: a `std_msgs/Header` subscription claims **672 bytes** of arena
+against a 9,768-byte budgeted region.
+
+So the UNDER-size described here is real and is fixed, but on those two backends
+it is not reachable through a Rust TYPED registration. It is reachable through
+`c_raw_no_hint`, and through `rust_typed_schemaless` on a schemaless backend
+that buffers. The measured fifth row is `RegistrationPath::RustTypedInPlace`,
+and the OVER-statement it exposes — 9,768 bytes per subscription on every zenoh
+and XRCE image — is
+[issue 1340](1340-arena-budgets-a-receive-region-an-in-place-backend-never-claims.md),
+which also records why W5 did not take that saving (the Rust GENERIC
+registration on the same backend does not reach the capability test).
+
 ---
 
 ## What the model says and what the runtime does
@@ -27,6 +94,9 @@ not the same:
 | Rust typed, backend WITH type descriptors (Cyclone) | `min(transport_framed(bound), RX_BUF)` — at or below the model |
 | Rust typed, backend WITHOUT type descriptors (zenoh, XRCE) | **`RX_BUF`** |
 | C/C++ raw with no hint | **`RX_BUF`** |
+
+*(The third row is CORRECTED above: those two backends dispatch in place and
+claim no region. The row stands for a schemaless backend that buffers.)*
 
 The last two rows are the gap. `default_subscription_rx_bytes::<M>` has two
 arms, and the `#[cfg(not(rmw_needs_type_descriptors))]` one returns `None` for
@@ -84,3 +154,6 @@ An image that declares its entities, subscribes from RUST on zenoh, and sets
 `NROS_SUBSCRIBER_BUFFER_SIZE` below `NROS_SUBSCRIPTION_BUFFER_SIZE` is the
 shape that would show it, as `NodeError::BufferTooSmall` at a registration the
 arena oracle passed.
+
+*(Done — phase-454 W5. See the Resolution at the top: that exact image is what
+corrected the third row of the table above.)*

--- a/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
+++ b/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
@@ -178,9 +178,47 @@ Gates and tests: `just check sizing-descriptor-reader`
 `keep_all` per-field refusal, zero surviving unfloored), the producer's 10, the
 verb's 4, and `sizing_descriptor_portable.rs` for the issue-0320 acceptance.
 
-### W5 — the executor reads the descriptor, and the model learns the registration path
+### W5 — the executor reads the descriptor, and the model learns the registration path — **LANDED**
 
 Two halves, and the second is the one with a live defect behind it.
+
+**What landed.**
+
+| piece | where |
+| --- | --- |
+| the slot rule, issue 1319's table as code | `Endpoint::claimed_slot_bytes` / `may_claim_closure_buffer` in `nros-sizing-descriptor`, beside the vocabulary that already documented the table |
+| the endpoint facts, on ONE road | `nros-node/build.rs`'s `descriptor_subscriptions` → `subs_arena_from_descriptor`; the `NROS_ENTITY_DECLARED_DEPTHS` / `NROS_SUBSCRIBED_TYPE_BOUNDS` carriers stay BELOW it, and W9 retires them |
+| the default term | `default_sub_slot_bytes`, emitted as `arena_model::PUBSUB_SLOT_BYTES` |
+| the reproduction | `executor::tests::a_schemaless_subscription_outgrows_an_arena_priced_at_its_types_bound` |
+
+**The fifth registration path, measured.** The reproduction corrected the
+issue's analysis, which is what a reproduction is for. Issue 1319 assigns zenoh
+and XRCE to the `RX_BUF` row; `register_subscription_buffered_on` asks
+`handle.supports_process_in_place()` **before** it computes a slot size, both
+answer an unconditional `true`, and the registration returns through
+`SubInplaceEntry` having allocated no region at all — 672 bytes of arena on
+`contract-monitor-sub` over zenoh, against a 9,768-byte budgeted region. So:
+
+* `RegistrationPath::RustTypedInPlace` is a fifth row, and the producer needs a
+  second backend fact (`BackendDispatch`) to pick it;
+* its PRICE is deliberately left where it was. Lowering it is worth ~9.7 KiB a
+  subscription and is [issue 1340](../issues/1340-arena-budgets-a-receive-region-an-in-place-backend-never-claims.md),
+  because the Rust GENERIC registration on the same backend does not reach the
+  capability test and an endpoint row cannot say which spelling an image writes.
+
+**Measured.** `arena_model::REQUIRED` for one `KEEP_LAST(1)` subscription at the
+island's 880-against-1,496: 5,712 with no descriptor, 5,712 for `c_typed_hint` /
+`rust_typed_descriptors` / `rust_typed_in_place`, **7,560** for
+`rust_typed_schemaless` / `c_raw_no_hint` / a REFUSED path — a delta of 1,848,
+which is this issue's own number. `mem-report` on `contract-monitor-sub`:
+`EXECUTOR_BACKING` 27,152 B and `.bss+.data` 523,528 B both UNCHANGED by the
+descriptor `nros sync` now writes for it, and +6,776 B (= `11 × (1496 − 880)`)
+when a closure-claiming row fires.
+
+**Byte-identical with no descriptor**, diffed against `bc7ae4617`: every emitted
+VALUE matches; the only textual difference is the new `PUBSUB_SLOT_BYTES` const,
+whose value is the number the derivation already used.
+
 
 **W5.a** — the executor takes its facts from the descriptor rather than from env
 carriers. One road instead of two, so an image no longer sizes differently

--- a/packages/cli/nros-cli-core/src/sizing_descriptor.rs
+++ b/packages/cli/nros-cli-core/src/sizing_descriptor.rs
@@ -91,6 +91,31 @@ pub enum BackendSchema {
     Schemaless,
 }
 
+/// Does the backend dispatch a received sample IN PLACE?
+///
+/// **The axis issue 1319's four-row table did not have, and phase-454 W5
+/// measured.** `register_subscription_buffered_on` asks
+/// `handle.supports_process_in_place()` BEFORE it computes a slot size, and
+/// returns through `SubInplaceEntry` when the answer is yes — so a Rust typed
+/// subscription on such a backend allocates no receive region at all, whatever
+/// its type's bound or the image's `RX_BUF` say. Measured on
+/// `contract-monitor-sub` over zenoh: 672 bytes of arena for the whole
+/// registration.
+///
+/// It is a property of the BACKEND and not of the entry, which is why it sits
+/// beside [`BackendSchema`] rather than inside [`EntryLanguage`]: both of the
+/// schemaless backends this tree ships answer an unconditional `true`
+/// (`nros-rmw-zenoh`'s `supports_process_in_place`, and XRCE's
+/// `xrce_subscription_supports_in_place`), while Cyclone leaves both vtable
+/// slots NULL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendDispatch {
+    /// The sample is handed to the callback out of the backend's own ring.
+    InPlace,
+    /// The runtime copies into an arena receive region it must budget for.
+    Buffered,
+}
+
 /// Everything the producer needs, stated by the caller that HAS it.
 ///
 /// A struct rather than nine arguments because every one of these is
@@ -129,6 +154,10 @@ pub struct DescriptorInputs<'a> {
     pub language: Option<EntryLanguage>,
     /// Whether the linked backend carries type descriptors.
     pub backend_schema: Option<BackendSchema>,
+    /// Whether the linked backend dispatches in place (phase-454 W5). `None`
+    /// for a backend this writer does not know — refused with the schema half,
+    /// because the two together select the path and neither alone can.
+    pub backend_dispatch: Option<BackendDispatch>,
     /// The backend's name, for prose only.
     pub rmw: Option<String>,
 }
@@ -494,18 +523,33 @@ fn registration_path(
     // for every kind anyway: a service server's request buffer takes the same
     // four paths, and W6.b prices it.
     let _ = kind;
-    match (inputs.language?, inputs.backend_schema?) {
+    match (
+        inputs.language?,
+        inputs.backend_schema?,
+        inputs.backend_dispatch?,
+    ) {
         // A C/C++ entry that registers typed supplies `rx_size_bound<M>`; the
         // raw no-hint row is a property of an individual call site, not of the
         // image, and nothing this writer reads distinguishes them. The typed
         // hint is therefore what a C/C++ entry is credited with, and W10 --
         // which closes the C half of the declared-QoS check -- is where a
         // per-call-site answer becomes available.
-        (EntryLanguage::CFamily, _) => Some(RegistrationPath::CTypedHint),
-        (EntryLanguage::Rust, BackendSchema::Descriptors) => {
+        //
+        // The C path does NOT consult the in-place capability
+        // (`add_arena_subscription_c_callback` allocates a region
+        // unconditionally), so the dispatch axis does not reach this arm.
+        (EntryLanguage::CFamily, _, _) => Some(RegistrationPath::CTypedHint),
+        // phase-454 W5 -- in-place wins over the schema question, because the
+        // capability test in `register_subscription_buffered_on` happens BEFORE
+        // the slot size is computed. A descriptor-carrying backend that also
+        // dispatched in place would take this row too; none does today.
+        (EntryLanguage::Rust, _, BackendDispatch::InPlace) => {
+            Some(RegistrationPath::RustTypedInPlace)
+        }
+        (EntryLanguage::Rust, BackendSchema::Descriptors, BackendDispatch::Buffered) => {
             Some(RegistrationPath::RustTypedDescriptors)
         }
-        (EntryLanguage::Rust, BackendSchema::Schemaless) => {
+        (EntryLanguage::Rust, BackendSchema::Schemaless, BackendDispatch::Buffered) => {
             Some(RegistrationPath::RustTypedSchemaless)
         }
     }
@@ -520,6 +564,12 @@ fn registration_path_refusal(inputs: &DescriptorInputs<'_>) -> String {
         missing.push(match &inputs.rmw {
             Some(r) => format!("whether backend `{r}` carries type descriptors"),
             None => "which backend this image links".into(),
+        });
+    }
+    if inputs.backend_dispatch.is_none() && inputs.backend_schema.is_some() {
+        missing.push(match &inputs.rmw {
+            Some(r) => format!("whether backend `{r}` dispatches in place"),
+            None => "how this image's backend dispatches".into(),
         });
     }
     format!(
@@ -708,6 +758,7 @@ pub fn write_for_leaf(
         // the C/C++ images go through cmake.
         language: Some(EntryLanguage::Rust),
         backend_schema: rmw.as_deref().and_then(backend_schema),
+        backend_dispatch: rmw.as_deref().and_then(backend_dispatch),
         rmw,
     };
     let desc = build(&inputs);
@@ -807,6 +858,27 @@ fn backend_schema(rmw: &str) -> Option<BackendSchema> {
         // `MessageForRmw` carries no schema on either, so the schemaless arm
         // returns `None` for every type and the registration takes `RX_BUF`.
         "zenoh" | "xrce" => Some(BackendSchema::Schemaless),
+        _ => None,
+    }
+}
+
+/// Does this backend hand a sample to the callback IN PLACE? `None` for a name
+/// this writer does not know — refused rather than guessed, like its sibling.
+///
+/// **Read off the backend's own answer, not off its family.** Both are
+/// unconditional in source and both were measured in phase-454 W5:
+///
+/// * `nros-rmw-zenoh`'s `Subscription::supports_process_in_place` is
+///   `fn(&self) -> bool { true }`;
+/// * XRCE's `xrce_subscription_supports_in_place` writes `true` and its
+///   `process_raw_in_place` slot is non-NULL — the capability is the
+///   CONJUNCTION of the two, per `rmw_vtable.h`;
+/// * Cyclone leaves both slots NULL, which the cffi adapter reads as
+///   unsupported.
+fn backend_dispatch(rmw: &str) -> Option<BackendDispatch> {
+    match rmw {
+        "cyclonedds" | "cyclone" => Some(BackendDispatch::Buffered),
+        "zenoh" | "xrce" => Some(BackendDispatch::InPlace),
         _ => None,
     }
 }
@@ -1037,6 +1109,7 @@ mod tests {
             heap_budget_bytes: Some(65536),
             language: Some(EntryLanguage::Rust),
             backend_schema: Some(BackendSchema::Schemaless),
+            backend_dispatch: Some(BackendDispatch::InPlace),
             rmw: Some("zenoh".into()),
         }
     }
@@ -1052,11 +1125,95 @@ mod tests {
         // have measured (RFC-0100 D1, phase-118-E).
         assert_eq!(d.target.pointer_bytes().stated(), Some(&4));
         assert_eq!(ep.storage_bytes().stated(), Some(&(11 * 1170 + 11 * 4)));
+        // phase-454 W5 — zenoh dispatches IN PLACE, measured, so a Rust typed
+        // registration on it is that row and not the schemaless one issue
+        // 1319's table assigned it.
         assert_eq!(
             ep.registration_path().stated(),
-            Some(&RegistrationPath::RustTypedSchemaless)
+            Some(&RegistrationPath::RustTypedInPlace)
         );
         assert_eq!(d.meta.status, Status::Derived);
+    }
+
+    /// The dispatch axis decides, and it decides BEFORE the schema question —
+    /// the same order `register_subscription_buffered_on` asks them in.
+    #[test]
+    fn the_registration_path_reads_dispatch_before_schema() {
+        let inv = inventory(vec![sub("std_msgs/msg/String", "/chatter", Some(10))]);
+        for (schema, dispatch, want) in [
+            (
+                BackendSchema::Schemaless,
+                BackendDispatch::InPlace,
+                RegistrationPath::RustTypedInPlace,
+            ),
+            (
+                BackendSchema::Descriptors,
+                BackendDispatch::InPlace,
+                RegistrationPath::RustTypedInPlace,
+            ),
+            (
+                BackendSchema::Schemaless,
+                BackendDispatch::Buffered,
+                RegistrationPath::RustTypedSchemaless,
+            ),
+            (
+                BackendSchema::Descriptors,
+                BackendDispatch::Buffered,
+                RegistrationPath::RustTypedDescriptors,
+            ),
+        ] {
+            let mut i = base(&inv);
+            i.backend_schema = Some(schema);
+            i.backend_dispatch = Some(dispatch);
+            let d = build(&i);
+            assert_eq!(
+                d.endpoints[0].registration_path().stated(),
+                Some(&want),
+                "{schema:?} + {dispatch:?}"
+            );
+        }
+        // A C/C++ entry is credited the typed hint whatever the backend does:
+        // its registration path never consults the capability.
+        for dispatch in [BackendDispatch::InPlace, BackendDispatch::Buffered] {
+            let mut i = base(&inv);
+            i.language = Some(EntryLanguage::CFamily);
+            i.backend_dispatch = Some(dispatch);
+            let d = build(&i);
+            assert_eq!(
+                d.endpoints[0].registration_path().stated(),
+                Some(&RegistrationPath::CTypedHint)
+            );
+        }
+    }
+
+    /// An unknown backend refuses BOTH halves and says so by name — the same
+    /// rule as the schema half, because a guessed dispatch is worth a whole
+    /// receive region per subscription in either direction.
+    #[test]
+    fn an_unknown_dispatch_refuses_the_registration_path_by_name() {
+        let inv = inventory(vec![sub("std_msgs/msg/String", "/chatter", Some(10))]);
+        let mut i = base(&inv);
+        i.backend_dispatch = None;
+        let d = build(&i);
+        let path = d.endpoints[0].registration_path();
+        let r = path.refusal().unwrap();
+        assert!(r.contains("dispatches in place"), "{r}");
+        assert!(r.contains("zenoh"), "{r}");
+    }
+
+    /// The name-keyed halves must agree about every backend this writer knows:
+    /// a name that answers one and not the other refuses the whole path, which
+    /// is a silent loss of the saving rather than a wrong number.
+    #[test]
+    fn every_known_backend_answers_both_halves() {
+        for rmw in ["cyclonedds", "cyclone", "zenoh", "xrce"] {
+            assert!(
+                backend_schema(rmw).is_some() && backend_dispatch(rmw).is_some(),
+                "backend `{rmw}` answers only one half of the registration path"
+            );
+        }
+        assert!(backend_schema("uorb").is_none());
+        assert!(backend_dispatch("uorb").is_none());
     }
 
     #[test]

--- a/packages/cli/nros-cli-core/tests/sizing_descriptor_portable.rs
+++ b/packages/cli/nros-cli-core/tests/sizing_descriptor_portable.rs
@@ -25,7 +25,7 @@ use std::path::Path;
 
 use nros_cli_core::{
     leaf_entity_env::inventory_for_leaf,
-    sizing_descriptor::{BackendSchema, DescriptorInputs, EntryLanguage, build},
+    sizing_descriptor::{BackendDispatch, BackendSchema, DescriptorInputs, EntryLanguage, build},
 };
 use nros_sizing_descriptor::render;
 
@@ -118,6 +118,9 @@ fn descriptor_text(root: &Path) -> String {
         heap_budget_bytes: Some(65536),
         language: Some(EntryLanguage::Rust),
         backend_schema: Some(BackendSchema::Schemaless),
+        // phase-454 W5 — zenoh dispatches IN PLACE (measured), which is the
+        // second backend half the registration path is composed from.
+        backend_dispatch: Some(BackendDispatch::InPlace),
         rmw: Some("zenoh".into()),
     };
     render(&build(&inputs))

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -81,6 +81,101 @@ fn sizing_descriptor() -> Option<nros_sizing_descriptor::SizingDescriptor> {
     }
 }
 
+/// One SUBSCRIPTION row of the descriptor, as the arena derivation needs it —
+/// phase-454 W5.a, RFC-0100 D4/D5.
+///
+/// The three facts a subscription's arena claim is a function of, on ONE road.
+/// Before this they arrived on three env carriers —
+/// `NROS_ENTITY_DECLARED_DEPTHS` (a `type|topic=depth` string),
+/// `NROS_SUBSCRIBED_TYPE_BOUNDS` (a `type=bytes` string) and nothing at all for
+/// the registration path — and the first two could only carry a table by
+/// encoding it in a string, which is the transport RFC-0100 D4 replaces:
+///
+/// > It is also the only transport that can carry per-endpoint structure
+/// > without encoding it in a string.
+///
+/// The env carriers are still read, BELOW this, and W9 retires them. Two roads
+/// is what issue 1199 is about, so the descriptor is preferred wherever it can
+/// answer, and an image with no descriptor derives byte-identically to before.
+struct SubEndpoint {
+    /// For diagnostics only — a refusal that does not say WHICH endpoint costs
+    /// a reader the same hand-decode `check-default-gates-run-somewhere` names.
+    topic: String,
+    /// `None` when the row states none, or `keep_all` refused it.
+    depth: Option<u32>,
+    /// Issue 1319's table, applied: the bytes this row's registration actually
+    /// claims per slot. `Refused`/`Absent` when the path is not known, never a
+    /// guess — the two closure-buffer rows are an UNDER-size.
+    slot: nros_sizing_descriptor::Fact<usize>,
+    /// Can this row claim `RX_BUF`? True for a path that does AND for one the
+    /// descriptor could not state, which price the same way.
+    may_claim_closure: bool,
+}
+
+/// The subscription rows this image's descriptor states, or `None` when they
+/// cannot be attributed per endpoint.
+///
+/// Two guards, and both are RFC-0100 D6's own:
+///
+///   * **basis** — `closure` rows describe the whole link graph, not this
+///     image's endpoints. *"Never silently widens the basis … that publishes
+///     the wrong row while every status still reads 'derived'."*
+///   * **`undeclared_endpoints`** — a non-zero count means some endpoint that
+///     could carry a per-endpoint fact carried none, so a sum over this table
+///     is a sum over PART of the image. Absence is not zero, so a refused or
+///     absent count refuses too.
+///
+/// Everything below a passed guard is per-FIELD: a row may still refuse its
+/// depth (`keep_all`) or its path, and the caller decides what that costs.
+fn descriptor_subscriptions(
+    desc: &nros_sizing_descriptor::SizingDescriptor,
+    rx_buf_size: usize,
+    rx_recv_size: usize,
+) -> Option<Vec<SubEndpoint>> {
+    use nros_sizing_descriptor::{Basis, EndpointKind};
+    if desc.meta.basis != Basis::Contract {
+        return None;
+    }
+    if desc.meta.undeclared_endpoints().get() != Some(0) {
+        return None;
+    }
+    Some(
+        desc.endpoints
+            .iter()
+            .filter(|ep| ep.kind == EndpointKind::Subscription)
+            .map(|ep| SubEndpoint {
+                topic: ep.topic.clone(),
+                depth: ep.depth().get(),
+                slot: ep.claimed_slot_bytes(rx_buf_size, rx_recv_size),
+                may_claim_closure: ep.may_claim_closure_buffer(),
+            })
+            .collect(),
+    )
+}
+
+/// The slot bytes one row is priced at, and the warning that owes the reader an
+/// explanation when it could not be derived.
+///
+/// RFC-0100 D6's second half — *"always the safe direction and always loud"* —
+/// and here the safe direction is the CLOSURE buffer: `RX_BUF` is an upper
+/// bound on every one of the five rows (`_RX <= RX_BUF`,
+/// `min(framed(bound), RX_BUF) <= RX_BUF`), so a row whose path is unknown is
+/// priced at the one number none of them can exceed.
+fn row_slot_bytes(row: &SubEndpoint, rx_buf_size: usize) -> usize {
+    let (slot, why) = row
+        .slot
+        .or_report("endpoint.registration_path", rx_buf_size);
+    if let Some(why) = why {
+        println!(
+            "cargo::warning=nros-node: subscription `{}`: {why}; its receive slot is priced at \
+             the closure buffer ({rx_buf_size} B), which over-states a typed registration rather \
+             than under-sizing a schemaless one (issue 1319)",
+            row.topic
+        );
+    }
+    slot
+}
+
 /// The QoS history depth an undeclared subscription actually gets:
 /// `QoSProfile::QOS_PROFILE_DEFAULT.depth`, i.e. `rmw_qos_profile_default`'s
 /// KEEP_LAST(10). Issue 1190 — modelling this as 1 (the triple-buffer case) is
@@ -143,6 +238,11 @@ const PUBSUB_QOS_DEPTH: usize = nros_rmw::QoSProfile::QOS_PROFILE_DEFAULT.depth 
 /// subscription was billed before this, so a missing table reproduces the old
 /// number byte for byte and a partially-populated one is exact where it can be
 /// and unchanged where it cannot.
+///
+/// phase-454 W5 -- and the SIZING DESCRIPTOR is now the road these three facts
+/// travel, when the image has one. The env carriers below are the fallback W9
+/// retires; see [`subs_arena_from_descriptor`] for what the file answers that
+/// they structurally cannot.
 fn subs_arena(
     subs: usize,
     pubsub_entry_at_default: usize,
@@ -185,6 +285,103 @@ fn subs_arena(
             buffered_region(d, slot, ring_len_bytes) + entry_struct
         })
         .sum()
+}
+
+/// The subscription half of the arena, summed from the DESCRIPTOR — phase-454
+/// W5.b, closing **issue 1319**.
+///
+/// [`subs_arena`] prices each subscription at its type's own bound. That is the
+/// right number for three of the five registration paths and 1,848 bytes per
+/// subscription too small for the other two:
+///
+/// | path | slot |
+/// | --- | --- |
+/// | `c_typed_hint` | the type's own `_RX` — matches the model |
+/// | `rust_typed_descriptors` | `min(framed(bound), RX_BUF)` — at or below it |
+/// | `rust_typed_in_place` | no region at all — the model OVER-states (issue 1340) |
+/// | **`rust_typed_schemaless`** | **`RX_BUF`** |
+/// | **`c_raw_no_hint`** | **`RX_BUF`** |
+///
+/// The last two are an UNDER-size, which lands as `NodeError::BufferTooSmall`
+/// at a registration `executor::arena_oracle` passed. It is not a repair the
+/// build could make before: which path a registration takes is composed from
+/// the entry's LANGUAGE and whether the linked backend carries type descriptors
+/// (`default_subscription_rx_bytes`'s two `cfg` arms), and a build script sees
+/// neither. The descriptor carries it as an image fact (RFC-0100 D1), which is
+/// issue 1319's second candidate fix; its first is a narrower repair that
+/// leaves the build blind, and its third — a stated per-image margin — is
+/// *"the answer that goes stale next time a path changes"*.
+///
+/// **Not "raise the term back to `RX_BUF`"**, which the issue rules out in the
+/// same breath: that gives up issue 1255's saving on the paths where the
+/// per-type bound IS what is allocated. Each row is priced at what ITS path
+/// claims, so a Cyclone image keeps the bound and a C image that registers raw
+/// gets the buffer it will actually ask for.
+///
+/// Phase-454 W5 MEASURED the table and found a fifth row: zenoh and XRCE
+/// dispatch IN PLACE, so a Rust typed registration on them allocates no region
+/// at all (672 bytes of arena on `contract-monitor-sub`, against a 9,768-byte
+/// budgeted region). That is the OVER direction, it is priced here exactly as
+/// it was before, and issue 1340 records why the saving is a separate decision.
+///
+/// `None` — keep the env road — when the table cannot answer for every
+/// subscription this image declares:
+///
+///   * the rows are not attributable at all ([`descriptor_subscriptions`]);
+///   * the row count disagrees with the declared subscription count, so the
+///     table describes a different set of endpoints than the one being summed;
+///   * some row states no `depth`. A receive region is sized from it and a
+///     default is wrong by up to 10x in either direction, which is the same
+///     refusal `set_storage_bytes` makes one layer up.
+///
+/// A refused PATH is not in that list on purpose: it has a safe direction and
+/// the row still carries its depth, so it is priced loudly at the closure
+/// buffer rather than dragging the whole image back to the worst case.
+fn subs_arena_from_descriptor(
+    rows: &[SubEndpoint],
+    subs: usize,
+    entry_struct: usize,
+    ring_len_bytes: usize,
+    rx_buf_size: usize,
+) -> Option<usize> {
+    if rows.len() != subs {
+        return None;
+    }
+    let mut total = 0usize;
+    for row in rows {
+        let depth = row.depth?;
+        total += buffered_region(
+            depth as usize,
+            row_slot_bytes(row, rx_buf_size),
+            ring_len_bytes,
+        ) + entry_struct;
+    }
+    Some(total)
+}
+
+/// The slot the DEFAULT pub/sub term is priced at — the other half of issue
+/// 1319, on the arm that does NOT sum per endpoint.
+///
+/// `arena_model::PUBSUB_ENTRY` stands for "one subscription slot" wherever the
+/// per-endpoint sum is unavailable: the fully-undeclared budget over `max_cbs`
+/// slots, the partial-declaration fallback, and the const `executor::arena`
+/// asserts against. Since issue 1255 it has been priced at `rx_recv_size`, the
+/// image-wide SUBSCRIBED class — which carries exactly the same 1,848-byte gap
+/// on a schemaless registration, and for the same reason.
+///
+/// So: the subscribed class STANDS, unless this image's descriptor says a
+/// subscription of its can claim the closure buffer — or cannot say which path
+/// it takes, which prices the same way. With no descriptor nothing says either,
+/// and the number is what it was.
+fn default_sub_slot_bytes(
+    rows: Option<&[SubEndpoint]>,
+    rx_recv_size: usize,
+    rx_buf_size: usize,
+) -> usize {
+    match rows {
+        Some(rows) if rows.iter().any(|r| r.may_claim_closure) => rx_buf_size,
+        _ => rx_recv_size,
+    }
 }
 
 /// `type=bytes` pairs from `NROS_SUBSCRIBED_TYPE_BOUNDS`, in the order cmake
@@ -556,6 +753,16 @@ fn main() {
     // its own type's bound and reaches this only for a type the bound table
     // does not carry.
     let rx_recv_size = env_usize("NROS_SUBSCRIBER_BUFFER_SIZE", rx_buf_size);
+    // phase-454 W5 -- the per-endpoint rows, on ONE road. `None` when this
+    // image has no descriptor, or when its table cannot be attributed endpoint
+    // by endpoint; both keep the env carriers below, unchanged.
+    let sub_rows = sizing
+        .as_ref()
+        .and_then(|d| descriptor_subscriptions(d, rx_buf_size, rx_recv_size));
+    // issue 1319 -- what ONE subscription slot is priced at where the sum
+    // cannot run per endpoint. The subscribed class, unless a row of this image
+    // can claim the closure buffer.
+    let pubsub_slot_bytes = default_sub_slot_bytes(sub_rows.as_deref(), rx_recv_size, rx_buf_size);
     // issue 1190 -- the region a subscription's QoS history actually claims, at
     // the depth the runtime will actually use. `PUBSUB_QOS_DEPTH` is a
     // RESTATEMENT of `QoSProfile::QOS_PROFILE_DEFAULT.depth`, which a build
@@ -613,7 +820,10 @@ fn main() {
         "NROS_PUBSUB_QOS_DEPTH",
         declared_max_qos_depth().unwrap_or(PUBSUB_QOS_DEPTH),
     );
-    let pubsub_region = buffered_region(pubsub_depth, rx_recv_size, ring_len_bytes);
+    // issue 1319 -- `pubsub_slot_bytes`, not `rx_recv_size`. The two are the
+    // same number on every image that states no registration path, so nothing
+    // moves without a descriptor saying it should.
+    let pubsub_region = buffered_region(pubsub_depth, pubsub_slot_bytes, ring_len_bytes);
     let pubsub_entry = pubsub_region + PUBSUB_ENTRY_STRUCT;
 
     // phase-403 step 3 -- SUM OVER WHAT THE IMAGE DECLARES, when it declares.
@@ -678,13 +888,30 @@ fn main() {
         declared_action_servers,
     ) {
         (Some(subs), Some(timers), Some(services), Some(acl), Some(asv)) => Some(
-            subs_arena(
-                subs,
-                pubsub_entry,
-                rx_recv_size,
-                PUBSUB_ENTRY_STRUCT,
-                ring_len_bytes,
-            ) + timers * TIMER_ENTRY
+            // phase-454 W5 -- the descriptor first, the env carriers second.
+            // ONE road wherever the file can answer (issue 1199); the second
+            // is what W9 retires, and what an image with no `nros sync` keeps.
+            sub_rows
+                .as_deref()
+                .and_then(|rows| {
+                    subs_arena_from_descriptor(
+                        rows,
+                        subs,
+                        PUBSUB_ENTRY_STRUCT,
+                        ring_len_bytes,
+                        rx_buf_size,
+                    )
+                })
+                .unwrap_or_else(|| {
+                    subs_arena(
+                        subs,
+                        pubsub_entry,
+                        rx_recv_size,
+                        PUBSUB_ENTRY_STRUCT,
+                        ring_len_bytes,
+                    )
+                })
+                + timers * TIMER_ENTRY
                 + services * service_entry
                 + (acl + asv) * action_client_entry
                 + ARENA_BASE_OVERHEAD,
@@ -803,6 +1030,19 @@ fn main() {
              resolved `NROS_PUBSUB_QOS_DEPTH`, which defaults to `QOS_DEPTH` \
              when nothing states one.\n    \
              pub const BUDGETED_QOS_DEPTH: u32 = {budgeted_qos_depth};\n    \
+             /// issue 1319 -- the per-slot receive size the pub/sub term was \
+             priced at.\n    \
+             ///\n    \
+             /// The image-wide SUBSCRIBED class, unless this image's sizing \
+             descriptor\n    \
+             /// says a subscription of its registers on a path that claims \
+             the CLOSURE\n    \
+             /// buffer (`DEFAULT_RX_BUF_SIZE`) -- a Rust typed registration \
+             on a\n    \
+             /// schemaless backend, or a C raw one with no hint. Equal to the \
+             subscribed\n    \
+             /// class on every image that states no registration path.\n    \
+             pub const PUBSUB_SLOT_BYTES: usize = {pubsub_slot_bytes};\n    \
              /// Buffered receive region for ONE subscription at that depth.\n    \
              pub const PUBSUB_REGION: usize = {pubsub_region};\n    \
              /// Allowance for the entry STRUCT beside that region.\n    \

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -854,6 +854,18 @@ mod arena_model_tests {
     /// image with one declared subscription therefore derived an 8,192-byte
     /// arena for a 12,144-byte registration.
     ///
+    /// phase-454 W5 / issue 1319 — measured at the slot size the derivation
+    /// PRICED, not at `DEFAULT_RX_BUF_SIZE`.
+    ///
+    /// Those were the same number until issue 1255 narrowed the term to the
+    /// image-wide subscribed class, and this assertion went on reading `RX_BUF`
+    /// — which made it right about the two registration paths that take the
+    /// closure buffer and wrong about the three that do not.
+    /// A Cyclone image priced at its bound would have failed here for sizing
+    /// CORRECTLY. `PUBSUB_SLOT_BYTES` is what the build actually charged, and
+    /// `the_modelled_slot_never_exceeds_the_closure_buffer` below is the other
+    /// half — the one that says the price is an upper bound on every path.
+    ///
     /// Deliberately measured through `buffered_region_size`, the function the
     /// allocator itself calls, and not through a second copy of its arithmetic.
     #[test]
@@ -869,18 +881,55 @@ mod arena_model_tests {
         // What it still catches is the thing that matters — a budget that does
         // not cover its own claim.
         let (slots, region) =
-            super::buffered_region_size(model::BUDGETED_QOS_DEPTH, DEFAULT_RX_BUF_SIZE);
+            super::buffered_region_size(model::BUDGETED_QOS_DEPTH, model::PUBSUB_SLOT_BYTES);
         assert!(
             model::PUBSUB_REGION >= region,
             "the arena derivation budgets {} bytes for a subscription's \
              buffered region and the allocator claims {region} for it \
-             ({slots} slots of {DEFAULT_RX_BUF_SIZE} at the budgeted \
+             ({slots} slots of {} at the budgeted \
              KEEP_LAST({}) ) — every image that derives its arena from a \
              declared subscription count is short by {} bytes per \
              subscription (issue 1190)",
             model::PUBSUB_REGION,
+            model::PUBSUB_SLOT_BYTES,
             model::BUDGETED_QOS_DEPTH,
             region.saturating_sub(model::PUBSUB_REGION),
+        );
+    }
+
+    /// **Issue 1319** — the slot the model prices may never exceed `RX_BUF`,
+    /// because `RX_BUF` is what the widest registration path claims and the
+    /// model is an upper bound or it is nothing.
+    ///
+    /// The direction that shipped the bug is the other one, and it has no
+    /// TOTAL assertion available here: a slot priced BELOW `RX_BUF` is correct
+    /// for a `c_typed_hint` or `rust_typed_descriptors` registration and 1,848
+    /// bytes per subscription short for the other two, and which one this image
+    /// takes is composed from the entry's language and the linked backend —
+    /// neither of which the runtime can read out of a `cfg`. That is why the
+    /// fact travels in the sizing descriptor and the check is on the DERIVATION
+    /// (`nros-sizing-descriptor`'s slot table, `nros-node/build.rs`'s
+    /// `row_slot_bytes`) rather than here. What stands here is the cheap half
+    /// and the reproduction in `executor::tests`.
+    ///
+    /// Both sides go through `black_box`, for the reason `config.rs`'s
+    /// `opaque` exists: they are build-emitted CONSTANTS, and clippy
+    /// const-propagates the comparison and refuses the `assert!` as
+    /// `assertions_on_constants` under `-D warnings`. A `const { assert!(…) }`
+    /// would satisfy it and cost the message its two numbers, which are the
+    /// whole diagnostic.
+    #[test]
+    fn the_modelled_slot_never_exceeds_the_closure_buffer() {
+        fn opaque(v: usize) -> usize {
+            core::hint::black_box(v)
+        }
+        assert!(
+            opaque(model::PUBSUB_SLOT_BYTES) <= opaque(DEFAULT_RX_BUF_SIZE),
+            "the arena model prices a subscription slot at {} bytes while the \
+             widest registration path claims DEFAULT_RX_BUF_SIZE = \
+             {DEFAULT_RX_BUF_SIZE} — a model term above every path it stands \
+             for is not an upper bound, it is a second number (issue 1319)",
+            model::PUBSUB_SLOT_BYTES,
         );
     }
 

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -499,6 +499,151 @@ fn the_default_subscription_buffer_is_derived_from_the_type() {
     }
 }
 
+/// An executor whose ARENA is exactly `arena` bytes, everything else default.
+///
+/// [`executor_with_clock`] takes `ExecutorSizing::DEFAULT`, whose arena is the
+/// build's derived `ARENA_SIZE`. A test that asks *does what the DERIVATION
+/// budgeted hold what the REGISTRATION claims* has to be able to state the
+/// budget, which is the only thing this adds.
+fn executor_with_arena(session: MockSession, arena: usize) -> Executor<'static> {
+    let sizing = super::storage::ExecutorSizing {
+        arena,
+        ..super::storage::ExecutorSizing::DEFAULT
+    };
+    let backing: &'static mut [core::mem::MaybeUninit<u64>] =
+        alloc::boxed::Box::leak(alloc::boxed::Box::new_uninit_slice(sizing.u64_len()));
+    // SAFETY: `backing` is exactly `sizing.u64_len()` words, `'static`, and is
+    // handed to this executor alone -- nothing else holds the leaked slice.
+    unsafe { Executor::from_session_in(session, backing, sizing) }
+}
+
+/// **Issue 1319, reproduced** — phase-454 W5.b.
+///
+/// The issue was analysis-only: *"Not reproduced as a failing image … An image
+/// that declares its entities, subscribes from RUST on zenoh, and sets
+/// `NROS_SUBSCRIBER_BUFFER_SIZE` below `NROS_SUBSCRIPTION_BUFFER_SIZE` is the
+/// shape that would show it, as `NodeError::BufferTooSmall` at a registration
+/// the arena oracle passed."* This is that shape, with the two build-time
+/// numbers stated as arenas so the whole thing fits in one process.
+///
+/// * **the image declares its entities** — so `arena_model::REQUIRED` is the
+///   per-endpoint SUM and not the worst-case budget. Here that is the arena
+///   this test hands the executor.
+/// * **subscribes from Rust** — `.typed::<TestMsg>().build(cb)`, naming no
+///   buffer. The default path, which is what a declarative node emits.
+/// * **on a SCHEMALESS backend that buffers** — `MessageForRmw` carries no
+///   schema, which is `cfg(not(rmw_needs_type_descriptors))` and is why this
+///   test is gated on it, and the handle does not advertise in-place dispatch,
+///   which `MockSubscriber` does not. On the descriptor arm the registration
+///   reaches the type's own bound and the model was already right;
+///   `the_default_subscription_buffer_is_derived_from_the_type` pins that row.
+///
+///   Issue 1319 names zenoh and XRCE for this row and phase-454 W5 measured
+///   otherwise: both advertise `supports_process_in_place`, and
+///   `register_subscription_buffered_on` tests that BEFORE it computes a slot
+///   size, so a typed Rust registration on either claims no region at all (672
+///   bytes on `contract-monitor-sub`; issue 1340). What is reproduced here is
+///   the mechanism and the two rows that do take it —
+///   `RegistrationPath::CRawNoHint`, which the C path reaches on every backend,
+///   and `RustTypedSchemaless` on a schemaless backend that buffers.
+/// * **the subscribed class below the closure bound** — `MODELLED_SLOT`
+///   against `DEFAULT_RX_BUF_SIZE`. The reference island measures 880 against
+///   1,496; the RATIO is not what matters, the direction is.
+///
+/// Both arenas are MEASURED from a registration rather than computed from
+/// `buffered_region_size`, because the arena aligns what it hands out and the
+/// raw region formula is off by that padding at some slot sizes — which would
+/// make this pass or fail for a reason that is not the one under test.
+#[cfg(not(rmw_needs_type_descriptors))]
+#[test]
+fn a_schemaless_subscription_outgrows_an_arena_priced_at_its_types_bound() {
+    /// What the BUILD charged before W5.b: the subscription's own type bound,
+    /// which `NROS_SUBSCRIBED_TYPE_BOUNDS` carries and `subs_arena` prices at.
+    const MODELLED_SLOT: usize = crate::config::DEFAULT_RX_BUF_SIZE / 2;
+    const {
+        assert!(
+            MODELLED_SLOT > 0,
+            "the fixture needs a type bound strictly below the closure buffer, \
+             or there is no gap to reproduce"
+        )
+    };
+    // KEEP_LAST(1) -- a TripleBuffer, three slots, the island's own depth and
+    // the cheapest shape the gap survives.
+    let qos = qos_with_depth(1);
+
+    // --- what each number IS, measured on an arena large enough for both ---
+    let mut wide = executor_with_arena(MockSession::new(), crate::config::ARENA_SIZE);
+    let nid = wide.node_builder("island").build().unwrap();
+    let node_overhead = wide.arena_used();
+    let modelled = {
+        let before = wide.arena_used();
+        wide.node_mut(nid)
+            .subscription("/modelled")
+            .qos(qos)
+            .typed::<TestMsg>()
+            .rx_buffer::<MODELLED_SLOT>()
+            .build(|_: &TestMsg| {})
+            .unwrap();
+        wide.arena_used() - before
+    };
+    let claimed = arena_delta(&mut wide, nid, "/claimed", qos, RxAsk::Default);
+    assert!(
+        claimed > modelled,
+        "the fixture did not reproduce the gap: a default registration claimed \
+         {claimed} bytes and the model's per-type price is {modelled}. On this \
+         arm `default_subscription_rx_bytes` must return `None`, so the \
+         registration takes DEFAULT_RX_BUF_SIZE = {} (issue 1319)",
+        crate::config::DEFAULT_RX_BUF_SIZE,
+    );
+    // The gap has the shape the issue reports: the SLOT COUNT times the
+    // difference in slot size, and nothing else -- both registrations build the
+    // same entry struct. On the island that is `3 x (1496 - 880)` = 1,848 bytes
+    // per subscription at depth 1.
+    assert_eq!(
+        claimed - modelled,
+        3 * (crate::config::DEFAULT_RX_BUF_SIZE - MODELLED_SLOT),
+        "the shortfall is a TripleBuffer's three slots times the difference in \
+         slot size (issue 1319); a different number means the entry struct \
+         moved too and this test is measuring two things"
+    );
+
+    // --- FAILS FIRST: the arena the OLD model derives ---------------------
+    let mut short = executor_with_arena(MockSession::new(), node_overhead + modelled);
+    let nid = short.node_builder("island").build().unwrap();
+    let err = short
+        .node_mut(nid)
+        .subscription("/chatter")
+        .qos(qos)
+        .typed::<TestMsg>()
+        .build(|_: &TestMsg| {})
+        .expect_err(
+            "issue 1319 is that this registration does NOT fit an arena priced \
+             at the type's own bound -- if it now fits, the schemaless \
+             registration path stopped claiming RX_BUF and this test has \
+             outlived the defect it reproduces",
+        );
+    assert_eq!(
+        err,
+        NodeError::BufferTooSmall,
+        "the shortfall must surface as BufferTooSmall at registration -- that \
+         is the symptom issue 1319 predicted and the one an image sees"
+    );
+
+    // --- and fits at the number phase-454 W5.b derives --------------------
+    let mut sized = executor_with_arena(MockSession::new(), node_overhead + claimed);
+    let nid = sized.node_builder("island").build().unwrap();
+    sized
+        .node_mut(nid)
+        .subscription("/chatter")
+        .qos(qos)
+        .typed::<TestMsg>()
+        .build(|_: &TestMsg| {})
+        .expect(
+            "priced at what the registration path CLAIMS, the same subscription \
+             fits -- which is the whole of the W5.b fix",
+        );
+}
+
 /// phase-392 W3c -- `.rx_buffer::<N>()` is the OPT-OUT, and it is exact.
 ///
 /// The consumer named a number, so the derivation is skipped and every slot

--- a/packages/tooling/nros-sizing-descriptor/src/schema.rs
+++ b/packages/tooling/nros-sizing-descriptor/src/schema.rs
@@ -336,6 +336,80 @@ impl Endpoint {
         fact(&self.registration_path, "registration_path", &self.refused)
     }
 
+    /// **Issue 1319's table, applied to this row** — the bytes ONE receive slot
+    /// actually claims at registration.
+    ///
+    /// [`storage_bytes`](Self::storage_bytes) is the whole region priced at the
+    /// TYPE'S bound, which is the right number for two of the four registration
+    /// paths and 1,848 bytes per subscription too small for the other two. This
+    /// is the per-slot half, and it is the half that turns on the path:
+    ///
+    /// | path | slot |
+    /// | --- | --- |
+    /// | `c_typed_hint` | the type's own `_RX` |
+    /// | `rust_typed_descriptors` | `min(framed(bound), RX_BUF)` — at or below it |
+    /// | `rust_typed_schemaless` | `closure_buffer_bytes` |
+    /// | `c_raw_no_hint` | `closure_buffer_bytes` |
+    ///
+    /// `closure_buffer_bytes` is the consumer's `RX_BUF` — `DEFAULT_RX_BUF_SIZE`
+    /// in the executor, `NROS_SUBSCRIPTION_BUFFER_SIZE` on the wire. It is not a
+    /// descriptor fact and cannot be: it is derived over the whole LINK CLOSURE
+    /// by the lane that builds the image, and a type this image only publishes
+    /// still has to fit it. So the caller supplies it.
+    ///
+    /// `unpriced_type_fallback` stands in for a row whose `wire_bound_bytes` the
+    /// producer could not state — the image-wide subscribed class, which is an
+    /// upper bound over every type this image subscribes to and therefore over
+    /// this one. **Absence is not zero**, at either level.
+    ///
+    /// # Why a refused path yields no number
+    ///
+    /// The two `closure_buffer_bytes` rows are an UNDER-size, which is the
+    /// direction that ships `NodeError::BufferTooSmall` at a registration the
+    /// arena oracle passed. A reader that guessed here would guess in that
+    /// direction half the time, so this refuses and hands the refusal's prose to
+    /// the caller — which then picks the safe direction LOUDLY, the way
+    /// [`Fact::or_report`] is written for.
+    ///
+    /// `Fact::Absent` for any kind that receives no topic sample: a publisher
+    /// serializes into a per-call transmit buffer and claims no slot at all, so
+    /// there is nothing here to refuse.
+    pub fn claimed_slot_bytes(
+        &self,
+        closure_buffer_bytes: usize,
+        unpriced_type_fallback: usize,
+    ) -> Fact<usize> {
+        if !self.kind.receives_topic_sample() {
+            return Fact::Absent;
+        }
+        match self.registration_path() {
+            Fact::Stated(p) if p.claims_closure_buffer() => Fact::Stated(closure_buffer_bytes),
+            Fact::Stated(_) => Fact::Stated(
+                self.wire_bound_bytes()
+                    .get()
+                    .unwrap_or(unpriced_type_fallback),
+            ),
+            Fact::Refused(r) => Fact::Refused(r),
+            Fact::Absent => Fact::Absent,
+        }
+    }
+
+    /// Can this row's registration claim the CLOSURE buffer?
+    ///
+    /// `true` for the two paths that do — and for a path this row does not
+    /// state, because "I cannot tell" and "it does" call for the same price.
+    /// The asymmetry is issue 1319's: over-stating a slot costs bytes, and
+    /// under-stating one costs the registration.
+    ///
+    /// `false` for a kind that claims no slot.
+    pub fn may_claim_closure_buffer(&self) -> bool {
+        self.kind.receives_topic_sample()
+            && match self.registration_path() {
+                Fact::Stated(p) => p.claims_closure_buffer(),
+                Fact::Refused(_) | Fact::Absent => true,
+            }
+    }
+
     /// Bytes this endpoint's receive region claims in the executor arena.
     ///
     /// Target-ABI-dependent, so it is refused whenever `[target]` is — D6's
@@ -672,5 +746,133 @@ impl SizingDescriptor {
         self.types.validate()?;
         self.policy.validate()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod slot_table_tests {
+    use super::*;
+
+    /// `RX_BUF` and the image-wide subscribed class, as the reference island
+    /// measures them: 1,496 over the whole link closure, 880 over the types it
+    /// subscribes to. The 616-byte difference is what issue 1319 is about.
+    const CLOSURE: usize = 1496;
+    const SUBSCRIBED_CLASS: usize = 880;
+
+    fn sub(path: Option<RegistrationPath>, bound: Option<usize>) -> Endpoint {
+        let mut ep = Endpoint::new(
+            EndpointKind::Subscription,
+            "std_msgs/msg/String",
+            "/chatter",
+        );
+        ep.set_registration_path(path).set_wire_bound_bytes(bound);
+        ep
+    }
+
+    /// The whole of issue 1319, as a table. Two rows take the type's bound and
+    /// two take the closure buffer; nothing else decides it.
+    #[test]
+    fn each_registration_path_claims_what_issue_1319_measured() {
+        let bound = 700;
+        for (path, expected) in [
+            (RegistrationPath::CTypedHint, bound),
+            (RegistrationPath::RustTypedDescriptors, bound),
+            (RegistrationPath::RustTypedSchemaless, CLOSURE),
+            (RegistrationPath::CRawNoHint, CLOSURE),
+        ] {
+            let ep = sub(Some(path), Some(bound));
+            assert_eq!(
+                ep.claimed_slot_bytes(CLOSURE, SUBSCRIBED_CLASS).stated(),
+                Some(&expected),
+                "{} claims the wrong slot",
+                path.tag()
+            );
+            assert_eq!(
+                ep.may_claim_closure_buffer(),
+                expected == CLOSURE,
+                "{} disagrees with its own slot size",
+                path.tag()
+            );
+        }
+    }
+
+    /// The gap, priced. A schemaless row and a descriptor-carrying row over the
+    /// SAME type differ by exactly what the issue measured, and the model used
+    /// to charge both the smaller one.
+    #[test]
+    fn the_two_schemaless_rows_are_the_measured_gap_above_the_type_bound() {
+        let typed = sub(
+            Some(RegistrationPath::RustTypedDescriptors),
+            Some(SUBSCRIBED_CLASS),
+        );
+        let schemaless = sub(
+            Some(RegistrationPath::RustTypedSchemaless),
+            Some(SUBSCRIBED_CLASS),
+        );
+        let typed = typed.claimed_slot_bytes(CLOSURE, SUBSCRIBED_CLASS).get();
+        let schemaless = schemaless
+            .claimed_slot_bytes(CLOSURE, SUBSCRIBED_CLASS)
+            .get();
+        assert_eq!(typed, Some(SUBSCRIBED_CLASS));
+        assert_eq!(schemaless, Some(CLOSURE));
+        // 3 slots at depth 1 -> 1,848 bytes per subscription, which is the
+        // number issue 1319 reports.
+        assert_eq!(3 * (schemaless.unwrap() - typed.unwrap()), 1848);
+    }
+
+    /// A row whose type the bound inventory could not price keeps the
+    /// image-wide subscribed class -- the same "absence is not zero" rule
+    /// `nros-node/build.rs` applies to `NROS_SUBSCRIBED_TYPE_BOUNDS`.
+    #[test]
+    fn an_unpriced_type_keeps_the_image_wide_class_rather_than_zero() {
+        let mut ep = sub(Some(RegistrationPath::CTypedHint), None);
+        ep.refuse("wire_bound_bytes", "`demo_msgs/msg/Mystery` was not priced");
+        assert_eq!(
+            ep.claimed_slot_bytes(CLOSURE, SUBSCRIBED_CLASS).stated(),
+            Some(&SUBSCRIBED_CLASS)
+        );
+    }
+
+    /// The negative control for the whole fix: a path nobody could state yields
+    /// NO number, so the caller has to choose the direction in the open.
+    #[test]
+    fn a_refused_path_yields_no_number_and_carries_its_prose() {
+        let mut ep = sub(None, Some(700));
+        ep.refuse(
+            "registration_path",
+            "cannot tell which registration path this endpoint takes -- issue 1319",
+        );
+        let slot = ep.claimed_slot_bytes(CLOSURE, SUBSCRIBED_CLASS);
+        assert!(slot.stated().is_none());
+        assert!(slot.refusal().unwrap().contains("1319"));
+        assert!(ep.may_claim_closure_buffer());
+        // And the loud fallback a build script writes is the SAFE direction.
+        let (v, why) = slot.or_report("endpoint.registration_path", CLOSURE);
+        assert_eq!(v, CLOSURE);
+        assert!(why.unwrap().contains("1319"));
+    }
+
+    /// An absent path is not a refused one, and neither is a number.
+    #[test]
+    fn an_absent_path_is_distinguishable_from_a_refused_one() {
+        let ep = sub(None, Some(700));
+        let slot = ep.claimed_slot_bytes(CLOSURE, SUBSCRIBED_CLASS);
+        assert_eq!(slot.tag(), "absent");
+        assert!(slot.refusal().is_none());
+        assert!(ep.may_claim_closure_buffer());
+    }
+
+    /// A publisher claims no receive slot at all, so there is nothing here to
+    /// refuse -- and nothing for a consumer to charge it for.
+    #[test]
+    fn a_kind_that_receives_no_topic_sample_claims_no_slot() {
+        let mut ep = Endpoint::new(EndpointKind::Publisher, "std_msgs/msg/String", "/chatter");
+        ep.set_registration_path(Some(RegistrationPath::RustTypedSchemaless))
+            .set_wire_bound_bytes(Some(700));
+        assert_eq!(
+            ep.claimed_slot_bytes(CLOSURE, SUBSCRIBED_CLASS).tag(),
+            "absent"
+        );
+        assert!(!ep.may_claim_closure_buffer());
     }
 }

--- a/packages/tooling/nros-sizing-descriptor/src/vocabulary.rs
+++ b/packages/tooling/nros-sizing-descriptor/src/vocabulary.rs
@@ -173,12 +173,14 @@ vocabulary! {
     /// `[[endpoint]] registration_path` — issue 1319, RFC-0100 D1.
     ///
     /// **A subscription's SLOT SIZE is a function of this and nothing else can
-    /// supply it.** The four rows are measured in issue 1319:
+    /// supply it.** Issue 1319 measured four rows from the source; phase-454 W5
+    /// ran them and found a FIFTH, which is why the vocabulary has five:
     ///
     /// | path | slot size |
     /// | --- | --- |
     /// | `c_typed_hint` | the type's own `_RX` — matches the model |
     /// | `rust_typed_descriptors` | `min(framed(bound), RX_BUF)` — at or below |
+    /// | `rust_typed_in_place` | **no receive region at all** |
     /// | `rust_typed_schemaless` | **`RX_BUF`** |
     /// | `c_raw_no_hint` | **`RX_BUF`** |
     ///
@@ -188,19 +190,46 @@ vocabulary! {
     /// from it, and a descriptor that omitted it would leave W5 with the same
     /// blindness the build has today.
     ///
-    /// It is an IMAGE fact, not a backend fact: which of the four a registration
-    /// takes is decided by the entry's language, whether it passes a bound hint,
-    /// and whether the linked backend carries type descriptors — all three known
-    /// where this descriptor is written and none of them known to the build
-    /// script that prices the arena.
+    /// It is an IMAGE fact, not a backend fact: which row a registration takes
+    /// is decided by the entry's language, whether it passes a bound hint, and
+    /// two properties of the linked backend — all known where this descriptor is
+    /// written and none of them known to the build script that prices the arena.
     RegistrationPath {
         /// C or C++, typed, `nros::rx_size_bound<M>` supplied.
         CTypedHint => "c_typed_hint",
         /// Rust, typed, against a backend WITH type descriptors (Cyclone).
         RustTypedDescriptors => "rust_typed_descriptors",
-        /// Rust, typed, against a SCHEMALESS backend (zenoh, XRCE).
+        /// Rust, typed, against a backend that dispatches IN PLACE — zenoh and
+        /// XRCE, whose `supports_process_in_place` is an unconditional `true`.
+        ///
+        /// **MEASURED, phase-454 W5, and it is the row issue 1319's analysis
+        /// did not have.** `register_subscription_buffered_on` tests the
+        /// capability BEFORE it computes a slot size and returns through
+        /// `SubInplaceEntry` when it holds, so no receive region is allocated at
+        /// all — an explicit `.rx_buffer::<N>()` on such a backend is not even
+        /// read. Measured on `contract-monitor-sub` over zenoh: a
+        /// `std_msgs/Header` subscription claims **672 bytes** of arena, against
+        /// the 9,768-byte region the model budgets it at `KEEP_LAST(10)`.
+        ///
+        /// So this row is an OVER-statement, not an under-size, and its price is
+        /// deliberately left where it was: the same type's-bound term
+        /// [`Self::RustTypedDescriptors`] takes. Lowering it is worth ~9.7 KiB a
+        /// subscription and is issue 1340, because the Rust GENERIC
+        /// (`.generic(ty, hash)`) registration on the SAME backend does not
+        /// reach that capability test and does claim `RX_BUF` — and nothing in
+        /// this descriptor distinguishes a typed endpoint from a generic one.
+        RustTypedInPlace => "rust_typed_in_place",
+        /// Rust, typed, against a SCHEMALESS backend that BUFFERS — no schema on
+        /// `MessageForRmw`, so no bound is reachable at the type-erased site and
+        /// the registration takes `RX_BUF`.
+        ///
+        /// Issue 1319 attributes this row to zenoh and XRCE. They are
+        /// [`Self::RustTypedInPlace`] instead, measured; this row stands for a
+        /// schemaless backend that does not dispatch in place, which is a
+        /// configuration the tree admits and does not currently ship.
         RustTypedSchemaless => "rust_typed_schemaless",
-        /// C or C++, raw, no hint.
+        /// C or C++, raw, no hint. The C registration path never consults the
+        /// in-place capability, so this row is live on every backend.
         CRawNoHint => "c_raw_no_hint",
     }
 }
@@ -210,9 +239,14 @@ impl RegistrationPath {
     /// own bound?
     ///
     /// The two `true` rows are exactly issue 1319's gap. Stated as a predicate
-    /// here so W5's arena term asks the question once instead of matching four
-    /// variants in each of its call sites — and so adding a fifth path has to
-    /// answer it.
+    /// here so W5's arena term asks the question once instead of matching every
+    /// variant in each of its call sites — and so adding a path has to answer
+    /// it. Phase-454 W5 added one and this is where it had to.
+    ///
+    /// `false` is NOT "claims the type's bound" for every row: it is "does not
+    /// claim `RX_BUF`". [`Self::RustTypedInPlace`] claims no region at all and
+    /// is priced at the bound anyway, which is an over-statement its own doc
+    /// argues for.
     pub const fn claims_closure_buffer(self) -> bool {
         matches!(
             self,
@@ -265,5 +299,31 @@ mod tests {
         assert!(RegistrationPath::CRawNoHint.claims_closure_buffer());
         assert!(!RegistrationPath::CTypedHint.claims_closure_buffer());
         assert!(!RegistrationPath::RustTypedDescriptors.claims_closure_buffer());
+        // phase-454 W5 — and the row 1319's analysis did not have. It claims no
+        // region at all, which is the opposite direction from the two above.
+        assert!(!RegistrationPath::RustTypedInPlace.claims_closure_buffer());
+    }
+
+    /// Every path must ANSWER the predicate, and the five spellings must stay
+    /// distinct. A sixth row added without a decision is what this catches:
+    /// the macro gives it a spelling for free, and `claims_closure_buffer`'s
+    /// `matches!` would silently answer `false` for it — which is the
+    /// under-sizing direction (issue 1319).
+    #[test]
+    fn every_registration_path_is_classified_and_spelled_once() {
+        assert_eq!(RegistrationPath::ALL.len(), 5);
+        let mut tags: Vec<&str> = RegistrationPath::ALL.iter().map(|p| p.tag()).collect();
+        tags.sort_unstable();
+        tags.dedup();
+        assert_eq!(tags.len(), RegistrationPath::ALL.len());
+        assert_eq!(
+            RegistrationPath::ALL
+                .iter()
+                .filter(|p| p.claims_closure_buffer())
+                .count(),
+            2,
+            "a new registration path changed which rows claim RX_BUF -- that is \
+             a sizing decision, not a spelling (issue 1319)"
+        );
     }
 }


### PR DESCRIPTION
phase-454 W5. Carries W3 (#984) and W4 (#993); the queue drops them by patch-id.

## W5.a — the executor reads the descriptor

`nros-node/build.rs` took a subscription's depth from `NROS_ENTITY_DECLARED_DEPTHS`
and its type bound from `NROS_SUBSCRIBED_TYPE_BOUNDS` — two tables encoded into
scalar strings. `descriptor_subscriptions` reads
`build/nros/sizing/<entry>.toml` instead, refusing per D6 (a `closure` basis is
not a per-endpoint table; a non-zero *or absent* `undeclared_endpoints` means the
rows describe part of the image). The env carriers stay **below** it — W9 owns
retirement.

## W5.b — and the reproduction falsified issue 1319's premise

Issue 1319 assigns zenoh and XRCE to the `RX_BUF` row. **They are not there.**

`register_subscription_buffered_on` asks `supports_process_in_place()` *before*
computing a slot size. Both schemaless backends answer an unconditional `true`
and return through `SubInplaceEntry` with **no region at all**. Measured on
`contract-monitor-sub` over zenoh:

```
arena used: open=0  node=0  sub=672      (against a 9,768-byte budgeted region)
```

So a fifth row exists — `RegistrationPath::RustTypedInPlace` — and its price is
**left exactly where it was**. Had I priced it at `RX_BUF` as 1319's table
implied, **every zenoh image would have grown 6,776 B for a claim it never
makes.**

The ~9.7 KiB/subscription over-statement is real and is filed as **issue 1340**
rather than taken here: the Rust *generic* registration on the same backend does
not reach that capability test, and an endpoint row cannot say which spelling an
image writes. Taking it needs a producer fact that does not exist yet.

Each row is now priced at what it claims, via `Endpoint::claimed_slot_bytes` —
the table as code, beside the vocabulary that documented it. A refused path is
priced at the closure buffer with a `cargo::warning` naming the refusal.

## Measured

Derived arena, one `KEEP_LAST(1)` subscription, island numbers (880 / 1,496):

| descriptor | `REQUIRED` | slot |
| --- | --- | --- |
| none · `c_typed_hint` · `rust_typed_descriptors` · `rust_typed_in_place` | 5,712 | 880 |
| `rust_typed_schemaless` · `c_raw_no_hint` · REFUSED | **7,560** | 1,496 |

Δ = **1,848** = `3 × (1496 − 880)` — issue 1319's own number, reproduced.

`mem-report` on `contract-monitor-sub` (Rust/zenoh, 1 declared sub at depth 10):

| descriptor | `EXECUTOR_BACKING` | `.bss+.data` | `ARENA_SIZE` |
| --- | --- | --- | --- |
| none (= before) | 27,152 | 523,528 | 12,840 |
| `rust_typed_in_place` (what sync writes) | 27,152 | 523,528 | 12,840 |
| `rust_typed_schemaless` | 33,928 | 530,304 | 19,616 |

`+6,776 = 11 × (1496 − 880)` when a closure-claiming row fires, **nothing when it
does not**. `ARENA_SIZE == arena_model::REQUIRED` in every column.

**No descriptor ⇒ byte-identical**: generated `nros_node_config.rs` diffed
against the base with and without env carriers — every emitted *value* identical.
The only textual difference is a new `arena_model::PUBSUB_SLOT_BYTES`, whose
value is the number the derivation already used.

## The 1319 reproduction

`executor::tests::a_schemaless_subscription_outgrows_an_arena_priced_at_its_types_bound`:
an arena at the OLD model's number refuses the registration with
`BufferTooSmall`; the same registration fits W5.b's number; the gap is asserted
to be slot-count × slot-size-difference. It fails first, then passes.

## Gates

Green: `check fast` (307, 0 failed), `workspace-all`, `test-targets`,
`cli-tests`, `test-unit`, `test-lane-contracts` (17/17), `nros-node --lib` 415,
`nros-sizing-descriptor` 26, `nros-cli-core sizing` 17, `fmt --all` on both
workspaces.

Two of those were red on **real breaks of mine** and are fixed: a clippy
`assertions_on_constants` (resolved with `black_box`, the `config.rs::opaque`
pattern) and `sizing_descriptor_portable.rs` missing the new `backend_dispatch`
field.

Remaining `check::build` reds are the **issue-1280 class** and untouched:
`rmw-uorb`/`rmw-xrce` on a cmake cache generated from the main checkout,
`staticlib-symbols`/`borrowed-e2e` on fixtures this worktree never built.

## One finding for W9

**`NROS_SIZING_DESCRIPTOR` has no rebuild edge on the unset→set transition.**
`from_build_env` reads the variable; `load_for_build_script` watches only the
file's *content*. A build that ran before `nros sync` first wrote a descriptor
will not re-run when one appears, keeping the pre-W5 (possibly too-small) arena.

Adding `rerun-if-env-changed` would re-create issue 0491 — the path is
per-leaf/per-image and phase-340 leaves share one cargo group — so it is left as
W4's transport decision. **Worth closing before W9 retires the old carriers.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1