### PR TITLE
feat(phase-454 W7): the contract and `qos_overrides.*` are two statements about one fact, and they must agree

### DIFF
--- a/docs/design/0100-rmw-agnostic-sizing-model.md
+++ b/docs/design/0100-rmw-agnostic-sizing-model.md
@@ -421,6 +421,39 @@ This extends the rule that module already holds itself to:
 > `filter_map`ed an unrecognised role or policy away … the image ran different
 > delivery semantics than the model declared."*
 
+### As implemented (phase-454 W7)
+
+`nros_orchestration_ir::qos_agreement::check_model` is the rule, one function
+over a resolved `SystemModel`, called from all four roads a model reaches a bake
+or a sizing derivation on — the two CLI sizing roads W3 already guards
+(`nros ws entity-inventory`, fatal; `nros build`'s seed, a refusal reason) and
+the two BAKE roads (`codegen::entry::plan_from_model`, `nros::main!`). Only the
+bake road is guaranteed to see an override, and only the sizing road is
+guaranteed to see the contract, so a check on either alone is issue 1199's shape.
+It lives in `nros-orchestration-ir` because the proc-macro cannot depend on
+`nros-cli-core`.
+
+Three refinements the ruling did not have to state, each measured:
+
+* **Scope is CAPACITY.** `qos_override::MODELLED_POLICIES` flags each of the
+  eight policies `lower` accepts as capacity or occupancy, and only the four
+  capacity ones are compared: `reliability`, `durability`, `history`, `depth` —
+  exactly the four the contract's `qos:` block can state. `deadline`, `lifespan`
+  and the two liveliness policies bound occupancy or liveness of a queue whose
+  size is already decided; the schema has no key for them, so comparing them
+  would refuse every legal `deadline` override.
+* **It abstains where no contract was authored.** No topic wiring means no
+  contract statement about any topic, hence ONE producer and nothing to diverge
+  from — the same abstention `EntityInventory::from_model` makes by returning
+  `None`. 109 of 114 resolvable models are in that state, including both in-tree
+  producers of a `qos_overrides.*` parameter, which is why the wave moves no
+  sizing number.
+* **One vocabulary, structurally.** The comparison reads a parameter with
+  `qos_override::sizing_statement`, which shares the key parser and the value
+  functions with `lower`; a test asserts the two accept the same policy names,
+  read one value, and refuse the same keys. A second `match policy` would be the
+  drift that module's own header was written about.
+
 ## D9 — `buffer:` is a cross-check, not a `SLOTS` source
 
 `buffer: latest | queue` is fault-analysis vocabulary, not queue sizing:

--- a/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
+++ b/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
@@ -437,7 +437,7 @@ to 1 with a line that says so — `NROS_RMW_UORB_PX4_MAX_CALLBACKS=0 raised to 1
 That is D7 working in both directions in one image: zero reaches cffi's `[T; 0]`
 untouched and is refused by the C++ array that cannot express it.
 
-### W7 — contract and `qos_overrides` must agree
+### W7 — contract and `qos_overrides` must agree — **LANDED**
 
 Build error on any divergence, naming both sites (D8). Where an override states a
 policy the contract omits, the error names the contract line to add.
@@ -449,6 +449,54 @@ cause.
 
 Acceptance: a divergent pair fails the build naming both; an agreeing pair
 builds; a params-only policy fails naming the contract.
+
+**What landed.**
+
+| piece | where |
+| --- | --- |
+| the rule | `nros_orchestration_ir::qos_agreement::check_model` — one function over a resolved `SystemModel` |
+| the vocabulary it reads with | `qos_override::sizing_statement`, sharing `split_key` and the `parse_*` value functions with `lower`, so the bake and the comparison cannot read one parameter two ways |
+| the scope decision | `qos_override::MODELLED_POLICIES` — every policy `lower` accepts, each flagged capacity or occupancy |
+| sizing road | `cmd::entity_inventory::reject_qos_override_divergence` (fatal at configure) + `cmd::build`'s stage-3.5 seed (a refusal reason), beside W3's `reject_unknown_qos_values` |
+| bake roads | `codegen::entry::plan_from_model` (C/C++ and `nros build`'s Rust entry) and `nros::main!` (`main_macro.rs`) |
+
+**Four roads and not two, because only the BAKE road is guaranteed to see an
+override.** An image can bake `qos_overrides./t.subscription.depth = 64` without
+ever running `nros ws entity-inventory --model`, which is issue 1190 exactly; and
+a contract-sizing configure can run on an image whose overrides live in a params
+YAML the entry emitter never reads. The check is the same function at all four —
+the proc-macro cannot dep `nros-cli-core`, which is why the rule lives in
+`nros-orchestration-ir` rather than beside its first caller.
+
+**Scope: capacity, not occupancy.** `reliability`, `durability`, `history`,
+`depth` — the four the contract states and the four that decide how many bytes an
+image reserves. `deadline`, `lifespan` and the two liveliness policies bound
+occupancy or liveness of a queue whose size is already decided, the contract
+schema has no key for them, and comparing them would refuse every legal
+`deadline` override in the tree. The `agrees` fixture carries one on purpose, so
+a widened scope is a red rather than a discovery.
+
+**It abstains where no contract was authored**, which is 109 of the tree's 114
+resolvable models and both in-tree producers of a `qos_overrides.*` parameter
+(`examples/templates/multi-node-workspace-cpp`, `examples/workspaces/features`).
+No contract means ONE producer and nothing to disagree with — the same abstention
+`EntityInventory::from_model` makes by returning `None`. That is why this wave
+moves no sizing number: measured over every one of the tree's 82 launch files,
+80 produce the same derived knobs and the only two refusals are this wave's own
+divergence fixtures.
+
+**Narrowing is a disagreement.** The ruling is not a bound check, and the
+`diverges` fixture carries both directions in one model — a subscription that
+widens `depth` 3 → 64 and a publisher that narrows `reliability` reliable →
+best_effort. Honouring the narrowing silently would leave the image running QoS
+the contract does not describe, and the contract is what sizes the arena, XRCE's
+reliable buffers and zenoh's ring.
+
+Tests: 12 unit tests in `qos_agreement`, 3 binding tests in `qos_override` (the
+two readers accept the same policy names, read one value, and refuse the same
+keys), and `contract_qos_override_agreement.rs` — five cases through the pinned
+resolver, including the no-contract abstention measured against the real
+`multi-node-workspace-cpp` bringup.
 
 ### W8 — `buffer:` earns its keep — LANDED, and ARMED rather than firing
 

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -2432,6 +2432,14 @@ fn resolve_image(
         // WRONGLY is not.
         crate::cmd::entity_inventory::reject_unknown_qos_values(&model)
             .map_err(|e| format!("{e}"))?;
+        // phase-454 W7 (RFC-0100 D8) -- and a `qos_overrides.*` parameter that
+        // disagrees with the contract refuses the seed, for the same reason:
+        // the seed would otherwise compose an image sized from the contract
+        // while the bake ran the parameter's QoS. A refusal reason and not a
+        // process failure, exactly as above -- `nros ws entity-inventory`
+        // fatals on the same model at configure time.
+        crate::cmd::entity_inventory::reject_qos_override_divergence(&model)
+            .map_err(|e| format!("{e}"))?;
         // `None` is "no wiring described", which is a DECLARATION GAP and not
         // an error: 5 of the tree's 114 resolvable models describe wiring, and
         // they are exactly the 5 with a contract sidecar (issue 0973).

--- a/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
@@ -236,6 +236,12 @@ pub fn run(args: EntityInventoryArgs) -> Result<()> {
         // enters the verb and the only one with an error channel.
         reject_unknown_qos_values(&model)
             .wrap_err_with(|| format!("model `{}`", model_path.display()))?;
+        // phase-454 W7 (RFC-0100 D8) -- and a `qos_overrides.*` parameter that
+        // states a capacity policy the contract does not. Third refusal at the
+        // same seam, for the same reason: this is the one point a model enters
+        // the verb and the only one with an error channel.
+        reject_qos_override_divergence(&model)
+            .wrap_err_with(|| format!("model `{}`", model_path.display()))?;
         if args.output_params_header.is_some() {
             params_header = Some(crate::declared_params_header::render(
                 Some(&model),
@@ -478,6 +484,33 @@ pub(crate) fn reject_unknown_qos_values(
         }
     }
     Ok(())
+}
+
+/// The contract and `qos_overrides.*` must state the same QoS (phase-454 W7,
+/// RFC-0100 D8).
+///
+/// `qos_overrides.<topic>.<role>.<policy>` feeds the baked RUNTIME table and the
+/// contract feeds SIZING, and until W7 the two never met:
+/// `qos_overrides./t.subscription.depth = 64` reached the runtime and the arena
+/// never heard about it -- issue 1190's `BufferTooSmall` with a config-shaped
+/// cause and no diagnostic.
+///
+/// A thin wrapper over [`nros_orchestration_ir::qos_agreement::check_model`],
+/// which is where the rule lives because the `nros::main!` proc-macro cannot dep
+/// this crate and it must ask the same question.
+///
+/// FOUR call sites, not two. `reject_unknown_qos_values` guards the two SIZING
+/// roads (this verb and `nros build`'s seed) because those are the two roads a
+/// model reaches `from_model` on. This rule also needs the two BAKE roads
+/// (`codegen::entry::plan_from_model` and the proc-macro), because only a bake
+/// is guaranteed to see an override: an image can bake
+/// `qos_overrides./t.subscription.depth = 64` without ever running this verb
+/// with a `--model`. A check that guards a subset of the roads a fact travels
+/// is the shape issue 1199 names.
+pub(crate) fn reject_qos_override_divergence(
+    model: &ros_launch_manifest_model::SystemModel,
+) -> Result<()> {
+    nros_orchestration_ir::qos_agreement::check_model(model).map_err(|e| eyre::eyre!("{e}"))
 }
 
 /// Keep only the named component (phase-403 step 2).

--- a/packages/cli/nros-cli-core/src/codegen/entry/mod.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/mod.rs
@@ -753,6 +753,18 @@ pub fn plan_from_model(model_path: &Path, board: Option<String>) -> Result<Plan>
     use ros_launch_manifest_model::Target;
 
     let model = model_ingest::load_model(model_path)?;
+    // phase-454 W7 (RFC-0100 D8) -- before anything is baked, the contract and
+    // the `qos_overrides.*` parameters must state the same QoS.
+    //
+    // Checked on the BAKE road and not only where the contract is SIZED from,
+    // because these are the two producers and only this one is guaranteed to
+    // see an override: an image can bake `qos_overrides./t.subscription.depth =
+    // 64` without ever running `nros ws entity-inventory --model`, and that is
+    // issue 1190 exactly. The check is a property of the model, so it runs
+    // before the board slice -- a divergence is not something a board filter
+    // can make true.
+    nros_orchestration_ir::qos_agreement::check_model(&model)
+        .map_err(|e| eyre::eyre!("model `{}`: {e}", model_path.display()))?;
     let board = board.unwrap_or_else(|| "native".to_string());
     // Issue 1285 — only a key the entry table knows HAS a tier sub-table.
     //

--- a/packages/cli/nros-cli-core/tests/contract_qos_override_agreement.rs
+++ b/packages/cli/nros-cli-core/tests/contract_qos_override_agreement.rs
@@ -1,0 +1,273 @@
+//! phase-454 W7 (RFC-0100 D8) -- the contract and `qos_overrides.*` must agree,
+//! through the whole channel a build takes.
+//!
+//! The unit tests in `nros_orchestration_ir::qos_agreement` feed `check_model` a
+//! hand-built model. This one produces the model the way a build does: the
+//! pinned `nros-launch-resolve` over a launch file and its contract sidecar,
+//! exactly as `nros sync` would. Both halves have to work for a divergence to
+//! be caught -- a `<param>` has to survive resolution into
+//! `structure.nodes.<n>.params` and a `qos:` block has to survive into
+//! `contracts.{pub,sub}_endpoints`, and until this wave nothing had ever read
+//! the two together.
+//!
+//! Three fixtures, one per outcome of the ruling:
+//!
+//! * `agrees` -- every override restates a policy the contract states, with the
+//!   same value. BUILDS.
+//! * `diverges` -- the same policy with different values, in BOTH directions (a
+//!   widening depth and a narrowing reliability). REFUSED.
+//! * `params_only` -- the override states a policy the contract omits. REFUSED,
+//!   naming the contract line to add.
+//!
+//! The fourth case -- a contract-only policy, which is every in-tree contract --
+//! is asserted against W3's own `qos_policies` fixture, so the normal case is
+//! checked against a file this wave did not author.
+//!
+//! Run with:
+//! `cargo test --manifest-path packages/cli/Cargo.toml --test contract_qos_override_agreement`
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use nros_orchestration_ir::qos_agreement::{QosAgreementError, check_model};
+use ros_launch_manifest_model::SystemModel;
+
+/// ACCEPTANCE 2 -- an agreeing pair builds.
+///
+/// Also the guard on scope: the talker carries a `deadline` override, which is
+/// modelled, is not a capacity, and has no contract key. A comparison that
+/// widened past the four capacity policies would refuse this file.
+#[test]
+fn an_agreeing_pair_builds() {
+    let m = resolve("agrees");
+    // The precondition, asserted rather than assumed: both halves must have
+    // survived resolution, or a green here would mean the check found nothing
+    // to compare. That is the vacuous shape `check-no-vacuous-tests` names.
+    let params = &m.structure.nodes["/listener"].params;
+    assert_eq!(
+        params
+            .get("qos_overrides./chatter.subscription.depth")
+            .map(|v| v.to_bake_string())
+            .as_deref(),
+        Some("3"),
+        "the launch `<param>` must reach the model: {params:#?}"
+    );
+    assert_eq!(
+        m.contracts.sub_endpoints["/listener/chatter"]
+            .qos
+            .as_ref()
+            .and_then(|q| q.depth),
+        Some(3),
+        "the contract `qos:` must reach the model"
+    );
+    assert_eq!(check_model(&m), Ok(()), "an agreeing pair must build");
+}
+
+/// ACCEPTANCE 1 -- a divergent pair fails, naming BOTH sites and BOTH values.
+///
+/// Both directions in one model: the subscription WIDENS (contract 3,
+/// parameter 64 -- issue 1190's under-size) and the publisher NARROWS (contract
+/// `reliable`, parameter `best_effort`). The ruling is not a bound check, so
+/// both are red.
+#[test]
+fn a_divergent_pair_is_refused_naming_both_sites() {
+    let m = resolve("diverges");
+    let e = check_model(&m).expect_err("a divergent pair must be refused");
+    let QosAgreementError::Divergent(ds) = &e else {
+        panic!("expected divergences, got: {e}");
+    };
+    let mut seen: Vec<(&str, &str, Option<&str>, &str)> = ds
+        .iter()
+        .map(|d| {
+            (
+                d.role,
+                d.policy,
+                d.contract_value.as_deref(),
+                d.param_value.as_str(),
+            )
+        })
+        .collect();
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec![
+            ("publisher", "reliability", Some("reliable"), "best_effort"),
+            ("subscription", "depth", Some("3"), "64"),
+        ],
+        "both directions must be reported, each with both values"
+    );
+
+    let text = e.to_string();
+    for want in [
+        // The PARAMETER site, verbatim -- someone has to be able to grep for it.
+        "qos_overrides./chatter.subscription.depth",
+        "qos_overrides./chatter.publisher.reliability",
+        // The CONTRACT site: the file and the endpoint.
+        "diverges.contract.yaml",
+        "/listener/chatter",
+        "/talker/chatter",
+        // Both values, on both rows.
+        "depth: 3",
+        "`64`",
+        "reliability: reliable",
+        "`best_effort`",
+    ] {
+        assert!(text.contains(want), "missing `{want}` in:\n{text}");
+    }
+}
+
+/// ACCEPTANCE 3 -- a params-only policy fails, naming the contract line to add.
+#[test]
+fn a_params_only_policy_is_refused_naming_the_contract_line() {
+    let m = resolve("params_only");
+    let e = check_model(&m).expect_err("a params-only policy must be refused");
+    let QosAgreementError::Divergent(ds) = &e else {
+        panic!("expected divergences, got: {e}");
+    };
+    assert_eq!(ds.len(), 1, "{ds:#?}");
+    assert_eq!(ds[0].policy, "reliability");
+    assert_eq!(
+        ds[0].contract_value, None,
+        "the contract states nothing -- that is the whole case"
+    );
+    assert_eq!(ds[0].endpoint.as_deref(), Some("/listener/chatter"));
+
+    let text = e.to_string();
+    // The contract line to add, as a user would paste it. Asserted as ONE
+    // block: the nesting is what makes it pasteable, and asserting the keys
+    // separately would pass on a message that named them in any order.
+    assert!(
+        text.contains(
+            "    nodes:\n      listener:\n        sub:\n          chatter:\n            \
+             qos:\n              reliability: reliable"
+        ),
+        "the contract line to add is not in:\n{text}"
+    );
+    assert!(
+        text.contains("params_only.contract.yaml"),
+        "the file to edit is not named in:\n{text}"
+    );
+}
+
+/// ACCEPTANCE 4 -- a contract-only policy builds. That is the normal case, and
+/// this asserts it against W3's fixture rather than one written for this wave:
+/// `qos_policies` states all four policies on both sides of a topic and sets no
+/// parameter at all, which is every contract in the tree today.
+#[test]
+fn a_contract_only_policy_builds() {
+    let m = resolve_in("qos_policies", "policies");
+    assert!(
+        m.structure
+            .nodes
+            .values()
+            .all(|n| n.resolved_params("/x").is_empty()),
+        "the precondition of this test is that NOTHING states an override"
+    );
+    assert!(
+        m.contracts.sub_endpoints["/listener/chatter"]
+            .qos
+            .as_ref()
+            .is_some_and(|q| q.reliability.is_some()),
+        "…and that the contract states one"
+    );
+    assert_eq!(check_model(&m), Ok(()));
+}
+
+/// A model with no contract abstains: nobody authored one, so there is a single
+/// producer and nothing to disagree with.
+///
+/// This is what keeps every existing image building. Measured against the real
+/// file -- `multi-node-workspace-cpp`'s bringup sets
+/// `qos_overrides./chatter.publisher.reliability` and has no contract sidecar,
+/// and it is one of the two in-tree producers of a `qos_overrides.*` parameter.
+#[test]
+fn an_image_with_no_contract_is_untouched() {
+    let repo = repo_root();
+    let bringup = repo.join("examples/templates/multi-node-workspace-cpp/src/demo_bringup");
+    assert!(
+        bringup.join("launch/system.launch.xml").is_file(),
+        "the in-tree producer this test measures has moved: {}",
+        bringup.display()
+    );
+    let m = resolve_at(&bringup, "system");
+    assert!(
+        m.structure.nodes["/talker"]
+            .params
+            .contains_key("qos_overrides./chatter.publisher.reliability"),
+        "the override must be present, or this test proves nothing"
+    );
+    assert!(
+        m.structure.topics.is_empty(),
+        "…and no contract describes wiring, which is why the check abstains"
+    );
+    assert_eq!(check_model(&m), Ok(()));
+}
+
+/// Resolve `qos_agreement/launch/<stem>.launch.xml` through the pinned
+/// resolver, by ABSOLUTE path (issue 0285).
+fn resolve(stem: &str) -> SystemModel {
+    resolve_in("qos_agreement", stem)
+}
+
+fn resolve_in(fixture: &str, stem: &str) -> SystemModel {
+    let bringup = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(fixture);
+    resolve_at(&bringup, stem)
+}
+
+fn resolve_at(bringup: &Path, stem: &str) -> SystemModel {
+    let repo = repo_root();
+    let resolver = repo.join("packages/cli/nros-launch-resolve/target/release/nros-launch-resolve");
+    assert!(
+        resolver.is_file(),
+        "nros-launch-resolve not built at {} -- run `just setup-launch-resolve`",
+        resolver.display()
+    );
+    let out = temp_output(&repo, stem);
+    fs::create_dir_all(&out).expect("create model out dir");
+    let model = out.join("system_model.yaml");
+    let output = std::process::Command::new(&resolver)
+        .arg(bringup.join(format!("launch/{stem}.launch.xml")))
+        .arg("--bringup-root")
+        .arg(bringup)
+        .arg("-o")
+        .arg(&model)
+        .output()
+        .expect("spawn nros-launch-resolve");
+    assert!(
+        output.status.success(),
+        "nros-launch-resolve failed for {stem}:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = fs::read_to_string(&model).expect("read the resolved model");
+    let _ = fs::remove_dir_all(&out);
+    SystemModel::from_yaml_str(&text).expect("the resolved model parses")
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("repo root")
+        .to_path_buf()
+}
+
+/// Unique scratch dir under the repo's gitignored `tmp/` (repo rule: temp
+/// files live in `$project/tmp/`, not the system temp dir).
+fn temp_output(repo: &Path, name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = repo.join("tmp").join(format!(
+        "qos-agreement-{name}-{}-{stamp}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    dir
+}

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/agrees.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/agrees.contract.yaml
@@ -1,0 +1,41 @@
+# phase-454 W7 (RFC-0100 D8) -- the contract and `qos_overrides.*` state the
+# SAME QoS, which is the pair that must build.
+#
+# `agrees.launch.xml` sets three `qos_overrides.*` parameters on the listener
+# and one on the talker. Every one of them restates a policy this contract also
+# states, with the same value, so the runtime table and the sizing model
+# describe one image.
+#
+# `/quiet` carries no override and no `qos:` at all -- the "nobody said"
+# baseline, so a check that fired on silence would be caught here rather than in
+# a divergence fixture where a red is expected.
+
+version: 1
+
+nodes:
+  talker:
+    pub:
+      chatter:
+        qos:
+          depth: 8
+          durability: transient_local
+      quiet: {}
+
+  listener:
+    sub:
+      chatter:
+        qos:
+          depth: 3
+          reliability: best_effort
+          history: keep_last
+      quiet: {}
+
+topics:
+  /chatter:
+    type: std_msgs/msg/Int32
+    pub: [talker/chatter]
+    sub: [listener/chatter]
+  /quiet:
+    type: std_msgs/msg/Int32
+    pub: [talker/quiet]
+    sub: [listener/quiet]

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/agrees.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/agrees.launch.xml
@@ -1,0 +1,19 @@
+<launch>
+  <!-- phase-454 W7 (RFC-0100 D8): every `qos_overrides.*` parameter here
+       restates a policy `agrees.contract.yaml` also states, with the same
+       value. This is the pair that must BUILD.
+
+       A `deadline` rides along deliberately: it is a modelled override that
+       bounds occupancy rather than capacity, the contract has no key for it,
+       and it must not be compared. A check that widened its scope to every
+       policy would refuse this file. -->
+  <node pkg="demo_pkg" exec="talker" name="talker">
+    <param name="qos_overrides./chatter.publisher.depth" value="8"/>
+    <param name="qos_overrides./chatter.publisher.deadline" value="100"/>
+  </node>
+  <node pkg="demo_pkg" exec="listener" name="listener">
+    <param name="qos_overrides./chatter.subscription.depth" value="3"/>
+    <param name="qos_overrides./chatter.subscription.reliability" value="best_effort"/>
+    <param name="qos_overrides./chatter.subscription.history" value="keep_last"/>
+  </node>
+</launch>

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/diverges.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/diverges.contract.yaml
@@ -1,0 +1,35 @@
+# phase-454 W7 (RFC-0100 D8) -- the contract and `qos_overrides.*` state the
+# same policy with DIFFERENT values.
+#
+# `diverges.launch.xml` sets `qos_overrides./chatter.subscription.depth = 64`
+# against this contract's `depth: 3`. That is issue 1190 exactly: the 64 reaches
+# the runtime QoS table and the arena is sized from the 3, so the first burst
+# that fills the queue is a `BufferTooSmall` with a config-shaped cause and no
+# diagnostic.
+#
+# The publisher's `reliability` diverges the other way -- the contract states
+# `reliable` and the parameter NARROWS it to `best_effort`. Narrowing is a
+# disagreement too: honouring it silently would leave the image running QoS the
+# contract does not describe, and the contract is what every other size consumer
+# reads.
+
+version: 1
+
+nodes:
+  talker:
+    pub:
+      chatter:
+        qos:
+          reliability: reliable
+
+  listener:
+    sub:
+      chatter:
+        qos:
+          depth: 3
+
+topics:
+  /chatter:
+    type: std_msgs/msg/Int32
+    pub: [talker/chatter]
+    sub: [listener/chatter]

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/diverges.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/diverges.launch.xml
@@ -1,0 +1,15 @@
+<launch>
+  <!-- phase-454 W7 (RFC-0100 D8): both directions of a divergence in one file.
+
+       The subscription WIDENS (contract `depth: 3`, parameter 64), which is
+       issue 1190's under-size. The publisher NARROWS (contract `reliability:
+       reliable`, parameter `best_effort`), which the ruling refuses just as
+       hard, because it is still an image running QoS the contract does not
+       describe. -->
+  <node pkg="demo_pkg" exec="talker" name="talker">
+    <param name="qos_overrides./chatter.publisher.reliability" value="best_effort"/>
+  </node>
+  <node pkg="demo_pkg" exec="listener" name="listener">
+    <param name="qos_overrides./chatter.subscription.depth" value="64"/>
+  </node>
+</launch>

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/params_only.contract.yaml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/params_only.contract.yaml
@@ -1,0 +1,31 @@
+# phase-454 W7 (RFC-0100 D8) -- the override states a policy the contract
+# OMITS.
+#
+# The subscriber's endpoint states a `depth:` and nothing else, and
+# `params_only.launch.xml` sets `qos_overrides./chatter.subscription.reliability
+# = reliable`. The contract is the authoritative producer of what an image
+# declares, so the parameter must not quietly become a second one: the build
+# refuses and names the contract line to add.
+#
+# The direction matters. A node whose parameter says `reliability = reliable`
+# and whose contract says nothing is sized as if best-effort -- on XRCE that is
+# two 64 KiB reliable buffers nobody reserved.
+
+version: 1
+
+nodes:
+  talker:
+    pub:
+      chatter: {}
+
+  listener:
+    sub:
+      chatter:
+        qos:
+          depth: 3
+
+topics:
+  /chatter:
+    type: std_msgs/msg/Int32
+    pub: [talker/chatter]
+    sub: [listener/chatter]

--- a/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/params_only.launch.xml
+++ b/packages/cli/nros-cli-core/tests/fixtures/qos_agreement/launch/params_only.launch.xml
@@ -1,0 +1,9 @@
+<launch>
+  <!-- phase-454 W7 (RFC-0100 D8): the parameter states `reliability` and
+       `params_only.contract.yaml` states only a `depth:` for the same endpoint.
+       The build must refuse and name the contract line to add. -->
+  <node pkg="demo_pkg" exec="talker" name="talker"/>
+  <node pkg="demo_pkg" exec="listener" name="listener">
+    <param name="qos_overrides./chatter.subscription.reliability" value="reliable"/>
+  </node>
+</launch>

--- a/packages/core/nros-macros/src/main_macro.rs
+++ b/packages/core/nros-macros/src/main_macro.rs
@@ -743,6 +743,22 @@ fn build_main(mut args: MainArgs) -> MacroResult<proc_macro2::TokenStream> {
             )
         })?;
 
+        // phase-454 W7 (RFC-0100 D8) -- the contract and the `qos_overrides.*`
+        // parameters are two statements about ONE fact, so a divergence is a
+        // COMPILE ERROR naming both sites.
+        //
+        // The same check the CLI's entry emitter and `nros ws entity-inventory`
+        // run, from the same function in `nros-orchestration-ir`, because this
+        // macro cannot dep `nros-cli-core` and a rule that holds on one of two
+        // bake roads is not a rule. Before the node slice: a divergence is a
+        // property of the model, and a board filter cannot make one true.
+        nros_orchestration_ir::qos_agreement::check_model(&model).map_err(|e| {
+            syn::Error::new(
+                model_lit.span(),
+                format!("nros::main!: model `{}`: {e}", model_path.display()),
+            )
+        })?;
+
         // Bridge entry (phase-267 / R-code.1): the model's `execution.bridges`
         // is the SSoT for "this bringup relays between two RMW sessions". When
         // non-empty AND `nros sync` generated the runtime config

--- a/packages/core/nros-orchestration-ir/src/lib.rs
+++ b/packages/core/nros-orchestration-ir/src/lib.rs
@@ -52,6 +52,12 @@ pub mod mapper_input;
 // phase-330 W3.b — the ONE place that decides where a SystemModel is read
 // from, shared by the proc-macro, `nros-build` and (via its default) cmake.
 pub mod model_location;
+// phase-454 W7 (RFC-0100 D8) — the contract and `qos_overrides.*` are two
+// statements about ONE fact, so any divergence is a build error naming both
+// sites. Here rather than in the CLI because BOTH producers must ask: the
+// `nros::main!` proc-macro cannot dep `nros-cli-core`, and a check on one of
+// two roads is the shape issue 1199 names.
+pub mod qos_agreement;
 // issue 0303 — the ONE lowering of `qos_overrides.*` params into baked codes,
 // shared by the CLI's entry emitters and the nros::main! proc-macro, and
 // fail-loud on anything it cannot lower.

--- a/packages/core/nros-orchestration-ir/src/qos_agreement.rs
+++ b/packages/core/nros-orchestration-ir/src/qos_agreement.rs
@@ -1,0 +1,772 @@
+//! phase-454 W7 (RFC-0100 D8) — the launch contract and `qos_overrides.*` are
+//! two statements about ONE fact, so any divergence is a build error naming
+//! both sites.
+//!
+//! `qos_overrides.<topic>.<role>.<policy>` is ROS 2's own mechanism for
+//! overriding QoS declared in code, delivered as ordinary node parameters — so
+//! it reaches a build from launch XML `<param>`, a params YAML, or
+//! `system.toml [[component]] params`. It feeds the baked RUNTIME table
+//! ([`crate::qos_override::lower_all`] → the C/C++ entry emitters and the
+//! `nros::main!` proc-macro). The contract's `qos:` block feeds SIZING
+//! (`EntityInventory::from_model`, all four policies since W3).
+//!
+//! Until this module the two never met. `qos_overrides./t.subscription.depth =
+//! 64` was baked into the runtime and **the arena never heard about it** —
+//! issue 1190's `BufferTooSmall` with a config-shaped cause and no diagnostic.
+//! A node whose parameter said `reliability = reliable` and whose contract said
+//! nothing was sized as if best-effort.
+//!
+//! # Why a bound check is the wrong shape
+//!
+//! Narrowing is still a disagreement. Honouring
+//! `qos_overrides./t.subscription.depth = 1` against a contract's `depth: 64`
+//! silently would leave the image running QoS the contract does not describe,
+//! and the contract is what every other consumer sizes from — the arena, XRCE's
+//! reliable buffers, zenoh's ring depth. The two must say the same thing or the
+//! build must stop.
+//!
+//! Where an override states a policy the contract OMITS, the error names the
+//! contract line to add. The contract stays the single authoritative producer;
+//! the override must not quietly become a second one.
+//!
+//! # Scope: capacity, not occupancy
+//!
+//! Only the four policies [`crate::qos_override::MODELLED_POLICIES`] marks as
+//! capacity — `reliability`, `durability`, `history`, `depth`. `deadline`,
+//! `lifespan` and the two liveliness policies bound occupancy or liveness of a
+//! queue whose size is already decided, the contract has no key for them, and
+//! they stay runtime-only.
+//!
+//! # When this abstains
+//!
+//! When the model describes NO topic wiring. Then no contract was authored (5
+//! of the tree's 114 resolvable models describe wiring, and they are exactly the
+//! 5 with a contract sidecar — issue 0973), so there is ONE producer and
+//! nothing to disagree with. That abstention is the same one
+//! `EntityInventory::from_model` makes by returning `None`, and it is why this
+//! wave changes no sizing number in the tree: neither in-tree image that states
+//! a `qos_overrides.*` parameter has a contract.
+
+use std::{collections::BTreeMap, fmt};
+
+use ros_launch_manifest_model::SystemModel;
+
+use crate::qos_override::{
+    self, QoSOverrideError, SizingStatement, parse_durability, parse_history, parse_reliability,
+    role_spelling,
+};
+
+/// What the contract says for one endpoint, in the four capacity policies.
+///
+/// The three enum policies are the RAW strings the contract wrote, not parsed
+/// values: an unreadable spelling must show up as a DISAGREEMENT naming what
+/// the author typed, never as "the contract is silent" — which is the silent
+/// drop the whole W3/W7 pair exists to refuse. (`nros ws entity-inventory`'s
+/// `reject_unknown_qos_values` gives that case its own better message on the
+/// CLI road; this road must not depend on having been there first.)
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ContractQos<'a> {
+    reliability: Option<&'a str>,
+    durability: Option<&'a str>,
+    history: Option<&'a str>,
+    depth: Option<u32>,
+}
+
+impl<'a> ContractQos<'a> {
+    fn of(q: Option<&'a ros_launch_manifest_model::Qos>) -> Self {
+        match q {
+            None => ContractQos::default(),
+            Some(q) => ContractQos {
+                reliability: q.reliability.as_deref(),
+                durability: q.durability.as_deref(),
+                history: q.history.as_deref(),
+                depth: q.depth,
+            },
+        }
+    }
+
+    /// The contract's answer for ONE policy: `None` = it states nothing,
+    /// `Some(raw)` = what it wrote.
+    fn stated(&self, statement: &SizingStatement) -> Option<String> {
+        match statement {
+            SizingStatement::Reliability(_) => self.reliability.map(str::to_string),
+            SizingStatement::Durability(_) => self.durability.map(str::to_string),
+            SizingStatement::History(_) => self.history.map(str::to_string),
+            SizingStatement::Depth(_) => self.depth.map(|d| d.to_string()),
+        }
+    }
+
+    /// Does the contract state the SAME value this override states?
+    ///
+    /// Parsed through the one vocabulary (`parse_reliability` and siblings), so
+    /// `best_effort` in a contract and `best_effort` in a parameter are the same
+    /// value rather than two strings that happen to match. A contract spelling
+    /// that does not parse can equal nothing, which is correct: it does not
+    /// state the override's value, and saying so loudly is the point.
+    fn agrees_with(&self, statement: &SizingStatement) -> bool {
+        match statement {
+            SizingStatement::Reliability(p) => {
+                self.reliability.and_then(parse_reliability) == Some(*p)
+            }
+            SizingStatement::Durability(p) => {
+                self.durability.and_then(parse_durability) == Some(*p)
+            }
+            SizingStatement::History(p) => self.history.and_then(parse_history) == Some(*p),
+            SizingStatement::Depth(d) => self.depth == Some(*d),
+        }
+    }
+}
+
+/// One `(contract, parameter)` pair that does not state the same fact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Disagreement {
+    /// The node FQN whose parameter states the override.
+    pub node: String,
+    /// The parameter key, verbatim — one of the two sites.
+    pub param_key: String,
+    /// What the override states, spelled as the author wrote it.
+    pub param_value: String,
+    /// The contract file this image resolved, when the model records one.
+    pub contract_file: Option<String>,
+    /// The contract endpoint ref (`/talker/chatter`), when one exists.
+    pub endpoint: Option<String>,
+    /// What the contract states for the same policy — `None` when it states
+    /// nothing, which is the "params-only policy" case.
+    pub contract_value: Option<String>,
+    /// The topic, as both sites name it.
+    pub topic: String,
+    /// `publisher` or `subscription`.
+    pub role: &'static str,
+    /// The policy in dispute.
+    pub policy: &'static str,
+}
+
+impl Disagreement {
+    /// The `qos:` block a user should paste into the contract, indented as the
+    /// schema nests it. Only meaningful when the endpoint ref is known; a
+    /// missing endpoint is a bigger gap than one key and says so instead.
+    fn contract_line(&self) -> String {
+        let Some(ep) = &self.endpoint else {
+            let side = if self.role == "publisher" {
+                "pub"
+            } else {
+                "sub"
+            };
+            return format!(
+                "    Declare the endpoint under the node's `{side}:` block, wire it into \
+                 `topics:` beneath `{}:`, and give it:\n            qos:\n              {}: {}",
+                self.topic, self.policy, self.param_value
+            );
+        };
+        // `/talker/chatter` → node `talker`, endpoint `chatter`. The contract
+        // addresses a node by the name its `nodes:` key uses, which is the FQN
+        // without its leading `/`.
+        let (node, local) = ep
+            .rsplit_once('/')
+            .map(|(n, l)| (n.trim_start_matches('/'), l))
+            .unwrap_or((ep.as_str(), ep.as_str()));
+        let side = if self.role == "publisher" {
+            "pub"
+        } else {
+            "sub"
+        };
+        format!(
+            "    nodes:\n      {node}:\n        {side}:\n          {local}:\n            qos:\n\
+             \x20             {}: {}",
+            self.policy, self.param_value
+        )
+    }
+}
+
+impl fmt::Display for Disagreement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "topic `{}`, {} `{}`:",
+            self.topic, self.role, self.policy
+        )?;
+        writeln!(
+            f,
+            "  parameter: `{}` = `{}`  (node `{}`)",
+            self.param_key, self.param_value, self.node
+        )?;
+        match (&self.contract_value, &self.endpoint) {
+            (Some(v), Some(ep)) => {
+                writeln!(
+                    f,
+                    "  contract : endpoint `{ep}` states `{}: {v}`{}",
+                    self.policy,
+                    self.contract_file
+                        .as_deref()
+                        .map(|p| format!("  ({p})"))
+                        .unwrap_or_default()
+                )?;
+                write!(
+                    f,
+                    "  They are two statements about one fact and they differ. Narrowing is a \
+                     disagreement too: the contract is what sizes the arena, the XRCE reliable \
+                     buffers and the zenoh ring, so honouring the parameter silently would run \
+                     QoS the contract does not describe. Change one of them."
+                )
+            }
+            (Some(v), None) => write!(
+                f,
+                "  contract : states `{}: {v}` for this topic{}, but declares no {} endpoint on \
+                 it for node `{}`.",
+                self.policy,
+                self.contract_file
+                    .as_deref()
+                    .map(|p| format!(" ({p})"))
+                    .unwrap_or_default(),
+                self.role,
+                self.node
+            ),
+            (None, ep) => {
+                match ep {
+                    Some(ep) => writeln!(
+                        f,
+                        "  contract : endpoint `{ep}` states no `{}`{}",
+                        self.policy,
+                        self.contract_file
+                            .as_deref()
+                            .map(|p| format!("  ({p})"))
+                            .unwrap_or_default()
+                    )?,
+                    None => writeln!(
+                        f,
+                        "  contract : declares no {} endpoint for node `{}` on this topic{}",
+                        self.role,
+                        self.node,
+                        self.contract_file
+                            .as_deref()
+                            .map(|p| format!("  ({p})"))
+                            .unwrap_or_default()
+                    )?,
+                }
+                writeln!(
+                    f,
+                    "  The parameter reaches the runtime table and the contract sizes the \
+                     buffers, so a policy stated on only one side is an image sized for QoS it \
+                     does not run. The contract is the authoritative producer -- state it there \
+                     too:"
+                )?;
+                write!(f, "{}", self.contract_line())
+            }
+        }
+    }
+}
+
+/// Every way this check can refuse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QosAgreementError {
+    /// A `qos_overrides.*` parameter this build cannot read at all. The same
+    /// refusals [`crate::qos_override::lower`] makes, surfaced here because the
+    /// comparison reaches the parameter first and must not quietly skip one.
+    Unreadable {
+        node: String,
+        source: QoSOverrideError,
+    },
+    /// One or more statements disagree.
+    Divergent(Vec<Disagreement>),
+}
+
+impl fmt::Display for QosAgreementError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QosAgreementError::Unreadable { node, source } => {
+                write!(f, "node `{node}`: {source}")
+            }
+            QosAgreementError::Divergent(ds) => {
+                writeln!(
+                    f,
+                    "{} QoS statement(s) disagree between the launch contract and the \
+                     `qos_overrides.*` parameters. They are two statements about one fact \
+                     (RFC-0100 D8): the parameters are baked into the runtime QoS table and the \
+                     contract is what every size consumer reads, so a divergence is an image \
+                     whose buffers do not match its delivery semantics.",
+                    ds.len()
+                )?;
+                for d in ds {
+                    writeln!(f)?;
+                    writeln!(f, "{d}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for QosAgreementError {}
+
+/// The node FQN an endpoint ref belongs to: `/talker/chatter` → `/talker`.
+///
+/// Same rule as `EntityInventory::from_model`'s `node_of`, and the same reason:
+/// the contract addresses an endpoint as `<node fqn>/<local name>`.
+fn node_of(ep: &str) -> &str {
+    ep.rsplit_once('/').map(|(n, _)| n).unwrap_or(ep)
+}
+
+/// Compare every `qos_overrides.*` parameter in `model` against the contract
+/// statement for the same endpoint.
+///
+/// See the module header for the ruling, the scope and the abstention.
+pub fn check_model(model: &SystemModel) -> Result<(), QosAgreementError> {
+    // No topic wiring means no contract statement about any topic, so there is
+    // one producer and nothing to disagree with. NOT a silent pass over a
+    // missing check: `EntityInventory::from_model` abstains on exactly this
+    // model for exactly this reason, and an image whose sizing has no contract
+    // input has no second statement to diverge from.
+    if model.structure.topics.is_empty() {
+        return Ok(());
+    }
+
+    // The contract file each scope resolved from, so a message can name the
+    // file to edit rather than "the contract".
+    let manifest_of: BTreeMap<&str, &str> = model
+        .structure
+        .scopes
+        .iter()
+        .filter_map(|(name, s)| s.manifest.as_deref().map(|m| (name.as_str(), m)))
+        .collect();
+
+    let mut out: Vec<Disagreement> = Vec::new();
+    for (fqn, inst) in &model.structure.nodes {
+        let contract_file = manifest_of.get(inst.scope.as_str()).map(|m| m.to_string());
+        for (name, value) in inst.resolved_params(fqn) {
+            let value = value.to_bake_string();
+            let stated = qos_override::sizing_statement(name.as_str(), &value).map_err(|e| {
+                QosAgreementError::Unreadable {
+                    node: fqn.clone(),
+                    source: e,
+                }
+            })?;
+            let Some(ovr) = stated else { continue };
+
+            let role = role_spelling(ovr.role);
+            let endpoints: Vec<&String> = model
+                .structure
+                .topics
+                .get(&ovr.topic)
+                .map(|w| {
+                    if ovr.role == qos_override::role::PUBLISHER {
+                        &w.publishers
+                    } else {
+                        &w.subscribers
+                    }
+                })
+                .map(|eps| eps.iter().filter(|ep| node_of(ep) == fqn).collect())
+                .unwrap_or_default();
+
+            // The contract's topic-level `qos:` block, when there is one, is
+            // the fallback statement for a topic whose endpoint states none --
+            // it is the SAME fact one level up, so reading it here keeps a
+            // contract that states a policy once from reading as silent.
+            let topic_qos = ContractQos::of(
+                model
+                    .contracts
+                    .topics
+                    .get(&ovr.topic)
+                    .and_then(|t| t.qos.as_ref()),
+            );
+
+            if endpoints.is_empty() {
+                // The contract describes this image's wiring and does not
+                // describe this endpoint. The override applies to an entity the
+                // contract never priced, which is issue 1190's shape at its
+                // widest.
+                out.push(Disagreement {
+                    node: fqn.clone(),
+                    param_key: name.clone(),
+                    param_value: ovr.statement.value(),
+                    contract_file: contract_file.clone(),
+                    endpoint: None,
+                    contract_value: topic_qos.stated(&ovr.statement),
+                    topic: ovr.topic.clone(),
+                    role,
+                    policy: ovr.statement.policy(),
+                });
+                continue;
+            }
+
+            for ep in endpoints {
+                let q = if ovr.role == qos_override::role::PUBLISHER {
+                    ContractQos::of(
+                        model
+                            .contracts
+                            .pub_endpoints
+                            .get(ep)
+                            .and_then(|c| c.qos.as_ref()),
+                    )
+                } else {
+                    ContractQos::of(
+                        model
+                            .contracts
+                            .sub_endpoints
+                            .get(ep)
+                            .and_then(|c| c.qos.as_ref()),
+                    )
+                };
+                // An endpoint that states nothing for this policy inherits the
+                // topic-level statement, if the contract made one.
+                let q = if q.stated(&ovr.statement).is_none() {
+                    ContractQos {
+                        reliability: q.reliability.or(topic_qos.reliability),
+                        durability: q.durability.or(topic_qos.durability),
+                        history: q.history.or(topic_qos.history),
+                        depth: q.depth.or(topic_qos.depth),
+                    }
+                } else {
+                    q
+                };
+                if q.agrees_with(&ovr.statement) {
+                    continue;
+                }
+                out.push(Disagreement {
+                    node: fqn.clone(),
+                    param_key: name.clone(),
+                    param_value: ovr.statement.value(),
+                    contract_file: contract_file.clone(),
+                    endpoint: Some(ep.clone()),
+                    contract_value: q.stated(&ovr.statement),
+                    topic: ovr.topic.clone(),
+                    role,
+                    policy: ovr.statement.policy(),
+                });
+            }
+        }
+    }
+
+    if out.is_empty() {
+        Ok(())
+    } else {
+        Err(QosAgreementError::Divergent(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ros_launch_manifest_model::{
+        NodeInstance, ParamValue, PubContract, Qos, ScopeInfo, SubContract, SystemModel,
+        TopicWiring,
+    };
+
+    /// A one-topic model: `/talker` publishes `/chatter`, `/listener`
+    /// subscribes, and each endpoint carries whatever `qos` the caller hands in.
+    fn model(pub_qos: Option<Qos>, sub_qos: Option<Qos>, params: &[(&str, &str)]) -> SystemModel {
+        let mut m = SystemModel::default();
+        m.structure.scopes.insert(
+            "bringup".to_string(),
+            ScopeInfo {
+                manifest: Some("/ws/launch/bringup.contract.yaml".to_string()),
+                ..ScopeInfo::default()
+            },
+        );
+        for (fqn, node_params) in [("/talker", params), ("/listener", &[] as &[(&str, &str)])] {
+            m.structure.nodes.insert(
+                fqn.to_string(),
+                NodeInstance {
+                    scope: "bringup".to_string(),
+                    pkg: Some("demo".to_string()),
+                    params: node_params
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), ParamValue::Str(v.to_string())))
+                        .collect(),
+                    ..NodeInstance::default()
+                },
+            );
+        }
+        m.structure.topics.insert(
+            "/chatter".to_string(),
+            TopicWiring {
+                msg_type: "std_msgs/msg/Int32".to_string(),
+                publishers: vec!["/talker/chatter".to_string()],
+                subscribers: vec!["/listener/chatter".to_string()],
+            },
+        );
+        m.contracts.pub_endpoints.insert(
+            "/talker/chatter".to_string(),
+            PubContract {
+                qos: pub_qos,
+                ..PubContract::default()
+            },
+        );
+        m.contracts.sub_endpoints.insert(
+            "/listener/chatter".to_string(),
+            SubContract {
+                qos: sub_qos,
+                ..SubContract::default()
+            },
+        );
+        m
+    }
+
+    fn qos(reliability: Option<&str>, depth: Option<u32>) -> Qos {
+        Qos {
+            reliability: reliability.map(str::to_string),
+            depth,
+            ..Qos::default()
+        }
+    }
+
+    fn divergences(r: Result<(), QosAgreementError>) -> Vec<Disagreement> {
+        match r {
+            Ok(()) => Vec::new(),
+            Err(QosAgreementError::Divergent(d)) => d,
+            Err(e) => panic!("expected a divergence, got: {e}"),
+        }
+    }
+
+    /// ACCEPTANCE 2 -- an agreeing pair builds.
+    #[test]
+    fn an_agreeing_pair_passes() {
+        let m = model(
+            Some(qos(Some("best_effort"), Some(8))),
+            None,
+            &[
+                (
+                    "qos_overrides./chatter.publisher.reliability",
+                    "best_effort",
+                ),
+                ("qos_overrides./chatter.publisher.depth", "8"),
+            ],
+        );
+        assert_eq!(check_model(&m), Ok(()));
+    }
+
+    /// ACCEPTANCE 1 -- a divergent pair fails, naming BOTH sites and BOTH
+    /// values.
+    #[test]
+    fn a_divergent_pair_names_both_sites_and_both_values() {
+        let m = model(
+            Some(qos(Some("reliable"), Some(8))),
+            None,
+            &[("qos_overrides./chatter.publisher.depth", "64")],
+        );
+        let d = divergences(check_model(&m));
+        assert_eq!(d.len(), 1, "{d:#?}");
+        assert_eq!(d[0].policy, "depth");
+        assert_eq!(d[0].contract_value.as_deref(), Some("8"));
+        assert_eq!(d[0].param_value, "64");
+        assert_eq!(d[0].endpoint.as_deref(), Some("/talker/chatter"));
+        let text = QosAgreementError::Divergent(d).to_string();
+        for want in [
+            "qos_overrides./chatter.publisher.depth",
+            "/ws/launch/bringup.contract.yaml",
+            "/talker/chatter",
+            "`depth: 8`",
+            "`64`",
+        ] {
+            assert!(text.contains(want), "missing `{want}` in:\n{text}");
+        }
+    }
+
+    /// NARROWING is a disagreement too -- the ruling is not a bound check.
+    #[test]
+    fn narrowing_is_a_disagreement() {
+        let m = model(
+            Some(qos(None, Some(64))),
+            None,
+            &[("qos_overrides./chatter.publisher.depth", "1")],
+        );
+        let d = divergences(check_model(&m));
+        assert_eq!(d.len(), 1, "a narrowing override must not pass: {d:#?}");
+        assert_eq!(d[0].contract_value.as_deref(), Some("64"));
+    }
+
+    /// ACCEPTANCE 3 -- a params-only policy fails, naming the contract line to
+    /// add.
+    #[test]
+    fn a_params_only_policy_names_the_contract_line_to_add() {
+        let m = model(
+            Some(qos(None, Some(8))),
+            None,
+            &[(
+                "qos_overrides./chatter.publisher.reliability",
+                "best_effort",
+            )],
+        );
+        let d = divergences(check_model(&m));
+        assert_eq!(d.len(), 1, "{d:#?}");
+        assert_eq!(d[0].contract_value, None);
+        let text = QosAgreementError::Divergent(d).to_string();
+        for want in [
+            "states no `reliability`",
+            "nodes:",
+            "talker:",
+            "pub:",
+            "chatter:",
+            "qos:",
+            "reliability: best_effort",
+        ] {
+            assert!(text.contains(want), "missing `{want}` in:\n{text}");
+        }
+    }
+
+    /// ACCEPTANCE 4 -- a contract-only policy builds. That is the normal case
+    /// and every in-tree contract is it.
+    #[test]
+    fn a_contract_only_policy_passes() {
+        let m = model(
+            Some(qos(Some("reliable"), Some(8))),
+            Some(qos(Some("best_effort"), Some(3))),
+            &[],
+        );
+        assert_eq!(check_model(&m), Ok(()));
+    }
+
+    /// A model with no topic wiring abstains -- nobody authored a contract, so
+    /// there is one producer. This is what keeps every existing image building
+    /// and every sizing number where it was.
+    #[test]
+    fn no_contract_means_nothing_to_disagree_with() {
+        let mut m = model(
+            None,
+            None,
+            &[(
+                "qos_overrides./chatter.publisher.reliability",
+                "best_effort",
+            )],
+        );
+        m.structure.topics.clear();
+        m.contracts.pub_endpoints.clear();
+        m.contracts.sub_endpoints.clear();
+        assert_eq!(check_model(&m), Ok(()));
+    }
+
+    /// The role is part of the pairing: an override on the SUBSCRIPTION side
+    /// must not be compared against the publisher's contract.
+    #[test]
+    fn the_role_selects_which_endpoint_is_compared() {
+        // The publisher states depth 8; the subscriber states 3. An override
+        // for the subscription role at 8 therefore DISAGREES, and the
+        // disagreement must name the subscriber's endpoint.
+        let mut m = model(
+            Some(qos(None, Some(8))),
+            Some(qos(None, Some(3))),
+            &[("qos_overrides./chatter.subscription.depth", "8")],
+        );
+        // Move the parameter onto the node that actually subscribes.
+        let p = m.structure.nodes["/talker"].params.clone();
+        m.structure.nodes.get_mut("/talker").unwrap().params.clear();
+        m.structure.nodes.get_mut("/listener").unwrap().params = p;
+        let d = divergences(check_model(&m));
+        assert_eq!(d.len(), 1, "{d:#?}");
+        assert_eq!(d[0].endpoint.as_deref(), Some("/listener/chatter"));
+        assert_eq!(d[0].contract_value.as_deref(), Some("3"));
+        assert_eq!(d[0].role, "subscription");
+    }
+
+    /// An override whose node has no such endpoint in the contract is the
+    /// widest form of "the contract is silent": the override applies to an
+    /// entity nothing priced.
+    #[test]
+    fn an_override_on_an_undeclared_endpoint_is_a_disagreement() {
+        let m = model(
+            Some(qos(Some("reliable"), Some(8))),
+            None,
+            &[("qos_overrides./chatter.subscription.depth", "4")],
+        );
+        // `/talker` publishes `/chatter`; it subscribes to nothing.
+        let d = divergences(check_model(&m));
+        assert_eq!(d.len(), 1, "{d:#?}");
+        assert_eq!(d[0].endpoint, None);
+        let text = QosAgreementError::Divergent(d).to_string();
+        assert!(text.contains("declares no subscription endpoint"), "{text}");
+        // The remedy is prose here rather than a pasteable block, and it must
+        // still read as YAML -- an escaped `\n` in a format string would print
+        // the two characters and tell the user to type them.
+        assert!(
+            !text.contains("\\n"),
+            "the remedy must not print `\\n`:\n{text}"
+        );
+        assert!(
+            text.contains("\n            qos:\n              depth: 4"),
+            "{text}"
+        );
+    }
+
+    /// The topic-level `qos:` block is the SAME fact one level up, so a
+    /// contract that states a policy once does not read as silent.
+    #[test]
+    fn a_topic_level_contract_statement_counts() {
+        let mut m = model(
+            None,
+            None,
+            &[(
+                "qos_overrides./chatter.publisher.reliability",
+                "best_effort",
+            )],
+        );
+        m.contracts.topics.insert(
+            "/chatter".to_string(),
+            ros_launch_manifest_model::TopicContract {
+                qos: Some(qos(Some("best_effort"), None)),
+                ..ros_launch_manifest_model::TopicContract::default()
+            },
+        );
+        assert_eq!(check_model(&m), Ok(()));
+        // …and it diverges when it says something else.
+        m.contracts.topics.get_mut("/chatter").unwrap().qos = Some(qos(Some("reliable"), None));
+        assert_eq!(divergences(check_model(&m)).len(), 1);
+    }
+
+    /// The four capacity policies, all of them -- this comparison is not the
+    /// depth check with three siblings left out.
+    #[test]
+    fn all_four_capacity_policies_are_compared() {
+        for (policy, contract_value, override_value) in [
+            ("reliability", "reliable", "best_effort"),
+            ("durability", "volatile", "transient_local"),
+            ("history", "keep_last", "keep_all"),
+            ("depth", "8", "64"),
+        ] {
+            let mut q = Qos::default();
+            match policy {
+                "reliability" => q.reliability = Some(contract_value.to_string()),
+                "durability" => q.durability = Some(contract_value.to_string()),
+                "history" => q.history = Some(contract_value.to_string()),
+                _ => q.depth = Some(contract_value.parse().unwrap()),
+            }
+            let key = format!("qos_overrides./chatter.publisher.{policy}");
+            let m = model(Some(q), None, &[(key.as_str(), override_value)]);
+            let d = divergences(check_model(&m));
+            assert_eq!(d.len(), 1, "{policy} must be compared: {d:#?}");
+            assert_eq!(d[0].policy, policy);
+            assert_eq!(d[0].contract_value.as_deref(), Some(contract_value));
+            assert_eq!(d[0].param_value, override_value);
+        }
+    }
+
+    /// The three occupancy policies are OUT of scope and must stay silent --
+    /// the contract has no key for them, so comparing them would refuse every
+    /// legal `deadline` override in the tree.
+    #[test]
+    fn occupancy_policies_are_not_compared() {
+        for (policy, value) in [
+            ("deadline", "100"),
+            ("lifespan", "250"),
+            ("liveliness", "automatic"),
+            ("liveliness_lease_duration", "500"),
+        ] {
+            let key = format!("qos_overrides./chatter.publisher.{policy}");
+            let m = model(Some(qos(None, Some(8))), None, &[(key.as_str(), value)]);
+            assert_eq!(check_model(&m), Ok(()), "{policy} must not be compared");
+        }
+    }
+
+    /// An override this build cannot read is an ERROR here too. The comparison
+    /// reaches the parameter before the bake does, and a skip would be the
+    /// silence issue 0303 removed.
+    #[test]
+    fn an_unreadable_override_is_an_error_not_a_skip() {
+        let m = model(
+            Some(qos(None, Some(8))),
+            None,
+            &[("qos_overrides./chatter.pub.depth", "8")],
+        );
+        let e = check_model(&m).unwrap_err();
+        assert!(matches!(e, QosAgreementError::Unreadable { .. }), "{e:?}");
+        assert!(e.to_string().contains("publisher"), "{e}");
+    }
+}

--- a/packages/core/nros-orchestration-ir/src/qos_override.rs
+++ b/packages/core/nros-orchestration-ir/src/qos_override.rs
@@ -108,6 +108,33 @@ impl std::error::Error for QoSOverrideError {}
 const POLICY_NAMES: &str = "reliability, durability, history, depth, deadline, lifespan, \
                             liveliness, liveliness_lease_duration";
 
+/// Every policy [`lower`] accepts, and whether it bounds CAPACITY.
+///
+/// phase-454 W7 (RFC-0100 D8). The second flag is the whole of this wave's
+/// scope decision, so it is a field rather than a comment: `reliability`,
+/// `durability`, `history` and `depth` decide how many bytes an image must
+/// reserve, and the launch CONTRACT states the same four per endpoint
+/// (`QosDecl`, read since W3). Those two statements have to agree.
+/// `deadline`, `lifespan` and the two liveliness policies bound OCCUPANCY or
+/// LIVENESS of a queue whose size is already decided, so they stay
+/// runtime-only and the contract has no key for them.
+///
+/// A table and not a `match` because it is read by three things that must not
+/// drift: [`sizing_statement`] classifies a policy against it, `POLICY_NAMES`
+/// enumerates it for the diagnostic, and the tests assert that what [`lower`]
+/// accepts is exactly what this lists — a new policy that reaches `lower` and
+/// not this table is a policy nobody decided the sizing question for.
+pub const MODELLED_POLICIES: [(&str, bool); 8] = [
+    ("reliability", true),
+    ("durability", true),
+    ("history", true),
+    ("depth", true),
+    ("deadline", false),
+    ("lifespan", false),
+    ("liveliness", false),
+    ("liveliness_lease_duration", false),
+];
+
 // ---------------------------------------------------------------------------
 // The VALUE vocabulary -- phase-454 W3.
 // ---------------------------------------------------------------------------
@@ -211,12 +238,29 @@ pub fn is_qos_override(name: &str) -> bool {
     name.starts_with(QOS_OVERRIDE_PREFIX)
 }
 
-/// Lower one `qos_overrides.<topic>.<role>.<policy>` parameter.
+/// The canonical spelling of a [`qos_override_role`] code, for a diagnostic.
 ///
-/// Returns `Ok(None)` when `name` is not a QoS override at all — the caller is
-/// walking a mixed parameter list. A name that DOES carry the prefix but is
-/// unusable is an `Err`, never a skip.
-pub fn lower(name: &str, value: &str) -> Result<Option<LoweredOverride>, QoSOverrideError> {
+/// The inverse of the role match in [`split_key`], and the reason it is a
+/// function: phase-454 W7's messages name the role the author WROTE, and a
+/// message that respelled it would send someone looking for a key they did not
+/// type.
+pub fn role_spelling(role: u8) -> &'static str {
+    match role {
+        qos_override_role::SUBSCRIPTION => "subscription",
+        // `PUBLISHER` is 0 and a code this build does not know cannot be
+        // produced by `split_key`, which is the only producer.
+        _ => "publisher",
+    }
+}
+
+/// Split `qos_overrides.<topic>.<role>.<policy>` into its three segments.
+///
+/// `Ok(None)` when `name` carries no prefix. THE one parser of the key shape:
+/// [`lower`] and [`sizing_statement`] are two readers of the same parameter and
+/// this module's own header says what a second spelling costs. The VALUE
+/// vocabulary is shared the same way, through `parse_reliability` and its
+/// siblings.
+fn split_key(name: &str) -> Result<Option<(&str, u8, &str)>, QoSOverrideError> {
     let Some(rest) = name.strip_prefix(QOS_OVERRIDE_PREFIX) else {
         return Ok(None);
     };
@@ -243,6 +287,19 @@ pub fn lower(name: &str, value: &str) -> Result<Option<LoweredOverride>, QoSOver
             });
         }
     };
+    Ok(Some((topic, role, policy_s)))
+}
+
+/// Lower one `qos_overrides.<topic>.<role>.<policy>` parameter.
+///
+/// Returns `Ok(None)` when `name` is not a QoS override at all — the caller is
+/// walking a mixed parameter list. A name that DOES carry the prefix but is
+/// unusable is an `Err`, never a skip.
+pub fn lower(name: &str, value: &str) -> Result<Option<LoweredOverride>, QoSOverrideError> {
+    let Some((topic, role, policy_s)) = split_key(name)? else {
+        return Ok(None);
+    };
+    let key = name.to_string();
 
     let v = value.trim();
     let bad = |expected: &'static str| QoSOverrideError::BadValue {
@@ -343,6 +400,110 @@ pub fn lower(name: &str, value: &str) -> Result<Option<LoweredOverride>, QoSOver
         role,
         policy,
         value,
+    }))
+}
+
+/// What one `qos_overrides.*` parameter states about SIZING, in the same
+/// vocabulary the launch contract states it in (phase-454 W7, RFC-0100 D8).
+///
+/// The four capacity policies of [`MODELLED_POLICIES`] and no others. This is
+/// deliberately NOT the wire encoding [`LoweredOverride`] carries: comparing an
+/// override against a contract is a comparison of two AUTHORED statements, and
+/// the wire's `0`/`1` are an ABI that says nothing about what either author
+/// wrote. `reliability_spelling` and its siblings render these back out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SizingStatement {
+    Reliability(QoSReliabilityPolicy),
+    Durability(QoSDurabilityPolicy),
+    History(QoSHistoryPolicy),
+    Depth(u32),
+}
+
+impl SizingStatement {
+    /// The policy's spelling in a parameter key and in a contract `qos:` block
+    /// — one name, because it is one fact stated twice.
+    pub fn policy(&self) -> &'static str {
+        match self {
+            SizingStatement::Reliability(_) => "reliability",
+            SizingStatement::Durability(_) => "durability",
+            SizingStatement::History(_) => "history",
+            SizingStatement::Depth(_) => "depth",
+        }
+    }
+
+    /// The VALUE, spelled as an author would write it on either surface.
+    pub fn value(&self) -> String {
+        match self {
+            SizingStatement::Reliability(p) => reliability_spelling(*p).to_string(),
+            SizingStatement::Durability(p) => durability_spelling(*p).to_string(),
+            SizingStatement::History(p) => history_spelling(*p).to_string(),
+            SizingStatement::Depth(d) => d.to_string(),
+        }
+    }
+}
+
+/// One override's statement about sizing: `(topic, role, statement)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SizingOverride {
+    /// Resolved topic, e.g. `"/chatter"`.
+    pub topic: String,
+    /// [`qos_override_role`] code.
+    pub role: u8,
+    pub statement: SizingStatement,
+}
+
+/// Read one parameter as a statement about SIZING.
+///
+/// Three outcomes, and keeping them apart is the point:
+///
+/// * `Ok(None)` — the parameter is not an override, or it is an override of a
+///   policy that bounds occupancy rather than capacity ([`MODELLED_POLICIES`]'s
+///   second column). Nothing to compare; the runtime table still bakes it.
+/// * `Ok(Some(_))` — what this parameter says about a buffer's size.
+/// * `Err(_)` — the same refusals [`lower`] makes, from the same parser and the
+///   same value vocabulary. A caller that reached this before the bake must not
+///   get a second opinion about whether the key is usable.
+pub fn sizing_statement(
+    name: &str,
+    value: &str,
+) -> Result<Option<SizingOverride>, QoSOverrideError> {
+    let Some((topic, role, policy_s)) = split_key(name)? else {
+        return Ok(None);
+    };
+    let v = value.trim();
+    let bad = |expected: &'static str| QoSOverrideError::BadValue {
+        key: name.to_string(),
+        policy: policy_s.to_string(),
+        value: v.to_string(),
+        expected,
+    };
+    let statement = match policy_s {
+        "reliability" => SizingStatement::Reliability(
+            parse_reliability(v).ok_or_else(|| bad(RELIABILITY_VALUES))?,
+        ),
+        "durability" => {
+            SizingStatement::Durability(parse_durability(v).ok_or_else(|| bad(DURABILITY_VALUES))?)
+        }
+        "history" => SizingStatement::History(parse_history(v).ok_or_else(|| bad(HISTORY_VALUES))?),
+        "depth" => SizingStatement::Depth(
+            v.parse::<u32>()
+                .map_err(|_| bad("a non-negative integer"))?,
+        ),
+        // Modelled, and not a capacity: `deadline`, `lifespan` and the two
+        // liveliness policies. `None` rather than an error — they are perfectly
+        // legal overrides that this comparison has nothing to say about.
+        other if MODELLED_POLICIES.iter().any(|(n, _)| *n == other) => return Ok(None),
+        _ => {
+            return Err(QoSOverrideError::UnknownPolicy {
+                key: name.to_string(),
+                policy: policy_s.to_string(),
+            });
+        }
+    };
+    Ok(Some(SizingOverride {
+        topic: topic.to_string(),
+        role,
+        statement,
     }))
 }
 
@@ -579,6 +740,142 @@ mod tests {
         assert_eq!(got.len(), 2);
         assert_eq!(got[0].topic, "/a");
         assert_eq!(got[1].topic, "/z");
+    }
+
+    /// phase-454 W7 -- `lower` and `sizing_statement` accept exactly the same
+    /// policy names, and [`MODELLED_POLICIES`] lists exactly those.
+    ///
+    /// Three readers of one vocabulary: the bake, the sizing comparison, and
+    /// the `POLICY_NAMES` diagnostic. A policy added to `lower` and forgotten
+    /// in the table is one nobody answered the capacity question for -- it
+    /// would silently become "not a capacity", which is the safe-looking
+    /// direction and the wrong one. This is the test that makes it a decision.
+    #[test]
+    fn every_lowerable_policy_is_classified_for_sizing() {
+        // A value that parses for whichever policy it is handed to. `1` is a
+        // legal depth and a legal duration; the three enum policies get their
+        // own spellings below.
+        let value_for = |policy: &str| match policy {
+            "reliability" => "reliable",
+            "durability" => "volatile",
+            "history" => "keep_last",
+            "liveliness" => "automatic",
+            _ => "1",
+        };
+        for (policy, is_capacity) in MODELLED_POLICIES {
+            let key = format!("qos_overrides./t.publisher.{policy}");
+            let v = value_for(policy);
+            lower(&key, v)
+                .unwrap_or_else(|e| panic!("{policy} must lower: {e}"))
+                .unwrap_or_else(|| panic!("{policy} must be recognised as an override"));
+            let sized =
+                sizing_statement(&key, v).unwrap_or_else(|e| panic!("{policy} must classify: {e}"));
+            assert_eq!(
+                sized.is_some(),
+                is_capacity,
+                "`{policy}` is classified {} by MODELLED_POLICIES and the other way by \
+                 sizing_statement",
+                if is_capacity { "capacity" } else { "occupancy" }
+            );
+            if let Some(s) = sized {
+                assert_eq!(s.statement.policy(), policy);
+            }
+            assert!(
+                POLICY_NAMES.contains(policy),
+                "`{policy}` is modelled but the diagnostic does not list it"
+            );
+        }
+        // …and nothing outside the table lowers, so the two lists cannot drift
+        // by an ADDITION to `lower` either.
+        for policy in ["bandwidth", "reliability_", "", "Depth"] {
+            let key = format!("qos_overrides./t.publisher.{policy}");
+            assert!(lower(&key, "1").is_err(), "`{policy}` must not lower");
+        }
+    }
+
+    /// phase-454 W7 -- the two readers agree about the VALUE, not just the
+    /// name.
+    ///
+    /// `lower` produces the wire's `0`/`1` and `sizing_statement` produces the
+    /// variant; they are two encodings of one authored value, so this asserts
+    /// the pairing rather than either half. A renumbered wire code or a
+    /// mis-mapped spelling shows up here as a mismatched pair.
+    #[test]
+    fn the_bake_and_the_sizing_statement_read_one_value() {
+        let cases: &[(&str, &str, SizingStatement, u32)] = &[
+            (
+                "reliability",
+                "best_effort",
+                SizingStatement::Reliability(QoSReliabilityPolicy::BestEffort),
+                0,
+            ),
+            (
+                "reliability",
+                "reliable",
+                SizingStatement::Reliability(QoSReliabilityPolicy::Reliable),
+                1,
+            ),
+            (
+                "durability",
+                "volatile",
+                SizingStatement::Durability(QoSDurabilityPolicy::Volatile),
+                0,
+            ),
+            (
+                "durability",
+                "transient_local",
+                SizingStatement::Durability(QoSDurabilityPolicy::TransientLocal),
+                1,
+            ),
+            (
+                "history",
+                "keep_last",
+                SizingStatement::History(QoSHistoryPolicy::KeepLast),
+                0,
+            ),
+            (
+                "history",
+                "keep_all",
+                SizingStatement::History(QoSHistoryPolicy::KeepAll),
+                1,
+            ),
+            ("depth", "64", SizingStatement::Depth(64), 64),
+        ];
+        for (policy, written, statement, wire) in cases {
+            let key = format!("qos_overrides./chatter.subscription.{policy}");
+            let lowered = lower(&key, written).unwrap().unwrap();
+            let sized = sizing_statement(&key, written).unwrap().unwrap();
+            assert_eq!(lowered.value, *wire, "{policy}={written} wire code");
+            assert_eq!(sized.statement, *statement, "{policy}={written} statement");
+            assert_eq!(sized.topic, lowered.topic);
+            assert_eq!(sized.role, lowered.role);
+            assert_eq!(
+                sized.statement.value(),
+                *written,
+                "the statement must render back to what the author wrote"
+            );
+        }
+    }
+
+    /// phase-454 W7 -- the shared key parser refuses the same keys on both
+    /// roads. A sizing comparison that accepted `pub` where the bake refuses it
+    /// would compare an endpoint nothing runs.
+    #[test]
+    fn both_readers_refuse_the_same_keys() {
+        for key in [
+            "qos_overrides.",
+            "qos_overrides./t",
+            "qos_overrides./t.publisher",
+            "qos_overrides./t..depth",
+            "qos_overrides./t.pub.depth",
+        ] {
+            assert!(lower(key, "1").is_err(), "{key} must not lower");
+            assert!(
+                sizing_statement(key, "1").is_err(),
+                "{key} must not classify"
+            );
+        }
+        assert_eq!(sizing_statement("use_sim_time", "true").unwrap(), None);
     }
 
     /// One bad override fails the whole list — a half-applied QoS table is


### PR DESCRIPTION
phase-454 W7. Carries W3 (#984) and W4 (#993); the queue drops them by patch-id.

## The defect

`qos_overrides.<topic>.<role>.<policy>` fed the baked **runtime** table; the
contract fed **sizing**; the two never met. So an image could bake `depth = 64`
while the arena was sized from `depth = 3` — issue 1190's `BufferTooSmall` with a
config-shaped cause and no diagnostic.

RFC-0100 **D8**: they are two statements about one fact, so any divergence is a
build error naming both sites. Not a bound check — **narrowing is a disagreement
too**, because honouring it silently means the image runs QoS the contract does
not describe.

## Four roads, not two

`nros_orchestration_ir::qos_agreement::check_model`, one function over a resolved
`SystemModel`, called from:

| road | behaviour |
| --- | --- |
| `cmd::entity_inventory::run` (configure) | fatal, beside W3's `reject_unknown_qos_values` |
| `cmd::build` stage-3.5 seed | refusal reason (W3's own split) |
| `codegen::entry::plan_from_model` | fatal — C/C++ entry + `nros build`'s Rust entry |
| `nros::main!` (`main_macro.rs`) | compile error |

**Four because only a *bake* road is guaranteed to see an override** — an image
can bake `depth=64` without ever running `entity-inventory --model`, and that
*is* 1190 — **and only a *sizing* road is guaranteed to see the contract.** It
lives in `nros-orchestration-ir` because the proc-macro cannot dep
`nros-cli-core`.

**Scope** is `MODELLED_POLICIES`: each of the eight policies `lower` accepts
carries a capacity/occupancy flag, and only `reliability`/`durability`/`history`/
`depth` are compared. `deadline`/`lifespan`/`liveliness*` stay runtime-only — the
`agrees` fixture carries a `deadline`, so a widened scope is a red.

**One vocabulary**: `lower` and the new `sizing_statement` share `split_key` and
W3's `parse_*` functions, bound by three tests (same names accepted, one value
read two ways, same keys refused) rather than testing each separately.

**Abstains** where the model describes no topic wiring — nothing to disagree
with. 109 of 114 models, including both in-tree `qos_overrides.*` producers.

## Error text, live

Divergent, both directions in one model:

```
2 QoS statement(s) disagree between the launch contract and the `qos_overrides.*` parameters.
topic `/chatter`, publisher `reliability`:
  parameter: `qos_overrides./chatter.publisher.reliability` = `best_effort`  (node `/talker`)
  contract : endpoint `/talker/chatter` states `reliability: reliable`
  They are two statements about one fact and they differ. Narrowing is a disagreement too: …
```

Params-only names the contract line to add, as a pasteable block:

```
  contract : endpoint `/listener/chatter` states no `reliability`
    nodes:
      listener:
        sub:
          chatter:
            qos:
              reliability: reliable
```

## Sizing-unchanged proof, mechanical

`nros ws entity-inventory --model` over **all 82** in-tree launch files, with a
CLI built from the base and again from this branch. The recordings differ in
**exactly two places** — this wave's own divergence fixtures flipping `rc=0 →
rc=1`. Every other model, all five contract-bearing ones included, emits
byte-identical knobs.

**The diff also captures the bug**: before W7 the `diverges` model derived
`NROS_EXECUTOR_MAX_CBS=1` and **exited 0** with `depth: 64` in the runtime and
`depth: 3` sizing the buffers.

Structurally, no derivation file is touched — `entity_inventory.rs`, `derive.rs`,
`executor_sizing.rs`, `cyclonedds_type_sizing.rs`, `declared_params.rs` all
unchanged — and the four call sites are `?` statements whose value nothing
consumes.

## Negative control

`agrees.contract.yaml`'s `depth: 3` → `4`: red, naming parameter, endpoint,
contract file and both values. Reverted: same three knobs as before. A
one-character edit to an otherwise-passing file.

## Gates

`cli-fresh` OK · `fast` OK (313, 2 skipped) · `build` **20/21** · `api-parity` OK
· `test-unit` 1486 run / 1484 passed / 2 `[SKIPPED]` preconditions, exit 0 ·
`test-lane-contracts` 17/17 · `cli-tests` PASSED. `fmt` and `clippy -D warnings`
clean on both workspaces.

`test-targets` and `workspace-all` were red on **my own** clippy
(`doc_overindented_list_items`) — fixed, both green. `rmw-uorb`, `rmw-xrce` and
`staticlib-symbols` went **green** once `NROS_REPO_DIR` pointed at this worktree
and the vendored sources were provisioned (issue #1280, fixed in #1004). The one
remaining red is `cpp` — issue **#1331**, pre-existing.

## Not this diff

W3's CLI-stamp worktree defect recurred: `nros-cli-core/build.rs` registers
`rerun-if-changed=<root>/.git/index`, but `.git` is a *file* in a linked
worktree, so committing moves the recomputed stamp while the baked one stands and
`just setup-cli` reports success without rebuilding. Worked around by touching
`lib.rs`. That is **issue #1336**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1