### PR TITLE
feat(phase-454 W6.b): XRCE sizes from the descriptor — 83% off a session, and reliability cannot buy what the brief assumed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-platform-config",
  "nros-rmw-cffi",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
 ]
 

--- a/docs/design/0100-rmw-agnostic-sizing-model.md
+++ b/docs/design/0100-rmw-agnostic-sizing-model.md
@@ -291,7 +291,7 @@ maintainer of that backend reads it.
 | --- | --- | --- | --- |
 | executor | counts; per-endpoint `depth`+`history`; rx class; `[target]` | `MAX_CBS`, `ARENA_SIZE`, `BACKING_U64S` | partly derived; rx class is the dead knob above |
 | zenoh | counts; `depth`; small/large bounds; service req/resp bounds; `[policy]` | `ZPICO_MAX_*`, `SUBSCRIBER_RING_DEPTH`, payload pools, `SERVICE_BUFFERS` | counts and payload classes derived; ring depth DERIVED from the declared depths (phase-454 W6.a, −124,032 B measured); `SERVICE_BUFFERS`'s slot size takes the declared service bound as its default and carries a stated non-annotation — but **no service or action type has a bound row to read** (`record_message` runs for `.msg` only), so it refuses on every image today |
-| XRCE | counts (**zero legal**); per-family bounds; `depth`; MTU; `reliability` | `MAX_*`, per-family `BUFFER_SIZE`, ring depths, `STREAM_HISTORY` | two counts derivable via `-1`; one global `BUFFER_SIZE = 1024` serves three families; reliability unread |
+| XRCE | counts (**zero legal**); per-family bounds; `depth`; MTU; `reliability` | `MAX_*`, per-family `BUFFER_SIZE`, ring depths, `STREAM_HISTORY` | phase-454 W6.b: `BUFFER_SIZE` split into three family knobs; `reliability` gates `STREAM_HISTORY` down to its protocol floor; the SUBSCRIBER family's bound and ring depth derive together (separately they can GROW the pool — measured). The two SERVICE families are split and not derived: the parameter and lifecycle server families are not `[[endpoint]]` rows |
 | Cyclone | `[types]`, `[target].heap_budget_bytes`. **Nothing else** | `MAX_TYPES`, `MAX_DESCRIPTOR_TYPES`, `MAX_FIELDS`, `MAX_KINDS`, heap assertion | **all derived, phase-454 W6.c** |
 | uORB | distinct topic count; subscription count | `REGISTRY_CAPACITY`, `PX4_MAX_CALLBACKS` | neither wired |
 | cffi | subscription count; node count; backend count | `RMW_SUBSCRIBER_SLOTS`, `MAX_NODES`, `MAX_BACKENDS` | slots derived; `max_nodes = components().len()` computed and discarded |
@@ -534,7 +534,7 @@ state, and "nobody said" is not "too small" (D6).
 | gap | bytes | direction | cause |
 | --- | --- | --- | --- |
 | Rust typed on a schemaless backend | 1,848 per subscription | **UNDER** (issue 1319) | the registration path decides the slot size and the build cannot see it |
-| XRCE reliable streams | ~131,072 per session | over | reliability declared but unread |
+| XRCE reliable streams | ~131,072 per session, **98,304 of it recoverable** | over | reliability declared but unread. Recovered by phase-454 W6.b, measured: the two buffers drop to `SLOTS = 4` on a best-effort-only image. The residue is not a leak — both streams carry session CONTROL (every entity CREATE/DELETE, and the `uxr_buffer_request_data` that names the input stream for every reader whatever its QoS), so the `SLOTS` term shrinks to the protocol floor and the pool does not vanish |
 | zenoh `SERVICE_BUFFERS` | 144,128 on a native talker | over | not derived, not in the inventory |
 | island arena, depth 10 vs declared | 135,432 | over | 207,096 against 71,664 with the eleven `QoS(1)` declarations the code already makes |
 

--- a/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
+++ b/docs/roadmap/phase-454-contract-states-facts-backends-derive.md
@@ -218,7 +218,7 @@ One sub-wave per consumer; they are independent and can run in parallel.
 | sub-wave | backend | lands |
 | --- | --- | --- |
 | W6.a | zenoh | `SUBSCRIBER_RING_DEPTH` from declared depth (authored today); `SERVICE_BUFFERS` derived from request/response bounds and given a `// nros-pool:` annotation or a stated reason — it is 144,128 B on a native talker and in neither |
-| W6.b | XRCE | `reliability` gates the two 64 KiB `*_reliable_buf`; one global `BUFFER_SIZE = 1024` splits into three per-family sizes; ring depths take declared depth as their default |
+| W6.b | XRCE | **Landed.** `reliability` gates the two 64 KiB `*_reliable_buf`; one global `BUFFER_SIZE = 1024` splits into three per-family sizes; the subscriber ring takes declared bound and depth. See the correction below — the streams shrink to a protocol floor rather than vanishing, and two of the three families are split but not derived |
 | W6.c | Cyclone | **LANDED** — `MAX_DESCRIPTOR_TYPES` derived from the same count as `MAX_TYPES` (silent-drop overflow at ~86 types today); `MAX_FIELDS`/`MAX_KINDS`/`MAX_NESTED_DEPTH` from the schema walk codegen already does; heap budget asserted at boot (D11) |
 | W6.d | uORB | `REGISTRY_CAPACITY` and `PX4_MAX_CALLBACKS` — both trivially derivable, neither wired |
 | W6.e | cffi | `MAX_NODES` from `components().len()`, which is already computed and discarded |
@@ -292,6 +292,46 @@ Three outcomes, the same three W4 established: no descriptor → byte-identical 
 every build before this wave (verified: both constants unchanged, no warning
 printed); a refused field → the builtin plus a `cargo::warning` naming the
 refusal; a corrupt descriptor → a hard build error naming the file.
+
+#### W6.b — XRCE — **LANDED**
+
+**"Stops paying both buffers" was not available, and the reason is structural.**
+Both reliable streams stay LIVE on a best-effort-only image, because this
+backend sends *every control message* on `st->output_reliable` — participant,
+topic, publisher, datawriter and datareader CREATE, DELETE,
+`uxr_buffer_request_data` — and `uxr_buffer_request_data` names
+`st->input_reliable` as the stream the Agent delivers on, for **every reader,
+whatever its QoS**. A declaration about data delivery is not a licence to make
+session setup lossy, so what `reliability` gates is the `SLOTS` term, down to
+the protocol floor of 4 that D2 already writes into its own table. Measured on
+`xrce_session_state_t` (x86-64, defaults otherwise): **427,968 → 329,664**, i.e.
+**98,304 bytes of the 131,072**, and the residue is a protocol requirement
+rather than money on the table.
+
+**Only the subscriber family is derived; the two service families are split and
+not.** The parameter (6 per node) and lifecycle (5) families open service
+servers that no `[[endpoint]]` row itemises, and an action server opens three
+more — so a size taken from the declared service rows alone is short for exactly
+those, in the UNDER direction. That is D6's `undeclared_endpoints != 0` rule
+reaching a set the field does not count. The split still lands in full: three
+macros, three arrays, three knobs, each settable.
+
+**The subscriber pool's two factors move TOGETHER or not at all,** and the
+mutation control is measured rather than argued: a declared `std_msgs/msg/String`
+prices its ring entry at 1,174 bytes against the literal 1,024 while a declared
+`depth = 10` prices the ring at 10 entries against the literal 32, so taking the
+bound WITHOUT the depth is **427,968 → 466,880, a 38,912-byte growth**. Taking
+both, at depth 1: **427,968 → 72,960**, and with the reliability gate as well
+**→ 72,960 from 171,264**. A pool sized from one declaration and one literal
+describes no image at all.
+
+**`mem-report --baseline` cannot show any of this**, and that is a property of
+the pool rather than of the tool: `xrce_session_state_t` is ONE
+`nros_platform_alloc` at session open, and `mem-report` joins declared pools to
+ELF SYMBOLS. The figures above are `sizeof` under the two `-D` sets. The knobs
+themselves ARE enumerable — all three reach `static-pool-inventory.md` with
+their defaults, which needed `gen-pool-inventory.py` to follow a `#ifndef`
+default that is another guarded MACRO rather than a literal.
 
 #### W6.c — Cyclone — **LANDED**
 
@@ -495,7 +535,7 @@ named image, each with a before/after from `just mem-report --baseline`:
 | gap | direction | acceptance |
 | --- | --- | --- |
 | Rust typed on a schemaless backend (issue 1319) | **UNDER**, 1,848 B per subscription | a reproduction that fails with `BufferTooSmall` FIRST, then passes |
-| XRCE reliable streams | over, ~131,072 B per session | a best-effort-only image stops paying both buffers |
+| XRCE reliable streams | over, ~131,072 B per session | **MET at 98,304 B** (W6.b, measured): a best-effort-only image drops both buffers to the protocol floor. It cannot drop them entirely — both streams carry session control for every image, whatever its QoS; see "W6.b, as built" |
 | zenoh `SERVICE_BUFFERS` | over, 144,128 B (native talker) | derived, and either annotated or given a stated reason |
 | island arena, declared vs default depth | over, 135,432 B (207,096 → 71,664) | already true on the Zephyr road; holds on the cargo road too |
 

--- a/packages/api/nros/src/guide/configuration.rs
+++ b/packages/api/nros/src/guide/configuration.rs
@@ -33,8 +33,19 @@
 //! | Variable | Description | Posix | Embedded |
 //! |----------|-------------|-------|----------|
 //! | `XRCE_TRANSPORT_MTU` | Transport MTU (also sizes stream buffers) | 4096 | 512 |
-//! | `XRCE_BUFFER_SIZE` | Per-entity static buffer size | 1024 | 1024 |
+//! | `XRCE_BUFFER_SIZE` | Default of the three receive families below | 1024 | 1024 |
+//! | `XRCE_SUBSCRIBER_BUFFER_SIZE` | Subscriber ring entry | `XRCE_BUFFER_SIZE` | ditto |
+//! | `XRCE_SERVICE_REQUEST_BUFFER_SIZE` | Service-server request entry | `XRCE_BUFFER_SIZE` | ditto |
+//! | `XRCE_SERVICE_REPLY_BUFFER_SIZE` | Service-client reply slot | `XRCE_BUFFER_SIZE` | ditto |
 //! | `XRCE_STREAM_HISTORY` | Reliable stream history depth (>= 2) | 4 | 4 |
+//!
+//! The three families were one number until phase-454 W6.b, so a subscriber
+//! ring entry paid for the largest type a SERVICE carried, 32 x 8 times over.
+//! Two of them are also DERIVED from what the image declares when it declares
+//! it (RFC-0100): the subscriber entry takes the largest wire bound over the
+//! declared subscriptions and `XRCE_STREAM_HISTORY` drops to the protocol
+//! floor of 4 when no endpoint declares `reliability = reliable`. Stating
+//! either here still wins.
 //!
 //! **Core (`NROS_*`, C API only):**
 //!

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-platform-config",
  "nros-rmw-cffi",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
 ]
 

--- a/packages/rmw/xrce/nros-rmw-xrce-cffi/Cargo.toml
+++ b/packages/rmw/xrce/nros-rmw-xrce-cffi/Cargo.toml
@@ -67,6 +67,12 @@ nros-cc-flags = { path = "../../../tooling/nros-cc-flags" }
 # RUST image inherits none of cmake's `set(ENV{...})` exports. One spelling of
 # the `$DOTCONFIG` fallback, shared with the zenoh shim.
 nros-zephyr-build = { path = "../../../tooling/nros-zephyr-build" }
+# phase-454 W6.b (RFC-0100 D4/D5) — the ONE reader of
+# `<build>/nros/sizing/<entry>.toml`. Never hand-parse it: six hand-written TOML
+# parsers over one schema is six answers to "what does an absent `depth` mean",
+# and the three the reader gives (stated / refused / absent) are the whole
+# point.
+nros-sizing-descriptor = { path = "../../../tooling/nros-sizing-descriptor" }
 
 [lints]
 workspace = true

--- a/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
+++ b/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
@@ -69,6 +69,14 @@ const VENDOR_BUILD_POINTER: &str = "nros-xrce-vendor-build.txt";
 // lanes had already stopped agreeing.
 
 fn main() {
+    // phase-454 W6.b — the derivation's negative controls, on the NORMAL path.
+    // A control nobody runs decays into a comment (`check-gate-selftests`
+    // holds the same line for the Python gates), and this one guards a rule
+    // whose failure is silent in the expensive direction: an image whose pool
+    // grew because half the formula came from a declaration and half from a
+    // literal still builds, boots and passes every knob gate.
+    xrce_demand_selftest();
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     // phase-321 W2.d — FOUR parents, not three. The crate sits at
     // packages/rmw/xrce/nros-rmw-xrce-cffi/, one level deeper than the old
@@ -339,8 +347,18 @@ fn main() {
     // it in an `#ifndef`, and that is the one statement of it. Nothing stated
     // ⇒ nothing defined ⇒ the header's default stands, identically in both
     // lanes.
+    //
+    // phase-454 W6.b — rung 3.5 sits between them: what the image's own
+    // declarations imply, read from the sizing descriptor (RFC-0100 D4/D5). A
+    // stated value still wins, and an image with no descriptor reaches exactly
+    // the bytes it did before this wave.
+    let demand = XrceDemand::derive(sizing_descriptor().as_ref());
+    demand.report();
     for row in &config.defines {
-        if let Some(n) = knobs.stated(&row.env, row.min, &config_path) {
+        let value = knobs
+            .stated(&row.env, row.min, &config_path)
+            .or_else(|| demand.for_knob(&row.env));
+        if let Some(n) = value {
             build.define(&row.macro_name, n.to_string().as_str());
         }
     }
@@ -872,4 +890,467 @@ impl ConfigManifest {
     fn flags_for(&self, template: &str) -> impl Iterator<Item = &FlagRow> {
         self.flags.iter().filter(move |r| r.template == template)
     }
+}
+
+// ---------------------------------------------------------------------------
+// phase-454 W6.b — what this image's own declarations imply for the XRCE pools.
+//
+// RFC-0100 D5: "the backend owns its formula, in its own build". So the
+// arithmetic is here, beside the `cc::Build` that applies it, rather than in the
+// shared reader — adding a fifth backend must touch no shared code, and a
+// maintainer of this backend must not have to read another crate to find out
+// how its buffers are sized.
+//
+// D2 gives the shape, one line per pool:
+//
+//   pool_bytes = COUNT(class) x SLOTS(class) x SLOT_BYTES(class) + fixed
+//
+//   reliable stream buffers  COUNT 1 per session  SLOTS history   SLOT_BYTES MTU
+//   subscriber slots         COUNT subscriptions  SLOTS ring depth SLOT_BYTES bound
+//
+// The COUNT terms are already derived, on a road that predates this one
+// (`NROS_XRCE_MAX_SUBSCRIBERS` and its two siblings, issue 1033, where ZERO is
+// the answer and worth 33,296 bytes a slot). What this adds is the other two
+// factors.
+// ---------------------------------------------------------------------------
+
+use nros_sizing_descriptor::{Basis, Endpoint, EndpointKind, Reliability, SizingDescriptor};
+use std::collections::BTreeMap;
+
+// The 4-byte CDR header `internal.h` names, and `xrce_stage_inbound` refuses a
+// payload unless `len + header <= cap` — so a buffer sized at the bound alone
+// is four bytes short of every message that actually reaches the bound.
+const CDR_HEADER_LEN: usize = 4;
+
+// The reliable streams' history when no endpoint declares reliable delivery.
+//
+// Not zero, and the reason is in `internal.h` beside the knob: both reliable
+// streams stay LIVE on a best-effort-only image, because every control message
+// this backend sends rides the output reliable stream and `uxr_buffer_request_data`
+// names the input reliable stream as the Agent's delivery stream for every
+// reader whatever its QoS. A declaration about DATA delivery is not a licence to
+// make session setup lossy. Four is the protocol floor the header's `#error`
+// states (reliable retransmit headroom), and upstream splits the buffer into
+// `history` blocks, so an MTU-sized message still fits at 4.
+const RELIABLE_CONTROL_HISTORY: usize = 4;
+
+// Both buffers, at the default history and the default MTU — the number a
+// declaration is worth, quoted in the refusal that says so.
+const RELIABLE_STREAM_SAVING_BYTES: usize = 2 * (16 - RELIABLE_CONTROL_HISTORY) * 4096;
+
+const ENV_STREAM_HISTORY: &str = "NROS_XRCE_STREAM_HISTORY";
+const ENV_SUBSCRIBER_BUFFER: &str = "NROS_XRCE_SUBSCRIBER_BUFFER_SIZE";
+const ENV_SUBSCRIBER_RING_DEPTH: &str = "NROS_XRCE_SUBSCRIBER_RING_DEPTH";
+
+/// Rung 3.5 of the ladder in `packages/rmw/xrce/xrce-config.txt`.
+///
+/// Keyed on the ENV name a `define` row carries, never on the C macro: the
+/// macro is a configuration value and `check-xrce-config-manifest` refuses a
+/// lane that states one of its own (phase-420 W9). The env name is the row's
+/// own field, so this is a lookup into the manifest rather than a second copy
+/// of it.
+#[derive(Default)]
+struct XrceDemand {
+    values: BTreeMap<&'static str, usize>,
+    /// What was NOT derived, and why. D6: *"always the safe direction and
+    /// always loud — the build prints what declaring would save"*.
+    notes: Vec<String>,
+}
+
+impl XrceDemand {
+    /// The value this image's declarations imply for `env`, if any.
+    fn for_knob(&self, env: &str) -> Option<usize> {
+        self.values.get(env).copied()
+    }
+
+    fn note(&mut self, what: impl Into<String>) {
+        self.notes.push(what.into());
+    }
+
+    fn report(&self) {
+        for n in &self.notes {
+            println!("cargo::warning=nros-rmw-xrce: {n}");
+        }
+    }
+
+    fn derive(desc: Option<&SizingDescriptor>) -> Self {
+        let mut d = Self::default();
+        // No descriptor: nobody ran `nros sync` for this image. Every number
+        // below stays exactly where it was before this wave — the acceptance
+        // criterion, not a convenience.
+        let Some(desc) = desc else {
+            return d;
+        };
+
+        // A `closure` basis describes every type the link closure can reach,
+        // not the set this image creates. D6 forbids silently widening it, and
+        // it cuts both ways here: sizing a POOL from the closure over-states,
+        // while sizing a QoS-gated buffer from it can UNDER-state, because a
+        // closure row carries no endpoint's QoS.
+        if desc.meta.basis != Basis::Contract {
+            d.note(format!(
+                "the sizing descriptor states `basis = {}`, which describes the link closure \
+                 rather than what this image creates, so no pool is derived from it \
+                 (RFC-0100 D6)",
+                desc.meta.basis
+            ));
+            return d;
+        }
+        // "Absence is not zero" — D6's second trigger. An endpoint that stated
+        // no QoS at all is one whose reliability and depth this table cannot
+        // speak for, and both derivations below are ALL-endpoint predicates.
+        match desc.meta.undeclared_endpoints().get() {
+            Some(0) => {}
+            Some(n) => {
+                d.note(format!(
+                    "{n} endpoint(s) declare no QoS at all, so this image's reliability and \
+                     depth are not attributable and the XRCE pools keep their defaults. \
+                     Declaring them is worth up to {RELIABLE_STREAM_SAVING_BYTES} bytes of \
+                     session heap"
+                ));
+                return d;
+            }
+            None => {
+                d.note(
+                    "the sizing descriptor refuses `undeclared_endpoints`, so it cannot say \
+                     whether an endpoint stayed silent; the XRCE pools keep their defaults",
+                );
+                return d;
+            }
+        }
+        if desc.endpoints.is_empty() {
+            return d;
+        }
+
+        d.derive_stream_history(desc);
+        d.derive_subscriber_family(desc);
+        d
+    }
+
+    /// Reliability gates the two reliable stream buffers.
+    ///
+    /// The predicate is ALL, and "undeclared implies reliable" is what makes it
+    /// the safe direction: an endpoint whose reliability nobody stated keeps
+    /// the full history, so the saving needs a declaration rather than a
+    /// silence.
+    ///
+    /// Services and actions count as reliable without asking. A ROS service is
+    /// reliable by construction and an action expands into services — so a row
+    /// of either kind means this stream carries traffic that must be
+    /// retransmitted, which is exactly what phase 130.4's default of 16 was
+    /// measured for (feedback + result + status_array + replies fanned out
+    /// inside one user handler).
+    fn derive_stream_history(&mut self, desc: &SizingDescriptor) {
+        let is_best_effort = |e: &Endpoint| {
+            matches!(e.kind, EndpointKind::Publisher | EndpointKind::Subscription)
+                && e.reliability().stated() == Some(&Reliability::BestEffort)
+        };
+        if desc.endpoints.iter().all(is_best_effort) {
+            self.values
+                .insert(ENV_STREAM_HISTORY, RELIABLE_CONTROL_HISTORY);
+            return;
+        }
+        // One declaration away from the saving: every endpoint that DID state a
+        // reliability said best_effort, and the rest said nothing. Worth a line,
+        // because this is the largest single number in the backend and nothing
+        // else would tell them.
+        let stated_any = desc.endpoints.iter().any(|e| e.reliability().is_stated());
+        let none_reliable = desc
+            .endpoints
+            .iter()
+            .all(|e| e.reliability().stated() != Some(&Reliability::Reliable));
+        let pubsub_only = desc
+            .endpoints
+            .iter()
+            .all(|e| matches!(e.kind, EndpointKind::Publisher | EndpointKind::Subscription));
+        if stated_any && none_reliable && pubsub_only {
+            self.note(format!(
+                "no endpoint declares `reliability = reliable` and some declare nothing, so \
+                 both reliable stream buffers keep the full history — an undeclared \
+                 reliability is assumed reliable (RFC-0100 D6). Declaring `best_effort` on \
+                 every endpoint is worth {RELIABLE_STREAM_SAVING_BYTES} bytes of session heap"
+            ));
+        }
+    }
+
+    /// The subscriber pool's two remaining factors, TOGETHER or not at all.
+    ///
+    /// The coupling is the whole reason this cannot make an image bigger. The
+    /// pool is one product (D2) and the two factors move in opposite directions
+    /// on a typical image: a declared `std_msgs/msg/String` prices its entry at
+    /// 1,174 bytes against the literal 1,024, while a declared `depth = 10`
+    /// prices the ring at 10 entries against the literal 32. Taking the first
+    /// without the second is a 15% GROWTH; taking both is a 64% saving. A pool
+    /// sized from one declaration and one literal describes no image at all.
+    ///
+    /// Refused outright when the image declares an action of either role: an
+    /// action client opens a subscription underneath itself that no
+    /// `[[endpoint]]` row itemises, so the maximum over the declared
+    /// subscriptions would be short for it — the UNDER direction, which is the
+    /// one that ships a runtime failure (issue 1319's lesson, one pool over).
+    fn derive_subscriber_family(&mut self, desc: &SizingDescriptor) {
+        let subs: Vec<&Endpoint> = desc
+            .endpoints
+            .iter()
+            .filter(|e| e.kind == EndpointKind::Subscription)
+            .collect();
+        // No subscriptions: no demand. The slot COUNT is already derived to 0
+        // on the other road, so the array is gone and its entry size prices
+        // nothing. D7 — an abstention, not a floor.
+        if subs.is_empty() {
+            return;
+        }
+        if desc.endpoints.iter().any(|e| {
+            matches!(
+                e.kind,
+                EndpointKind::ActionServer | EndpointKind::ActionClient
+            )
+        }) {
+            self.note(
+                "this image declares an action, which opens subscriptions the endpoint table \
+                 does not itemise, so the subscriber ring keeps its default size and depth \
+                 rather than being sized from the declared subscriptions alone",
+            );
+            return;
+        }
+
+        let mut bound = 0usize;
+        let mut depth = 0usize;
+        for e in &subs {
+            let (Some(b), Some(n)) = (e.wire_bound_bytes().get(), e.depth().get()) else {
+                self.note(format!(
+                    "subscription `{}` states {}, so the subscriber ring keeps its defaults: \
+                     the pool is COUNT x DEPTH x BOUND and half a formula prices no image",
+                    e.topic,
+                    missing_half(e)
+                ));
+                return;
+            };
+            // A depth of 0 is this backend's SYSTEM_DEFAULT sentinel on the
+            // wire (`session.c` leaves it unresolved so the Agent's DDS layer
+            // supplies its own), not a queue of nothing. It cannot size a ring.
+            if n == 0 {
+                self.note(format!(
+                    "subscription `{}` states `depth = 0`, which is the defer-to-the-Agent \
+                     sentinel rather than a queue length, so the subscriber ring keeps its \
+                     defaults",
+                    e.topic
+                ));
+                return;
+            }
+            bound = bound.max(b);
+            depth = depth.max(n as usize);
+        }
+        self.values
+            .insert(ENV_SUBSCRIBER_BUFFER, bound + CDR_HEADER_LEN);
+        self.values.insert(ENV_SUBSCRIBER_RING_DEPTH, depth);
+    }
+}
+
+/// Which half of the product this endpoint is missing, in prose.
+fn missing_half(e: &Endpoint) -> String {
+    let mut missing = Vec::new();
+    if !e.wire_bound_bytes().is_stated() {
+        missing.push(match e.wire_bound_bytes().refusal() {
+            Some(r) => format!("no wire bound ({r})"),
+            None => "no wire bound".to_string(),
+        });
+    }
+    if !e.depth().is_stated() {
+        missing.push(match e.depth().refusal() {
+            Some(r) => format!("no depth ({r})"),
+            None => "no depth".to_string(),
+        });
+    }
+    missing.join(" and ")
+}
+
+/// The descriptor this build was pointed at, or `None`.
+///
+/// Same three outcomes as `nros-node/build.rs` (phase-454 W4) and for the same
+/// reasons: no descriptor keeps every literal, a refused field keeps its
+/// literal loudly, and a descriptor that does not parse — or names a schema
+/// this reader does not know — is a hard build error. A descriptor EXISTS in
+/// that last case, so defaulting would size from numbers a user believes they
+/// supplied.
+fn sizing_descriptor() -> Option<SizingDescriptor> {
+    match nros_sizing_descriptor::from_build_env() {
+        Ok(d) => d,
+        Err(e) => panic!("nros-rmw-xrce-cffi: {e}"),
+    }
+}
+
+// --- negative controls, run on the normal path -----------------------------
+
+fn xrce_demand_selftest() {
+    use nros_sizing_descriptor::{History, RegistrationPath, Status};
+
+    // A descriptor shaped like a real one: contract basis, nothing undeclared.
+    let image = |eps: Vec<Endpoint>| -> SizingDescriptor {
+        let mut d = SizingDescriptor::new("selftest", Status::Derived, Basis::Contract);
+        d.meta.set_undeclared_endpoints(Some(0));
+        d.endpoints = eps;
+        d
+    };
+    let endpoint = |kind: EndpointKind,
+                    topic: &str,
+                    rel: Option<Reliability>,
+                    depth: Option<u32>,
+                    bound: Option<usize>| {
+        let mut e = Endpoint::new(kind, "std_msgs/msg/String", topic);
+        e.set_history(Some(History::KeepLast))
+            .set_reliability(rel)
+            .set_depth(depth)
+            .set_wire_bound_bytes(bound)
+            .set_registration_path(Some(RegistrationPath::RustTypedSchemaless));
+        e
+    };
+    let be = Some(Reliability::BestEffort);
+
+    // 1. No descriptor derives nothing. Every existing image builds unchanged.
+    let none = XrceDemand::derive(None);
+    assert!(
+        none.values.is_empty(),
+        "a build with no descriptor must move no knob"
+    );
+    assert!(none.notes.is_empty(), "and must say nothing about it");
+
+    // 2. Best-effort-only pub/sub: the reliable streams drop to the protocol
+    //    floor. The wave's headline number.
+    let d = XrceDemand::derive(Some(&image(vec![
+        endpoint(EndpointKind::Publisher, "/chatter", be, Some(1), Some(1170)),
+        endpoint(EndpointKind::Subscription, "/echo", be, Some(1), Some(1170)),
+    ])));
+    assert_eq!(
+        d.for_knob(ENV_STREAM_HISTORY),
+        Some(RELIABLE_CONTROL_HISTORY),
+        "every endpoint declared best_effort, so the reliable streams carry control only"
+    );
+
+    // 3. ONE reliable endpoint and the whole image pays, because one stream
+    //    serves them all.
+    let d = XrceDemand::derive(Some(&image(vec![
+        endpoint(EndpointKind::Publisher, "/chatter", be, Some(1), Some(1170)),
+        endpoint(
+            EndpointKind::Subscription,
+            "/echo",
+            Some(Reliability::Reliable),
+            Some(1),
+            Some(1170),
+        ),
+    ])));
+    assert_eq!(d.for_knob(ENV_STREAM_HISTORY), None);
+
+    // 4. Undeclared reliability is ASSUMED RELIABLE — the safe direction. A
+    //    mutation to "assume best_effort" is a silent under-size on the one
+    //    path that retransmits, and it would pass tests 2 and 3.
+    let d = XrceDemand::derive(Some(&image(vec![
+        endpoint(EndpointKind::Publisher, "/chatter", be, Some(1), Some(1170)),
+        endpoint(
+            EndpointKind::Subscription,
+            "/echo",
+            None,
+            Some(1),
+            Some(1170),
+        ),
+    ])));
+    assert_eq!(d.for_knob(ENV_STREAM_HISTORY), None);
+    assert!(
+        d.notes.iter().any(|n| n.contains("assumed reliable")),
+        "and it says so: {:?}",
+        d.notes
+    );
+
+    // 5. A service is reliable by construction, so a service image keeps the
+    //    full history even with best_effort on everything it declares.
+    let d = XrceDemand::derive(Some(&image(vec![endpoint(
+        EndpointKind::ServiceServer,
+        "/add",
+        be,
+        Some(10),
+        Some(64),
+    )])));
+    assert_eq!(d.for_knob(ENV_STREAM_HISTORY), None);
+
+    // 6. The subscriber family: both factors, from the declaration.
+    let d = XrceDemand::derive(Some(&image(vec![
+        endpoint(EndpointKind::Subscription, "/a", be, Some(10), Some(1170)),
+        endpoint(EndpointKind::Subscription, "/b", be, Some(4), Some(96)),
+    ])));
+    assert_eq!(
+        d.for_knob(ENV_SUBSCRIBER_BUFFER),
+        Some(1170 + CDR_HEADER_LEN),
+        "the entry must hold the largest declared payload PLUS its CDR header"
+    );
+    assert_eq!(
+        d.for_knob(ENV_SUBSCRIBER_RING_DEPTH),
+        Some(10),
+        "the ring must hold the deepest declared queue"
+    );
+
+    // 7. THE COUPLING. Bounds without depths derives NEITHER. Mutating this to
+    //    emit the buffer alone makes the pool 15% LARGER than the defaults it
+    //    replaced (1,174 x 32 against 1,024 x 32) — a regression that builds,
+    //    boots and passes every knob gate.
+    let d = XrceDemand::derive(Some(&image(vec![endpoint(
+        EndpointKind::Subscription,
+        "/a",
+        be,
+        None,
+        Some(1170),
+    )])));
+    assert_eq!(d.for_knob(ENV_SUBSCRIBER_BUFFER), None);
+    assert_eq!(d.for_knob(ENV_SUBSCRIBER_RING_DEPTH), None);
+    // The reliability half is a different fact and must NOT be degraded by it
+    // — D6: a refusal "never degrades another consumer's facts".
+    assert_eq!(
+        d.for_knob(ENV_STREAM_HISTORY),
+        Some(RELIABLE_CONTROL_HISTORY)
+    );
+
+    // 8. An action opens subscriptions this table does not itemise.
+    let d = XrceDemand::derive(Some(&image(vec![
+        endpoint(EndpointKind::Subscription, "/a", be, Some(10), Some(1170)),
+        endpoint(EndpointKind::ActionClient, "/fib", be, Some(10), Some(96)),
+    ])));
+    assert_eq!(d.for_knob(ENV_SUBSCRIBER_BUFFER), None);
+    assert_eq!(d.for_knob(ENV_SUBSCRIBER_RING_DEPTH), None);
+
+    // 9. "Absence is not zero": one silent endpoint refuses every derivation,
+    //    including the reliability one the others would have satisfied.
+    let mut d9 = image(vec![endpoint(
+        EndpointKind::Subscription,
+        "/a",
+        be,
+        Some(10),
+        Some(1170),
+    )]);
+    d9.meta.set_undeclared_endpoints(Some(1));
+    let d = XrceDemand::derive(Some(&d9));
+    assert!(d.values.is_empty(), "{:?}", d.values);
+    assert!(!d.notes.is_empty(), "and it is loud about it");
+
+    // 10. A closure basis sizes nothing.
+    let mut d10 = image(vec![endpoint(
+        EndpointKind::Subscription,
+        "/a",
+        be,
+        Some(10),
+        Some(1170),
+    )]);
+    d10.meta.basis = Basis::Closure;
+    assert!(XrceDemand::derive(Some(&d10)).values.is_empty());
+
+    // 11. Zero survives unfloored (D7, issues 1015/1033). An empty message is
+    //     the CDR header and nothing else, and the floor that keeps that legal
+    //     lives at the array rather than here.
+    let d = XrceDemand::derive(Some(&image(vec![endpoint(
+        EndpointKind::Subscription,
+        "/tick",
+        be,
+        Some(1),
+        Some(0),
+    )])));
+    assert_eq!(d.for_knob(ENV_SUBSCRIBER_BUFFER), Some(CDR_HEADER_LEN));
+    assert_eq!(d.for_knob(ENV_SUBSCRIBER_RING_DEPTH), Some(1));
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
@@ -110,6 +110,37 @@ static inline void nros_xrce_free(void* ptr) {
 #ifndef XRCE_BUFFER_SIZE
 #define XRCE_BUFFER_SIZE 1024
 #endif
+/* phase-454 W6.b (RFC-0100 D2/D5) — ONE number served THREE families, and the
+ * three have nothing to do with each other.
+ *
+ * `XRCE_BUFFER_SIZE` sized the subscriber ring entry, the service-server
+ * request entry and the service-client reply slot alike, so every family paid
+ * for the largest type ANY of them carries. D2's formula is per-pool
+ * (`COUNT x SLOTS x SLOT_BYTES`), and `SLOT_BYTES` is a property of the types
+ * THAT family receives — the subscriber ring is by far the biggest pool
+ * (`XRCE_MAX_SUBSCRIBERS x XRCE_SUBSCRIBER_RING_DEPTH` entries against the
+ * service families' 4 and 1), so the shared number is paid ~32x over there and
+ * once here.
+ *
+ * `XRCE_BUFFER_SIZE` stays as the DEFAULT of all three rather than being
+ * deleted, for two reasons that are both about not moving bytes nobody asked to
+ * move: an image that states nothing derives byte-identically to before this
+ * wave, and `NROS_XRCE_BUFFER_SIZE` remains the one lever that raises every
+ * receive buffer at once (`large_msg.rs` is built on exactly that, and the
+ * backend's own MESSAGE_TOO_LARGE diagnostic names it).
+ *
+ * Only the SUBSCRIBER family is derived from declarations today
+ * (`nros-rmw-xrce-cffi/build.rs`). The two service families are settable and
+ * not derived, and the reason is stated there rather than guessed here. */
+#ifndef XRCE_SUBSCRIBER_BUFFER_SIZE
+#define XRCE_SUBSCRIBER_BUFFER_SIZE XRCE_BUFFER_SIZE
+#endif
+#ifndef XRCE_SERVICE_REQUEST_BUFFER_SIZE
+#define XRCE_SERVICE_REQUEST_BUFFER_SIZE XRCE_BUFFER_SIZE
+#endif
+#ifndef XRCE_SERVICE_REPLY_BUFFER_SIZE
+#define XRCE_SERVICE_REPLY_BUFFER_SIZE XRCE_BUFFER_SIZE
+#endif
 /* Phase 130.4 — bumped default from 4 to 16. Action server callbacks
  * that publish feedback + result + status_array + service replies
  * in a single user-handler invocation could exhaust 4 unACK'd slots
@@ -125,7 +156,28 @@ static inline void nros_xrce_free(void* ptr) {
  * RAM RTOS targets can drop to 8 (32 KiB) when the application
  * doesn't run server-side action callbacks that fan out replies.
  * Lower than 4 is rejected — reliable retransmission needs at
- * least 2 unACK'd messages outstanding plus headroom. */
+ * least 2 unACK'd messages outstanding plus headroom.
+ *
+ * phase-454 W6.b — the floor below is a PROTOCOL requirement and the
+ * default above is a statement about ENDPOINTS, which is why only the
+ * second one moves. Read the 130.4 justification again: every message
+ * it names (feedback, result, status_array, service replies) is
+ * ENDPOINT traffic. An image whose every endpoint declares
+ * `reliability = best_effort` fans out none of it on this stream, so
+ * `nros-rmw-xrce-cffi/build.rs` derives 4 for it from the sizing
+ * descriptor — the RFC-0100 D1 shape, a policy that is stated and a
+ * derived fact supplying its default.
+ *
+ * What it does NOT derive is 0, and that is not conservatism. Both
+ * reliable streams stay LIVE on a best-effort-only image: every
+ * control message this backend sends rides `st->output_reliable`
+ * (participant/topic/publisher/datawriter/datareader CREATE, DELETE,
+ * `uxr_buffer_request_data`), and `uxr_buffer_request_data` names
+ * `st->input_reliable` as the stream the Agent delivers on, for every
+ * reader, whatever its QoS. A declaration about DATA delivery is not a
+ * licence to make session setup lossy. The buffer therefore shrinks
+ * with the history and does not go away; the block size is
+ * `size / history`, so an MTU-sized message still fits at 4. */
 #ifndef XRCE_STREAM_HISTORY
 #define XRCE_STREAM_HISTORY 16
 #endif
@@ -162,7 +214,7 @@ static inline void nros_xrce_free(void* ptr) {
  * back-to-back publish burst doesn't silently overwrite unread
  * messages (root cause of `test_xrce_throughput_{100hz,burst}` only
  * receiving 1 of 100 msgs). Each ring entry carries its own
- * `data[XRCE_BUFFER_SIZE]` + `len`; the topic callback writes to
+ * `data[XRCE_SUBSCRIBER_BUFFER_SIZE]` + `len`; the topic callback writes to
  * `entries[write_idx]` and advances, `take_serialized` reads from
  * `entries[read_idx]` and advances. `count` distinguishes empty (0)
  * from full (XRCE_SUBSCRIBER_RING_DEPTH). On full, the callback
@@ -186,19 +238,37 @@ static inline void nros_xrce_free(void* ptr) {
  * publishes 100 msgs back-to-back; depth 32 caps the visible burst
  * at the head 32 (matches the `test_xrce_throughput_*` expectations
  * of ≥3 / ≥10) without paying the memory cost of a 100+ entry
- * ring. Memory cost: 32 × XRCE_BUFFER_SIZE per subscriber × 8
- * max = 256 KB. Tight-RAM RTOS targets can override via
- * `-DXRCE_SUBSCRIBER_RING_DEPTH=...` at build time. */
+ * ring. Memory cost: 32 × XRCE_SUBSCRIBER_BUFFER_SIZE per
+ * subscriber × 8 max = 256 KB. Tight-RAM RTOS targets can override
+ * via `-DXRCE_SUBSCRIBER_RING_DEPTH=...` at build time.
+ *
+ * phase-454 W6.b — still a POLICY and still stated, exactly as
+ * `zephyr/Kconfig` argues: no inventory knows how deep a burst a
+ * subscriber must survive. What changed is where its DEFAULT comes
+ * from when the image declared one (RFC-0100 D1: "a policy fact is
+ * stated, and a derived fact may supply its default"). A subscription
+ * declaring `qos.depth = 10` is a KEEP_LAST(10) queue that drops past
+ * ten anyway, so 10 is a better default for that image than a literal
+ * chosen for a 100-message burst test.
+ *
+ * The derivation moves this knob and XRCE_SUBSCRIBER_BUFFER_SIZE
+ * TOGETHER or not at all, and that coupling is the whole reason it
+ * cannot make an image bigger: this pool is one product
+ * (`MAX_SUBSCRIBERS x RING_DEPTH x BUFFER_SIZE`, RFC-0100 D2), and a
+ * declared bound of 1,174 bytes against a literal depth of 32 prices a
+ * pool 15% LARGER than the defaults it replaced. Supplying one factor
+ * from the declaration and the other from a literal prices a pool
+ * neither describes. */
 #define XRCE_SUBSCRIBER_RING_DEPTH 32
 #endif
 
-/* ---- Smallest legal size for the four PER-SLOT arrays (issue 1131) ---
+/* ---- Smallest legal size for the PER-SLOT arrays (issue 1131) ---
  *
  * BELOW the `#ifndef` fallbacks above, never before one: in `#if` an undefined
  * identifier reads as 0, so a guard placed above its own default fires on every
  * build instead of protecting anything (issue 1167).
  *
- * These four are CAPACITIES INSIDE a slot, and that is what separates them from
+ * These are CAPACITIES INSIDE a slot, and that is what separates them from
  * the three slot COUNTS above, which issue 1033 ruled zero-legal. An image that
  * wants none of an entity sets its COUNT to 0 and the whole slot array goes
  * away — that is the 33,296-bytes-a-subscriber saving. Setting a capacity to 0
@@ -206,9 +276,20 @@ static inline void nros_xrce_free(void* ptr) {
  *
  *   XRCE_BUFFER_SIZE=0          `xrce_stage_inbound` needs `len + 4 <= cap`, so
  *                               every inbound payload fails to stage and every
- *                               take reports MESSAGE_TOO_LARGE. The only
+ *                               take reports MESSAGE_TOO_LARGE. Its human
  *                               producer, `nros-rmw-xrce-cffi/build.rs`, already
- *                               refuses anything under 64.
+ *                               refuses anything under 64. It sizes no array
+ *                               directly since phase-454 W6.b — it is the
+ *                               DEFAULT of the three family knobs below, so a 0
+ *                               here reaches all three and the guard still has
+ *                               work to do.
+ *   XRCE_SUBSCRIBER_BUFFER_SIZE=0 / XRCE_SERVICE_REQUEST_BUFFER_SIZE=0 /
+ *   XRCE_SERVICE_REPLY_BUFFER_SIZE=0
+ *                               the same `xrce_stage_inbound` arm, one family at
+ *                               a time. Guarded each rather than by analogy with
+ *                               the line above: the analogy is what issue 1131
+ *                               ruled out, and a derived producer reaching one
+ *                               of these is exactly the 1015 shape.
  *   XRCE_SUBSCRIBER_RING_DEPTH=0  `count >= depth` is true at 0, so the topic
  *                               callback takes its ring-full drop arm for every
  *                               message and the subscriber receives nothing —
@@ -222,7 +303,16 @@ static inline void nros_xrce_free(void* ptr) {
  *                               so the server can never answer anything.
  */
 #if XRCE_BUFFER_SIZE < 1
-#error "XRCE_BUFFER_SIZE must be >= 1: it sizes a C array (issue 1015)"
+#error "XRCE_BUFFER_SIZE must be >= 1: it is the default of the family buffers (issue 1015)"
+#endif
+#if XRCE_SUBSCRIBER_BUFFER_SIZE < 1
+#error "XRCE_SUBSCRIBER_BUFFER_SIZE must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#if XRCE_SERVICE_REQUEST_BUFFER_SIZE < 1
+#error "XRCE_SERVICE_REQUEST_BUFFER_SIZE must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#if XRCE_SERVICE_REPLY_BUFFER_SIZE < 1
+#error "XRCE_SERVICE_REPLY_BUFFER_SIZE must be >= 1: it sizes a C array (issue 1015)"
 #endif
 #if XRCE_SUBSCRIBER_RING_DEPTH < 1
 #error "XRCE_SUBSCRIBER_RING_DEPTH must be >= 1: it sizes a C array (issue 1015)"
@@ -235,7 +325,7 @@ static inline void nros_xrce_free(void* ptr) {
 #endif
 
 typedef struct xrce_subscriber_ring_entry {
-    uint8_t data[XRCE_BUFFER_SIZE];
+    uint8_t data[XRCE_SUBSCRIBER_BUFFER_SIZE];
     size_t len;
     bool overflow;
 } xrce_subscriber_ring_entry;
@@ -262,7 +352,7 @@ typedef struct xrce_reply_token {
 
 /* One buffered request in the service-server inbox ring. */
 typedef struct xrce_service_request_entry {
-    uint8_t data[XRCE_BUFFER_SIZE];
+    uint8_t data[XRCE_SERVICE_REQUEST_BUFFER_SIZE];
     size_t len;
     bool overflow;
     SampleIdentity sample_id;
@@ -286,7 +376,7 @@ typedef struct xrce_service_server_slot {
 
 /* Service-client slot — reply inbox. */
 typedef struct xrce_service_client_slot {
-    uint8_t data[XRCE_BUFFER_SIZE];
+    uint8_t data[XRCE_SERVICE_REPLY_BUFFER_SIZE];
     size_t len;
     bool has_reply;
     bool overflow;

--- a/packages/rmw/xrce/nros-rmw-xrce/src/service.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/service.c
@@ -50,7 +50,8 @@ void xrce_request_callback(uxrSession* session, uxrObjectId object_id, uint16_t 
         xrce_service_request_entry* e = &slot->req_ring[slot->req_write_idx];
         /* Issue 0819 — one staging path for every inbound payload, fragments
          * included; see `xrce_stage_inbound`. */
-        e->overflow = !xrce_stage_inbound(e->data, XRCE_BUFFER_SIZE, ub, len, &e->len);
+        e->overflow =
+            !xrce_stage_inbound(e->data, XRCE_SERVICE_REQUEST_BUFFER_SIZE, ub, len, &e->len);
         e->sample_id = *sample_id;
         slot->req_write_idx =
             (uint16_t)((slot->req_write_idx + 1) % XRCE_SERVICE_REQUEST_RING_DEPTH);
@@ -77,7 +78,8 @@ void xrce_reply_callback(uxrSession* session, uxrObjectId object_id, uint16_t re
         slot->reply_request_id = request_id;
         /* Issue 0819 — one staging path for every inbound payload, fragments
          * included; see `xrce_stage_inbound`. */
-        slot->overflow = !xrce_stage_inbound(slot->data, XRCE_BUFFER_SIZE, ub, len, &slot->len);
+        slot->overflow =
+            !xrce_stage_inbound(slot->data, XRCE_SERVICE_REPLY_BUFFER_SIZE, ub, len, &slot->len);
         slot->has_reply = true;
         return;
     }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/session.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/session.c
@@ -79,10 +79,13 @@ void xrce_report_capacity_exhausted(const char* kind, const char* name, unsigned
 void xrce_report_session_alloc_failed(size_t bytes) {
     xrce_log_error("xrce_session_state_t (%lu bytes) did not fit. Its size is decided "
                    "at BUILD time by NROS_XRCE_MAX_SUBSCRIBERS x "
-                   "NROS_XRCE_SUBSCRIBER_RING_DEPTH x NROS_XRCE_BUFFER_SIZE, plus the "
-                   "service server/client slots; it is ONE allocation, so a heap larger "
-                   "than the shortfall does not help. Lower a cap or raise the platform "
-                   "heap (CONFIG_NROS_ZEPHYR_HEAP_SIZE on Zephyr).",
+                   "NROS_XRCE_SUBSCRIBER_RING_DEPTH x NROS_XRCE_SUBSCRIBER_BUFFER_SIZE, "
+                   "plus the service server/client slots and two reliable stream buffers "
+                   "of NROS_XRCE_TRANSPORT_MTU x NROS_XRCE_STREAM_HISTORY each; it is ONE "
+                   "allocation, so a heap larger than the shortfall does not help. Lower a "
+                   "cap or raise the platform heap (CONFIG_NROS_ZEPHYR_HEAP_SIZE on Zephyr). "
+                   "Declaring this image's endpoints lets the build derive most of these "
+                   "(RFC-0100).",
                    (unsigned long)bytes);
 }
 

--- a/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
@@ -56,7 +56,8 @@ void xrce_topic_callback(uxrSession* session, uxrObjectId object_id, uint16_t re
          * `xrce_stage_inbound`, shared with the two service inboxes because all
          * three had the same fragment bug. A refusal sets the entry's overflow
          * flag, which the take reports as NROS_RMW_RET_MESSAGE_TOO_LARGE. */
-        entry->overflow = !xrce_stage_inbound(entry->data, XRCE_BUFFER_SIZE, ub, len, &entry->len);
+        entry->overflow =
+            !xrce_stage_inbound(entry->data, XRCE_SUBSCRIBER_BUFFER_SIZE, ub, len, &entry->len);
         slot->write_idx = (uint16_t)((slot->write_idx + 1) % XRCE_SUBSCRIBER_RING_DEPTH);
         slot->count++;
         return;

--- a/packages/rmw/xrce/xrce-config.txt
+++ b/packages/rmw/xrce/xrce-config.txt
@@ -98,7 +98,17 @@
 #   1. the environment variable          — a person, right now
 #   2. `CONFIG_<env>` in `$DOTCONFIG`    — a person, in the tree (Kconfig)
 #   3. the `[knobs.xrce]` rung           — RUST LANE ONLY, see below
+#   3.5 the SIZING DESCRIPTOR            — RUST LANE ONLY, phase-454 W6.b
 #   4. the `<default>` column here       — nobody stated one
+#
+# Rung 3.5 is a DERIVED default under every stated rung above it, which is
+# RFC-0100 D1's rule ("a policy fact is stated, and a derived fact may supply
+# its default") and RFC-0049's ladder rather than a new mechanism. It is
+# cargo-only for the same mechanical reason rung 3 is: reading
+# `<build>/nros/sizing/<entry>.toml` needs the `nros-sizing-descriptor` crate,
+# which the CMake lane cannot link. It reaches `define` rows only — a template
+# `knob` is upstream's configuration, not ours to derive. What it decides, and
+# what it refuses to decide, is in `nros-rmw-xrce-cffi/build.rs`'s `XrceDemand`.
 #
 # Rung 3 (`nros_platform_config`'s `[knobs.xrce]` in a platform/board TOML) is
 # a CARGO build-script front-end: reading it needs a TOML parser, which the
@@ -228,6 +238,24 @@ define  XRCE_MAX_SERVICE_SERVERS   NROS_XRCE_MAX_SERVICE_SERVERS   0
 define  XRCE_MAX_SERVICE_CLIENTS   NROS_XRCE_MAX_SERVICE_CLIENTS   0
 define  XRCE_SUBSCRIBER_RING_DEPTH NROS_XRCE_SUBSCRIBER_RING_DEPTH 1
 define  XRCE_BUFFER_SIZE           NROS_XRCE_BUFFER_SIZE           64
+# phase-454 W6.b (RFC-0100 D2/D5) — one number served three receive families
+# and none of them describes the other two. `XRCE_BUFFER_SIZE` above is now the
+# DEFAULT of these three (in `internal.h`'s `#ifndef`, so unset still means one
+# number for all three and an image that states nothing builds byte-identically
+# to before the split).
+#
+# Their <min> is 1 rather than the 64 above, and the difference is about WHO
+# produces the number. 64 guards a person typing one: `xrce_stage_inbound` needs
+# `len + XRCE_CDR_HEADER_LEN <= cap`, and a hand-picked 8 is a mistake with no
+# feedback. These three also have a DERIVING producer — the cargo lane's
+# `XrceDemand`, which computes exactly `max(wire_bound) + XRCE_CDR_HEADER_LEN`
+# over the family's declared endpoints — and for that producer any value above 0
+# is exact rather than a guess. The array's real floor is the `#if < 1 / #error`
+# beside each array in `internal.h` (issues 1015/1131), which is where a floor
+# belongs (D7).
+define  XRCE_SUBSCRIBER_BUFFER_SIZE      NROS_XRCE_SUBSCRIBER_BUFFER_SIZE      1
+define  XRCE_SERVICE_REQUEST_BUFFER_SIZE NROS_XRCE_SERVICE_REQUEST_BUFFER_SIZE 1
+define  XRCE_SERVICE_REPLY_BUFFER_SIZE   NROS_XRCE_SERVICE_REPLY_BUFFER_SIZE   1
 # Phase 130.6 — reliable-stream history. `internal.h` documents why 16 is the
 # default; 4 is the floor (reliable retransmission needs at least 2 unACK'd
 # messages outstanding plus headroom).

--- a/packages/testing/nros-tests/tests/large_msg.rs
+++ b/packages/testing/nros-tests/tests/large_msg.rs
@@ -335,14 +335,19 @@ fn xrce_roundtrip(binary: &std::path::Path, payload: &str, topic: &str) -> Strin
     output
 }
 
-/// A payload over `XRCE_BUFFER_SIZE` must be refused by NAME.
+/// A payload over `XRCE_SUBSCRIBER_BUFFER_SIZE` must be refused by NAME.
 ///
-/// The ceiling is ours — `XRCE_BUFFER_SIZE` (1024) in
+/// The ceiling is ours — `XRCE_SUBSCRIBER_BUFFER_SIZE` in
 /// `packages/rmw/xrce/nros-rmw-xrce/src/internal.h`, checked in the topic
-/// callback as `len + XRCE_CDR_HEADER_LEN > XRCE_BUFFER_SIZE`. The stress
-/// binary's `PAYLOAD_SIZE` includes the 4-byte CDR header that the publish side
-/// strips, so the predicate is exactly `PAYLOAD_SIZE > 1024` and 1025 is the
-/// first refused size.
+/// callback as `len + XRCE_CDR_HEADER_LEN > XRCE_SUBSCRIBER_BUFFER_SIZE`. The
+/// stress binary's `PAYLOAD_SIZE` includes the 4-byte CDR header that the
+/// publish side strips, so the predicate is exactly `PAYLOAD_SIZE > 1024` and
+/// 1025 is the first refused size.
+///
+/// 1024 rather than a family-specific number because phase-454 W6.b left
+/// `XRCE_BUFFER_SIZE` as the DEFAULT of the three receive families, and this
+/// fixture declares no endpoints for the build to derive one from. That is why
+/// `NROS_XRCE_BUFFER_SIZE=8192` still raises it, in the sibling test below.
 ///
 /// What this test actually guards is the ERROR NAME, not the refusal. Before
 /// phase-384 W1 the backend's `MessageTooLarge` was rewritten to
@@ -439,8 +444,8 @@ fn xrce_raising_the_ring_delivers_the_same_payload(xrce_stress_test_large_buf_bi
 /// distance — a count-only assertion passes through the truncation, and a
 /// `MessageTooLarge`-only assertion passes through the regression.
 ///
-/// The ring is raised so `XRCE_BUFFER_SIZE` is NOT the constraint — otherwise
-/// this would pass for phase-384's reason rather than this one.
+/// The ring is raised so `XRCE_SUBSCRIBER_BUFFER_SIZE` is NOT the constraint —
+/// otherwise this would pass for phase-384's reason rather than this one.
 #[rstest]
 fn xrce_fragmented_payload_is_delivered_intact(xrce_stress_test_large_buf_binary: PathBuf) {
     if !require_xrce_agent() {

--- a/scripts/check/check-knob-ends.py
+++ b/scripts/check/check-knob-ends.py
@@ -92,6 +92,11 @@ ZEPHYR_C = re.compile(
 )
 ZEPHYR_FORWARDERS = re.compile(r"^zephyr/(CMakeLists\.txt|cmake/[^/]+\.cmake)$")
 
+# The XRCE backend's configuration, whose `knob` and `define` rows ARE the read
+# sites for its env knobs — neither lane spells a name. See
+# `xrce_manifest_readers`.
+XRCE_CONFIG_MANIFEST = "packages/rmw/xrce/xrce-config.txt"
+
 TEXT_EXT = (
     ".rs", ".c", ".h", ".cpp", ".hpp", ".cc", ".in", ".cmake", ".txt", ".sh",
     ".just", ".py", ".toml", ".md", ".conf", ".yml", ".yaml", ".example",
@@ -142,10 +147,43 @@ def _strip_comments(path: str, text: str) -> str:
     return text
 
 
+def xrce_manifest_readers(text: str) -> set[str]:
+    """The env names `packages/rmw/xrce/xrce-config.txt` binds — phase-454 W6.b.
+
+    A READ TABLE, exactly like the `(env, "CONFIG_*")` pair tables the Rust arm
+    below already credits: both XRCE lanes walk these rows and resolve each
+    row's `<env>` column through the knob ladder, so a name here is consumed by
+    two build lanes even though neither spells it.
+
+    Before this arm the XRCE knobs were credited by ACCIDENT — the reader the
+    gate found for `NROS_XRCE_BUFFER_SIZE` was its own name inside an error
+    STRING in `session.c`, which is precisely the mention-is-not-a-read shape
+    this file's header says the first version of the method got wrong. Editing
+    that diagnostic's wording was enough to make a live knob read as dead.
+
+    The grammar is not re-implemented here: `check-xrce-config-manifest.py` is
+    the gate over that file and already owns the parser, and a second copy is
+    how two readers come to disagree about a record the gate accepts.
+    """
+    mod = xrce_manifest_readers.__dict__.get("_mod")
+    if mod is None:
+        spec = importlib.util.spec_from_file_location(
+            "_knob_ends_xrce_manifest",
+            os.path.join(ROOT, "scripts", "check-xrce-config-manifest.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        xrce_manifest_readers._mod = mod
+    _values, knobs, _flags, defines = mod.parse_manifest(text, XRCE_CONFIG_MANIFEST)
+    return {env for _t, _token, env, _d, _m in knobs} | {env for _m, env, _min in defines}
+
+
 def readers_in(path: str, text: str, read_callees: set[str]) -> set[str]:
     """Names read from the environment, or consumed as a C macro, in one file."""
     if is_doc(path):
         return set()
+    if path == XRCE_CONFIG_MANIFEST:
+        return xrce_manifest_readers(text)
     t = _strip_comments(path, text)
     out: set[str] = set()
     if path.endswith(".rs"):
@@ -301,6 +339,21 @@ def self_test() -> None:
     # a `.cargo/config.toml` [env] key is a claim; a [patch] key is not
     cfg = '[env]\nNROS_A = "1"\n\n[patch.crates-io]\nNROS_B = { path = "x" }\n'
     assert claims_in("ex/.cargo/config.toml", cfg) == {"NROS_A"}, "selftest: [env] scoping"
+
+    # the XRCE manifest is a READ TABLE (phase-454 W6.b). Both record types
+    # bind an env name; `value` and `flag` rows bind none, and a name in a
+    # COMMENT is a mention rather than a read, exactly as everywhere else here.
+    man = (
+        "# NROS_XRCE_MENTIONED_ONLY in prose\n"
+        "value  ucdr CONFIG_MACHINE_ENDIANNESS 1\n"
+        "knob   uxr  UCLIENT_UDP_TRANSPORT_MTU NROS_XRCE_TRANSPORT_MTU 4096 128\n"
+        "flag   uxr  UCLIENT_PROFILE_UDP posix_ip\n"
+        "define XRCE_BUFFER_SIZE NROS_XRCE_BUFFER_SIZE 64\n"
+    )
+    got = readers_in(XRCE_CONFIG_MANIFEST, man, callees)
+    assert got == {"NROS_XRCE_TRANSPORT_MTU", "NROS_XRCE_BUFFER_SIZE"}, (
+        f"selftest: xrce manifest reads {sorted(got)}"
+    )
 
 
 def load_census():

--- a/scripts/gen-pool-inventory.py
+++ b/scripts/gen-pool-inventory.py
@@ -199,6 +199,39 @@ _IFNDEF_DEFAULT = re.compile(
     r"^#ifndef\s+([A-Za-z_][A-Za-z0-9_]*)\s*$.*?^#define\s+\1\s+([0-9]+)\s*$",
     re.M | re.S,
 )
+# The same pair whose default is ANOTHER guarded macro rather than a literal —
+# phase-454 W6.b. `XRCE_SUBSCRIBER_BUFFER_SIZE` and its two siblings default to
+# `XRCE_BUFFER_SIZE`, because one number legitimately serves three families
+# until an image says otherwise. Writing 1024 beside each of them would be the
+# fourth, fifth and sixth home for a figure this file exists to stop copying;
+# following the alias publishes what the compiler actually computes.
+_IFNDEF_ALIAS = re.compile(
+    r"^#ifndef\s+([A-Za-z_][A-Za-z0-9_]*)\s*$.*?"
+    r"^#define\s+\1\s+([A-Za-z_][A-Za-z0-9_]*)\s*$",
+    re.M | re.S,
+)
+
+
+def xrce_guarded_defaults(header_text):
+    """macro -> its `#ifndef` default, following one macro-valued alias chain.
+
+    An alias whose target has no guarded default of its own resolves to
+    NOTHING, deliberately: "say `computed`, never invent one" is the rule the
+    literal case already holds to, and an alias is not a reason to guess.
+    """
+    numeric = {m: int(n) for m, n in _IFNDEF_DEFAULT.findall(header_text)}
+    alias = {m: t for m, t in _IFNDEF_ALIAS.findall(header_text) if m not in numeric}
+    for macro, target in alias.items():
+        seen = {macro}
+        # Bounded walk. A cycle is a header that would not compile, but this
+        # reads a file rather than trusting one, and an unbounded walk over a
+        # cycle is a hang with no message.
+        while target in alias and target not in seen:
+            seen.add(target)
+            target = alias[target]
+        if target in numeric:
+            numeric[macro] = numeric[target]
+    return numeric
 
 
 def _xrce_parse_manifest(text, where):
@@ -229,7 +262,7 @@ def xrce_knobs(manifest_text, header_text, manifest_rel=XRCE_MANIFEST):
     no guarded default reports no figure rather than inventing one.
     """
     _values, knob_rows, _flags, define_rows = _xrce_parse_manifest(manifest_text, manifest_rel)
-    guarded = {m: int(n) for m, n in _IFNDEF_DEFAULT.findall(header_text)}
+    guarded = xrce_guarded_defaults(header_text)
 
     line_of = {}
     for n, raw in enumerate(manifest_text.splitlines(), 1):
@@ -487,7 +520,7 @@ def self_test():
     # broken wire moves only one.
     man_text, hdr_text = xrce_sources()
     _v, knob_rows, _f, define_rows = _xrce_parse_manifest(man_text, XRCE_MANIFEST)
-    guarded = {m: int(n) for m, n in _IFNDEF_DEFAULT.findall(hdr_text)}
+    guarded = xrce_guarded_defaults(hdr_text)
     assert define_rows and knob_rows, (
         f"{XRCE_MANIFEST} parsed to no `define`/`knob` rows — the relation below "
         "would hold vacuously, which is the shape `check-no-vacuous-tests` bans"
@@ -560,11 +593,17 @@ def self_test():
         "define XRCE_BUFFER_SIZE  NROS_XRCE_BUFFER_SIZE  64\n"
         "define XRCE_MAX_SUBSCRIBERS NROS_XRCE_MAX_SUBSCRIBERS 0\n"
         "define XRCE_UNGUARDED    NROS_XRCE_UNGUARDED    1\n"
+        "define XRCE_SUB_ALIAS    NROS_XRCE_SUB_ALIAS    1\n"
+        "define XRCE_DANGLING     NROS_XRCE_DANGLING     1\n"
     )
     hdr = (
         "#ifndef XRCE_BUFFER_SIZE\n/* prose */\n#define XRCE_BUFFER_SIZE 1024\n#endif\n"
         "#ifndef XRCE_MAX_SUBSCRIBERS\n#define XRCE_MAX_SUBSCRIBERS 8\n#endif\n"
         "#define XRCE_UNGUARDED 77\n"  # not overridable ⇒ not a knob's default
+        # phase-454 W6.b — a guarded default that IS another guarded macro.
+        "#ifndef XRCE_SUB_ALIAS\n/* prose */\n#define XRCE_SUB_ALIAS XRCE_BUFFER_SIZE\n#endif\n"
+        # …and one whose target has no guarded default. Still `computed`.
+        "#ifndef XRCE_DANGLING\n#define XRCE_DANGLING XRCE_UNGUARDED\n#endif\n"
     )
     xk = xrce_knobs(man, hdr, "M")
     assert xk["NROS_XRCE_BUFFER_SIZE"][0] == 1024, (
@@ -580,6 +619,16 @@ def self_test():
     assert xk["NROS_XRCE_UNGUARDED"][0] is None, (
         "a macro with no `#ifndef` guard is not overridable, so this file has no "
         "default to publish — say `computed`, never invent one"
+    )
+    assert xk["NROS_XRCE_SUB_ALIAS"][0] == 1024, (
+        "a guarded default that is another guarded MACRO must resolve to what the "
+        "compiler computes; publishing nothing would drop the three phase-454 W6.b "
+        "family knobs out of this table, and writing 1024 beside each of them would "
+        "be the copy this file exists to prevent"
+    )
+    assert xk["NROS_XRCE_DANGLING"][0] is None, (
+        "…and an alias whose target has no guarded default resolves to NOTHING. An "
+        "alias is not a reason to guess"
     )
     assert "NROS_XRCE_STREAM_HISTORY" not in xk, "only rows in the manifest"
     assert "CONFIG_MACHINE_ENDIANNESS" not in xk and "UCLIENT_PROFILE_UDP" not in xk, (

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1133,6 +1133,57 @@ config NROS_XRCE_BUFFER_SIZE
       Size of the static buffer for each subscriber/service slot (bytes).
       Maps to XRCE_BUFFER_SIZE.
 
+      phase-454 W6.b — this is the DEFAULT of the three per-family sizes
+      below, not an array size of its own. It stays the one lever that
+      moves every receive buffer at once; state a family option instead
+      when only one of them needs the room.
+
+config NROS_XRCE_SUBSCRIBER_BUFFER_SIZE
+    int "Subscriber ring entry size"
+    default -1
+    help
+      Size of one subscriber ring entry (bytes).
+      Maps to XRCE_SUBSCRIBER_BUFFER_SIZE.
+
+      The biggest of the three families by a wide margin: a slot is
+      NROS_XRCE_SUBSCRIBER_RING_DEPTH entries and the image holds
+      NROS_XRCE_MAX_SUBSCRIBERS slots, so 32 x 8 copies of this number
+      against 4 and 1 for the two service families. Sharing one size with
+      them meant every subscriber entry paid for the largest type a
+      SERVICE carries, and the other way round.
+
+      -1 is the DERIVE sentinel (phase-403 W8): the build takes the
+      largest wire bound over the subscriptions this image declares, plus
+      the 4-byte CDR header, and falls back to NROS_XRCE_BUFFER_SIZE when
+      the declaration does not price every one of them. It moves together
+      with the ring depth or not at all — see
+      XRCE_SUBSCRIBER_RING_DEPTH in nros-rmw-xrce/src/internal.h for why
+      one of the two alone can make the pool LARGER.
+
+config NROS_XRCE_SERVICE_REQUEST_BUFFER_SIZE
+    int "Service-server request ring entry size"
+    default -1
+    help
+      Size of one service-server request inbox entry (bytes).
+      Maps to XRCE_SERVICE_REQUEST_BUFFER_SIZE.
+
+      Settable, and NOT derived: the parameter (6 per node) and lifecycle
+      (5) families open service servers that no `[[endpoint]]` row in the
+      sizing descriptor itemises, and an action server opens three more.
+      A size taken from the declared service rows alone would be short for
+      exactly those, in the UNDER direction. Falls back to
+      NROS_XRCE_BUFFER_SIZE.
+
+config NROS_XRCE_SERVICE_REPLY_BUFFER_SIZE
+    int "Service-client reply slot size"
+    default -1
+    help
+      Size of one service-client reply inbox (bytes).
+      Maps to XRCE_SERVICE_REPLY_BUFFER_SIZE.
+
+      Settable, and not derived, for the same reason as the request size
+      above. Falls back to NROS_XRCE_BUFFER_SIZE.
+
 config NROS_XRCE_STREAM_HISTORY
     int "Reliable stream history depth"
     default 16

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -963,6 +963,46 @@ function(nros_resolve_knobs)
         _nros_resolve_knob(NROS_XRCE_BUFFER_SIZE "${CONFIG_NROS_XRCE_BUFFER_SIZE}")
         _nros_resolve_knob(NROS_XRCE_STREAM_HISTORY
             "${CONFIG_NROS_XRCE_STREAM_HISTORY}")
+        # phase-454 W6.b — the three per-family receive buffers. Each defaults
+        # to the DERIVE sentinel, and the derivation they fall through to is
+        # `nros-rmw-xrce-cffi/build.rs` reading the sizing descriptor
+        # (RFC-0100 D4/D5), NOT a `NROS_DERIVED_*` this resolver could supply.
+        # So the third argument names a variable this file deliberately never
+        # sets: at the sentinel nothing is forwarded, the build script keeps
+        # ownership of the answer, and a STATED number still wins here exactly
+        # as it does for every other knob on this ladder.
+        #
+        # `_nros_resolve_knob` would have been wrong: it forwards the Kconfig
+        # value verbatim, so the `-1` sentinel would reach the build script as
+        # a rung-1 environment value and `stated()` would panic on it.
+        #
+        # The variable is deliberately NOT spelled `NROS_DERIVED_*`.
+        # `check-knob-delivery` harvests that prefix out of this file as "a
+        # fact this road carries to a knob", and then checks the fact ARRIVED
+        # in the CMake cache. This road carries no such fact — the derivation
+        # is `XrceDemand` on the cargo side, past the point that gate can see —
+        # so naming one here would claim a delivery nothing performs.
+        #
+        # Spelled one call per knob rather than a `foreach` over the three:
+        # `check-xrce-config-manifest` reads the forwarded set out of THIS FILE
+        # by matching `_nros_resolve*_knob(NROS_XRCE_...`, so a loop variable
+        # would leave all three reading as unforwarded — a gate blind in the
+        # safe-looking direction.
+        _nros_resolve_derivable_knob(NROS_XRCE_SUBSCRIBER_BUFFER_SIZE
+            "${CONFIG_NROS_XRCE_SUBSCRIBER_BUFFER_SIZE}"
+            _NROS_XRCE_FAMILY_DERIVED_BY_BUILD_SCRIPT
+            "the sizing descriptor, which only the cargo lane reads"
+            "${CMAKE_BINARY_DIR}/nros/sizing")
+        _nros_resolve_derivable_knob(NROS_XRCE_SERVICE_REQUEST_BUFFER_SIZE
+            "${CONFIG_NROS_XRCE_SERVICE_REQUEST_BUFFER_SIZE}"
+            _NROS_XRCE_FAMILY_DERIVED_BY_BUILD_SCRIPT
+            "the sizing descriptor, which only the cargo lane reads"
+            "${CMAKE_BINARY_DIR}/nros/sizing")
+        _nros_resolve_derivable_knob(NROS_XRCE_SERVICE_REPLY_BUFFER_SIZE
+            "${CONFIG_NROS_XRCE_SERVICE_REPLY_BUFFER_SIZE}"
+            _NROS_XRCE_FAMILY_DERIVED_BY_BUILD_SCRIPT
+            "the sizing descriptor, which only the cargo lane reads"
+            "${CMAKE_BINARY_DIR}/nros/sizing")
     endif()
 
     # Executor limits (nros-node build.rs, shared by both Rust and C APIs)


### PR DESCRIPTION
phase-454 W6.b. Carries W3 (#984) and W4 (#993); the queue drops them by patch-id.

## Measured — `sizeof(xrce_session_state_t)`, x86-64, everything else default

| | bytes | delta |
| --- | --- | --- |
| baseline, nothing declared | 427,968 | — |
| **reliability gate** (every endpoint `best_effort`) | 329,664 | **−98,304** |
| subscriber family (String bound 1,174, depth 1) | 171,264 | −256,704 |
| **both** | **72,960** | **−355,008 (83 %)** |
| *mutation control:* bound WITHOUT depth | 466,880 | **+38,912 GROWTH** |

Proven end-to-end through the real transport: a best-effort descriptor emits
exactly `-DXRCE_STREAM_HISTORY=4 -DXRCE_SUBSCRIBER_BUFFER_SIZE=1174
-DXRCE_SUBSCRIBER_RING_DEPTH=1`; **no descriptor emits zero `-D`s**, byte-identical
to before.

## Two corrections the brief's premise needed

**1. "Stops paying both 64 KiB buffers" is not available, structurally.**

Every control message rides `st->output_reliable` — participant, topic,
publisher, datawriter, datareader CREATE and DELETE, and
`uxr_buffer_request_data` — and that last one names `st->input_reliable` as the
Agent's delivery stream for **every** reader, whatever its QoS.

> A declaration about data is not a licence to make session setup lossy.

So `reliability` gates the **SLOTS** term to the protocol floor of 4 — which is
what RFC-0100 D2's own table already says. That is 98,304 of the 131,072; the
residue is a protocol requirement, not an oversight. The RFC's stakes table and
the phase's acceptance row now carry that with the number.

**2. Only the subscriber family is derived.** The parameter (6/node) and
lifecycle (5) families open service servers that **no `[[endpoint]]` row
itemises**, and an action server opens three more. A size from the declared
service rows alone would be short for exactly those — in the UNDER direction.

All three families are still **split** (three macros, three arrays, three knobs);
two are settable and not derived, with the reason in code. That is the same
argument W6.a made for `ZPICO_SERVICE_BUFFER_SIZE` only raising its builtin.

## The coupling is the row that matters

Bound and ring depth move **together or not at all** — separately, the buffer
alone grows the pool 9 %. `xrce_demand_selftest` case 7 is that mutation,
asserted, and it runs on every build of the crate.

## Two gates were wrong *before* this change, and are fixed

- **`check-knob-ends` credited `NROS_XRCE_BUFFER_SIZE` with a reader that was its
  own name inside an error string** in `session.c` — the mention-is-not-a-read
  shape its own header says the first version got wrong. **Rewording a diagnostic
  was enough to make a live knob read as dead.** `xrce-config.txt` is now read as
  a READ TABLE, through `check-xrce-config-manifest.py`'s own parser.
- **`gen-pool-inventory` required a `define` row's `#ifndef` default to be a
  literal**, so all three new knobs reached the inventory with no figure — issue
  0271's enumeration failure. It now follows one macro-alias chain; a dangling
  alias still resolves to nothing.

## Gates

`check fast` **315/315** · `check build` **20/21** with a worktree-local
`NROS_BUILD_ROOT` · `api-parity` OK · `test-unit` **1469 run, 0 failed** ·
`test-lane-contracts` 17/17 · `cli-tests` OK · `check rmw-xrce` OK including both
CTest binaries · `check-c-array-pool-floors` 26 arrays / 23 guarded / 0
unclassified · `check-c-array-guard-probe` 23 guards fire at 0, silent at
defaults (all three new ones probed) · `check-xrce-config-manifest`,
`check-kconfig-knob-forwarding`, `check-knob-ends`, `gen-pool-inventory` green.

The one red is `cpp` — issue **#1331**, pre-existing, 0 nros-cpp files in this
diff. `rmw-uorb`, `rmw-xrce`, `staticlib-symbols` and `borrowed-e2e` go green
with `NROS_BUILD_ROOT=$PWD/build`; that is issue **#1280** (fixed in #1004), and
`rmw-xrce` reading as a *backend* failure when it is a shared-cache failure is
worth keeping in mind.

## Stated limits

`mem-report --baseline` **cannot** show this: the struct is one
`nros_platform_alloc` and mem-report joins pools to ELF symbols. The figures
above are `sizeof` under the two `-D` sets, and the phase doc says so.

No runtime cell exercises a best-effort-only XRCE image end to end yet; coverage
is the build-script selftest (11 cases), the `check rmw-xrce` CTest pair, and the
`-D` capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je1V96viWocxYpyW21SFP1