### PR TITLE
docs(#1353): the nightly compile-tier lane has answered once in ten nights

### DIFF
--- a/docs/issues/1353-nightly-gate-runner-out-of-disk.md
+++ b/docs/issues/1353-nightly-gate-runner-out-of-disk.md
@@ -1,0 +1,103 @@
+---
+id: 1353
+title: "The scheduled `gate` run dies at `just check build` with `No space left on
+  device` on the GitHub-hosted runner — 8 of the last 10 nights, so the compile
+  tier's only unattended lane has produced almost no verdict for a week"
+status: open
+type: bug
+area: ci
+severity: medium
+found: 2026-09-12
+related: [1350, 0996, 1177, 1158]
+---
+
+## What happens
+
+`gate.yml` runs on `schedule` at 02:0x UTC, and that event is the only one that
+reaches the compile tier: `just check build (nightly / manual only)` and
+`just check no-std (nightly / manual only)` are both gated to
+`schedule`/`workflow_dispatch`. On the hosted runner, the job reaches that step
+and then the **runner process itself** runs out of disk:
+
+```
+System.IO.IOException: No space left on device :
+  '/home/runner/actions-runner/cached/2.337.0/_diag/Worker_20260912-020326-utc.log'
+   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ...)
+```
+
+The exception is on the runner's own `_diag` log, not on anything the build
+writes, so by the time it surfaces there is no room left even to record why.
+The job's own log blob is unavailable afterwards (`BlobNotFound` from the log
+API), which is consistent with the upload having nowhere to write.
+
+## Evidence
+
+| run | date | job | failing step |
+| --- | --- | --- | --- |
+| 34666582331 | 2026-09-12T02:03 | 103479596699 | 22 `just check build (nightly / manual only)` |
+| 34301642480 | 2026-09-09T02:03 | 102309634092 | same step |
+| 34178686534 | 2026-09-08T02:02 | 101913144010 | same step |
+
+All three carry the identical `No space left on device` annotation on
+`_diag/Worker_<date>-utc.log`. The scheduled `gate` history is:
+
+```
+34666582331 failure 09-12    34075012860 failure 09-07
+34553102010 SUCCESS 09-11    34005439803 failure 09-06
+34427875667 failure 09-10    33937933817 failure 09-05
+34301642480 failure 09-09    33828029043 failure 09-04
+34178686534 failure 09-08    33706473516 failure 09-03
+```
+
+**One success in ten nights** (2026-09-11).
+
+## Why it matters
+
+This is the "a red lane answers one of two questions and they look identical"
+class the pitfall index already names: the lane has no signal capacity while it
+is uniformly red, so a real compile-tier regression landing tonight is
+indistinguishable from the disk failure. And the compile tier is exactly where
+the `pre-push` `check-fast` hook deliberately does *not* look — `check build`
+caught two reds on `main` in its first two runs for that reason. Since
+2026-09-03 it has answered once.
+
+It also weakens two claims made elsewhere. CLAUDE.md says `check-build` is
+`schedule`/`workflow_dispatch` only *because* it cannot pass on the merge group;
+that is a sound argument for where it runs, but it assumes the schedule
+actually runs it. And `check-default-gates-run-somewhere` (issue 1040) asks
+whether a gate is *reachable* from some lane, not whether that lane *completes*
+— so a gate whose only lane dies before reaching it still counts as covered.
+
+## What this is NOT
+
+Issue **1350** is the same error string on a different machine. That one is the
+local dev host: orphaned `-P 32` gate fan-out kept building after its lane was
+killed and took `/home` to 0 bytes free twice. This issue is the **GitHub-hosted
+runner**, where no orphan from this repo can exist across jobs — the runner is
+fresh per job. The two share a symptom and nothing else, so fixing 1350 will not
+fix this.
+
+## What would close it
+
+Measurement first, because the cause is not yet established and a guessed fix
+here is a guessed fix to the only unattended compile-tier lane:
+
+1. Add a disk report to `gate.yml` around the compile-tier steps (`df -h` before
+   `just check build` and after it, plus `du -sh` of the cargo target dir, the
+   sccache dir and `third-party/`) so the next failure says how much was used and
+   by what. Today the only artifact is an exception about a log file.
+2. From that, decide between the two shapes: the tier genuinely needs more than
+   a hosted runner's free space, or something is accumulating within the job
+   (the compile-check fixtures, the message bindings and the provisioned
+   compile-tier sources are all built in the same job, before this step).
+3. If it is the former, the honest options are pruning what the tier builds,
+   freeing space explicitly at the start of the job, or moving this tier to a
+   runner that has the disk — not leaving a lane red and calling it known.
+4. Acceptance is a scheduled run that **reaches a verdict** on `check build` and
+   `check no-std` — green or red, but a verdict — on three consecutive nights.
+
+Until then, treat a red scheduled `gate` as "no answer", not as "the compile
+tier is broken", and read `just check fast` in that same job separately: it
+passed in run 34666582331 (step 13), because the scheduled job provisions the
+submodule sources that make `capability-conditionals` and
+`xrce-vendored-versions` fail everywhere else.


### PR DESCRIPTION
Files issue 1353.

`gate.yml`'s `schedule` event is the only one that reaches the compile tier — both `just check build` and `just check no-std` are gated to `schedule`/`workflow_dispatch`. On the GitHub-hosted runner that job dies at `just check build`, with the runner's own diagnostic log unable to write:

```
System.IO.IOException: No space left on device :
  '/home/runner/actions-runner/cached/2.337.0/_diag/Worker_20260912-020326-utc.log'
```

The identical annotation is on runs 34666582331 (09-12), 34301642480 (09-09) and 34178686534 (09-08), and the scheduled history is **one success in the last ten nights**. So the tier that `pre-push` deliberately skips — the one that caught two reds on `main` in its first two runs — has produced almost no verdict since 2026-09-03. That is the uniformly-red-lane class the pitfall index already names: while it stays red it cannot tell a real compile-tier regression from the disk failure.

Filed rather than fixed, deliberately. The cause is not established, and the only artifact today is an exception about a log file. The issue asks for a disk report around the compile-tier steps first (`df -h` before and after, plus `du -sh` of the cargo target dir, sccache and `third-party/`), then names the three honest outcomes measurement could lead to. Acceptance is a scheduled run that reaches a *verdict* — green or red — on three consecutive nights.

This is **not** issue 1350. That one is the same error string on the local dev host, caused by an orphaned `-P 32` gate fan-out; a hosted runner is fresh per job and cannot inherit one. They share a symptom and nothing else, so fixing 1350 will not fix this.

Docs-only. `check issue-ids`, `check markdown-links` and `check prose-issue-refs` all pass; `just check fast` is 317 of 319, the two reds being `capability-conditionals` and `xrce-vendored-versions`, which need submodule sources this worktree does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APoAduuwwHtW2CK36A1R4X
