### PR TITLE
fix(#0359): the two NuttX FFI leaf locks did not follow their manifest

### DIFF
--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",
+ "nros-sizing-descriptor",
  "nros-zephyr-build",
  "portable-atomic",
 ]


### PR DESCRIPTION
`check-leaf-lockfiles` is red on `main`, and only the scheduled `host-tests` lane can see it — the push lane has no NuttX sources, so it skips exactly these two leaves. Run 34669950817, job 103489308628, step `just ci tier1`:

```
ERROR: leaf Cargo.lock drift in crate(s) not covered by the baseline:
       packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi
       packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi
       Their manifest changed and the lock was not regenerated, so the lock
       pins nothing and the crate resolves fresh on every build (issue 0359).
```

phase-454 W6.a (`f825d218b`) gave `nros-board-nuttx-qemu` a dependency on `nros-sizing-descriptor` and updated the board's own lock, but not the two FFI leaves that path-depend on it — so their locks pinned a resolution their manifests no longer describe.

Regenerated the sanctioned way, `just lock-update "" "" <leaf-dir>` for each, never a bare `cargo generate-lockfile`. The diff is **one line per lock**:

```
 [[package]] nros-board-nuttx-qemu
  dependencies = [
+  "nros-sizing-descriptor",
```

No `[[package]]` block added or removed, no registry package moved — the refresh the gate asks for, not a dependency change.

Verified with `just check leaf-lockfiles` → "every tracked leaf lock satisfies its manifest", after initialising `third-party/nuttx/libc` at its **recorded** pin `826c4ca91` (the resolution cannot run without it, which is the same reason the push lane never sees this gate). No pin moved. `just check fast` is 317 of 319, the two reds being `capability-conditionals` and `xrce-vendored-versions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APoAduuwwHtW2CK36A1R4X
