### PR TITLE
docs(#1353): a second hosted lane hit the same disk exhaustion, so it is not `check build`

### DIFF
--- a/docs/issues/1353-nightly-gate-runner-out-of-disk.md
+++ b/docs/issues/1353-nightly-gate-runner-out-of-disk.md
@@ -77,6 +77,33 @@ runner**, where no orphan from this repo can exist across jobs — the runner is
 fresh per job. The two share a symptom and nothing else, so fixing 1350 will not
 fix this.
 
+## It is not one lane — a second hosted lane hit it (2026-09-12)
+
+The `live-peer regression` workflow, run **34672525328** (schedule, 04:15), job
+**103496470349** (`rows whose board IS this runner`), carries the same
+annotation on the same file:
+
+```
+Unhandled exception. System.IO.IOException: No space left on device :
+  '/home/runner/actions-runner/cached/2.337.0/_diag/Worker_20260912-041530-utc.log'
+```
+
+Its sibling job **103496661226** (`rows whose board is NOT this runner`) failed
+at step 11, `Build the fixtures those rows resolve`, reporting only `Process
+completed with exit code 1` with no compiler diagnostic in the log — the same
+shape the `host-tests` job showed on 2026-09-12T02:27, where the stream is
+truncated mid-compile and the run ends. That truncation is itself a symptom:
+when the disk is gone the log has nowhere to land, so the lane that failed
+cannot say why.
+
+So the title's "the scheduled `gate` run" understates it. At least three hosted
+lanes are affected — `gate` (schedule), `live-peer regression` (schedule) and
+`host-tests` (push) — which rules out anything specific to `just check build`
+and points at the job image's free space against what a full provision plus
+compile-tier build now costs. The disk report the section below asks for should
+therefore be added to the shared setup the lanes have in common, not only around
+the compile-tier steps.
+
 ## What would close it
 
 Measurement first, because the cause is not yet established and a guessed fix


### PR DESCRIPTION
Adds evidence to issue 1353 rather than filing a second issue.

The `live-peer regression` workflow (run 34672525328, schedule, 04:15) failed its `rows whose board IS this runner` job with the identical annotation on the identical file:

```
Unhandled exception. System.IO.IOException: No space left on device :
  '/home/runner/actions-runner/cached/2.337.0/_diag/Worker_20260912-041530-utc.log'
```

Its sibling job (`rows whose board is NOT this runner`) died at step 11, `Build the fixtures those rows resolve`, reporting only `Process completed with exit code 1` — log truncated, no compiler diagnostic. That is the same shape the `host-tests` push job showed at 02:27, and the truncation is itself part of the symptom: with the disk gone the log has nowhere to land, so the lane that failed cannot say why.

So 1353's title understated the scope. Three hosted lanes are affected — `gate` (schedule), `live-peer regression` (schedule) and `host-tests` (push) — which rules out anything specific to `just check build` and points instead at the job image's free space against what a full provision plus compile-tier build now costs. The issue's remedy is widened to match: the disk report belongs in the setup those lanes share, not only around the compile-tier steps.

Docs-only. `check markdown-links`, `check issue-ids` pass; `just check fast` is 320 of 322, the two reds being `capability-conditionals` and `xrce-vendored-versions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APoAduuwwHtW2CK36A1R4X
