### PR TITLE
fix(check): `feature-contract` required one TOML module and exited 2 without it

### DIFF
--- a/scripts/check-feature-contract.py
+++ b/scripts/check-feature-contract.py
@@ -73,11 +73,26 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from lib.tracked import tracked
 
+# `tomllib` is 3.11+, `tomli` the 3.10 backport, `toml` the older third-party
+# package this gate used to require outright. All three expose `loads(str)`,
+# which is the only entry point below. The chain is widest-first so the gate
+# runs wherever ANY of them is present: requiring `toml` alone made it exit 2
+# on the `run-matrix` container, and a gate that cannot run reports the same
+# red as a gate that failed. Sibling spelling: `scripts/check-fixture-groups.py`.
 try:
-    import toml
-except ImportError:  # pragma: no cover - environment guard
-    sys.stderr.write("check-feature-contract: python3 `toml` module required\n")
-    sys.exit(2)
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib  # the 3.10 backport
+    except ModuleNotFoundError:
+        try:
+            import toml as tomllib  # older third-party package
+        except ModuleNotFoundError:
+            sys.stderr.write(
+                "check-feature-contract: need one of python3 `tomllib` (3.11+), "
+                "`tomli` or `toml`\n"
+            )
+            sys.exit(2)
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCOPE = "packages"
@@ -257,7 +272,10 @@ def read(p):
 
 def load(man):
     try:
-        return toml.load(man)
+        # `loads`, not `load`: `tomllib`/`tomli` take a BINARY file while `toml`
+        # takes a text one, and only the string entry point is common to all three.
+        with open(man, encoding="utf-8") as fh:
+            return tomllib.loads(fh.read())
     except Exception as exc:  # a malformed manifest is someone else's gate
         sys.stderr.write(f"  (skipping unparseable {rel(man)}: {exc})\n")
         return None


### PR DESCRIPTION
`run-matrix`'s tier-2 lane (run 34678058729, job 103511388007, step `just build tier2`) went red on this, and the message is the whole story:

```
===== FAIL (feature-contract, rc=2, 280ms) =====
check-feature-contract: python3 `toml` module required
```

Nothing about the tree was wrong. The gate hard-required the third-party `toml` package, and the `run-matrix` container does not carry it — so the lane reported `1 of 322 gate(s) FAILED` for a gate that **never ran**, and took the whole build down with it (`fast` → `_build-scope` → `build` → the job). That is the red-lane class the pitfall index names: a gate that cannot run is indistinguishable from a gate whose subject is broken.

Three packages parse TOML in this repo — `tomllib` (3.11+), `tomli` (the 3.10 backport) and `toml` — and all three expose `loads(str)`. The import chain now tries them widest-first and fails only when none is present, naming all three. This strictly widens where the gate runs; nothing that worked before stops working.

`load()` moves from `toml.load(path)` to reading the file and calling `loads()`, because that is the one entry point common to all three: `tomllib`/`tomli` take a **binary** handle while `toml` takes a text one, so the file object is not interchangeable and the string is.

Verified per arm, by blocking modules through a `sys.meta_path` finder and running the real script — not by reading:

```
blocked=tomllib              -> self-test OK (21 cases)
blocked=tomllib,tomli        -> self-test OK (21 cases)
blocked=tomllib,tomli,toml   -> need one of python3 `tomllib`, `tomli` or `toml`
```

Plus `just check feature-contract` green over 207 crates / 6 clauses, and `just check fast` 320 of 322 — the two reds being `capability-conditionals` and `xrce-vendored-versions`, which need submodule sources this worktree does not have.

Sibling spelling of the same chain, kept in step: `scripts/check-fixture-groups.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APoAduuwwHtW2CK36A1R4X
