### PR TITLE
docs(#1355, #1356, #1304, #1353): the nightly's eight failing jobs, one cause each

### DIFF
--- a/docs/issues/1304-installed-setup-cannot-provision-submodule-sources.md
+++ b/docs/issues/1304-installed-setup-cannot-provision-submodule-sources.md
@@ -82,6 +82,22 @@ Items 1–3 are separate and smaller: a Rust-toolchain step (or a probe) on the
 installed path, a configure that finds an installed `cyclonedds` dist, and
 scaffold "next steps" that follow the same ladder the CMakeLists does.
 
+## Still red in the nightly, 2026-09-12
+
+Nightly run **34680021029** (schedule, 07:10), job **103516832336**
+(`installed-probe`), step `Run installed-path probe`:
+
+```
+  [FAILED]  cyclonedds-src — provision source: read gitlink sha for
+            third-party/dds/cyclonedds (source cyclonedds-src)
+Error: 1 package(s) failed to install (see [FAILED] above)
+```
+
+Same failure this issue describes, reached through `just probe installed`
+(phase-447 A3) rather than by hand — so the installed front door is the thing
+the nightly exercises, and it has not worked since. Recorded here so the lane's
+red has an owner; no separate issue filed.
+
 ## Acceptance
 
 `just probe installed` passes: install -> `nros setup native --rmw cyclonedds`

--- a/docs/issues/1353-nightly-gate-runner-out-of-disk.md
+++ b/docs/issues/1353-nightly-gate-runner-out-of-disk.md
@@ -104,6 +104,26 @@ compile-tier build now costs. The disk report the section below asks for should
 therefore be added to the shared setup the lanes have in common, not only around
 the compile-tier steps.
 
+## The truncation is confirmed as disk, from cargo itself (2026-09-12)
+
+Until now `host-tests` was attributed to this issue by the SHAPE of its
+failure — a log truncated mid-compile with no diagnostic. Run **34679397895**
+(push, 06:55), job **103515049240**, step `just ci tier1`, says it outright:
+
+```
+===== FAIL (test-targets, rc=101, 62936ms) =====
+error: failed to write to `target/debug/deps/rmetaYBvbcx/full.rmeta`:
+  No space left on device (os error 28)
+error: could not compile `zerocopy` (lib) due to 1 previous error
+error: failed to run custom build command for `zpico-sys v0.5.0`
+```
+
+So the inference was right, and this replaces it with a measurement. It also
+narrows where the space goes: the failure is a write into the HOST workspace's
+`target/debug`, during `check test-targets`, which is a workspace-wide plus
+per-crate clippy — i.e. the tier-1 lane fills the same disk the compile tier
+does, without touching the compile tier at all.
+
 ## What would close it
 
 Measurement first, because the cause is not yet established and a guessed fix

--- a/docs/issues/1355-threadx-riscv64-builds-the-linux-threadx-port.md
+++ b/docs/issues/1355-threadx-riscv64-builds-the-linux-threadx-port.md
@@ -1,0 +1,66 @@
+---
+id: 1355
+title: "The `threadx_riscv64` nightly job builds ThreadX's **linux/gnu** port, whose
+  `tx_port.h` includes `<semaphore.h>` — so the board crate's build script dies on a
+  target that has no POSIX headers, and the lane has never reached a cell"
+status: open
+type: bug
+area: ci, boards, threadx
+severity: medium
+found: 2026-09-12
+related: [1158, 1145, phase-448]
+---
+
+## What happens
+
+Nightly run **34680021029** (schedule, 07:10), job **103517111698**
+(`threadx_riscv64`), step `Build (threadx_riscv64)`:
+
+```
+cargo:warning=third-party/threadx/kernel/ports/linux/gnu/inc/tx_port.h:118:10:
+  fatal error: semaphore.h: No such file or directory
+error: failed to run custom build command for `nros-board-threadx v0.4.0
+  (packages/boards/nros-board-threadx)`
+error: recipe `build-fixture-extras` failed with exit code 1
+```
+
+The path is the whole finding: `ports/linux/gnu`. A riscv64 bare-metal build is
+compiling ThreadX's **Linux** port, and that port's `tx_port.h` includes
+`<semaphore.h>` because on Linux ThreadX is a pthread-hosted simulation. The
+riscv64 toolchain has no such header, so the failure is not "a header is
+missing" — it is "the wrong port was selected".
+
+## Why it matters
+
+`threadx_riscv64` is one of the two ThreadX coordinates in the nightly, and the
+board it names (`nros-board-threadx-qemu-riscv64`) exists precisely to cover the
+ThreadX × riscv axis. While the build script dies, that axis reports `failure`
+every night for a reason that has nothing to do with the code under test — the
+uniformly-red-lane class the pitfall index describes, where a real regression on
+this coordinate would be indistinguishable from this.
+
+It also quietly weakens issue 1145's ThreadX entry, which records
+`threadx-riscv64` as "still unstated, and unstated is the safe state" and says
+the mechanism is in place awaiting a measurement on that board's own images.
+That measurement cannot be taken while the board crate will not build.
+
+## What this is NOT
+
+- Not the `threadx-linux` executor-backing failure in the same run (issue 1145) —
+  that is a `const` assert in `nros-node`, on a different job, with a different
+  error.
+- Not a missing sysroot package. Adding `semaphore.h` to a bare-metal riscv
+  toolchain would be papering over the port selection, and the Linux port also
+  wants pthreads at link time.
+
+## What would close it
+
+1. Find where `nros-board-threadx`'s build script chooses the port directory and
+   determine what it keys on — target triple, a cargo feature, or
+   `NROS_PLATFORM_NAME`. The linux/gnu path being reached from a riscv64 build
+   means that key is absent or defaulted in this lane.
+2. Select the riscv port for the riscv64 board, and make a wrong/absent
+   selection a build-script `panic!` that names the target and the port it tried,
+   rather than a compiler error thirteen frames down in a vendored header.
+3. Acceptance is the `threadx_riscv64` nightly job reaching a verdict — green or
+   red on its own cells, not on its board crate's build script.

--- a/docs/issues/1356-esp32-offline-build-missing-registry-deps.md
+++ b/docs/issues/1356-esp32-offline-build-missing-registry-deps.md
@@ -1,0 +1,72 @@
+---
+id: 1356
+title: "The esp32 nightly build runs `--offline`/`--frozen` against a cache that has
+  neither `esp-backtrace` nor `allocator-api2` — the same cold-cache class as archived
+  issue 0873, recurring on a different dependency set"
+status: open
+type: bug
+area: ci, esp32
+severity: medium
+found: 2026-09-12
+related: [0873, 1025, 1070, 1158]
+---
+
+## What happens
+
+Nightly run **34680021029** (schedule, 07:10), job **103517111645** (`esp32`),
+step `Build (esp32)`. The build resolves its entry and then cannot resolve its
+dependencies:
+
+```
+nros build demo_bringup:esp32 --workspace . --offline -- --profile nros-relwithdebinfo …
+nros build: demo_bringup:esp32 -> board esp32-c3-baremetal (platform esp32), driver cargo
+error: no matching package named `esp-backtrace` found
+error: failed to download `allocator-api2 v0.3.1`
+
+Caused by:
+  attempting to make an HTTP request, but --frozen was specified
+error: recipe `build-examples` failed with exit code 101
+```
+
+Two distinct symptoms, one cause: the job builds offline, and the crates the
+esp32 entry needs are not in the cache it was given. `esp-backtrace` is not
+present at all (`no matching package named`), and `allocator-api2 v0.3.1` is
+known but not downloaded, so `--frozen` refuses the fetch rather than making it.
+
+## Why offline is right and the cache is the bug
+
+The `--offline`/`--frozen` posture is deliberate — it is what makes a lockfile a
+promise rather than a suggestion, and `NROS_CARGO_FLAGS` injects `--locked`
+project-wide for the same reason (issues 0359/0378). So the fix is not to drop
+the flag; it is that the lane must populate what its own manifests resolve to
+before the build starts.
+
+This is the class archived issue **0873** ("nightly offline lockfile, cold
+cache") already closed once. It is recurring on a different dependency set,
+which is the signal that the previous fix addressed the instances rather than
+the mechanism: nothing checks that the warmed cache actually covers the esp32
+entry's resolution.
+
+## What this is NOT
+
+- Not a missing-crate-version problem in the manifests. The same entry builds
+  where the cache is warm; the resolution is not in dispute.
+- Not the disk exhaustion of issue 1353 — this job fails in seconds, on
+  resolution, with no `No space left on device` anywhere in its log.
+- Not issue 1025 (the esp32 packer deriving the wrong fixture artifact dir),
+  though it is the same lane and that one also hid behind a first failure.
+
+## What would close it
+
+1. Establish what warms the cargo cache for the esp32 nightly job and why the
+   esp32 entry's graph is outside it — the entry is generated (`nros build`
+   writes the selection facade and the entry), so its dependency set may not
+   exist at the time the warming step runs. That ordering is the likeliest
+   mechanism and should be confirmed, not assumed.
+2. Make the gap loud where it happens: a build that resolves an entry and then
+   goes offline should assert its resolution is satisfiable from the cache and
+   name the crates that are not, rather than surfacing as two unrelated-looking
+   cargo errors.
+3. Acceptance is the `esp32` nightly job reaching a verdict on its cells on
+   three consecutive nights, and the mechanism — not just these two crates —
+   being what changed.


### PR DESCRIPTION
The MAIN-HEALTH check had been diagnosing the first failing job of a run and calling the run accounted for. Nightly **34680021029** has **eight** failing jobs and they do not share a cause. This is the full sweep.

## Filed new

**1355 — `threadx_riscv64` builds ThreadX's linux/gnu port.** Job 103517111698:

```
cargo:warning=third-party/threadx/kernel/ports/linux/gnu/inc/tx_port.h:118:10:
  fatal error: semaphore.h: No such file or directory
error: failed to run custom build command for `nros-board-threadx v0.4.0`
```

The path is the finding — a riscv64 bare-metal build is compiling the **Linux** port, whose `tx_port.h` includes `<semaphore.h>` because on Linux ThreadX is a pthread-hosted simulation. Wrong port selected, not a header missing. It also blocks the measurement issue 1145 is waiting on for that board.

**1356 — the esp32 build is offline against a cache that lacks its deps.** Job 103517111645:

```
error: no matching package named `esp-backtrace` found
error: failed to download `allocator-api2 v0.3.1`
Caused by:
  attempting to make an HTTP request, but --frozen was specified
```

Offline is the right posture (it is what makes a lockfile a promise), so the cache is the bug. Archived issue 0873 closed this class once; it recurs on a different dependency set, which says the earlier fix addressed instances rather than the mechanism.

## Evidence added to issues that already own the cause

**1304** — `installed-probe` still cannot read the cyclonedds gitlink sha, now through `just probe installed` rather than by hand.

**1353** — `host-tests` was attributed to the disk exhaustion by the *shape* of its failure, a log truncated mid-compile. Run 34679397895 says it outright: `failed to write to target/debug/deps/…/full.rmeta: No space left on device (os error 28)`. Inference replaced by measurement — and it narrows where the space goes, since the tier-1 lane fills the same disk without touching the compile tier.

## Attributed, no change needed

`threadx_linux` → 1145 (recorded yesterday). `freertos`'s three `test_rtos_action_e2e` failures across Rust/C/C++ → 1341, which 1145 already names as pre-existing. `tier 2 nightly` → the `feature-contract` TOML-module red, fixed by #1019 after this run.

## Still undiagnosed

`bootstrap-probe` — its log tail carries only checkout cleanup. Named for the next cycle rather than guessed at.

Docs-only. `check markdown-links` and `check issue-ids` pass; `just check fast` is 320 of 322, the two reds being `capability-conditionals` and `xrce-vendored-versions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APoAduuwwHtW2CK36A1R4X
